### PR TITLE
Update gree to use the network component to set discovery interfaces

### DIFF
--- a/homeassistant/components/gree/__init__.py
+++ b/homeassistant/components/gree/__init__.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+from homeassistant.components.network import async_get_ipv4_broadcast_addresses
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -32,7 +33,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def _async_scan_update(_=None):
-        await gree_discovery.discovery.scan()
+        bcast_addr = list(await async_get_ipv4_broadcast_addresses(hass))
+        await gree_discovery.discovery.scan(0, bcast_addr)
 
     _LOGGER.debug("Scanning network for Gree devices")
     await _async_scan_update()

--- a/homeassistant/components/gree/__init__.py
+++ b/homeassistant/components/gree/__init__.py
@@ -34,7 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def _async_scan_update(_=None):
         bcast_addr = list(await async_get_ipv4_broadcast_addresses(hass))
-        await gree_discovery.discovery.scan(0, bcast_addr)
+        await gree_discovery.discovery.scan(0, bcast_ifaces=bcast_addr)
 
     _LOGGER.debug("Scanning network for Gree devices")
     await _async_scan_update()

--- a/homeassistant/components/gree/config_flow.py
+++ b/homeassistant/components/gree/config_flow.py
@@ -13,7 +13,7 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
     gree_discovery = Discovery(DISCOVERY_TIMEOUT)
     bcast_addr = list(await async_get_ipv4_broadcast_addresses(hass))
     devices = await gree_discovery.scan(
-        wait_for=DISCOVERY_TIMEOUT, bcast_iface=bcast_addr
+        wait_for=DISCOVERY_TIMEOUT, bcast_ifaces=bcast_addr
     )
     return len(devices) > 0
 

--- a/homeassistant/components/gree/config_flow.py
+++ b/homeassistant/components/gree/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Gree."""
 from greeclimate.discovery import Discovery
 
+from homeassistant.components.network import async_get_ipv4_broadcast_addresses
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 
@@ -10,7 +11,10 @@ from .const import DISCOVERY_TIMEOUT, DOMAIN
 async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if there are devices that can be discovered."""
     gree_discovery = Discovery(DISCOVERY_TIMEOUT)
-    devices = await gree_discovery.scan(wait_for=DISCOVERY_TIMEOUT)
+    bcast_addr = list(await async_get_ipv4_broadcast_addresses(hass))
+    devices = await gree_discovery.scan(
+        wait_for=DISCOVERY_TIMEOUT, bcast_iface=bcast_addr
+    )
     return len(devices) > 0
 
 

--- a/homeassistant/components/gree/manifest.json
+++ b/homeassistant/components/gree/manifest.json
@@ -3,7 +3,7 @@
   "name": "Gree Climate",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/gree",
-  "requirements": ["greeclimate==1.2.0"],
+  "requirements": ["greeclimate==1.3.0"],
   "dependencies": ["network"],
   "codeowners": ["@cmroche"],
   "iot_class": "local_polling",

--- a/homeassistant/components/gree/manifest.json
+++ b/homeassistant/components/gree/manifest.json
@@ -4,6 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/gree",
   "requirements": ["greeclimate==1.2.0"],
+  "dependencies": ["network"],
   "codeowners": ["@cmroche"],
   "iot_class": "local_polling",
   "loggers": ["greeclimate"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -772,7 +772,7 @@ gpiozero==1.6.2
 gps3==0.33.3
 
 # homeassistant.components.gree
-greeclimate==1.2.0
+greeclimate==1.3.0
 
 # homeassistant.components.greeneye_monitor
 greeneye_monitor==3.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -564,7 +564,7 @@ googlemaps==2.5.1
 govee-ble==0.12.6
 
 # homeassistant.components.gree
-greeclimate==1.2.0
+greeclimate==1.3.0
 
 # homeassistant.components.greeneye_monitor
 greeneye_monitor==3.0.3

--- a/tests/components/gree/common.py
+++ b/tests/components/gree/common.py
@@ -28,7 +28,7 @@ class FakeDiscovery:
         """Add an event listener."""
         self._listeners.append(listener)
 
-    async def scan(self, wait_for: int = 0, bcast_ifaces = None):
+    async def scan(self, wait_for: int = 0, bcast_ifaces=None):
         """Search for devices, return mocked data."""
         self.scan_count += 1
         _LOGGER.info("CALLED SCAN %d TIMES", self.scan_count)

--- a/tests/components/gree/common.py
+++ b/tests/components/gree/common.py
@@ -28,7 +28,7 @@ class FakeDiscovery:
         """Add an event listener."""
         self._listeners.append(listener)
 
-    async def scan(self, wait_for: int = 0):
+    async def scan(self, wait_for: int = 0, bcast_ifaces = None):
         """Search for devices, return mocked data."""
         self.scan_count += 1
         _LOGGER.info("CALLED SCAN %d TIMES", self.scan_count)


### PR DESCRIPTION
## Proposed change

For me, discovery does not work for this component. It uses `netifaces` to build a list of broadcast addresses. But the ones it generates are incorrect. This is using the official container for the latest stable release of HA. I have not got to the bottom of why `netifaces` seems to be broken, but it seems like instead of relying on the library to pick interfaces we should just use `async_get_ipv4_broadcast_addresses` - and this *does* generate the correct broadcast addresses for me, and also allows me to control which interfaces to use.

https://github.com/cmroche/greeclimate/compare/v1.2.1...v1.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
