### PR TITLE
Fix Xiaomi BLE not detecting encryption for some devices

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -1,7 +1,7 @@
 """The bluetooth integration."""
 from __future__ import annotations
 
-from asyncio import CancelledError, Future
+from asyncio import Future
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -1,6 +1,7 @@
 """The bluetooth integration."""
 from __future__ import annotations
 
+from asyncio import CancelledError, Future
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -8,6 +9,7 @@ from enum import Enum
 import logging
 from typing import Final, Union
 
+import async_timeout
 from bleak import BleakError
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
@@ -95,6 +97,9 @@ BluetoothChange = Enum("BluetoothChange", "ADVERTISEMENT")
 BluetoothCallback = Callable[
     [Union[BluetoothServiceInfoBleak, BluetoothServiceInfo], BluetoothChange], None
 ]
+ProcessAdvertisementCallback = Callable[
+    [Union[BluetoothServiceInfoBleak, BluetoothServiceInfo]], bool
+]
 
 
 @hass_callback
@@ -157,6 +162,31 @@ def async_register_callback(
     """
     manager: BluetoothManager = hass.data[DOMAIN]
     return manager.async_register_callback(callback, match_dict)
+
+
+async def async_process_advertisements(
+    hass: HomeAssistant,
+    callback: ProcessAdvertisementCallback,
+    match_dict: BluetoothCallbackMatcher,
+    timeout: int,
+) -> BluetoothServiceInfo:
+    """Process advertisements until callback returns true or timeout expires."""
+    done: Future[BluetoothServiceInfo] = Future()
+
+    @hass_callback
+    def _async_discovered_device(
+        service_info: BluetoothServiceInfo, change: BluetoothChange
+    ) -> None:
+        if callback(service_info):
+            done.set_result(service_info)
+
+    unload = async_register_callback(hass, _async_discovered_device, match_dict)
+
+    try:
+        async with async_timeout.timeout(timeout):
+            return await done
+    finally:
+        unload()
 
 
 @hass_callback

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Xiaomi Bluetooth integration."""
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 from typing import Any
 
@@ -79,7 +80,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
         # Wait until we have received enough information about this device to detect its encryption type
         try:
             await self._async_wait_for_full_advertisement(discovery_info, device)
-        except TimeoutError:
+        except asyncio.TimeoutError:
             # If we don't see a valid packet within the timeout then this device is not supported.
             return self.async_abort(reason="not_supported")
 
@@ -196,7 +197,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self._async_wait_for_full_advertisement(
                     discovery.discovery_info, discovery.device
                 )
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 # If we don't see a valid packet within the timeout then this device is not supported.
                 return self.async_abort(reason="not_supported")
 

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -20,6 +20,9 @@ from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
 
+# How long to wait for additional advertisement packets if we don't have the right ones
+ADDITIONAL_DISCOVERY_TIMEOUT = 5
+
 
 @dataclasses.dataclass
 class Discovery:
@@ -60,7 +63,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             self.hass,
             _process_more_advertisements,
             {"address": discovery_info.address},
-            5,
+            ADDITIONAL_DISCOVERY_TIMEOUT,
         )
 
     async def async_step_bluetooth(

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -8,7 +8,7 @@
       "service_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.6.1"],
+  "requirements": ["xiaomi-ble==0.6.2"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2473,7 +2473,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.6.1
+xiaomi-ble==0.6.2
 
 # homeassistant.components.knx
 xknx==0.22.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1665,7 +1665,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.6.1
+xiaomi-ble==0.6.2
 
 # homeassistant.components.knx
 xknx==0.22.0

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Bluetooth integration."""
+import asyncio
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +13,7 @@ from homeassistant.components.bluetooth import (
     UNAVAILABLE_TRACK_SECONDS,
     BluetoothChange,
     BluetoothServiceInfo,
+    async_process_advertisements,
     async_track_unavailable,
     models,
 )
@@ -21,7 +23,7 @@ from homeassistant.components.bluetooth.const import (
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -789,6 +791,92 @@ async def test_register_callback_by_address(
         assert service_info.name == "wohand"
         assert service_info.manufacturer == "Nordic Semiconductor ASA"
         assert service_info.manufacturer_id == 89
+
+
+async def test_process_advertisements_bail_on_good_advertisement(
+    hass: HomeAssistant, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Test as soon as we see a 'good' advertisement we return it."""
+    done = asyncio.Future()
+
+    def _callback(service_info: BluetoothServiceInfo) -> bool:
+        done.set_result(None)
+        return len(service_info.service_data) > 0
+
+    handle = hass.async_create_task(
+        async_process_advertisements(
+            hass, _callback, {"address": "aa:44:33:11:23:45"}, 5
+        )
+    )
+
+    while not done.done():
+        device = BLEDevice("aa:44:33:11:23:45", "wohand")
+        adv = AdvertisementData(
+            local_name="wohand",
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51a"],
+            manufacturer_data={89: b"\xd8.\xad\xcd\r\x85"},
+            service_data={"00000d00-0000-1000-8000-00805f9b34fa": b"H\x10c"},
+        )
+
+        _get_underlying_scanner()._callback(device, adv)
+        await asyncio.sleep(0)
+
+    result = await handle
+    assert result.name == "wohand"
+
+
+async def test_process_advertisements_ignore_bad_advertisement(
+    hass: HomeAssistant, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Check that we ignore bad advertisements."""
+    done = asyncio.Event()
+    return_value = asyncio.Event()
+
+    device = BLEDevice("aa:44:33:11:23:45", "wohand")
+    adv = AdvertisementData(
+        local_name="wohand",
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51a"],
+        manufacturer_data={89: b"\xd8.\xad\xcd\r\x85"},
+        service_data={"00000d00-0000-1000-8000-00805f9b34fa": b""},
+    )
+
+    def _callback(service_info: BluetoothServiceInfo) -> bool:
+        done.set()
+        return return_value.is_set()
+
+    handle = hass.async_create_task(
+        async_process_advertisements(
+            hass, _callback, {"address": "aa:44:33:11:23:45"}, 5
+        )
+    )
+
+    # The goal of this loop is to make sure that async_process_advertisements sees at least one
+    # callback that returns False
+    while not done.is_set():
+        _get_underlying_scanner()._callback(device, adv)
+        await asyncio.sleep(0)
+
+    # Set the return value and mutate the advertisement
+    # Check that scan ends and correct advertisement data is returned
+    return_value.set()
+    adv.service_data["00000d00-0000-1000-8000-00805f9b34fa"] = b"H\x10c"
+    _get_underlying_scanner()._callback(device, adv)
+    await asyncio.sleep(0)
+
+    result = await handle
+    assert result.service_data["00000d00-0000-1000-8000-00805f9b34fa"] == b"H\x10c"
+
+
+async def test_process_advertisements_timeout(
+    hass, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Test we timeout if no advertisements at all."""
+
+    def _callback(service_info: BluetoothServiceInfo) -> bool:
+        return False
+
+    with pytest.raises(asyncio.TimeoutError):
+        await async_process_advertisements(hass, _callback, {}, 0)
 
 
 async def test_wrapped_instance_with_filter(

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -61,6 +61,18 @@ YLKG07YL_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+MISSING_PAYLOAD_ENCRYPTED = BluetoothServiceInfo(
+    name="LYWSD03MMC",
+    address="A4:C1:38:D4:3C:48",
+    rssi=-56,
+    manufacturer_data={},
+    service_data={
+        "0000fe95-0000-1000-8000-00805f9b34fb": b"0X[\x05\x02H<\xd48\xc1\xa4\x08",
+    },
+    service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
+    source="local",
+)
+
 
 def make_advertisement(address: str, payload: bytes) -> BluetoothServiceInfo:
     """Make a dummy advertisement."""

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -62,8 +62,8 @@ YLKG07YL_SERVICE_INFO = BluetoothServiceInfo(
 )
 
 MISSING_PAYLOAD_ENCRYPTED = BluetoothServiceInfo(
-    name="LYWSD03MMC",
-    address="A4:C1:38:D4:3C:48",
+    name="LYWSD02MMC",
+    address="A4:C1:38:56:53:84",
     rssi=-56,
     manufacturer_data={},
     service_data={

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -67,7 +67,7 @@ MISSING_PAYLOAD_ENCRYPTED = BluetoothServiceInfo(
     rssi=-56,
     manufacturer_data={},
     service_data={
-        "0000fe95-0000-1000-8000-00805f9b34fb": b"0X[\x05\x02H<\xd48\xc1\xa4\x08",
+        "0000fe95-0000-1000-8000-00805f9b34fb": b"0X[\x05\x02\x84\x53\x568\xc1\xa4\x08",
     },
     service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
     source="local",


### PR DESCRIPTION
## Proposed change

When a Xiaomi MiBeacon device sends its advertisements it can send packets that don't have a payload. As there is no payload, there is no encryption, and if there is no encryption we can't get the config flow to prompt for a bindkey.

After discussing with @bdraco, the best plan right now is to wait in the config flow until we see an advertisement matching our requirements OR we time out.

I broke out the bluetooth framework part of this code into a helper in case it would be useful to other integrations, but it can live in xiaomi_ble if thats preferred.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75833
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
