### PR TITLE
ZHA network backup and restore API

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -45,6 +45,7 @@ from .core.const import (
     CLUSTER_COMMANDS_SERVER,
     CLUSTER_TYPE_IN,
     CLUSTER_TYPE_OUT,
+    CONF_RADIO_TYPE,
     CUSTOM_CONFIGURATION,
     DATA_ZHA,
     DATA_ZHA_GATEWAY,
@@ -1000,7 +1001,7 @@ async def websocket_get_configuration(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Get ZHA configuration."""
-    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     import voluptuous_serialize  # pylint: disable=import-outside-toplevel
 
     def custom_serializer(schema: Any) -> Any:
@@ -1065,7 +1066,7 @@ async def websocket_get_network_settings(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Get ZHA network settings."""
-    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     application_controller = zha_gateway.application_controller
 
     # Serialize the current network settings
@@ -1074,7 +1075,13 @@ async def websocket_get_network_settings(
         network_info=application_controller.state.network_info,
     )
 
-    connection.send_result(msg[ID], backup.as_dict())
+    connection.send_result(
+        msg[ID],
+        {
+            "radio_type": zha_gateway.config_entry.data[CONF_RADIO_TYPE],
+            "settings": backup.as_dict(),
+        },
+    )
 
 
 @websocket_api.require_admin
@@ -1084,7 +1091,7 @@ async def websocket_list_network_backups(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Get ZHA network settings."""
-    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     application_controller = zha_gateway.application_controller
 
     # Serialize known backups
@@ -1100,7 +1107,7 @@ async def websocket_create_network_backup(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Create a ZHA network backup."""
-    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     application_controller = zha_gateway.application_controller
 
     # This can take 5-30s
@@ -1127,7 +1134,7 @@ async def websocket_restore_network_backup(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Restore a ZHA network backup."""
-    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     application_controller = zha_gateway.application_controller
     backup = msg["backup"]
 

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1068,12 +1068,12 @@ async def websocket_get_network_settings(
     zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     application_controller = zha_gateway.application_controller
 
+    # Serialize the current network settings
     backup = NetworkBackup(
         node_info=application_controller.state.node_info,
         network_info=application_controller.state.network_info,
     )
 
-    # Serialize the most recent backup
     connection.send_result(msg[ID], backup.as_dict())
 
 
@@ -1087,7 +1087,7 @@ async def websocket_list_network_backups(
     zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     application_controller = zha_gateway.application_controller
 
-    # Serialize the most recent backup
+    # Serialize known backups
     connection.send_result(
         msg[ID], [backup.as_dict() for backup in application_controller.backups]
     )

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1118,7 +1118,7 @@ async def websocket_create_network_backup(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/network/backups/restore",
-        vol.Required("data"): _cv_zigpy_network_backup,
+        vol.Required("backup"): _cv_zigpy_network_backup,
     }
 )
 @websocket_api.async_response
@@ -1131,7 +1131,7 @@ async def websocket_restore_network_backup(
 
     # This can take 30-40s
     try:
-        await application_controller.backups.restore_backup(msg["data"])
+        await application_controller.backups.restore_backup(msg["backup"])
     except ValueError as err:
         connection.send_error(msg[ID], websocket_api.const.ERR_INVALID_FORMAT, str(err))
     else:

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1105,7 +1105,13 @@ async def websocket_create_network_backup(
 
     # This can take 5-30s
     backup = await application_controller.backups.create_backup(load_devices=True)
-    connection.send_result(msg[ID], backup.as_dict())
+    connection.send_result(
+        msg[ID],
+        {
+            "backup": backup.as_dict(),
+            "is_complete": backup.is_complete(),
+        },
+    )
 
 
 @websocket_api.require_admin

--- a/homeassistant/components/zha/backup.py
+++ b/homeassistant/components/zha/backup.py
@@ -1,0 +1,21 @@
+"""Backup platform for the ZHA integration."""
+import logging
+
+from homeassistant.core import HomeAssistant
+
+from .core import ZHAGateway
+from .core.const import DATA_ZHA, DATA_ZHA_GATEWAY
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_pre_backup(hass: HomeAssistant) -> None:
+    """Perform operations before a backup starts."""
+    _LOGGER.debug("Performing coordinator backup")
+
+    zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    await zha_gateway.application_controller.backups.create_backup(load_devices=True)
+
+
+async def async_post_backup(hass: HomeAssistant) -> None:
+    """Perform operations before a backup starts."""

--- a/homeassistant/components/zha/backup.py
+++ b/homeassistant/components/zha/backup.py
@@ -18,4 +18,4 @@ async def async_pre_backup(hass: HomeAssistant) -> None:
 
 
 async def async_post_backup(hass: HomeAssistant) -> None:
-    """Perform operations before a backup starts."""
+    """Perform operations after a backup finishes."""

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
 import zigpy
 from zigpy.application import ControllerApplication
+import zigpy.backups
 import zigpy.config
 from zigpy.const import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 import zigpy.device
@@ -54,7 +55,16 @@ def zigpy_app_controller():
     app.ieee.return_value = zigpy.types.EUI64.convert("00:15:8d:00:02:32:4f:32")
     type(app).nwk = PropertyMock(return_value=zigpy.types.NWK(0x0000))
     type(app).devices = PropertyMock(return_value={})
-    type(app).state = PropertyMock(return_value=State())
+    type(app).backups = zigpy.backups.BackupManager(app)
+
+    state = State()
+    state.node_info.ieee = app.ieee.return_value
+    state.network_info.extended_pan_id = app.ieee.return_value
+    state.network_info.pan_id = 0x1234
+    state.network_info.channel = 15
+    state.network_info.network_key.key = zigpy.types.KeyData(range(16))
+    type(app).state = PropertyMock(return_value=state)
+
     return app
 
 

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -634,7 +634,8 @@ async def test_get_network_settings(app_controller, zha_client):
     assert msg["id"] == 6
     assert msg["type"] == const.TYPE_RESULT
     assert msg["success"]
-    assert "network_info" in msg["result"]
+    assert "radio_type" in msg["result"]
+    assert "network_info" in msg["result"]["settings"]
 
 
 async def test_list_network_backups(app_controller, zha_client):

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -620,3 +620,84 @@ async def test_ws_permit_ha12(app_controller, zha_client, params, duration, node
     assert app_controller.permit.await_args[1]["time_s"] == duration
     assert app_controller.permit.await_args[1]["node"] == node
     assert app_controller.permit_with_key.call_count == 0
+
+
+async def test_get_network_settings(app_controller, zha_client):
+    """Test current network settings are returned."""
+
+    await app_controller.backups.create_backup()
+
+    await zha_client.send_json({ID: 6, TYPE: f"{DOMAIN}/network/settings"})
+    msg = await zha_client.receive_json()
+
+    assert msg["id"] == 6
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+    assert "network_info" in msg["result"]
+
+
+async def test_list_network_backups(app_controller, zha_client):
+    """Test backups are serialized."""
+
+    await app_controller.backups.create_backup()
+
+    await zha_client.send_json({ID: 6, TYPE: f"{DOMAIN}/network/backups/list"})
+    msg = await zha_client.receive_json()
+
+    assert msg["id"] == 6
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+    assert "network_info" in msg["result"][0]
+
+
+async def test_create_network_backup(app_controller, zha_client):
+    """Test creating backup."""
+
+    assert not app_controller.backups.backups
+    await zha_client.send_json({ID: 6, TYPE: f"{DOMAIN}/network/backups/create"})
+    msg = await zha_client.receive_json()
+    assert len(app_controller.backups.backups) == 1
+
+    assert msg["id"] == 6
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+    assert "backup" in msg["result"] and "is_complete" in msg["result"]
+
+
+@patch("zigpy.backups.NetworkBackup.from_dict", new=lambda v: v)
+async def test_restore_network_backup_success(app_controller, zha_client):
+    """Test successfully restoring a backup."""
+
+    with patch.object(app_controller.backups, "restore_backup", new=AsyncMock()) as p:
+        await zha_client.send_json(
+            {ID: 6, TYPE: f"{DOMAIN}/network/backups/restore", "backup": "a backup"}
+        )
+        msg = await zha_client.receive_json()
+
+    p.assert_called_once_with("a backup")
+
+    assert msg["id"] == 6
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+
+
+@patch("zigpy.backups.NetworkBackup.from_dict", new=lambda v: v)
+async def test_restore_network_backup_failure(app_controller, zha_client):
+    """Test successfully restoring a backup."""
+
+    with patch.object(
+        app_controller.backups,
+        "restore_backup",
+        new=AsyncMock(side_effect=ValueError("Restore failed")),
+    ) as p:
+        await zha_client.send_json(
+            {ID: 6, TYPE: f"{DOMAIN}/network/backups/restore", "backup": "a backup"}
+        )
+        msg = await zha_client.receive_json()
+
+    p.assert_called_once_with("a backup")
+
+    assert msg["id"] == 6
+    assert msg["type"] == const.TYPE_RESULT
+    assert not msg["success"]
+    assert msg["error"]["code"] == const.ERR_INVALID_FORMAT

--- a/tests/components/zha/test_backup.py
+++ b/tests/components/zha/test_backup.py
@@ -1,0 +1,20 @@
+"""Unit tests for ZHA backup platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.zha.backup import async_post_backup, async_pre_backup
+
+
+async def test_pre_backup(hass, setup_zha):
+    """Test backup creation when `async_pre_backup` is called."""
+    with patch("zigpy.backups.BackupManager.create_backup", AsyncMock()) as backup_mock:
+        await setup_zha()
+        await async_pre_backup(hass)
+
+    backup_mock.assert_called_once_with(load_devices=True)
+
+
+async def test_post_backup(hass, setup_zha):
+    """Test no-op `async_post_backup`."""
+    await setup_zha()
+    await async_post_backup(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements the websocket API for listing, creating, and restoring ZHA network backups. This also adds a ZHA backup platform, which initiates network backup whenever a HA backup is created.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
