### PR TITLE
Migrate BraviaTV to new async backend

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -137,6 +137,7 @@ omit =
     homeassistant/components/bosch_shc/switch.py
     homeassistant/components/braviatv/__init__.py
     homeassistant/components/braviatv/const.py
+    homeassistant/components/braviatv/coordinator.py
     homeassistant/components/braviatv/entity.py
     homeassistant/components/braviatv/media_player.py
     homeassistant/components/braviatv/remote.py

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -9,7 +9,10 @@ from typing import Final
 import aiohttp
 from pybravia import BraviaTV
 
-from homeassistant.components.media_player.const import MEDIA_TYPE_CHANNEL
+from homeassistant.components.media_player.const import (
+    MEDIA_TYPE_APP,
+    MEDIA_TYPE_CHANNEL,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN, Platform
 from homeassistant.core import HomeAssistant
@@ -33,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     ignored_sources = config_entry.options.get(CONF_IGNORED_SOURCES, [])
 
     session = async_create_clientsession(
-        hass, cookie_jar=aiohttp.CookieJar(unsafe=True)
+        hass, cookie_jar=aiohttp.CookieJar(unsafe=True, quote_cookie=False)
     )
     client = BraviaTV(host, mac, session=session)
     coordinator = BraviaTVCoordinator(hass, client, pin, ignored_sources)
@@ -193,7 +196,8 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             self.media_content_id = None
             self.media_content_type = None
         if not playing_info:
-            self.media_title = "App"
+            self.media_title = "Smart TV"
+            self.media_content_type = MEDIA_TYPE_APP
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -1,31 +1,20 @@
-"""The Bravia TV component."""
+"""The Bravia TV integration."""
 from __future__ import annotations
 
-from collections.abc import Iterable
-from datetime import timedelta
-import logging
 from typing import Final
 
-import aiohttp
-from pybravia import BraviaTV, BraviaTVError
+from aiohttp import CookieJar
+from pybravia import BraviaTV
 
-from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_APP,
-    MEDIA_TYPE_CHANNEL,
-)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
-from homeassistant.helpers.debounce import Debouncer
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CLIENTID_PREFIX, CONF_IGNORED_SOURCES, DOMAIN, NICKNAME
-
-_LOGGER = logging.getLogger(__name__)
+from .const import CONF_IGNORED_SOURCES, DOMAIN
+from .coordinator import BraviaTVCoordinator
 
 PLATFORMS: Final[list[Platform]] = [Platform.MEDIA_PLAYER, Platform.REMOTE]
-SCAN_INTERVAL: Final = timedelta(seconds=10)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -36,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     ignored_sources = config_entry.options.get(CONF_IGNORED_SOURCES, [])
 
     session = async_create_clientsession(
-        hass, cookie_jar=aiohttp.CookieJar(unsafe=True, quote_cookie=False)
+        hass, cookie_jar=CookieJar(unsafe=True, quote_cookie=False)
     )
     client = BraviaTV(host, mac, session=session)
     coordinator = BraviaTVCoordinator(hass, client, pin, ignored_sources)
@@ -67,219 +56,3 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(config_entry.entry_id)
-
-
-class BraviaTVCoordinator(DataUpdateCoordinator[None]):
-    """Representation of a Bravia TV Coordinator.
-
-    An instance is used per device to share the same power state between
-    several platforms.
-    """
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        client: BraviaTV,
-        pin: str,
-        ignored_sources: list[str],
-    ) -> None:
-        """Initialize Bravia TV Client."""
-
-        self.client = client
-        self.pin = pin
-        self.ignored_sources = ignored_sources
-        self.source: str | None = None
-        self.source_list: list[str] = []
-        self.source_map: dict[str, dict] = {}
-        self.media_title: str | None = None
-        self.media_content_id: str | None = None
-        self.media_content_type: str | None = None
-        self.media_uri: str | None = None
-        self.media_duration: int | None = None
-        self.volume_level: float | None = None
-        self.volume_target: str | None = None
-        self.volume_muted = False
-        self.is_on = False
-        self.is_channel = False
-        self.connected = False
-        # Assume that the TV is in Play mode
-        self.playing = True
-
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=DOMAIN,
-            update_interval=SCAN_INTERVAL,
-            request_refresh_debouncer=Debouncer(
-                hass, _LOGGER, cooldown=1.0, immediate=False
-            ),
-        )
-
-    def _sources_extend(self, sources: dict, source_type: str) -> None:
-        """Extend source map and source list."""
-        for item in sources:
-            item["type"] = source_type
-            title = item.get("title")
-            uri = item.get("uri")
-            if not title or not uri:
-                continue
-            self.source_map[uri] = item
-            if title not in self.ignored_sources:
-                self.source_list.append(title)
-
-    async def _async_update_data(self) -> None:
-        """Connect and fetch data."""
-        power_status = await self.client.get_power_status()
-
-        if power_status == "off":
-            self.connected = False
-        else:
-            if not self.connected:
-                try:
-                    self.connected = await self.client.connect(
-                        pin=self.pin, clientid=CLIENTID_PREFIX, nickname=NICKNAME
-                    )
-                except BraviaTVError as err:
-                    self.is_on = False
-                    raise UpdateFailed("Error communicating with device") from err
-
-        self.is_on = self.connected and power_status == "active"
-
-        if self.is_on is False:
-            return
-
-        if not self.source_map:
-            await self._async_update_sources()
-        await self._async_update_volume()
-        await self._async_update_playing()
-
-    async def _async_update_sources(self) -> None:
-        """Update sources."""
-        self.source_list = []
-        self.source_map = {}
-
-        externals = await self.client.get_external_status()
-        self._sources_extend(externals, "input")
-
-        apps = await self.client.get_app_list()
-        self._sources_extend(apps, "app")
-
-        channels = await self.client.get_content_list_all("tv")
-        self._sources_extend(channels, "channel")
-
-    async def _async_update_volume(self) -> None:
-        """Update volume information."""
-        volume_info = await self.client.get_volume_info()
-        volume_level = volume_info.get("volume")
-        if volume_level is not None:
-            self.volume_level = volume_level / 100
-            self.volume_muted = volume_info.get("mute", False)
-            self.volume_target = volume_info.get("target")
-
-    async def _async_update_playing(self) -> None:
-        """Update current playing information."""
-        playing_info = await self.client.get_playing_info()
-        self.media_title = playing_info.get("title")
-        self.media_uri = playing_info.get("uri")
-        self.media_duration = playing_info.get("durationSec")
-        if program_title := playing_info.get("programTitle"):
-            self.media_title = f"{self.media_title}: {program_title}"
-        if self.media_uri:
-            source = self.source_map.get(self.media_uri, {})
-            self.source = source.get("title")
-            self.is_channel = self.media_uri[:2] == "tv"
-            if self.is_channel:
-                self.media_content_id = playing_info.get("dispNum")
-                self.media_content_type = MEDIA_TYPE_CHANNEL
-            else:
-                self.media_content_id = self.media_uri
-                self.media_content_type = None
-        else:
-            self.source = None
-            self.is_channel = False
-            self.media_content_id = None
-            self.media_content_type = None
-        if not playing_info:
-            self.media_title = "Smart TV"
-            self.media_content_type = MEDIA_TYPE_APP
-
-    async def async_turn_on(self) -> None:
-        """Turn the device on."""
-        await self.client.turn_on()
-        await self.async_request_refresh()
-
-    async def async_turn_off(self) -> None:
-        """Turn off device."""
-        await self.client.turn_off()
-        await self.async_request_refresh()
-
-    async def async_set_volume_level(self, volume: float) -> None:
-        """Set volume level, range 0..1."""
-        await self.client.volume_level(round(volume * 100))
-        await self.async_request_refresh()
-
-    async def async_volume_up(self) -> None:
-        """Send volume up command to device."""
-        await self.client.volume_up()
-        await self.async_request_refresh()
-
-    async def async_volume_down(self) -> None:
-        """Send volume down command to device."""
-        await self.client.volume_down()
-        await self.async_request_refresh()
-
-    async def async_volume_mute(self, mute: bool) -> None:
-        """Send mute command to device."""
-        await self.client.volume_mute()
-        await self.async_request_refresh()
-
-    async def async_media_play(self) -> None:
-        """Send play command to device."""
-        await self.client.play()
-        self.playing = True
-        await self.async_request_refresh()
-
-    async def async_media_pause(self) -> None:
-        """Send pause command to device."""
-        await self.client.pause()
-        self.playing = False
-        await self.async_request_refresh()
-
-    async def async_media_stop(self) -> None:
-        """Send stop command to device."""
-        await self.client.stop()
-        await self.async_request_refresh()
-
-    async def async_media_next_track(self) -> None:
-        """Send next track command."""
-        if self.is_channel:
-            await self.client.channel_up()
-        else:
-            await self.client.next_track()
-        await self.async_request_refresh()
-
-    async def async_media_previous_track(self) -> None:
-        """Send previous track command."""
-        if self.is_channel:
-            await self.client.channel_down()
-        else:
-            await self.client.previous_track()
-        await self.async_request_refresh()
-
-    async def async_select_source(self, source: str) -> None:
-        """Set the input source."""
-        for uri, item in self.source_map.items():
-            if item.get("title") == source:
-                if item.get("type") == "app":
-                    await self.client.set_active_app(uri)
-                else:
-                    await self.client.set_play_content(uri)
-                break
-        await self.async_request_refresh()
-
-    async def async_send_command(self, command: Iterable[str], repeats: int) -> None:
-        """Send command to device."""
-        for _ in range(repeats):
-            for cmd in command:
-                await self.client.send_command(cmd)
-        await self.async_request_refresh()

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -1,18 +1,19 @@
 """The Bravia TV component."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Iterable
 from datetime import timedelta
 import logging
 from typing import Final
 
-from bravia_tv import BraviaRC
-from bravia_tv.braviarc import NoIPControl
+import aiohttp
+from pybravia import BraviaTV
 
+from homeassistant.components.media_player.const import MEDIA_TYPE_CHANNEL
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -21,7 +22,7 @@ from .const import CLIENTID_PREFIX, CONF_IGNORED_SOURCES, DOMAIN, NICKNAME
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: Final[list[Platform]] = [Platform.MEDIA_PLAYER, Platform.REMOTE]
-SCAN_INTERVAL: Final = timedelta(seconds=10)
+SCAN_INTERVAL: Final = timedelta(seconds=5)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -31,7 +32,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     pin = config_entry.data[CONF_PIN]
     ignored_sources = config_entry.options.get(CONF_IGNORED_SOURCES, [])
 
-    coordinator = BraviaTVCoordinator(hass, host, mac, pin, ignored_sources)
+    session = async_create_clientsession(
+        hass, cookie_jar=aiohttp.CookieJar(unsafe=True)
+    )
+    client = BraviaTV(host, mac, session=session)
+    coordinator = BraviaTVCoordinator(hass, client, pin, ignored_sources)
     config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
 
     await coordinator.async_config_entry_first_refresh()
@@ -71,34 +76,31 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
     def __init__(
         self,
         hass: HomeAssistant,
-        host: str,
-        mac: str,
+        client: BraviaTV,
         pin: str,
         ignored_sources: list[str],
     ) -> None:
         """Initialize Bravia TV Client."""
 
-        self.braviarc = BraviaRC(host, mac)
+        self.client = client
         self.pin = pin
         self.ignored_sources = ignored_sources
-        self.muted: bool = False
-        self.channel_name: str | None = None
-        self.media_title: str | None = None
         self.source: str | None = None
         self.source_list: list[str] = []
-        self.original_content_list: list[str] = []
-        self.content_mapping: dict[str, str] = {}
-        self.duration: int | None = None
-        self.content_uri: str | None = None
-        self.program_media_type: str | None = None
-        self.audio_output: str | None = None
-        self.min_volume: int | None = None
-        self.max_volume: int | None = None
+        self.source_map: list[dict] = []
+        self.media_title: str | None = None
+        self.media_content_id: str | None = None
+        self.media_content_type: str | None = None
+        self.media_uri: str | None = None
+        self.media_duration: int | None = None
         self.volume_level: float | None = None
+        self.volume_muted: bool = False
+        self.volume_target: str | None = None
         self.is_on = False
+        self.is_channel = False
+        self.connected = False
         # Assume that the TV is in Play mode
         self.playing = True
-        self.state_lock = asyncio.Lock()
 
         super().__init__(
             hass,
@@ -110,178 +112,166 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             ),
         )
 
-    def _send_command(self, command: Iterable[str], repeats: int = 1) -> None:
-        """Send a command to the TV."""
-        for _ in range(repeats):
-            for cmd in command:
-                self.braviarc.send_command(cmd)
-
-    def _get_source(self) -> str | None:
-        """Return the name of the source."""
-        for key, value in self.content_mapping.items():
-            if value == self.content_uri:
-                return key
-        return None
-
-    def _refresh_volume(self) -> bool:
-        """Refresh volume information."""
-        volume_info = self.braviarc.get_volume_info(self.audio_output)
-        if volume_info is not None:
-            volume = volume_info.get("volume")
-            self.volume_level = volume / 100 if volume is not None else None
-            self.audio_output = volume_info.get("target")
-            self.min_volume = volume_info.get("minVolume")
-            self.max_volume = volume_info.get("maxVolume")
-            self.muted = volume_info.get("mute", False)
-            return True
-        return False
-
-    def _refresh_channels(self) -> bool:
-        """Refresh source and channels list."""
-        if not self.source_list:
-            self.content_mapping = self.braviarc.load_source_list()
-            self.source_list = []
-            if not self.content_mapping:
-                return False
-            for key in self.content_mapping:
-                if key not in self.ignored_sources:
-                    self.source_list.append(key)
-        return True
-
-    def _refresh_playing_info(self) -> None:
-        """Refresh playing information."""
-        playing_info = self.braviarc.get_playing_info()
-        program_name = playing_info.get("programTitle")
-        self.channel_name = playing_info.get("title")
-        self.program_media_type = playing_info.get("programMediaType")
-        self.content_uri = playing_info.get("uri")
-        self.source = self._get_source()
-        self.duration = playing_info.get("durationSec")
-        if not playing_info:
-            self.channel_name = "App"
-        if self.channel_name is not None:
-            self.media_title = self.channel_name
-            if program_name is not None:
-                self.media_title = f"{self.media_title}: {program_name}"
-        else:
-            self.media_title = None
-
-    def _update_tv_data(self) -> None:
-        """Connect and update TV info."""
-        power_status = self.braviarc.get_power_status()
-
-        if power_status != "off":
-            connected = self.braviarc.is_connected()
-            if not connected:
-                try:
-                    connected = self.braviarc.connect(
-                        self.pin, CLIENTID_PREFIX, NICKNAME
-                    )
-                except NoIPControl:
-                    _LOGGER.error("IP Control is disabled in the TV settings")
-            if not connected:
-                power_status = "off"
-
-        if power_status == "active":
-            self.is_on = True
-            if self._refresh_volume() and self._refresh_channels():
-                self._refresh_playing_info()
-                return
-
-        self.is_on = False
-
     async def _async_update_data(self) -> None:
-        """Fetch the latest data."""
-        if self.state_lock.locked():
+        """Connect and fetch data."""
+        power_status = await self.client.get_power_status()
+
+        if power_status == "off":
+            self.connected = False
+        else:
+            if not self.connected:
+                self.connected = await self.client.connect(
+                    pin=self.pin, clientid=CLIENTID_PREFIX, nickname=NICKNAME
+                )
+
+        self.is_on = self.connected and power_status == "active"
+
+        if self.is_on is False:
             return
 
-        await self.hass.async_add_executor_job(self._update_tv_data)
+        if not self.source_map:
+            await self._async_update_sources()
+        await self._async_update_volume()
+        await self._async_update_playing()
+
+    async def _async_update_sources(self) -> None:
+        self.source_list = []
+        self.source_map = []
+
+        externals = await self.client.get_external_status()
+        for item in externals:
+            item["type"] = "input"
+            self.source_map.append(item)
+            title = item.get("title")
+            if title not in self.ignored_sources:
+                self.source_list.append(title)
+
+        apps = await self.client.get_app_list()
+        for item in apps:
+            item["type"] = "app"
+            self.source_map.append(item)
+            title = item.get("title")
+            if title not in self.ignored_sources:
+                self.source_list.append(title)
+
+        channels = await self.client.get_content_list_all("tv")
+        for item in channels:
+            item["type"] = "channel"
+            self.source_map.append(item)
+            title = item.get("title")
+            if title not in self.ignored_sources:
+                self.source_list.append(title)
+
+    async def _async_update_volume(self) -> None:
+        volume_info = await self.client.get_volume_info()
+        volume_level = volume_info.get("volume")
+        if volume_level is not None:
+            self.volume_level = volume_level / 100
+            self.volume_muted = volume_info.get("mute", False)
+            self.volume_target = volume_info.get("target")
+
+    async def _async_update_playing(self) -> None:
+        playing_info = await self.client.get_playing_info()
+        self.media_title = playing_info.get("title")
+        self.media_uri = playing_info.get("uri")
+        self.media_duration = playing_info.get("durationSec")
+        if program_title := playing_info.get("programTitle"):
+            self.media_title = f"{self.media_title}: {program_title}"
+        if self.media_uri:
+            source: dict = next(
+                (item for item in self.source_map if item.get("uri") == self.media_uri),
+                {},
+            )
+            self.source = source.get("title")
+            self.is_channel = self.media_uri[:2] == "tv"
+            self.media_content_id = (
+                playing_info.get("dispNum") if self.is_channel else self.media_uri
+            )
+            self.media_content_type = MEDIA_TYPE_CHANNEL if self.is_channel else None
+        else:
+            self.source = None
+            self.is_channel = False
+            self.media_content_id = None
+            self.media_content_type = None
+        if not playing_info:
+            self.media_title = "App"
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(self.braviarc.turn_on)
-            await self.async_request_refresh()
+        await self.client.turn_on()
+        await self.async_request_refresh()
 
     async def async_turn_off(self) -> None:
         """Turn off device."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(self.braviarc.turn_off)
-            await self.async_request_refresh()
+        await self.client.turn_off()
+        await self.async_request_refresh()
 
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(
-                self.braviarc.set_volume_level, volume, self.audio_output
-            )
-            await self.async_request_refresh()
+        await self.client.volume_level(round(volume * 100))
+        await self.async_request_refresh()
 
     async def async_volume_up(self) -> None:
         """Send volume up command to device."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(
-                self.braviarc.volume_up, self.audio_output
-            )
-            await self.async_request_refresh()
+        await self.client.volume_up()
+        await self.async_request_refresh()
 
     async def async_volume_down(self) -> None:
         """Send volume down command to device."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(
-                self.braviarc.volume_down, self.audio_output
-            )
-            await self.async_request_refresh()
+        await self.client.volume_down()
+        await self.async_request_refresh()
 
     async def async_volume_mute(self, mute: bool) -> None:
         """Send mute command to device."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(self.braviarc.mute_volume, mute)
-            await self.async_request_refresh()
+        await self.client.volume_mute()
+        await self.async_request_refresh()
 
     async def async_media_play(self) -> None:
         """Send play command to device."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(self.braviarc.media_play)
-            self.playing = True
-            await self.async_request_refresh()
+        await self.client.play()
+        self.playing = True
+        await self.async_request_refresh()
 
     async def async_media_pause(self) -> None:
         """Send pause command to device."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(self.braviarc.media_pause)
-            self.playing = False
-            await self.async_request_refresh()
+        await self.client.pause()
+        self.playing = False
+        await self.async_request_refresh()
 
     async def async_media_stop(self) -> None:
         """Send stop command to device."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(self.braviarc.media_stop)
-            self.playing = False
-            await self.async_request_refresh()
+        await self.client.stop()
+        await self.async_request_refresh()
 
     async def async_media_next_track(self) -> None:
         """Send next track command."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(self.braviarc.media_next_track)
-            await self.async_request_refresh()
+        if self.is_channel:
+            await self.client.channel_up()
+        else:
+            await self.client.next_track()
+        await self.async_request_refresh()
 
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(self.braviarc.media_previous_track)
-            await self.async_request_refresh()
+        if self.is_channel:
+            await self.client.channel_down()
+        else:
+            await self.client.previous_track()
+        await self.async_request_refresh()
 
     async def async_select_source(self, source: str) -> None:
         """Set the input source."""
-        if source in self.content_mapping:
-            uri = self.content_mapping[source]
-            async with self.state_lock:
-                await self.hass.async_add_executor_job(self.braviarc.play_content, uri)
-                await self.async_request_refresh()
+        for item in self.source_map:
+            if item.get("title") == source:
+                if item.get("type") == "app":
+                    await self.client.set_active_app(item.get("uri"))
+                else:
+                    await self.client.set_play_content(item.get("uri"))
+                break
 
     async def async_send_command(self, command: Iterable[str], repeats: int) -> None:
         """Send command to device."""
-        async with self.state_lock:
-            await self.hass.async_add_executor_job(self._send_command, command, repeats)
-            await self.async_request_refresh()
+        for _ in range(repeats):
+            for cmd in command:
+                await self.client.send_command(cmd)
+        await self.async_request_refresh()

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -275,6 +275,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 else:
                     await self.client.set_play_content(uri)
                 break
+        await self.async_request_refresh()
 
     async def async_send_command(self, command: Iterable[str], repeats: int) -> None:
         """Send command to device."""

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -1,4 +1,4 @@
-"""Adds config flow for Bravia TV integration."""
+"""Config flow to configure the Bravia TV integration."""
 from __future__ import annotations
 
 from contextlib import suppress
@@ -6,11 +6,11 @@ import ipaddress
 import re
 from typing import Any
 
-import aiohttp
-from pybravia import BraviaTV, BraviaTVError
+from aiohttp import CookieJar
+from pybravia import BraviaTV, BraviaTVError, BraviaTVNotSupported
 import voluptuous as vol
 
-from homeassistant import config_entries, exceptions
+from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN
 from homeassistant.core import callback
@@ -46,27 +46,16 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize."""
-        self.client: BraviaTV | None = None
-        self.host: str | None = None
+        self.client: BraviaTV
+        self.host: str
         self.title = ""
-        self.mac: str | None = None
+        self.mac: str
 
     async def init_device(self, pin: str) -> None:
         """Initialize Bravia TV device."""
-        assert self.client is not None
-
-        try:
-            await self.client.connect(
-                pin=pin, clientid=CLIENTID_PREFIX, nickname=NICKNAME
-            )
-        except BraviaTVError as err:
-            raise CannotConnect() from err
-
-        system_info = await self.client.get_system_info()
-        if not system_info:
-            raise ModelNotSupported()
-
+        await self.client.connect(pin=pin, clientid=CLIENTID_PREFIX, nickname=NICKNAME)
         await self.client.set_wol_mode(True)
+        system_info = await self.client.get_system_info()
 
         await self.async_set_unique_id(system_info[ATTR_CID].lower())
         self._abort_if_unique_id_configured()
@@ -90,7 +79,7 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if host_valid(user_input[CONF_HOST]):
                 session = async_create_clientsession(
                     self.hass,
-                    cookie_jar=aiohttp.CookieJar(unsafe=True, quote_cookie=False),
+                    cookie_jar=CookieJar(unsafe=True, quote_cookie=False),
                 )
                 self.host = user_input[CONF_HOST]
                 self.client = BraviaTV(host=self.host, session=session)
@@ -114,19 +103,18 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await self.init_device(user_input[CONF_PIN])
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except ModelNotSupported:
+            except BraviaTVNotSupported:
                 errors["base"] = "unsupported_model"
+            except BraviaTVError:
+                errors["base"] = "cannot_connect"
             else:
                 user_input[CONF_HOST] = self.host
                 user_input[CONF_MAC] = self.mac
                 return self.async_create_entry(title=self.title, data=user_input)
 
-        assert self.client is not None
-
-        pair = await self.client.pair(CLIENTID_PREFIX, NICKNAME)
-        if not pair:
+        try:
+            await self.client.pair(CLIENTID_PREFIX, NICKNAME)
+        except BraviaTVError:
             return self.async_abort(reason="no_ip_control")
 
         return self.async_show_form(
@@ -153,6 +141,7 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
             self.config_entry.entry_id
         ]
 
+        await coordinator.async_update_sources()
         sources = coordinator.source_map.values()
         self.source_list = [item.get("title", "") for item in sources]
         return await self.async_step_user()
@@ -174,11 +163,3 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
                 }
             ),
         )
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class ModelNotSupported(exceptions.HomeAssistantError):
-    """Error to indicate not supported model."""

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -65,6 +65,8 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not system_info:
             raise ModelNotSupported()
 
+        await self.client.set_wol_mode(True)
+
         await self.async_set_unique_id(system_info[ATTR_CID].lower())
         self._abort_if_unique_id_configured()
 
@@ -86,7 +88,8 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if host_valid(user_input[CONF_HOST]):
                 session = async_create_clientsession(
-                    self.hass, cookie_jar=aiohttp.CookieJar(unsafe=True)
+                    self.hass,
+                    cookie_jar=aiohttp.CookieJar(unsafe=True, quote_cookie=False),
                 )
                 self.host = user_input[CONF_HOST]
                 self.client = BraviaTV(host=self.host, session=session)

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -148,7 +148,8 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
 
         assert coordinator is not None
 
-        self.source_list = [item.get("title", "") for item in coordinator.source_map]
+        sources = coordinator.source_map.values()
+        self.source_list = [item.get("title", "") for item in sources]
         return await self.async_step_user()
 
     async def async_step_user(

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.config_validation as cv
 
+from . import BraviaTVCoordinator
 from .const import (
     ATTR_CID,
     ATTR_MAC,
@@ -144,9 +145,9 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
-        coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]
-
-        assert coordinator is not None
+        coordinator: BraviaTVCoordinator = self.hass.data[DOMAIN][
+            self.config_entry.entry_id
+        ]
 
         sources = coordinator.source_map.values()
         self.source_list = [item.get("title", "") for item in sources]

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -7,7 +7,7 @@ import re
 from typing import Any
 
 import aiohttp
-from pybravia import BraviaTV
+from pybravia import BraviaTV, BraviaTVError
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
@@ -55,11 +55,12 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize Bravia TV device."""
         assert self.client is not None
 
-        connected = await self.client.connect(
-            pin=pin, clientid=CLIENTID_PREFIX, nickname=NICKNAME
-        )
-        if not connected:
-            raise CannotConnect()
+        try:
+            await self.client.connect(
+                pin=pin, clientid=CLIENTID_PREFIX, nickname=NICKNAME
+            )
+        except BraviaTVError as err:
+            raise CannotConnect() from err
 
         system_info = await self.client.get_system_info()
         if not system_info:

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -107,8 +107,8 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            self.device_config[CONF_PIN] = user_input[CONF_PIN]
             try:
-                self.device_config[CONF_PIN] = user_input[CONF_PIN]
                 return await self.async_init_device()
             except BraviaTVNotSupported:
                 errors["base"] = "unsupported_model"

--- a/homeassistant/components/braviatv/const.py
+++ b/homeassistant/components/braviatv/const.py
@@ -10,7 +10,6 @@ ATTR_MODEL: Final = "model"
 
 CONF_IGNORED_SOURCES: Final = "ignored_sources"
 
-BRAVIA_CONFIG_FILE: Final = "bravia.conf"
 CLIENTID_PREFIX: Final = "HomeAssistant"
 DOMAIN: Final = "braviatv"
 NICKNAME: Final = "Home Assistant"

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -41,9 +41,9 @@ def catch_braviatv_errors(
         """Catch BraviaTV errors and log message."""
         try:
             await func(self, *args, **kwargs)
-            await self.async_request_refresh()
         except BraviaTVError as err:
             _LOGGER.error("Command error: %s", err)
+        await self.async_request_refresh()
 
     return wrapper
 

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -41,6 +41,7 @@ def catch_braviatv_errors(
         """Catch BraviaTV errors and log message."""
         try:
             await func(self, *args, **kwargs)
+            await self.async_request_refresh()
         except BraviaTVError as err:
             _LOGGER.error("Command error: %s", err)
 
@@ -179,57 +180,48 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
     async def async_turn_on(self) -> None:
         """Turn the device on."""
         await self.client.turn_on()
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_turn_off(self) -> None:
         """Turn off device."""
         await self.client.turn_off()
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self.client.volume_level(round(volume * 100))
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_volume_up(self) -> None:
         """Send volume up command to device."""
         await self.client.volume_up()
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_volume_down(self) -> None:
         """Send volume down command to device."""
         await self.client.volume_down()
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_volume_mute(self, mute: bool) -> None:
         """Send mute command to device."""
         await self.client.volume_mute()
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_media_play(self) -> None:
         """Send play command to device."""
         await self.client.play()
         self.playing = True
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_media_pause(self) -> None:
         """Send pause command to device."""
         await self.client.pause()
         self.playing = False
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_media_stop(self) -> None:
         """Send stop command to device."""
         await self.client.stop()
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_media_next_track(self) -> None:
@@ -238,7 +230,6 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             await self.client.channel_up()
         else:
             await self.client.next_track()
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_media_previous_track(self) -> None:
@@ -247,7 +238,6 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             await self.client.channel_down()
         else:
             await self.client.previous_track()
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_select_source(self, source: str) -> None:
@@ -259,7 +249,6 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 else:
                     await self.client.set_play_content(uri)
                 break
-        await self.async_request_refresh()
 
     @catch_braviatv_errors
     async def async_send_command(self, command: Iterable[str], repeats: int) -> None:
@@ -267,4 +256,3 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         for _ in range(repeats):
             for cmd in command:
                 await self.client.send_command(cmd)
-        await self.async_request_refresh()

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -1,0 +1,270 @@
+"""Update coordinator for Bravia TV integration."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Coroutine, Iterable
+from datetime import timedelta
+from functools import wraps
+import logging
+from typing import Any, Final, TypeVar
+
+from pybravia import BraviaTV, BraviaTVError
+from typing_extensions import Concatenate, ParamSpec
+
+from homeassistant.components.media_player.const import (
+    MEDIA_TYPE_APP,
+    MEDIA_TYPE_CHANNEL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import CLIENTID_PREFIX, DOMAIN, NICKNAME
+
+_BraviaTVCoordinatorT = TypeVar("_BraviaTVCoordinatorT", bound="BraviaTVCoordinator")
+_P = ParamSpec("_P")
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL: Final = timedelta(seconds=10)
+
+
+def catch_braviatv_errors(
+    func: Callable[Concatenate[_BraviaTVCoordinatorT, _P], Awaitable[None]]
+) -> Callable[Concatenate[_BraviaTVCoordinatorT, _P], Coroutine[Any, Any, None]]:
+    """Catch BraviaTV errors."""
+
+    @wraps(func)
+    async def wrapper(
+        self: _BraviaTVCoordinatorT,
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> None:
+        """Catch BraviaTV errors and log message."""
+        try:
+            await func(self, *args, **kwargs)
+        except BraviaTVError as err:
+            _LOGGER.error("Command error: %s", err)
+
+    return wrapper
+
+
+class BraviaTVCoordinator(DataUpdateCoordinator[None]):
+    """Representation of a Bravia TV Coordinator."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: BraviaTV,
+        pin: str,
+        ignored_sources: list[str],
+    ) -> None:
+        """Initialize Bravia TV Client."""
+
+        self.client = client
+        self.pin = pin
+        self.ignored_sources = ignored_sources
+        self.source: str | None = None
+        self.source_list: list[str] = []
+        self.source_map: dict[str, dict] = {}
+        self.media_title: str | None = None
+        self.media_content_id: str | None = None
+        self.media_content_type: str | None = None
+        self.media_uri: str | None = None
+        self.media_duration: int | None = None
+        self.volume_level: float | None = None
+        self.volume_target: str | None = None
+        self.volume_muted = False
+        self.is_on = False
+        self.is_channel = False
+        self.connected = False
+        # Assume that the TV is in Play mode
+        self.playing = True
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+            request_refresh_debouncer=Debouncer(
+                hass, _LOGGER, cooldown=1.0, immediate=False
+            ),
+        )
+
+    def _sources_extend(self, sources: list[dict], source_type: str) -> None:
+        """Extend source map and source list."""
+        for item in sources:
+            item["type"] = source_type
+            title = item.get("title")
+            uri = item.get("uri")
+            if not title or not uri:
+                continue
+            self.source_map[uri] = item
+            if title not in self.ignored_sources:
+                self.source_list.append(title)
+
+    async def _async_update_data(self) -> None:
+        """Connect and fetch data."""
+        try:
+            if not self.connected:
+                await self.client.connect(
+                    pin=self.pin, clientid=CLIENTID_PREFIX, nickname=NICKNAME
+                )
+                self.connected = True
+
+            power_status = await self.client.get_power_status()
+            self.is_on = power_status == "active"
+
+            if self.is_on is False:
+                return
+
+            if not self.source_map:
+                await self.async_update_sources()
+            await self.async_update_volume()
+            await self.async_update_playing()
+        except BraviaTVError as err:
+            self.is_on = False
+            self.connected = False
+            raise UpdateFailed("Error communicating with device") from err
+
+    async def async_update_sources(self) -> None:
+        """Update sources."""
+        self.source_list = []
+        self.source_map = {}
+
+        externals = await self.client.get_external_status()
+        self._sources_extend(externals, "input")
+
+        apps = await self.client.get_app_list()
+        self._sources_extend(apps, "app")
+
+        channels = await self.client.get_content_list_all("tv")
+        self._sources_extend(channels, "channel")
+
+    async def async_update_volume(self) -> None:
+        """Update volume information."""
+        volume_info = await self.client.get_volume_info()
+        volume_level = volume_info.get("volume")
+        if volume_level is not None:
+            self.volume_level = volume_level / 100
+            self.volume_muted = volume_info.get("mute", False)
+            self.volume_target = volume_info.get("target")
+
+    async def async_update_playing(self) -> None:
+        """Update current playing information."""
+        playing_info = await self.client.get_playing_info()
+        self.media_title = playing_info.get("title")
+        self.media_uri = playing_info.get("uri")
+        self.media_duration = playing_info.get("durationSec")
+        if program_title := playing_info.get("programTitle"):
+            self.media_title = f"{self.media_title}: {program_title}"
+        if self.media_uri:
+            source = self.source_map.get(self.media_uri, {})
+            self.source = source.get("title")
+            self.is_channel = self.media_uri[:2] == "tv"
+            if self.is_channel:
+                self.media_content_id = playing_info.get("dispNum")
+                self.media_content_type = MEDIA_TYPE_CHANNEL
+            else:
+                self.media_content_id = self.media_uri
+                self.media_content_type = None
+        else:
+            self.source = None
+            self.is_channel = False
+            self.media_content_id = None
+            self.media_content_type = None
+        if not playing_info:
+            self.media_title = "Smart TV"
+            self.media_content_type = MEDIA_TYPE_APP
+
+    @catch_braviatv_errors
+    async def async_turn_on(self) -> None:
+        """Turn the device on."""
+        await self.client.turn_on()
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_turn_off(self) -> None:
+        """Turn off device."""
+        await self.client.turn_off()
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level, range 0..1."""
+        await self.client.volume_level(round(volume * 100))
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_volume_up(self) -> None:
+        """Send volume up command to device."""
+        await self.client.volume_up()
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_volume_down(self) -> None:
+        """Send volume down command to device."""
+        await self.client.volume_down()
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_volume_mute(self, mute: bool) -> None:
+        """Send mute command to device."""
+        await self.client.volume_mute()
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_media_play(self) -> None:
+        """Send play command to device."""
+        await self.client.play()
+        self.playing = True
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_media_pause(self) -> None:
+        """Send pause command to device."""
+        await self.client.pause()
+        self.playing = False
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_media_stop(self) -> None:
+        """Send stop command to device."""
+        await self.client.stop()
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_media_next_track(self) -> None:
+        """Send next track command."""
+        if self.is_channel:
+            await self.client.channel_up()
+        else:
+            await self.client.next_track()
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_media_previous_track(self) -> None:
+        """Send previous track command."""
+        if self.is_channel:
+            await self.client.channel_down()
+        else:
+            await self.client.previous_track()
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_select_source(self, source: str) -> None:
+        """Set the input source."""
+        for uri, item in self.source_map.items():
+            if item.get("title") == source:
+                if item.get("type") == "app":
+                    await self.client.set_active_app(uri)
+                else:
+                    await self.client.set_play_content(uri)
+                break
+        await self.async_request_refresh()
+
+    @catch_braviatv_errors
+    async def async_send_command(self, command: Iterable[str], repeats: int) -> None:
+        """Send command to device."""
+        for _ in range(repeats):
+            for cmd in command:
+                await self.client.send_command(cmd)
+        await self.async_request_refresh()

--- a/homeassistant/components/braviatv/entity.py
+++ b/homeassistant/components/braviatv/entity.py
@@ -1,4 +1,4 @@
-"""A entity class for BraviaTV integration."""
+"""A entity class for Bravia TV integration."""
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["pybravia==0.1.3"],
+  "requirements": ["pybravia==0.1.5"],
   "codeowners": ["@bieniu", "@Drafteed"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["pybravia==0.1.1"],
+  "requirements": ["pybravia==0.1.2"],
   "codeowners": ["@bieniu", "@Drafteed"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -6,5 +6,5 @@
   "codeowners": ["@bieniu", "@Drafteed"],
   "config_flow": true,
   "iot_class": "local_polling",
-  "loggers": ["bravia_tv"]
+  "loggers": ["pybravia"]
 }

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["pybravia==0.1.7"],
+  "requirements": ["pybravia==0.2.0"],
   "codeowners": ["@bieniu", "@Drafteed"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["bravia-tv==1.0.11"],
+  "requirements": ["pybravia==0.1.1"],
   "codeowners": ["@bieniu", "@Drafteed"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["pybravia==0.1.5"],
+  "requirements": ["pybravia==0.1.7"],
   "codeowners": ["@bieniu", "@Drafteed"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["pybravia==0.1.2"],
+  "requirements": ["pybravia==0.1.3"],
   "codeowners": ["@bieniu", "@Drafteed"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -1,4 +1,4 @@
-"""Support for interface with a Bravia TV."""
+"""Media player support for Bravia TV integration."""
 from __future__ import annotations
 
 from homeassistant.components.media_player import (

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -74,7 +74,7 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
     @property
     def is_volume_muted(self) -> bool:
         """Boolean if volume is currently muted."""
-        return self.coordinator.muted
+        return self.coordinator.volume_muted
 
     @property
     def media_title(self) -> str | None:
@@ -84,12 +84,17 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
     @property
     def media_content_id(self) -> str | None:
         """Content ID of current playing media."""
-        return self.coordinator.channel_name
+        return self.coordinator.media_content_id
+
+    @property
+    def media_content_type(self) -> str | None:
+        """Content type of current playing media."""
+        return self.coordinator.media_content_type
 
     @property
     def media_duration(self) -> int | None:
         """Duration of current playing media in seconds."""
-        return self.coordinator.duration
+        return self.coordinator.media_duration
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1402,7 +1402,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.3
+pybravia==0.1.5
 
 # homeassistant.components.nissan_leaf
 pycarwings2==2.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1402,7 +1402,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.2
+pybravia==0.1.3
 
 # homeassistant.components.nissan_leaf
 pycarwings2==2.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1402,7 +1402,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.5
+pybravia==0.1.7
 
 # homeassistant.components.nissan_leaf
 pycarwings2==2.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1402,7 +1402,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.7
+pybravia==0.2.0
 
 # homeassistant.components.nissan_leaf
 pycarwings2==2.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1402,7 +1402,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.1
+pybravia==0.1.2
 
 # homeassistant.components.nissan_leaf
 pycarwings2==2.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -431,9 +431,6 @@ boschshcpy==0.2.30
 # homeassistant.components.route53
 boto3==1.20.24
 
-# homeassistant.components.braviatv
-bravia-tv==1.0.11
-
 # homeassistant.components.broadlink
 broadlink==0.18.2
 
@@ -1403,6 +1400,9 @@ pyblackbird==0.5
 
 # homeassistant.components.neato
 pybotvac==0.0.23
+
+# homeassistant.components.braviatv
+pybravia==0.1.1
 
 # homeassistant.components.nissan_leaf
 pycarwings2==2.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -331,9 +331,6 @@ bond-async==0.1.22
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.30
 
-# homeassistant.components.braviatv
-bravia-tv==1.0.11
-
 # homeassistant.components.broadlink
 broadlink==0.18.2
 
@@ -960,6 +957,9 @@ pyblackbird==0.5
 
 # homeassistant.components.neato
 pybotvac==0.0.23
+
+# homeassistant.components.braviatv
+pybravia==0.1.1
 
 # homeassistant.components.cloudflare
 pycfdns==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -959,7 +959,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.7
+pybravia==0.2.0
 
 # homeassistant.components.cloudflare
 pycfdns==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -959,7 +959,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.5
+pybravia==0.1.7
 
 # homeassistant.components.cloudflare
 pycfdns==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -959,7 +959,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.3
+pybravia==0.1.5
 
 # homeassistant.components.cloudflare
 pycfdns==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -959,7 +959,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.1
+pybravia==0.1.2
 
 # homeassistant.components.cloudflare
 pycfdns==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -959,7 +959,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.1.2
+pybravia==0.1.3
 
 # homeassistant.components.cloudflare
 pycfdns==1.2.2

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -1,8 +1,6 @@
 """Define tests for the Bravia TV config flow."""
 from unittest.mock import patch
 
-from bravia_tv.braviarc import NoIPControl
-
 from homeassistant import data_entry_flow
 from homeassistant.components.braviatv.const import CONF_IGNORED_SOURCES, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -23,13 +21,13 @@ BRAVIA_SYSTEM_INFO = {
     "cid": "very_unique_string",
 }
 
-BRAVIA_SOURCE_LIST = {
-    "HDMI 1": "extInput:hdmi?port=1",
-    "HDMI 2": "extInput:hdmi?port=2",
-    "HDMI 3/ARC": "extInput:hdmi?port=3",
-    "HDMI 4": "extInput:hdmi?port=4",
-    "AV/Component": "extInput:component?port=1",
-}
+BRAVIA_SOURCES = [
+    {"title": "HDMI 1", "uri": "extInput:hdmi?port=1"},
+    {"title": "HDMI 2", "uri": "extInput:hdmi?port=2"},
+    {"title": "HDMI 3/ARC", "uri": "extInput:hdmi?port=3"},
+    {"title": "HDMI 4", "uri": "extInput:hdmi?port=4"},
+    {"title": "AV/Component", "uri": "extInput:component?port=1"},
+]
 
 
 async def test_show_form(hass):
@@ -53,8 +51,8 @@ async def test_user_invalid_host(hass):
 
 async def test_authorize_cannot_connect(hass):
     """Test that errors are shown when cannot connect to host at the authorize step."""
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=False
+    with patch("pybravia.BraviaTV.connect", return_value=False), patch(
+        "pybravia.BraviaTV.pair", return_value=True
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
@@ -68,12 +66,13 @@ async def test_authorize_cannot_connect(hass):
 
 async def test_authorize_model_unsupported(hass):
     """Test that errors are shown when the TV is not supported at the authorize step."""
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=True
-    ), patch("bravia_tv.BraviaRC.get_system_info", return_value={}):
+    with patch("pybravia.BraviaTV.connect", return_value=True), patch(
+        "pybravia.BraviaTV.pair", return_value=True
+    ), patch("pybravia.BraviaTV.get_system_info", return_value={}):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "10.10.10.12"}
         )
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PIN: "1234"}
         )
@@ -83,13 +82,12 @@ async def test_authorize_model_unsupported(hass):
 
 async def test_authorize_no_ip_control(hass):
     """Test that errors are shown when IP Control is disabled on the TV."""
-    with patch("bravia_tv.BraviaRC.connect", side_effect=NoIPControl("No IP Control")):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
+    )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
-        assert result["reason"] == "no_ip_control"
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "no_ip_control"
 
 
 async def test_duplicate_error(hass):
@@ -106,9 +104,9 @@ async def test_duplicate_error(hass):
     )
     config_entry.add_to_hass(hass)
 
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=True
-    ), patch("bravia_tv.BraviaRC.get_system_info", return_value=BRAVIA_SYSTEM_INFO):
+    with patch("pybravia.BraviaTV.connect", return_value=True), patch(
+        "pybravia.BraviaTV.pair", return_value=True
+    ), patch("pybravia.BraviaTV.get_system_info", return_value=BRAVIA_SYSTEM_INFO):
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
@@ -123,10 +121,10 @@ async def test_duplicate_error(hass):
 
 async def test_create_entry(hass):
     """Test that the user step works."""
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=True
+    with patch("pybravia.BraviaTV.connect", return_value=True), patch(
+        "pybravia.BraviaTV.pair", return_value=True
     ), patch(
-        "bravia_tv.BraviaRC.get_system_info", return_value=BRAVIA_SYSTEM_INFO
+        "pybravia.BraviaTV.get_system_info", return_value=BRAVIA_SYSTEM_INFO
     ), patch(
         "homeassistant.components.braviatv.async_setup_entry", return_value=True
     ):
@@ -154,10 +152,10 @@ async def test_create_entry(hass):
 
 async def test_create_entry_with_ipv6_address(hass):
     """Test that the user step works with device IPv6 address."""
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=True
+    with patch("pybravia.BraviaTV.connect", return_value=True), patch(
+        "pybravia.BraviaTV.pair", return_value=True
     ), patch(
-        "bravia_tv.BraviaRC.get_system_info", return_value=BRAVIA_SYSTEM_INFO
+        "pybravia.BraviaTV.get_system_info", return_value=BRAVIA_SYSTEM_INFO
     ), patch(
         "homeassistant.components.braviatv.async_setup_entry", return_value=True
     ):
@@ -199,19 +197,12 @@ async def test_options_flow(hass):
     )
     config_entry.add_to_hass(hass)
 
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=True
-    ), patch("bravia_tv.BraviaRC.get_power_status"), patch(
-        "bravia_tv.BraviaRC.get_system_info", return_value=BRAVIA_SYSTEM_INFO
-    ):
+    with patch("pybravia.BraviaTV.connect", return_value=True), patch(
+        "pybravia.BraviaTV.get_power_status", return_value="active"
+    ), patch("pybravia.BraviaTV.get_external_status", return_value=BRAVIA_SOURCES):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=False
-    ), patch("bravia_tv.BraviaRC.get_power_status"), patch(
-        "bravia_tv.BraviaRC.load_source_list", return_value=BRAVIA_SOURCE_LIST
-    ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -206,17 +206,6 @@ async def test_options_flow(hass):
     )
     config_entry.add_to_hass(hass)
 
-    # with patch("pybravia.BraviaTV.connect"), patch(
-    #     "pybravia.BraviaTV.get_power_status", return_value="active"
-    # ), patch("pybravia.BraviaTV.get_external_status", return_value=BRAVIA_SOURCES), patch(
-    #     "pybravia.BraviaTV.get_app_list", return_value={}
-    # ), patch(
-    #     "pybravia.BraviaTV.get_content_list_all", return_value={}
-    # ), patch(
-    #     "pybravia.BraviaTV.get_volume_info", return_value={}
-    # ), patch(
-    #     "pybravia.BraviaTV.get_playing_info", return_value={}
-    # ):
     with patch("pybravia.BraviaTV.connect"), patch(
         "pybravia.BraviaTV.get_power_status",
         return_value="active",

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -1,6 +1,8 @@
 """Define tests for the Bravia TV config flow."""
 from unittest.mock import patch
 
+from pybravia import BraviaTVConnectionError
+
 from homeassistant import data_entry_flow
 from homeassistant.components.braviatv.const import CONF_IGNORED_SOURCES, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -51,7 +53,7 @@ async def test_user_invalid_host(hass):
 
 async def test_authorize_cannot_connect(hass):
     """Test that errors are shown when cannot connect to host at the authorize step."""
-    with patch("pybravia.BraviaTV.connect", return_value=False), patch(
+    with patch("pybravia.BraviaTV.connect", side_effect=BraviaTVConnectionError), patch(
         "pybravia.BraviaTV.pair", return_value=True
     ):
         result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR will swap the [Sony Bravia TV](https://www.home-assistant.io/integrations/braviatv/) integration backend from unmaintained [bravia-tv](https://github.com/dcnielsen90/python-bravia-tv) to new [pybravia](https://github.com/Drafteed/pybravia). The new library has been completely rewritten using asynchronous calls and aiohttp. This is my first experience of creating a python library and if there are any comments regarding it, I have created a [separate issue in the library repository](https://github.com/Drafteed/pybravia/issues/1).

**Speed comparison (integration startup time/Apple M1):**

Old backend: **3.6s**
New backend: **1.6s** (**1.09s** if PSK auth used)

**Todo list for integration in the future:**
- [ ] Add new autorization method with PSK (Pre-Shared-Key) in `config_flow` (already supported by backend)
- [ ] Add `Button` platform for reboot TV and terminate apps
- [ ] Add `play_media` support
- [ ] Add support `media_browser` and separate channels from `source_list` ([related issue](https://github.com/home-assistant/core/issues/70886))
- [ ] Add `ssdp` discovery.

**Latest changelog of pybravia:**
https://github.com/Drafteed/pybravia/commits/v0.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72345, fixes #74658
- This PR is related to issue: #70886
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
