### PR TITLE
Add bluetooth API to allow rediscovery of address

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -212,6 +212,13 @@ def async_track_unavailable(
     return manager.async_track_unavailable(callback, address)
 
 
+@hass_callback
+def async_rediscover_domains(hass: HomeAssistant, domains: set[str]) -> None:
+    """Trigger discovery of devices which have already been seen on a domain."""
+    manager: BluetoothManager = hass.data[DOMAIN]
+    manager.async_rediscover_domains(domains)
+
+
 async def _async_has_bluetooth_adapter() -> bool:
     """Return if the device has a bluetooth adapter."""
     return bool(await async_get_bluetooth_adapters())
@@ -514,3 +521,8 @@ class BluetoothManager:
                 # change the bluetooth dongle.
                 _LOGGER.error("Error stopping scanner: %s", ex)
         uninstall_multiple_bleak_catcher()
+
+    @hass_callback
+    def async_rediscover_domains(self, domains: set[str]) -> None:
+        """Trigger discovery of devices which have already been seen on a domain."""
+        self._integration_matcher.async_clear_domains(domains)

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -213,10 +213,10 @@ def async_track_unavailable(
 
 
 @hass_callback
-def async_rediscover_domains(hass: HomeAssistant, domains: set[str]) -> None:
-    """Trigger discovery of devices which have already been seen on a domain."""
+def async_rediscover_address(hass: HomeAssistant, address: str) -> None:
+    """Trigger discovery of devices which have already been seen."""
     manager: BluetoothManager = hass.data[DOMAIN]
-    manager.async_rediscover_domains(domains)
+    manager.async_rediscover_address(address)
 
 
 async def _async_has_bluetooth_adapter() -> bool:
@@ -523,6 +523,6 @@ class BluetoothManager:
         uninstall_multiple_bleak_catcher()
 
     @hass_callback
-    def async_rediscover_domains(self, domains: set[str]) -> None:
-        """Trigger discovery of devices which have already been seen on a domain."""
-        self._integration_matcher.async_clear_domains(domains)
+    def async_rediscover_address(self, address: str) -> None:
+        """Trigger discovery of devices which have already been seen."""
+        self._integration_matcher.async_clear_address(address)

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -47,6 +47,7 @@ class IntegrationMatchHistory:
     manufacturer_data: bool
     service_data: bool
     service_uuids: bool
+    domains: set[str]
 
 
 def seen_all_fields(
@@ -78,6 +79,14 @@ class IntegrationMatcher:
         """Clear the history."""
         self._matched = {}
 
+    def async_clear_domains(self, domains: set[str]) -> None:
+        """Clear the history matches for a set of domains."""
+        self._matched = {
+            key: value
+            for key, value in self._matched.items()
+            if not (domains & value.domains)
+        }
+
     def match_domains(self, device: BLEDevice, adv_data: AdvertisementData) -> set[str]:
         """Return the domains that are matched."""
         matched_domains: set[str] = set()
@@ -102,6 +111,7 @@ class IntegrationMatcher:
                 manufacturer_data=bool(adv_data.manufacturer_data),
                 service_data=bool(adv_data.service_data),
                 service_uuids=bool(adv_data.service_uuids),
+                domains=matched_domains,
             )
         return matched_domains
 

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -47,7 +47,6 @@ class IntegrationMatchHistory:
     manufacturer_data: bool
     service_data: bool
     service_uuids: bool
-    domains: set[str]
 
 
 def seen_all_fields(
@@ -107,7 +106,6 @@ class IntegrationMatcher:
                 manufacturer_data=bool(adv_data.manufacturer_data),
                 service_data=bool(adv_data.service_data),
                 service_uuids=bool(adv_data.service_uuids),
-                domains=matched_domains,
             )
         return matched_domains
 

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -10,7 +10,7 @@ from lru import LRU  # pylint: disable=no-name-in-module
 from homeassistant.loader import BluetoothMatcher, BluetoothMatcherOptional
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import MutableMapping
 
     from bleak.backends.device import BLEDevice
     from bleak.backends.scanner import AdvertisementData
@@ -71,7 +71,7 @@ class IntegrationMatcher:
         self._integration_matchers = integration_matchers
         # Some devices use a random address so we need to use
         # an LRU to avoid memory issues.
-        self._matched: Mapping[str, IntegrationMatchHistory] = LRU(
+        self._matched: MutableMapping[str, IntegrationMatchHistory] = LRU(
             MAX_REMEMBER_ADDRESSES
         )
 
@@ -79,13 +79,9 @@ class IntegrationMatcher:
         """Clear the history."""
         self._matched = {}
 
-    def async_clear_domains(self, domains: set[str]) -> None:
+    def async_clear_address(self, address: str) -> None:
         """Clear the history matches for a set of domains."""
-        self._matched = {
-            key: value
-            for key, value in self._matched.items()
-            if not (domains & value.domains)
-        }
+        self._matched.pop(address, None)
 
     def match_domains(self, device: BLEDevice, adv_data: AdvertisementData) -> set[str]:
         """Return the domains that are matched."""
@@ -107,7 +103,7 @@ class IntegrationMatcher:
             previous_match.service_data |= bool(adv_data.service_data)
             previous_match.service_uuids |= bool(adv_data.service_uuids)
         else:
-            self._matched[device.address] = IntegrationMatchHistory(  # type: ignore[index]
+            self._matched[device.address] = IntegrationMatchHistory(
                 manufacturer_data=bool(adv_data.manufacturer_data),
                 service_data=bool(adv_data.service_data),
                 service_uuids=bool(adv_data.service_uuids),

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -15,6 +15,7 @@ from homeassistant.components.bluetooth import (
     BluetoothScanningMode,
     BluetoothServiceInfo,
     async_process_advertisements,
+    async_rediscover_domains,
     async_track_unavailable,
     models,
 )
@@ -557,6 +558,45 @@ async def test_discovery_match_first_by_service_uuid_and_then_manufacturer_id(
         _get_underlying_scanner()._callback(device, adv_manufacturer_data)
         await hass.async_block_till_done()
         assert len(mock_config_flow.mock_calls) == 0
+
+
+async def test_rediscovery(hass, mock_bleak_scanner_start, enable_bluetooth):
+    """Test bluetooth discovery can be re-enabled for a given domain."""
+    mock_bt = [
+        {"domain": "switchbot", "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"}
+    ]
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
+        assert await async_setup_component(
+            hass, bluetooth.DOMAIN, {bluetooth.DOMAIN: {}}
+        )
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_adv = AdvertisementData(
+            local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+        )
+
+        _get_underlying_scanner()._callback(switchbot_device, switchbot_adv)
+        await hass.async_block_till_done()
+
+        _get_underlying_scanner()._callback(switchbot_device, switchbot_adv)
+        await hass.async_block_till_done()
+
+        assert len(mock_config_flow.mock_calls) == 1
+        assert mock_config_flow.mock_calls[0][1][0] == "switchbot"
+
+        async_rediscover_domains(hass, {"switchbot"})
+
+        _get_underlying_scanner()._callback(switchbot_device, switchbot_adv)
+        await hass.async_block_till_done()
+
+        assert len(mock_config_flow.mock_calls) == 2
+        assert mock_config_flow.mock_calls[1][1][0] == "switchbot"
 
 
 async def test_async_discovered_device_api(hass, mock_bleak_scanner_start):

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.components.bluetooth import (
     BluetoothScanningMode,
     BluetoothServiceInfo,
     async_process_advertisements,
-    async_rediscover_domains,
+    async_rediscover_address,
     async_track_unavailable,
     models,
 )
@@ -590,7 +590,7 @@ async def test_rediscovery(hass, mock_bleak_scanner_start, enable_bluetooth):
         assert len(mock_config_flow.mock_calls) == 1
         assert mock_config_flow.mock_calls[0][1][0] == "switchbot"
 
-        async_rediscover_domains(hass, {"switchbot"})
+        async_rediscover_address(hass, "44:44:33:11:23:45")
 
         _get_underlying_scanner()._callback(switchbot_device, switchbot_adv)
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an API to rediscover bluetooth devices once an integration is removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

 - Link to relevant existing code or pull request: https://github.com/home-assistant/developers.home-assistant/pull/1423

Currently when an integration that was added using bluetooth discovery is removed, the device it managed will not be discovered again until next restart of home assistant.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
