### PR TITLE
Use device_tracker SourceType enum [a-g]

### DIFF
--- a/homeassistant/components/asuswrt/device_tracker.py
+++ b/homeassistant/components/asuswrt/device_tracker.py
@@ -1,7 +1,7 @@
 """Support for ASUSWRT routers."""
 from __future__ import annotations
 
-from homeassistant.components.device_tracker import SOURCE_TYPE_ROUTER
+from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -69,9 +69,9 @@ class AsusWrtDevice(ScannerEntity):
         return self._device.is_connected
 
     @property
-    def source_type(self) -> str:
+    def source_type(self) -> SourceType:
         """Return the source type."""
-        return SOURCE_TYPE_ROUTER
+        return SourceType.ROUTER
 
     @property
     def hostname(self) -> str | None:

--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -16,7 +16,7 @@ from homeassistant.components.device_tracker import (
 from homeassistant.components.device_tracker.const import (
     CONF_TRACK_NEW,
     SCAN_INTERVAL,
-    SOURCE_TYPE_BLUETOOTH_LE,
+    SourceType,
 )
 from homeassistant.components.device_tracker.legacy import (
     YAML_DEVICES,
@@ -106,7 +106,7 @@ async def async_setup_scanner(  # noqa: C901
         await async_see(
             mac=BLE_PREFIX + address,
             host_name=name,
-            source_type=SOURCE_TYPE_BLUETOOTH_LE,
+            source_type=SourceType.BLUETOOTH_LE,
             battery=battery,
         )
 

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -19,7 +19,7 @@ from homeassistant.components.device_tracker.const import (
     CONF_TRACK_NEW,
     DEFAULT_TRACK_NEW,
     SCAN_INTERVAL,
-    SOURCE_TYPE_BLUETOOTH,
+    SourceType,
 )
 from homeassistant.components.device_tracker.legacy import (
     YAML_DEVICES,
@@ -93,7 +93,7 @@ async def see_device(
         mac=f"{BT_PREFIX}{mac}",
         host_name=device_name,
         attributes=attributes,
-        source_type=SOURCE_TYPE_BLUETOOTH,
+        source_type=SourceType.BLUETOOTH,
     )
 
 

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -2,11 +2,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal
 
 from bimmer_connected.vehicle import MyBMWVehicle
 
-from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -80,6 +79,6 @@ class BMWDeviceTracker(BMWBaseEntity, TrackerEntity):
         )
 
     @property
-    def source_type(self) -> Literal["gps"]:
+    def source_type(self) -> SourceType:
         """Return the source type, eg gps or router, of the device."""
-        return SOURCE_TYPE_GPS
+        return SourceType.GPS

--- a/homeassistant/components/devolo_home_network/device_tracker.py
+++ b/homeassistant/components/devolo_home_network/device_tracker.py
@@ -7,7 +7,7 @@ from devolo_plc_api.device import Device
 
 from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN,
-    SOURCE_TYPE_ROUTER,
+    SourceType,
 )
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
@@ -149,9 +149,9 @@ class DevoloScannerEntity(CoordinatorEntity, ScannerEntity):
         return self._mac
 
     @property
-    def source_type(self) -> str:
+    def source_type(self) -> SourceType:
         """Return tracker source type."""
-        return SOURCE_TYPE_ROUTER
+        return SourceType.ROUTER
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -31,7 +31,7 @@ from homeassistant.components.device_tracker.const import (
     ATTR_SOURCE_TYPE,
     CONNECTED_DEVICE_REGISTERED,
     DOMAIN as DEVICE_TRACKER_DOMAIN,
-    SOURCE_TYPE_ROUTER,
+    SourceType,
 )
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
@@ -318,7 +318,7 @@ class DeviceTrackerWatcher(WatcherBase):
 
         attributes = state.attributes
 
-        if attributes.get(ATTR_SOURCE_TYPE) != SOURCE_TYPE_ROUTER:
+        if attributes.get(ATTR_SOURCE_TYPE) != SourceType.ROUTER:
             return
 
         ip_address = attributes.get(ATTR_IP)

--- a/homeassistant/components/freebox/device_tracker.py
+++ b/homeassistant/components/freebox/device_tracker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from homeassistant.components.device_tracker import SOURCE_TYPE_ROUTER
+from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -98,9 +98,9 @@ class FreeboxDevice(ScannerEntity):
         return self._active
 
     @property
-    def source_type(self) -> str:
+    def source_type(self) -> SourceType:
         """Return the source type."""
-        return SOURCE_TYPE_ROUTER
+        return SourceType.ROUTER
 
     @property
     def icon(self) -> str:

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 import logging
 
-from homeassistant.components.device_tracker import SOURCE_TYPE_ROUTER
+from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -118,6 +118,6 @@ class FritzBoxTracker(FritzDeviceBase, ScannerEntity):
         return attrs
 
     @property
-    def source_type(self) -> str:
+    def source_type(self) -> SourceType:
         """Return tracker source type."""
-        return SOURCE_TYPE_ROUTER
+        return SourceType.ROUTER

--- a/homeassistant/components/geofency/device_tracker.py
+++ b/homeassistant/components/geofency/device_tracker.py
@@ -1,5 +1,5 @@
 """Support for the Geofency device tracker platform."""
-from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
@@ -96,9 +96,9 @@ class GeofencyEntity(TrackerEntity, RestoreEntity):
         return DeviceInfo(identifiers={(GF_DOMAIN, self._unique_id)}, name=self._name)
 
     @property
-    def source_type(self):
+    def source_type(self) -> SourceType:
         """Return the source type, eg gps or router, of the device."""
-        return SOURCE_TYPE_GPS
+        return SourceType.GPS
 
     async def async_added_to_hass(self):
         """Register state update callback."""

--- a/homeassistant/components/google_maps/device_tracker.py
+++ b/homeassistant/components/google_maps/device_tracker.py
@@ -10,8 +10,8 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA as PLATFORM_SCHEMA_BASE,
-    SOURCE_TYPE_GPS,
     SeeCallback,
+    SourceType,
 )
 from homeassistant.const import (
     ATTR_BATTERY_CHARGING,
@@ -129,7 +129,7 @@ class GoogleMapsScanner:
                 dev_id=dev_id,
                 gps=(person.latitude, person.longitude),
                 picture=person.picture_url,
-                source_type=SOURCE_TYPE_GPS,
+                source_type=SourceType.GPS,
                 gps_accuracy=person.accuracy,
                 attributes=attrs,
             )

--- a/homeassistant/components/gpslogger/device_tracker.py
+++ b/homeassistant/components/gpslogger/device_tracker.py
@@ -1,5 +1,5 @@
 """Support for the GPSLogger device tracking."""
-from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -118,9 +118,9 @@ class GPSLoggerEntity(TrackerEntity, RestoreEntity):
         return DeviceInfo(identifiers={(GPL_DOMAIN, self._unique_id)}, name=self._name)
 
     @property
-    def source_type(self):
+    def source_type(self) -> SourceType:
         """Return the source type, eg gps or router, of the device."""
-        return SOURCE_TYPE_GPS
+        return SourceType.GPS
 
     async def async_added_to_hass(self):
         """Register state update callback."""


### PR DESCRIPTION
## Proposed change
Update integrations to use new `SourceType` enum.
Ref: #75892


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1414

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
