### PR TITLE
Handle failed connection attempts in opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -1,9 +1,11 @@
 """Support for OpenTherm Gateway devices."""
+import asyncio
 from datetime import date, datetime
 import logging
 
 import pyotgw
 import pyotgw.vars as gw_vars
+from serial import SerialException
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -23,6 +25,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
@@ -37,6 +40,7 @@ from .const import (
     CONF_PRECISION,
     CONF_READ_PRECISION,
     CONF_SET_PRECISION,
+    CONNECTION_TIMEOUT,
     DATA_GATEWAYS,
     DATA_OPENTHERM_GW,
     DOMAIN,
@@ -107,8 +111,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     config_entry.add_update_listener(options_updated)
 
-    # Schedule directly on the loop to avoid blocking HA startup.
-    hass.loop.create_task(gateway.connect_and_subscribe())
+    try:
+        await asyncio.wait_for(
+            hass.async_create_task(gateway.connect_and_subscribe()),
+            timeout=CONNECTION_TIMEOUT,
+        )
+    except (asyncio.TimeoutError, ConnectionError, SerialException) as ex:
+        raise ConfigEntryNotReady(
+            f"Could not connect to gateway at {gateway.device_path}: {ex}"
+        ) from ex
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
@@ -428,6 +439,9 @@ class OpenThermGatewayDevice:
     async def connect_and_subscribe(self):
         """Connect to serial device and subscribe report handler."""
         self.status = await self.gateway.connect(self.device_path)
+        if not self.status:
+            await self.cleanup()
+            raise ConnectionError
         version_string = self.status[gw_vars.OTGW].get(gw_vars.OTGW_ABOUT)
         self.gw_version = version_string[18:] if version_string else None
         _LOGGER.debug(

--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -113,7 +113,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     try:
         await asyncio.wait_for(
-            hass.async_create_task(gateway.connect_and_subscribe()),
+            gateway.connect_and_subscribe(),
             timeout=CONNECTION_TIMEOUT,
         )
     except (asyncio.TimeoutError, ConnectionError, SerialException) as ex:

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -64,7 +64,6 @@ class OpenThermGwConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 status = await otgw.connect(device)
                 await otgw.disconnect()
                 if not status:
-                    await otgw.cleanup()
                     raise ConnectionError
                 return status[gw_vars.OTGW].get(gw_vars.OTGW_ABOUT)
 

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_READ_PRECISION,
     CONF_SET_PRECISION,
     CONF_TEMPORARY_OVRD_MODE,
+    CONNECTION_TIMEOUT,
 )
 
 
@@ -62,15 +63,22 @@ class OpenThermGwConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 otgw = pyotgw.OpenThermGateway()
                 status = await otgw.connect(device)
                 await otgw.disconnect()
+                if not status:
+                    await otgw.cleanup()
+                    raise ConnectionError
                 return status[gw_vars.OTGW].get(gw_vars.OTGW_ABOUT)
 
             try:
-                res = await asyncio.wait_for(test_connection(), timeout=10)
-            except (asyncio.TimeoutError, SerialException):
+                await asyncio.wait_for(
+                    test_connection(),
+                    timeout=CONNECTION_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                return self._show_form({"base": "timeout_connect"})
+            except (ConnectionError, SerialException):
                 return self._show_form({"base": "cannot_connect"})
 
-            if res:
-                return self._create_entry(gw_id, name, device)
+            return self._create_entry(gw_id, name, device)
 
         return self._show_form()
 

--- a/homeassistant/components/opentherm_gw/const.py
+++ b/homeassistant/components/opentherm_gw/const.py
@@ -25,6 +25,8 @@ CONF_READ_PRECISION = "read_precision"
 CONF_SET_PRECISION = "set_precision"
 CONF_TEMPORARY_OVRD_MODE = "temporary_override_mode"
 
+CONNECTION_TIMEOUT = 10
+
 DATA_GATEWAYS = "gateways"
 DATA_OPENTHERM_GW = "opentherm_gw"
 

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -12,7 +12,8 @@
     "error": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "id_exists": "Gateway id already exists",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
     }
   },
   "options": {

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -164,7 +164,7 @@ async def test_form_connection_timeout(hass):
         )
 
     assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result2["errors"] == {"base": "timeout_connect"}
     assert len(mock_connect.mock_calls) == 1
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The opentherm_gw integration does not handle failed connection attempts properly both during Home Assistant start and in the config flow. This PR fixes the issue in both places.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75589
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
