### PR TITLE
Fix startup race in BLE integrations

### DIFF
--- a/homeassistant/components/bluetooth/passive_update_coordinator.py
+++ b/homeassistant/components/bluetooth/passive_update_coordinator.py
@@ -43,17 +43,6 @@ class PassiveBluetoothDataUpdateCoordinator(BasePassiveBluetoothCoordinator):
         self.async_update_listeners()
 
     @callback
-    def async_start(self) -> CALLBACK_TYPE:
-        """Start the data updater."""
-        self._async_start()
-
-        @callback
-        def _async_cancel() -> None:
-            self._async_stop()
-
-        return _async_cancel
-
-    @callback
     def async_add_listener(
         self, update_callback: CALLBACK_TYPE, context: Any = None
     ) -> Callable[[], None]:

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -78,20 +78,9 @@ class PassiveBluetoothProcessorCoordinator(BasePassiveBluetoothCoordinator):
         def remove_processor() -> None:
             """Remove a processor."""
             self._processors.remove(processor)
-            self._async_handle_processors_changed()
 
         self._processors.append(processor)
-        self._async_handle_processors_changed()
         return remove_processor
-
-    @callback
-    def _async_handle_processors_changed(self) -> None:
-        """Handle processors changed."""
-        running = bool(self._cancel_bluetooth_advertisements)
-        if running and not self._processors:
-            self._async_stop()
-        elif not running and self._processors:
-            self._async_start()
 
     @callback
     def _async_handle_unavailable(self, address: str) -> None:

--- a/homeassistant/components/bluetooth/update_coordinator.py
+++ b/homeassistant/components/bluetooth/update_coordinator.py
@@ -38,6 +38,17 @@ class BasePassiveBluetoothCoordinator:
         self._present = False
         self.last_seen = 0.0
 
+    @callback
+    def async_start(self) -> CALLBACK_TYPE:
+        """Start the data updater."""
+        self._async_start()
+
+        @callback
+        def _async_cancel() -> None:
+            self._async_stop()
+
+        return _async_cancel
+
     @property
     def available(self) -> bool:
         """Return if the device is available."""

--- a/homeassistant/components/govee_ble/__init__.py
+++ b/homeassistant/components/govee_ble/__init__.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Govee BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
-    hass.data.setdefault(DOMAIN, {})[
+    coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
     ] = PassiveBluetoothProcessorCoordinator(
         hass,
@@ -29,6 +29,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         address=address,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(
+        coordinator.async_start()
+    )  # only start after all platforms have had a chance to subscribe
     return True
 
 

--- a/homeassistant/components/govee_ble/sensor.py
+++ b/homeassistant/components/govee_ble/sensor.py
@@ -135,12 +135,12 @@ async def async_setup_entry(
             data.update(service_info)
         )
     )
-    entry.async_on_unload(coordinator.async_register_processor(processor))
     entry.async_on_unload(
         processor.async_add_entities_listener(
             GoveeBluetoothSensorEntity, async_add_entities
         )
     )
+    entry.async_on_unload(coordinator.async_register_processor(processor))
 
 
 class GoveeBluetoothSensorEntity(

--- a/homeassistant/components/inkbird/__init__.py
+++ b/homeassistant/components/inkbird/__init__.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up INKBIRD BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
-    hass.data.setdefault(DOMAIN, {})[
+    coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
     ] = PassiveBluetoothProcessorCoordinator(
         hass,
@@ -29,6 +29,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         address=address,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(
+        coordinator.async_start()
+    )  # only start after all platforms have had a chance to subscribe
     return True
 
 

--- a/homeassistant/components/inkbird/sensor.py
+++ b/homeassistant/components/inkbird/sensor.py
@@ -135,12 +135,12 @@ async def async_setup_entry(
             data.update(service_info)
         )
     )
-    entry.async_on_unload(coordinator.async_register_processor(processor))
     entry.async_on_unload(
         processor.async_add_entities_listener(
             INKBIRDBluetoothSensorEntity, async_add_entities
         )
     )
+    entry.async_on_unload(coordinator.async_register_processor(processor))
 
 
 class INKBIRDBluetoothSensorEntity(

--- a/homeassistant/components/moat/__init__.py
+++ b/homeassistant/components/moat/__init__.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Moat BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
-    hass.data.setdefault(DOMAIN, {})[
+    coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
     ] = PassiveBluetoothProcessorCoordinator(
         hass,
@@ -29,6 +29,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         address=address,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(
+        coordinator.async_start()
+    )  # only start after all platforms have had a chance to subscribe
     return True
 
 

--- a/homeassistant/components/moat/sensor.py
+++ b/homeassistant/components/moat/sensor.py
@@ -142,12 +142,12 @@ async def async_setup_entry(
             data.update(service_info)
         )
     )
-    entry.async_on_unload(coordinator.async_register_processor(processor))
     entry.async_on_unload(
         processor.async_add_entities_listener(
             MoatBluetoothSensorEntity, async_add_entities
         )
     )
+    entry.async_on_unload(coordinator.async_register_processor(processor))
 
 
 class MoatBluetoothSensorEntity(

--- a/homeassistant/components/sensorpush/__init__.py
+++ b/homeassistant/components/sensorpush/__init__.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SensorPush BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
-    hass.data.setdefault(DOMAIN, {})[
+    coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
     ] = PassiveBluetoothProcessorCoordinator(
         hass,
@@ -29,6 +29,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         address=address,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(
+        coordinator.async_start()
+    )  # only start after all platforms have had a chance to subscribe
     return True
 
 

--- a/homeassistant/components/sensorpush/sensor.py
+++ b/homeassistant/components/sensorpush/sensor.py
@@ -136,12 +136,12 @@ async def async_setup_entry(
             data.update(service_info)
         )
     )
-    entry.async_on_unload(coordinator.async_register_processor(processor))
     entry.async_on_unload(
         processor.async_add_entities_listener(
             SensorPushBluetoothSensorEntity, async_add_entities
         )
     )
+    entry.async_on_unload(coordinator.async_register_processor(processor))
 
 
 class SensorPushBluetoothSensorEntity(

--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Xiaomi BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
-    hass.data.setdefault(DOMAIN, {})[
+    coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
     ] = PassiveBluetoothProcessorCoordinator(
         hass,
@@ -29,6 +29,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         address=address,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(
+        coordinator.async_start()
+    )  # only start after all platforms have had a chance to subscribe
     return True
 
 

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -167,12 +167,12 @@ async def async_setup_entry(
             data.update(service_info)
         )
     )
-    entry.async_on_unload(coordinator.async_register_processor(processor))
     entry.async_on_unload(
         processor.async_add_entities_listener(
             XiaomiBluetoothSensorEntity, async_add_entities
         )
     )
+    entry.async_on_unload(coordinator.async_register_processor(processor))
 
 
 class XiaomiBluetoothSensorEntity(

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -107,6 +107,7 @@ async def test_basic_usage(hass, mock_bleak_scanner_start):
         _async_register_callback,
     ):
         unregister_processor = coordinator.async_register_processor(processor)
+        cancel_coordinator = coordinator.async_start()
 
     entity_key = PassiveBluetoothEntityKey("temperature", None)
     entity_key_events = []
@@ -171,6 +172,7 @@ async def test_basic_usage(hass, mock_bleak_scanner_start):
     assert coordinator.available is True
 
     unregister_processor()
+    cancel_coordinator()
 
 
 async def test_unavailable_after_no_data(hass, mock_bleak_scanner_start):
@@ -206,6 +208,7 @@ async def test_unavailable_after_no_data(hass, mock_bleak_scanner_start):
         _async_register_callback,
     ):
         unregister_processor = coordinator.async_register_processor(processor)
+        cancel_coordinator = coordinator.async_start()
 
     mock_entity = MagicMock()
     mock_add_entities = MagicMock()
@@ -259,6 +262,7 @@ async def test_unavailable_after_no_data(hass, mock_bleak_scanner_start):
     assert processor.available is False
 
     unregister_processor()
+    cancel_coordinator()
 
 
 async def test_no_updates_once_stopping(hass, mock_bleak_scanner_start):
@@ -290,6 +294,7 @@ async def test_no_updates_once_stopping(hass, mock_bleak_scanner_start):
         _async_register_callback,
     ):
         unregister_processor = coordinator.async_register_processor(processor)
+        cancel_coordinator = coordinator.async_start()
 
     all_events = []
 
@@ -310,6 +315,7 @@ async def test_no_updates_once_stopping(hass, mock_bleak_scanner_start):
     saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
     assert len(all_events) == 1
     unregister_processor()
+    cancel_coordinator()
 
 
 async def test_exception_from_update_method(hass, caplog, mock_bleak_scanner_start):
@@ -346,6 +352,7 @@ async def test_exception_from_update_method(hass, caplog, mock_bleak_scanner_sta
         _async_register_callback,
     ):
         unregister_processor = coordinator.async_register_processor(processor)
+        cancel_coordinator = coordinator.async_start()
 
     processor.async_add_listener(MagicMock())
 
@@ -361,6 +368,7 @@ async def test_exception_from_update_method(hass, caplog, mock_bleak_scanner_sta
     saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
     assert processor.available is True
     unregister_processor()
+    cancel_coordinator()
 
 
 async def test_bad_data_from_update_method(hass, mock_bleak_scanner_start):
@@ -397,6 +405,7 @@ async def test_bad_data_from_update_method(hass, mock_bleak_scanner_start):
         _async_register_callback,
     ):
         unregister_processor = coordinator.async_register_processor(processor)
+        cancel_coordinator = coordinator.async_start()
 
     processor.async_add_listener(MagicMock())
 
@@ -413,6 +422,7 @@ async def test_bad_data_from_update_method(hass, mock_bleak_scanner_start):
     saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
     assert processor.available is True
     unregister_processor()
+    cancel_coordinator()
 
 
 GOVEE_B5178_REMOTE_SERVICE_INFO = BluetoothServiceInfo(
@@ -737,6 +747,7 @@ async def test_integration_with_entity(hass, mock_bleak_scanner_start):
         _async_register_callback,
     ):
         coordinator.async_register_processor(processor)
+        cancel_coordinator = coordinator.async_start()
 
     processor.async_add_listener(MagicMock())
 
@@ -781,6 +792,7 @@ async def test_integration_with_entity(hass, mock_bleak_scanner_start):
     assert entity_one.entity_key == PassiveBluetoothEntityKey(
         key="temperature", device_id="remote"
     )
+    cancel_coordinator()
 
 
 NO_DEVICES_BLUETOOTH_SERVICE_INFO = BluetoothServiceInfo(
@@ -845,6 +857,7 @@ async def test_integration_with_entity_without_a_device(hass, mock_bleak_scanner
         _async_register_callback,
     ):
         coordinator.async_register_processor(processor)
+        cancel_coordinator = coordinator.async_start()
 
     mock_add_entities = MagicMock()
 
@@ -873,6 +886,7 @@ async def test_integration_with_entity_without_a_device(hass, mock_bleak_scanner
     assert entity_one.entity_key == PassiveBluetoothEntityKey(
         key="temperature", device_id=None
     )
+    cancel_coordinator()
 
 
 async def test_passive_bluetooth_entity_with_entity_platform(
@@ -907,6 +921,7 @@ async def test_passive_bluetooth_entity_with_entity_platform(
         _async_register_callback,
     ):
         coordinator.async_register_processor(processor)
+        cancel_coordinator = coordinator.async_start()
 
     processor.async_add_entities_listener(
         PassiveBluetoothProcessorEntity,
@@ -926,6 +941,7 @@ async def test_passive_bluetooth_entity_with_entity_platform(
         hass.states.get("test_domain.test_platform_aa_bb_cc_dd_ee_ff_pressure")
         is not None
     )
+    cancel_coordinator()
 
 
 SENSOR_PASSIVE_BLUETOOTH_DATA_UPDATE = PassiveBluetoothDataUpdate(
@@ -999,6 +1015,7 @@ async def test_integration_multiple_entity_platforms(hass, mock_bleak_scanner_st
     ):
         coordinator.async_register_processor(binary_sensor_processor)
         coordinator.async_register_processor(sesnor_processor)
+        cancel_coordinator = coordinator.async_start()
 
     binary_sensor_processor.async_add_listener(MagicMock())
     sesnor_processor.async_add_listener(MagicMock())
@@ -1056,3 +1073,4 @@ async def test_integration_multiple_entity_platforms(hass, mock_bleak_scanner_st
     assert binary_sensor_entity_one.entity_key == PassiveBluetoothEntityKey(
         key="motion", device_id=None
     )
+    cancel_coordinator()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We need to have all the listeners registered before we
start getting updates. To do this the integration
needs to be able to control when updates start otherwise
the data is missed on startup.

Found while testing https://github.com/hbldh/bleak/pull/902


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
