### PR TITLE
Use executor to finish stream recording

### DIFF
--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from io import BytesIO
 import logging
 import os
+from typing import TYPE_CHECKING
 
 import av
 
@@ -15,6 +16,9 @@ from .const import (
     SEGMENT_CONTAINER_FORMAT,
 )
 from .core import PROVIDERS, IdleTimer, Segment, StreamOutput, StreamSettings
+
+if TYPE_CHECKING:
+    import deque
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -139,8 +143,16 @@ class RecorderOutput(StreamOutput):
 
             source.close()
 
-        def finish_writing(output: av.OutputContainer, video_path: str) -> None:
+        def finish_writing(
+            segments: deque[Segment], output: av.OutputContainer, video_path: str
+        ) -> None:
             """Finish writing output."""
+            # Should only have 0 or 1 segments, but loop through just in case
+            while segments:
+                write_segment(segments.popleft())
+            if output is None:
+                _LOGGER.error("Recording failed to capture anything")
+                return
             output.close()
             try:
                 os.rename(video_path + ".tmp", video_path)
@@ -164,15 +176,7 @@ class RecorderOutput(StreamOutput):
             await self._hass.async_add_executor_job(
                 write_segment, self._segments.popleft()
             )
-        # Write remaining segments
-        # Should only have 0 or 1 segments, but loop through just in case
-        while self._segments:
-            await self._hass.async_add_executor_job(
-                write_segment, self._segments.popleft()
-            )
-        if output is None:
-            _LOGGER.error("Recording failed to capture anything")
-        else:
-            await self._hass.async_add_executor_job(
-                finish_writing, output, self.video_path
-            )
+        # Write remaining segments and close output
+        await self._hass.async_add_executor_job(
+            finish_writing, self._segments, output, self.video_path
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Finishing a stream recording touches the disk twice, and although they should be fast operations it's probably better to use an executor just in case (e.g., network storage).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
