### PR TITLE
Fix small type issues [core]

### DIFF
--- a/homeassistant/auth/mfa_modules/notify.py
+++ b/homeassistant/auth/mfa_modules/notify.py
@@ -320,6 +320,7 @@ class NotifySetupFlow(SetupFlow):
         errors: dict[str, str] = {}
 
         hass = self._auth_module.hass
+        assert self._secret and self._count
         if user_input:
             verified = await hass.async_add_executor_job(
                 _verify_otp, self._secret, user_input["code"], self._count
@@ -334,7 +335,6 @@ class NotifySetupFlow(SetupFlow):
             errors["base"] = "invalid_code"
 
         # generate code every time, no retry logic
-        assert self._secret and self._count
         code = await hass.async_add_executor_job(
             _generate_otp, self._secret, self._count
         )

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -23,7 +23,7 @@ PATH_CACHE = LRU(512)
 
 
 def _get_file_path(
-    filename: str, directory: Path, follow_symlinks: bool
+    filename: str | Path, directory: Path, follow_symlinks: bool
 ) -> Path | None:
     filepath = directory.joinpath(filename).resolve()
     if not follow_symlinks:

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -286,6 +286,7 @@ async def async_create_default_config(hass: HomeAssistant) -> bool:
 
     Return if creation was successful.
     """
+    assert hass.config.config_dir
     return await hass.async_add_executor_job(
         _write_default_config, hass.config.config_dir
     )

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -197,9 +197,9 @@ def async_track_state_change(
         """Handle specific state changes."""
         hass.async_run_hass_job(
             job,
-            event.data.get("entity_id"),
-            event.data.get("old_state"),
-            event.data.get("new_state"),
+            event.data["entity_id"],
+            event.data["old_state"],
+            event.data["new_state"],
         )
 
     @callback

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -141,7 +141,7 @@ def threaded_listener_factory(
 def async_track_state_change(
     hass: HomeAssistant,
     entity_ids: str | Iterable[str],
-    action: Callable[[str, State, State], Awaitable[None] | None],
+    action: Callable[[str, State | None, State], Awaitable[None] | None],
     from_state: None | str | Iterable[str] = None,
     to_state: None | str | Iterable[str] = None,
 ) -> CALLBACK_TYPE:
@@ -198,7 +198,7 @@ def async_track_state_change(
         hass.async_run_hass_job(
             job,
             event.data["entity_id"],
-            event.data["old_state"],
+            event.data.get("old_state"),
             event.data["new_state"],
         )
 


### PR DESCRIPTION
## Proposed change
#### `auth/mfa_modules/notify.py`
`_verify_otp`, needs the `secret` and `count`, too. Moving the assert a couple of lines up is enough.

--
#### `http/static.py`
`_get_file_path` is called with a `Path` argument for `filename` instead of `str`. It can work with both.
https://github.com/home-assistant/core/blob/eaee923e4cde4d6ed9a1fcf31f66484b063dabe6/homeassistant/components/http/static.py#L45-L56

--
#### `config.py`
`_write_default_config` needs a `str` argument for `config_dir`. `hass.config.config_dir` is always set before calling `async_create_default_config`.
https://github.com/home-assistant/core/blob/eaee923e4cde4d6ed9a1fcf31f66484b063dabe6/homeassistant/config.py#L284-L291

--
#### `helpers/event.py`
`state_change_dispatcher` is called after a `state_changed` event with always has an `entity_id`, ~`old_state`~, and `new_state`.
**Update**: Some tests don't pass `old_state`!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
