### PR TITLE
Fix AdGuard Home rules count sensor

### DIFF
--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -26,7 +26,7 @@ PARALLEL_UPDATES = 4
 class AdGuardHomeEntityDescriptionMixin:
     """Mixin for required keys."""
 
-    value_fn: Callable[[AdGuardHome], Callable[[], Coroutine[Any, Any, int | float]]]
+    value_fn: Callable[[AdGuardHome], Coroutine[Any, Any, int | float]]
 
 
 @dataclass
@@ -42,56 +42,56 @@ SENSORS: tuple[AdGuardHomeEntityDescription, ...] = (
         name="DNS queries",
         icon="mdi:magnify",
         native_unit_of_measurement="queries",
-        value_fn=lambda adguard: adguard.stats.dns_queries,
+        value_fn=lambda adguard: adguard.stats.dns_queries(),
     ),
     AdGuardHomeEntityDescription(
         key="blocked_filtering",
         name="DNS queries blocked",
         icon="mdi:magnify-close",
         native_unit_of_measurement="queries",
-        value_fn=lambda adguard: adguard.stats.blocked_filtering,
+        value_fn=lambda adguard: adguard.stats.blocked_filtering(),
     ),
     AdGuardHomeEntityDescription(
         key="blocked_percentage",
         name="DNS queries blocked ratio",
         icon="mdi:magnify-close",
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda adguard: adguard.stats.blocked_percentage,
+        value_fn=lambda adguard: adguard.stats.blocked_percentage(),
     ),
     AdGuardHomeEntityDescription(
         key="blocked_parental",
         name="Parental control blocked",
         icon="mdi:human-male-girl",
         native_unit_of_measurement="requests",
-        value_fn=lambda adguard: adguard.stats.replaced_parental,
+        value_fn=lambda adguard: adguard.stats.replaced_parental(),
     ),
     AdGuardHomeEntityDescription(
         key="blocked_safebrowsing",
         name="Safe browsing blocked",
         icon="mdi:shield-half-full",
         native_unit_of_measurement="requests",
-        value_fn=lambda adguard: adguard.stats.replaced_safebrowsing,
+        value_fn=lambda adguard: adguard.stats.replaced_safebrowsing(),
     ),
     AdGuardHomeEntityDescription(
         key="enforced_safesearch",
         name="Safe searches enforced",
         icon="mdi:shield-search",
         native_unit_of_measurement="requests",
-        value_fn=lambda adguard: adguard.stats.replaced_safesearch,
+        value_fn=lambda adguard: adguard.stats.replaced_safesearch(),
     ),
     AdGuardHomeEntityDescription(
         key="average_speed",
         name="Average processing speed",
         icon="mdi:speedometer",
         native_unit_of_measurement=TIME_MILLISECONDS,
-        value_fn=lambda adguard: adguard.stats.avg_processing_time,
+        value_fn=lambda adguard: adguard.stats.avg_processing_time(),
     ),
     AdGuardHomeEntityDescription(
         key="rules_count",
         name="Rules count",
         icon="mdi:counter",
         native_unit_of_measurement="rules",
-        value_fn=lambda adguard: adguard.stats.avg_processing_time,
+        value_fn=lambda adguard: adguard.filtering.rules_count(allowlist=False),
         entity_registry_enabled_default=False,
     ),
 )
@@ -144,7 +144,7 @@ class AdGuardHomeSensor(AdGuardHomeEntity, SensorEntity):
 
     async def _adguard_update(self) -> None:
         """Update AdGuard Home entity."""
-        value = await self.entity_description.value_fn(self.adguard)()
+        value = await self.entity_description.value_fn(self.adguard)
         self._attr_native_value = value
         if isinstance(value, float):
             self._attr_native_value = f"{value:.2f}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes the Rules counter sensor of AdGuard Home.
Adjusted the way these sensors work a little, to make this simpler to implement/fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
