### PR TITLE
Refactor volvooncall to (mostly) use DataUpdateCoordinator

### DIFF
--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -150,8 +150,8 @@ class VolvoData:
     ) -> None:
         """Initialize the component state."""
         self.hass = hass
-        self.vehicles = set()  # type: ignore[var-annotated]
-        self.instruments = set()  # type: ignore[var-annotated]
+        self.vehicles: set = set()
+        self.instruments: set = set()
         self.config = config[DOMAIN]
         self.connection = connection
 

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -92,26 +92,31 @@ RESOURCES = [
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(
-                    CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
-                ): vol.All(
-                    cv.time_period, vol.Clamp(min=DEFAULT_UPDATE_INTERVAL)
-                ),  # ignored, using DataUpdateCoordinator instead
-                vol.Optional(CONF_NAME, default={}): cv.schema_with_slug_keys(
-                    cv.string
-                ),  # ignored, users can modify names of entities in the UI
-                vol.Optional(CONF_RESOURCES): vol.All(
-                    cv.ensure_list, [vol.In(RESOURCES)]
-                ),  # ignored, users can disable entities in the UI
-                vol.Optional(CONF_REGION): cv.string,
-                vol.Optional(CONF_SERVICE_URL): cv.string,
-                vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
-                vol.Optional(CONF_SCANDINAVIAN_MILES, default=False): cv.boolean,
-            }
+        DOMAIN: vol.All(
+            cv.deprecated(CONF_SCAN_INTERVAL),
+            cv.deprecated(CONF_NAME),
+            cv.deprecated(CONF_RESOURCES),
+            vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME): cv.string,
+                    vol.Required(CONF_PASSWORD): cv.string,
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+                    ): vol.All(
+                        cv.time_period, vol.Clamp(min=DEFAULT_UPDATE_INTERVAL)
+                    ),  # ignored, using DataUpdateCoordinator instead
+                    vol.Optional(CONF_NAME, default={}): cv.schema_with_slug_keys(
+                        cv.string
+                    ),  # ignored, users can modify names of entities in the UI
+                    vol.Optional(CONF_RESOURCES): vol.All(
+                        cv.ensure_list, [vol.In(RESOURCES)]
+                    ),  # ignored, users can disable entities in the UI
+                    vol.Optional(CONF_REGION): cv.string,
+                    vol.Optional(CONF_SERVICE_URL): cv.string,
+                    vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
+                    vol.Optional(CONF_SCANDINAVIAN_MILES, default=False): cv.boolean,
+                }
+            ),
         )
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -136,7 +136,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.data[DATA_KEY] = VolvoUpdateCoordinator(hass, volvo_data)
 
-    _LOGGER.debug("Logging in to service")
     return await volvo_data.update()
 
 

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -212,7 +212,6 @@ class VolvoData:
     async def update(self):
         """Update status from the online service."""
         if not await self.connection.update(journal=True):
-            _LOGGER.warning("Could not query server")
             return False
 
         for vehicle in self.connection.vehicles:

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -157,26 +157,14 @@ class VolvoData:
 
     def instrument(self, vin, component, attr, slug_attr):
         """Return corresponding instrument."""
-        ret = next(
-            (
-                instrument
-                for instrument in self.instruments
-                if instrument.vehicle.vin == vin
-                and instrument.component == component
-                and instrument.attr == attr
-                and instrument.slug_attr == slug_attr
-            ),
-            None,
+        return next(
+            instrument
+            for instrument in self.instruments
+            if instrument.vehicle.vin == vin
+            and instrument.component == component
+            and instrument.attr == attr
+            and instrument.slug_attr == slug_attr
         )
-
-        if ret is None:
-            _LOGGER.warning(
-                "Unknown instrument requested: %s.%s, which means there is an issue with the volvooncall component or the underlying volvooncall package",
-                component,
-                slug_attr,
-            )
-
-        return ret
 
     def vehicle_name(self, vehicle):
         """Provide a friendly name for a vehicle."""

--- a/homeassistant/components/volvooncall/binary_sensor.py
+++ b/homeassistant/components/volvooncall/binary_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
+    DEVICE_CLASSES_SCHEMA,
     BinarySensorEntity,
 )
 from homeassistant.core import HomeAssistant
@@ -38,10 +38,7 @@ class VolvoSensor(VolvoEntity, BinarySensorEntity):
         """Initialize the sensor."""
         super().__init__(vin, component, attribute, slug_attr, coordinator)
 
-        if self.instrument.device_class in {
-            item.value for item in BinarySensorDeviceClass
-        }:
-            self._attr_device_class = self.instrument.device_class
+        self._attr_device_class = DEVICE_CLASSES_SCHEMA(self.instrument.device_class)
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/volvooncall/binary_sensor.py
+++ b/homeassistant/components/volvooncall/binary_sensor.py
@@ -1,7 +1,10 @@
 """Support for VOC."""
 from __future__ import annotations
 
-from homeassistant.components.binary_sensor import DEVICE_CLASSES, BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -35,7 +38,9 @@ class VolvoSensor(VolvoEntity, BinarySensorEntity):
         """Initialize the sensor."""
         super().__init__(vin, component, attribute, slug_attr, coordinator)
 
-        if self.instrument.device_class in DEVICE_CLASSES:
+        if self.instrument.device_class in {
+            item.value for item in BinarySensorDeviceClass
+        }:
             self._attr_device_class = self.instrument.device_class
 
     @property

--- a/homeassistant/components/volvooncall/binary_sensor.py
+++ b/homeassistant/components/volvooncall/binary_sensor.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from homeassistant.components.binary_sensor import DEVICE_CLASSES, BinarySensorEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DATA_KEY, VolvoEntity
+from . import VolvoEntity
 
 
 async def async_setup_platform(
@@ -18,22 +18,35 @@ async def async_setup_platform(
     """Set up the Volvo sensors."""
     if discovery_info is None:
         return
-    async_add_entities([VolvoSensor(hass.data[DATA_KEY], *discovery_info)])
+    async_add_entities([VolvoSensor(hass, *discovery_info)])
 
 
 class VolvoSensor(VolvoEntity, BinarySensorEntity):
     """Representation of a Volvo sensor."""
 
-    @property
-    def is_on(self):
-        """Return True if the binary sensor is on, but invert for the 'Door lock'."""
-        if self.instrument.attr == "is_locked":
-            return not self.instrument.is_on
-        return self.instrument.is_on
+    def __init__(
+        self, hass: HomeAssistant, vin, component, attribute, slug_attr, coordinator
+    ):
+        """Initialize the sensor."""
+        VolvoEntity.__init__(
+            self, hass, vin, component, attribute, slug_attr, coordinator
+        )
 
-    @property
-    def device_class(self):
-        """Return the class of this sensor, from DEVICE_CLASSES."""
         if self.instrument.device_class in DEVICE_CLASSES:
-            return self.instrument.device_class
-        return None
+            self._attr_device_class = self.instrument.device_class
+        else:
+            self._attr_device_class = None
+
+        if self.instrument.attr == "is_locked":
+            self._attr_is_on = not self.instrument.is_on
+        else:
+            self._attr_is_on = self.instrument.is_on
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if self.instrument.attr == "is_locked":
+            self._attr_is_on = not self.instrument.is_on
+        else:
+            self._attr_is_on = self.instrument.is_on
+        self.async_write_ha_state()

--- a/homeassistant/components/volvooncall/binary_sensor.py
+++ b/homeassistant/components/volvooncall/binary_sensor.py
@@ -1,6 +1,10 @@
 """Support for VOC."""
 from __future__ import annotations
 
+from contextlib import suppress
+
+import voluptuous as vol
+
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA,
     BinarySensorEntity,
@@ -38,7 +42,10 @@ class VolvoSensor(VolvoEntity, BinarySensorEntity):
         """Initialize the sensor."""
         super().__init__(vin, component, attribute, slug_attr, coordinator)
 
-        self._attr_device_class = DEVICE_CLASSES_SCHEMA(self.instrument.device_class)
+        with suppress(vol.Invalid):
+            self._attr_device_class = DEVICE_CLASSES_SCHEMA(
+                self.instrument.device_class
+            )
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/volvooncall/binary_sensor.py
+++ b/homeassistant/components/volvooncall/binary_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.components.binary_sensor import DEVICE_CLASSES, BinarySensorEntity
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -44,8 +44,3 @@ class VolvoSensor(VolvoEntity, BinarySensorEntity):
         if self.instrument.attr == "is_locked":
             return not self.instrument.is_on
         return self.instrument.is_on
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self.async_write_ha_state()

--- a/homeassistant/components/volvooncall/device_tracker.py
+++ b/homeassistant/components/volvooncall/device_tracker.py
@@ -22,7 +22,7 @@ async def async_setup_scanner(
     if discovery_info is None:
         return False
 
-    vin, component, attr, slug_attr = discovery_info
+    vin, component, attr, slug_attr, _ = discovery_info
     data = hass.data[DATA_KEY]
     instrument = data.instrument(vin, component, attr, slug_attr)
 

--- a/homeassistant/components/volvooncall/device_tracker.py
+++ b/homeassistant/components/volvooncall/device_tracker.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import slugify
 
-from . import DATA_KEY, SIGNAL_STATE_UPDATED
+from . import DATA_KEY, SIGNAL_STATE_UPDATED, VolvoUpdateCoordinator
 
 
 async def async_setup_scanner(
@@ -23,7 +23,8 @@ async def async_setup_scanner(
         return False
 
     vin, component, attr, slug_attr = discovery_info
-    volvo_data = hass.data[DATA_KEY].volvo_data
+    coordinator: VolvoUpdateCoordinator = hass.data[DATA_KEY]
+    volvo_data = coordinator.volvo_data
     instrument = volvo_data.instrument(vin, component, attr, slug_attr)
 
     async def see_vehicle():

--- a/homeassistant/components/volvooncall/device_tracker.py
+++ b/homeassistant/components/volvooncall/device_tracker.py
@@ -27,6 +27,9 @@ async def async_setup_scanner(
     volvo_data = coordinator.volvo_data
     instrument = volvo_data.instrument(vin, component, attr, slug_attr)
 
+    if instrument is None:
+        return False
+
     async def see_vehicle():
         """Handle the reporting of the vehicle position."""
         host_name = instrument.vehicle_name

--- a/homeassistant/components/volvooncall/device_tracker.py
+++ b/homeassistant/components/volvooncall/device_tracker.py
@@ -22,9 +22,9 @@ async def async_setup_scanner(
     if discovery_info is None:
         return False
 
-    vin, component, attr, slug_attr, _ = discovery_info
-    data = hass.data[DATA_KEY]
-    instrument = data.instrument(vin, component, attr, slug_attr)
+    vin, component, attr, slug_attr = discovery_info
+    volvo_data = hass.data[DATA_KEY].volvo_data
+    instrument = volvo_data.instrument(vin, component, attr, slug_attr)
 
     async def see_vehicle():
         """Handle the reporting of the vehicle position."""

--- a/homeassistant/components/volvooncall/lock.py
+++ b/homeassistant/components/volvooncall/lock.py
@@ -7,7 +7,7 @@ from typing import Any
 from volvooncall.dashboard import Lock
 
 from homeassistant.components.lock import LockEntity
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -42,13 +42,11 @@ class VolvoLock(VolvoEntity, LockEntity):
     ) -> None:
         """Initialize the lock."""
         super().__init__(vin, component, attribute, slug_attr, coordinator)
-        self._attr_is_locked = self.instrument.is_locked
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._attr_is_locked = self.instrument.is_locked
-        self.async_write_ha_state()
+    @property
+    def is_locked(self) -> bool | None:
+        """Determine if car is locked."""
+        return self.instrument.is_locked
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the car."""

--- a/homeassistant/components/volvooncall/lock.py
+++ b/homeassistant/components/volvooncall/lock.py
@@ -1,4 +1,5 @@
 """Support for Volvo On Call locks."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -6,11 +7,11 @@ from typing import Any
 from volvooncall.dashboard import Lock
 
 from homeassistant.components.lock import LockEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DATA_KEY, VolvoEntity
+from . import VolvoEntity
 
 
 async def async_setup_platform(
@@ -23,7 +24,7 @@ async def async_setup_platform(
     if discovery_info is None:
         return
 
-    async_add_entities([VolvoLock(hass.data[DATA_KEY], *discovery_info)])
+    async_add_entities([VolvoLock(hass, *discovery_info)])
 
 
 class VolvoLock(VolvoEntity, LockEntity):
@@ -31,15 +32,29 @@ class VolvoLock(VolvoEntity, LockEntity):
 
     instrument: Lock
 
-    @property
-    def is_locked(self) -> bool | None:
-        """Return true if lock is locked."""
-        return self.instrument.is_locked
+    def __init__(
+        self, hass: HomeAssistant, vin, component, attribute, slug_attr, coordinator
+    ):
+        """Initialize the lock."""
+        VolvoEntity.__init__(
+            self, hass, vin, component, attribute, slug_attr, coordinator
+        )
+
+        self._attr_is_locked = self.instrument.is_locked
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+
+        self._attr_is_locked = self.instrument.is_locked
+        self.async_write_ha_state()
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the car."""
         await self.instrument.lock()
+        await self.coordinator.async_request_refresh()
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the car."""
         await self.instrument.unlock()
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/volvooncall/lock.py
+++ b/homeassistant/components/volvooncall/lock.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import VolvoEntity
+from . import DATA_KEY, VolvoEntity, VolvoUpdateCoordinator
 
 
 async def async_setup_platform(
@@ -24,7 +24,7 @@ async def async_setup_platform(
     if discovery_info is None:
         return
 
-    async_add_entities([VolvoLock(hass, *discovery_info)])
+    async_add_entities([VolvoLock(hass.data[DATA_KEY], *discovery_info)])
 
 
 class VolvoLock(VolvoEntity, LockEntity):
@@ -33,19 +33,20 @@ class VolvoLock(VolvoEntity, LockEntity):
     instrument: Lock
 
     def __init__(
-        self, hass: HomeAssistant, vin, component, attribute, slug_attr, coordinator
-    ):
+        self,
+        coordinator: VolvoUpdateCoordinator,
+        vin: str,
+        component: str,
+        attribute: str,
+        slug_attr: str,
+    ) -> None:
         """Initialize the lock."""
-        VolvoEntity.__init__(
-            self, hass, vin, component, attribute, slug_attr, coordinator
-        )
-
+        super().__init__(vin, component, attribute, slug_attr, coordinator)
         self._attr_is_locked = self.instrument.is_locked
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-
         self._attr_is_locked = self.instrument.is_locked
         self.async_write_ha_state()
 

--- a/homeassistant/components/volvooncall/sensor.py
+++ b/homeassistant/components/volvooncall/sensor.py
@@ -33,14 +33,15 @@ class VolvoSensor(VolvoEntity, SensorEntity):
         slug_attr: str,
     ) -> None:
         """Initialize the sensor."""
-        VolvoEntity.__init__(self, vin, component, attribute, slug_attr, coordinator)
+        super().__init__(vin, component, attribute, slug_attr, coordinator)
+        self._update_value_and_unit()
 
+    def _update_value_and_unit(self) -> None:
         self._attr_native_value = self.instrument.state
         self._attr_native_unit_of_measurement = self.instrument.unit
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_native_value = self.instrument.state
-        self._attr_native_unit_of_measurement = self.instrument.unit
+        self._update_value_and_unit()
         self.async_write_ha_state()

--- a/homeassistant/components/volvooncall/sensor.py
+++ b/homeassistant/components/volvooncall/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import VolvoEntity
+from . import DATA_KEY, VolvoEntity, VolvoUpdateCoordinator
 
 
 async def async_setup_platform(
@@ -18,19 +18,22 @@ async def async_setup_platform(
     """Set up the Volvo sensors."""
     if discovery_info is None:
         return
-    async_add_entities([VolvoSensor(hass, *discovery_info)])
+    async_add_entities([VolvoSensor(hass.data[DATA_KEY], *discovery_info)])
 
 
 class VolvoSensor(VolvoEntity, SensorEntity):
     """Representation of a Volvo sensor."""
 
     def __init__(
-        self, hass: HomeAssistant, vin, component, attribute, slug_attr, coordinator
-    ):
+        self,
+        coordinator: VolvoUpdateCoordinator,
+        vin: str,
+        component: str,
+        attribute: str,
+        slug_attr: str,
+    ) -> None:
         """Initialize the sensor."""
-        VolvoEntity.__init__(
-            self, hass, vin, component, attribute, slug_attr, coordinator
-        )
+        VolvoEntity.__init__(self, vin, component, attribute, slug_attr, coordinator)
 
         self._attr_native_value = self.instrument.state
         self._attr_native_unit_of_measurement = self.instrument.unit

--- a/homeassistant/components/volvooncall/sensor.py
+++ b/homeassistant/components/volvooncall/sensor.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DATA_KEY, VolvoEntity
+from . import VolvoEntity
 
 
 async def async_setup_platform(
@@ -18,18 +18,26 @@ async def async_setup_platform(
     """Set up the Volvo sensors."""
     if discovery_info is None:
         return
-    async_add_entities([VolvoSensor(hass.data[DATA_KEY], *discovery_info)])
+    async_add_entities([VolvoSensor(hass, *discovery_info)])
 
 
 class VolvoSensor(VolvoEntity, SensorEntity):
     """Representation of a Volvo sensor."""
 
-    @property
-    def native_value(self):
-        """Return the state."""
-        return self.instrument.state
+    def __init__(
+        self, hass: HomeAssistant, vin, component, attribute, slug_attr, coordinator
+    ):
+        """Initialize the sensor."""
+        VolvoEntity.__init__(
+            self, hass, vin, component, attribute, slug_attr, coordinator
+        )
 
-    @property
-    def native_unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return self.instrument.unit
+        self._attr_native_value = self.instrument.state
+        self._attr_native_unit_of_measurement = self.instrument.unit
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_native_value = self.instrument.state
+        self._attr_native_unit_of_measurement = self.instrument.unit
+        self.async_write_ha_state()

--- a/homeassistant/components/volvooncall/switch.py
+++ b/homeassistant/components/volvooncall/switch.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -33,15 +33,12 @@ class VolvoSwitch(VolvoEntity, SwitchEntity):
         slug_attr: str,
     ) -> None:
         """Initialize the switch."""
-        VolvoEntity.__init__(self, vin, component, attribute, slug_attr, coordinator)
+        super().__init__(vin, component, attribute, slug_attr, coordinator)
 
-        self._attr_is_on = self.instrument.state
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._attr_is_on = self.instrument.state
-        self.async_write_ha_state()
+    @property
+    def is_on(self):
+        """Determine if switch is on."""
+        return self.instrument.state
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""

--- a/homeassistant/components/volvooncall/switch.py
+++ b/homeassistant/components/volvooncall/switch.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DATA_KEY, VolvoEntity
+from . import VolvoEntity
 
 
 async def async_setup_platform(
@@ -18,23 +18,34 @@ async def async_setup_platform(
     """Set up a Volvo switch."""
     if discovery_info is None:
         return
-    async_add_entities([VolvoSwitch(hass.data[DATA_KEY], *discovery_info)])
+    async_add_entities([VolvoSwitch(hass, *discovery_info)])
 
 
 class VolvoSwitch(VolvoEntity, SwitchEntity):
     """Representation of a Volvo switch."""
 
-    @property
-    def is_on(self):
-        """Return true if switch is on."""
-        return self.instrument.state
+    def __init__(
+        self, hass: HomeAssistant, vin, component, attribute, slug_attr, coordinator
+    ):
+        """Initialize the switch."""
+        VolvoEntity.__init__(
+            self, hass, vin, component, attribute, slug_attr, coordinator
+        )
+
+        self._attr_is_on = self.instrument.state
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_is_on = self.instrument.state
+        self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
         await self.instrument.turn_on()
-        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         await self.instrument.turn_off()
-        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/volvooncall/switch.py
+++ b/homeassistant/components/volvooncall/switch.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import VolvoEntity
+from . import DATA_KEY, VolvoEntity, VolvoUpdateCoordinator
 
 
 async def async_setup_platform(
@@ -18,19 +18,22 @@ async def async_setup_platform(
     """Set up a Volvo switch."""
     if discovery_info is None:
         return
-    async_add_entities([VolvoSwitch(hass, *discovery_info)])
+    async_add_entities([VolvoSwitch(hass.data[DATA_KEY], *discovery_info)])
 
 
 class VolvoSwitch(VolvoEntity, SwitchEntity):
     """Representation of a Volvo switch."""
 
     def __init__(
-        self, hass: HomeAssistant, vin, component, attribute, slug_attr, coordinator
-    ):
+        self,
+        coordinator: VolvoUpdateCoordinator,
+        vin: str,
+        component: str,
+        attribute: str,
+        slug_attr: str,
+    ) -> None:
         """Initialize the switch."""
-        VolvoEntity.__init__(
-            self, hass, vin, component, attribute, slug_attr, coordinator
-        )
+        VolvoEntity.__init__(self, vin, component, attribute, slug_attr, coordinator)
 
         self._attr_is_on = self.instrument.state
 


### PR DESCRIPTION
## Deprecation

The config options `name`, `resources` and `scan_interval` have been deprecated and can be removed from your `volvooncall` section in configuration.yaml.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactoring this component to use DataUpdateCoordinator is the first step towards another refactor I am working on to implement ConfigFlow.  Per recommendation of martinhjelmare on Discord (https://discord.com/channels/330944238910963714/330990195199442944/999976400327020584), I've done it in this order.

I have not implemented DataUpdateCoordinator for device_tracker because it appears that this will be easier to do after migrating to ConfigFlow, so I will do it as part of that refactor. Please correct me if I am wrong about this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23567

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
