### PR TITLE
Raise repair issue for Xiaomi Mijia BLE Temperature and Humidity Sensor

### DIFF
--- a/homeassistant/components/mitemp_bt/manifest.json
+++ b/homeassistant/components/mitemp_bt/manifest.json
@@ -2,8 +2,8 @@
   "domain": "mitemp_bt",
   "name": "Xiaomi Mijia BLE Temperature and Humidity Sensor",
   "documentation": "https://www.home-assistant.io/integrations/mitemp_bt",
-  "requirements": ["mitemp_bt==0.0.5"],
+  "requirements": [],
+  "dependencies": ["repairs"],
   "codeowners": [],
-  "iot_class": "local_polling",
-  "loggers": ["btlewrap", "mitemp_bt"]
+  "iot_class": "local_polling"
 }

--- a/homeassistant/components/mitemp_bt/sensor.py
+++ b/homeassistant/components/mitemp_bt/sensor.py
@@ -1,188 +1,29 @@
 """Support for Xiaomi Mi Temp BLE environmental sensor."""
 from __future__ import annotations
 
-import logging
-from typing import Any
-
-import btlewrap
-from btlewrap.base import BluetoothBackendException
-from mitemp_bt import mitemp_bt_poller
-import voluptuous as vol
-
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA,
-    SensorDeviceClass,
-    SensorEntity,
-    SensorEntityDescription,
-    SensorStateClass,
-)
-from homeassistant.const import (
-    CONF_FORCE_UPDATE,
-    CONF_MAC,
-    CONF_MONITORED_CONDITIONS,
-    CONF_NAME,
-    CONF_TIMEOUT,
-    PERCENTAGE,
-    TEMP_CELSIUS,
-)
+from homeassistant.components.repairs import IssueSeverity, async_create_issue
+from homeassistant.components.sensor import PLATFORM_SCHEMA_BASE
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-try:
-    import bluepy.btle  # noqa: F401 pylint: disable=unused-import
-
-    BACKEND = btlewrap.BluepyBackend
-except ImportError:
-    BACKEND = btlewrap.GatttoolBackend
-
-_LOGGER = logging.getLogger(__name__)
-
-CONF_ADAPTER = "adapter"
-CONF_CACHE = "cache_value"
-CONF_MEDIAN = "median"
-CONF_RETRIES = "retries"
-
-DEFAULT_ADAPTER = "hci0"
-DEFAULT_UPDATE_INTERVAL = 300
-DEFAULT_FORCE_UPDATE = False
-DEFAULT_MEDIAN = 3
-DEFAULT_NAME = "MiTemp BT"
-DEFAULT_RETRIES = 2
-DEFAULT_TIMEOUT = 10
+PLATFORM_SCHEMA = PLATFORM_SCHEMA_BASE
 
 
-SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
-        key="temperature",
-        name="Temperature",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=TEMP_CELSIUS,
-    ),
-    SensorEntityDescription(
-        key="humidity",
-        name="Humidity",
-        device_class=SensorDeviceClass.HUMIDITY,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=PERCENTAGE,
-    ),
-    SensorEntityDescription(
-        key="battery",
-        name="Battery",
-        device_class=SensorDeviceClass.BATTERY,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=PERCENTAGE,
-    ),
-)
-
-SENSOR_KEYS = [desc.key for desc in SENSOR_TYPES]
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_MAC): cv.string,
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_KEYS): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_KEYS)]
-        ),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_MEDIAN, default=DEFAULT_MEDIAN): cv.positive_int,
-        vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-        vol.Optional(CONF_RETRIES, default=DEFAULT_RETRIES): cv.positive_int,
-        vol.Optional(CONF_CACHE, default=DEFAULT_UPDATE_INTERVAL): cv.positive_int,
-        vol.Optional(CONF_ADAPTER, default=DEFAULT_ADAPTER): cv.string,
-    }
-)
-
-
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the MiTempBt sensor."""
-    backend = BACKEND
-    _LOGGER.debug("MiTempBt is using %s backend", backend.__name__)
-
-    cache = config[CONF_CACHE]
-    poller = mitemp_bt_poller.MiTempBtPoller(
-        config[CONF_MAC],
-        cache_timeout=cache,
-        adapter=config[CONF_ADAPTER],
-        backend=backend,
+    async_create_issue(
+        hass,
+        "mitemp_bt",
+        "replaced",
+        breaks_in_ha_version="2022.8.0",
+        is_fixable=False,
+        severity=IssueSeverity.ERROR,
+        translation_key="replaced",
+        learn_more_url="https://www.home-assistant.io/integrations/xiaomi_ble/",
     )
-    prefix = config[CONF_NAME]
-    force_update = config[CONF_FORCE_UPDATE]
-    median = config[CONF_MEDIAN]
-    poller.ble_timeout = config[CONF_TIMEOUT]
-    poller.retries = config[CONF_RETRIES]
-
-    monitored_conditions = config[CONF_MONITORED_CONDITIONS]
-    entities = [
-        MiTempBtSensor(poller, prefix, force_update, median, description)
-        for description in SENSOR_TYPES
-        if description.key in monitored_conditions
-    ]
-
-    add_entities(entities)
-
-
-class MiTempBtSensor(SensorEntity):
-    """Implementing the MiTempBt sensor."""
-
-    def __init__(
-        self, poller, prefix, force_update, median, description: SensorEntityDescription
-    ):
-        """Initialize the sensor."""
-        self.entity_description = description
-        self.poller = poller
-        self.data: list[Any] = []
-        self._attr_name = f"{prefix} {description.name}"
-        self._attr_force_update = force_update
-        # Median is used to filter out outliers. median of 3 will filter
-        # single outliers, while  median of 5 will filter double outliers
-        # Use median_count = 1 if no filtering is required.
-        self.median_count = median
-
-    def update(self):
-        """
-        Update current conditions.
-
-        This uses a rolling median over 3 values to filter out outliers.
-        """
-        try:
-            _LOGGER.debug("Polling data for %s", self.name)
-            data = self.poller.parameter_value(self.entity_description.key)
-        except OSError as ioerr:
-            _LOGGER.warning("Polling error %s", ioerr)
-            return
-        except BluetoothBackendException as bterror:
-            _LOGGER.warning("Polling error %s", bterror)
-            return
-
-        if data is not None:
-            _LOGGER.debug("%s = %s", self.name, data)
-            self.data.append(data)
-        else:
-            _LOGGER.warning(
-                "Did not receive any data from Mi Temp sensor %s", self.name
-            )
-            # Remove old data from median list or set sensor value to None
-            # if no data is available anymore
-            if self.data:
-                self.data = self.data[1:]
-            else:
-                self._attr_native_value = None
-            return
-
-        if len(self.data) > self.median_count:
-            self.data = self.data[1:]
-
-        if len(self.data) == self.median_count:
-            median = sorted(self.data)[int((self.median_count - 1) / 2)]
-            _LOGGER.debug("Median is: %s", median)
-            self._attr_native_value = median
-        else:
-            _LOGGER.debug("Not yet enough data for median calculation")

--- a/homeassistant/components/mitemp_bt/strings.json
+++ b/homeassistant/components/mitemp_bt/strings.json
@@ -1,0 +1,8 @@
+{
+  "issues": {
+    "replaced": {
+      "title": "The Xiaomi Mijia BLE Temperature and Humidity Sensor integration has been replaced",
+      "description": "The Xiaomi Mijia BLE Temperature and Humidity Sensor integration stopped working in Home Assistant 2022.7 and replaced by the Xiaomi BLE integration in the 2022.8 release.\n\nThere is no migration path possible, therefore, you have to add your Xiaomi Mijia BLE device using the new integration manually.\n\nYour existing Xiaomi Mijia BLE Temperature and Humidity sensor YAML configuration is no longer used by Home Assistant. Remove the YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
+    }
+  }
+}

--- a/homeassistant/components/mitemp_bt/translations/en.json
+++ b/homeassistant/components/mitemp_bt/translations/en.json
@@ -1,0 +1,8 @@
+{
+    "issues": {
+        "replaced": {
+            "description": "The Xiaomi Mijia BLE Temperature and Humidity Sensor integration stopped working in Home Assistant 2022.7 and replaced by the Xiaomi BLE integration in the 2022.8 release.\n\nThere is no migration path possible, therefore, you have to add your Xiaomi Mijia BLE device using the new integration manually.\n\nYour existing Xiaomi Mijia BLE Temperature and Humidity sensor YAML configuration is no longer used by Home Assistant. Remove the YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue.",
+            "title": "The Xiaomi Mijia BLE Temperature and Humidity Sensor integration has been replaced"
+        }
+    }
+}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1049,9 +1049,6 @@ millheater==0.9.0
 # homeassistant.components.minio
 minio==5.0.10
 
-# homeassistant.components.mitemp_bt
-mitemp_bt==0.0.5
-
 # homeassistant.components.moat
 moat-ble==0.1.1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR raises a repair issue for the Xiaomi Mijia BLE Temperature and Humidity Sensor integration, to tell the user it has been replaced by the Xiaomi BLE integration.

![CleanShot 2022-07-26 at 10 01 09](https://user-images.githubusercontent.com/195327/180955065-19c27cb2-3f9f-45b5-b51f-31957e731d68.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23532
- - Link to brands pull request: https://github.com/home-assistant/brands/pull/3556

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
