### PR TITLE
Add update entity to mikrotik

### DIFF
--- a/homeassistant/components/mikrotik/__init__.py
+++ b/homeassistant/components/mikrotik/__init__.py
@@ -14,7 +14,7 @@ from .hub import MikrotikDataUpdateCoordinator, get_api
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
-PLATFORMS = [Platform.DEVICE_TRACKER]
+PLATFORMS = [Platform.DEVICE_TRACKER, Platform.UPDATE]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -31,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     await coordinator.async_config_entry_first_refresh()
     config_entry.async_on_unload(
         async_track_time_interval(
-            hass, coordinator.api.update_firmware_details, timedelta(hours=1)
+            hass, coordinator.api.update_firmware_version, timedelta(hours=1)
         )
     )
 
@@ -46,7 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         manufacturer=ATTR_MANUFACTURER,
         model=coordinator.model,
         name=coordinator.hostname,
-        sw_version=coordinator.api.current_firmware_version,
+        sw_version=coordinator.api.installed_version,
     )
 
     return True

--- a/homeassistant/components/mikrotik/const.py
+++ b/homeassistant/components/mikrotik/const.py
@@ -8,7 +8,6 @@ DEFAULT_DETECTION_TIME: Final = 300
 
 ATTR_MANUFACTURER: Final = "Mikrotik"
 ATTR_SERIAL_NUMBER: Final = "serial-number"
-ATTR_FIRMWARE: Final = "current-firmware"
 ATTR_MODEL: Final = "model"
 
 CONF_ARP_PING: Final = "arp_ping"
@@ -26,6 +25,7 @@ DHCP: Final = "dhcp"
 WIRELESS: Final = "wireless"
 IS_WIRELESS: Final = "is_wireless"
 IS_CAPSMAN: Final = "is_capsman"
+FIRMWARE: Final = "firmware"
 
 MIKROTIK_SERVICES: Final = {
     ARP: "/ip/arp/getall",
@@ -36,8 +36,8 @@ MIKROTIK_SERVICES: Final = {
     WIRELESS: "/interface/wireless/registration-table/getall",
     IS_WIRELESS: "/interface/wireless/print",
     IS_CAPSMAN: "/caps-man/interface/print",
+    FIRMWARE: "/system/package/update",
 }
-
 
 ATTR_DEVICE_TRACKER: Final = [
     "comment",

--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -18,7 +18,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import (
     ARP,
-    ATTR_DEVICE_TRACKER,
     ATTR_MODEL,
     ATTR_SERIAL_NUMBER,
     CAPSMAN,
@@ -60,8 +59,8 @@ class MikrotikData:
         self.support_wireless: bool = False
         self.hostname: str = ""
         self.model: str = ""
-        self.current_firmware_version: str = ""
-        self.latest_firmware_version: str = ""
+        self.installed_version: str | None = None
+        self.latest_version: str | None = None
         self.serial_number: str = ""
 
     @staticmethod
@@ -91,17 +90,17 @@ class MikrotikData:
             return str(data[0].get(param))
         return ""
 
-    def update_firmware_details(self, now=None) -> None:
-        """Return hub firmware version."""
+    def update_firmware_version(self, *_: Any) -> None:
+        """Update hub firmware installed and latest version."""
         if data := self.command(f"{MIKROTIK_SERVICES[FIRMWARE]}/check-for-updates"):
-            self.current_firmware_version = str(data[-1]["installed-version"])
-            self.latest_firmware_version = str(data[-1]["latest-version"])
+            self.installed_version = str(data[-1].get("installed-version"))
+            self.latest_version = str(data[-1].get("latest-version"))
 
-    def install_latest_firmware_version(self) -> None:
+    def install_update(self) -> None:
         """Install hub latest firmware version."""
         if data := self.command(f"{MIKROTIK_SERVICES[FIRMWARE]}/install"):
-            self.current_firmware_version = str(data[-1]["installed-version"])
-            self.latest_firmware_version = str(data[-1]["latest-version"])
+            self.installed_version = str(data[-1].get("installed-version"))
+            self.latest_version = str(data[-1].get("latest-version"))
 
     def get_hub_details(self) -> None:
         """Get Hub info."""
@@ -110,7 +109,7 @@ class MikrotikData:
         self.serial_number = self.get_info(ATTR_SERIAL_NUMBER)
         self.support_capsman = bool(self.command(MIKROTIK_SERVICES[IS_CAPSMAN]))
         self.support_wireless = bool(self.command(MIKROTIK_SERVICES[IS_WIRELESS]))
-        self.update_firmware_details()
+        self.update_firmware_version()
 
     def get_list_from_interface(self, interface: str) -> dict[str, dict[str, Any]]:
         """Get devices from interface."""

--- a/homeassistant/components/mikrotik/update.py
+++ b/homeassistant/components/mikrotik/update.py
@@ -9,7 +9,6 @@ from homeassistant.components.update import (
     UpdateEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -36,13 +35,14 @@ class MikrotikUpdateEntity(
 
     _attr_device_class = UpdateDeviceClass.FIRMWARE
     _attr_supported_features = UpdateEntityFeature.INSTALL
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator: MikrotikDataUpdateCoordinator) -> None:
         """Initialize the update entity."""
         super().__init__(coordinator)
-        self._attr_name = f"{self.coordinator.config_entry.data[CONF_NAME]} Update"
+        self._attr_name = "Firmware"
         self._attr_title = self.coordinator.model
-        self._attr_unique_id = coordinator.serial_num
+        self._attr_unique_id = f"{coordinator.serial_num}-firmware-update"
         self._attr_device_info = DeviceInfo(
             connections={(DOMAIN, coordinator.serial_num)}, name=self._attr_name
         )
@@ -50,12 +50,12 @@ class MikrotikUpdateEntity(
     @property
     def installed_version(self) -> str | None:
         """Version currently installed and in use."""
-        return self.coordinator.api.current_firmware_version or None
+        return self.coordinator.api.installed_version
 
     @property
     def latest_version(self) -> str | None:
         """Latest version available for install."""
-        return self.coordinator.api.latest_firmware_version or None
+        return self.coordinator.api.latest_version
 
     @property
     def release_url(self) -> str | None:
@@ -66,6 +66,4 @@ class MikrotikUpdateEntity(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.install_latest_firmware_version
-        )
+        await self.hass.async_add_executor_job(self.coordinator.api.install_update)

--- a/homeassistant/components/mikrotik/update.py
+++ b/homeassistant/components/mikrotik/update.py
@@ -44,7 +44,8 @@ class MikrotikUpdateEntity(
         self._attr_title = self.coordinator.model
         self._attr_unique_id = f"{coordinator.serial_num}-firmware-update"
         self._attr_device_info = DeviceInfo(
-            connections={(DOMAIN, coordinator.serial_num)}, name=self._attr_name
+            connections={(DOMAIN, coordinator.serial_num)},
+            name=self.coordinator.hostname,
         )
 
     @property

--- a/homeassistant/components/mikrotik/update.py
+++ b/homeassistant/components/mikrotik/update.py
@@ -1,0 +1,71 @@
+"""Support for WLED updates."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .hub import MikrotikDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Mikrotik hub update entity."""
+    coordinator: MikrotikDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([MikrotikUpdateEntity(coordinator)])
+
+
+class MikrotikUpdateEntity(
+    CoordinatorEntity[MikrotikDataUpdateCoordinator], UpdateEntity
+):
+    """Defines a Mikrotik update entity."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_supported_features = UpdateEntityFeature.INSTALL
+
+    def __init__(self, coordinator: MikrotikDataUpdateCoordinator) -> None:
+        """Initialize the update entity."""
+        super().__init__(coordinator)
+        self._attr_name = f"{self.coordinator.config_entry.data[CONF_NAME]} Update"
+        self._attr_title = self.coordinator.model
+        self._attr_unique_id = coordinator.serial_num
+        self._attr_device_info = DeviceInfo(
+            connections={(DOMAIN, coordinator.serial_num)}, name=self._attr_name
+        )
+
+    @property
+    def installed_version(self) -> str | None:
+        """Version currently installed and in use."""
+        return self.coordinator.api.current_firmware_version or None
+
+    @property
+    def latest_version(self) -> str | None:
+        """Latest version available for install."""
+        return self.coordinator.api.latest_firmware_version or None
+
+    @property
+    def release_url(self) -> str | None:
+        """URL to the changelogs of the latest version available."""
+        return "https://mikrotik.com/download/changelogs"
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install an update."""
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.install_latest_firmware_version
+        )

--- a/tests/components/mikrotik/__init__.py
+++ b/tests/components/mikrotik/__init__.py
@@ -13,7 +13,6 @@ from homeassistant.components.mikrotik.const import (
 )
 from homeassistant.const import (
     CONF_HOST,
-    CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_USERNAME,
@@ -24,7 +23,6 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 MOCK_DATA = {
-    CONF_NAME: "Mikrotik",
     CONF_HOST: "0.0.0.0",
     CONF_USERNAME: "user",
     CONF_PASSWORD: "pass",
@@ -140,10 +138,16 @@ ARP_DATA = [
     },
 ]
 
-MOCK_UPDATE_INFO = {
+NEW_UPDATE_INFO = {
     "installed-version": "1.0",
     "latest-version": "2.0",
     "status": "New version is available",
+}
+
+UPDATE_INSTALLED_INFO = {
+    "installed-version": "2.0",
+    "latest-version": "2.0",
+    "status": "System is already up to date",
 }
 
 
@@ -166,7 +170,7 @@ async def setup_mikrotik_entry(hass: HomeAssistant, **kwargs: Any) -> None:
             cmd
             == f"{mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.FIRMWARE]}/check-for-updates"
         ):
-            return [MOCK_UPDATE_INFO]
+            return [NEW_UPDATE_INFO]
         return []
 
     options: dict[str, Any] = {}

--- a/tests/components/mikrotik/__init__.py
+++ b/tests/components/mikrotik/__init__.py
@@ -140,6 +140,12 @@ ARP_DATA = [
     },
 ]
 
+MOCK_UPDATE_INFO = {
+    "installed-version": "1.0",
+    "latest-version": "2.0",
+    "status": "New version is available",
+}
+
 
 async def setup_mikrotik_entry(hass: HomeAssistant, **kwargs: Any) -> None:
     """Set up Mikrotik integration successfully."""
@@ -156,7 +162,12 @@ async def setup_mikrotik_entry(hass: HomeAssistant, **kwargs: Any) -> None:
             return wireless_data
         if cmd == mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.ARP]:
             return ARP_DATA
-        return {}
+        if (
+            cmd
+            == f"{mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.FIRMWARE]}/check-for-updates"
+        ):
+            return [MOCK_UPDATE_INFO]
+        return []
 
     options: dict[str, Any] = {}
     if "force_dhcp" in kwargs:

--- a/tests/components/mikrotik/test_update.py
+++ b/tests/components/mikrotik/test_update.py
@@ -1,5 +1,7 @@
 """Tests for Fritz!Tools update platform."""
+from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant.components.mikrotik.const import FIRMWARE, MIKROTIK_SERVICES
@@ -7,13 +9,13 @@ from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
 from homeassistant.components.update.const import SERVICE_INSTALL
 from homeassistant.core import HomeAssistant
 
-from . import MOCK_UPDATE_INFO, setup_mikrotik_entry
+from . import UPDATE_INSTALLED_INFO, setup_mikrotik_entry
 
 
-def mock_command(self, cmd, params=None):
+def mock_command(self, cmd: str, params: dict[str, Any] | None = None) -> Any:
     """Mock the Mikrotik command method."""
     if cmd == f"{MIKROTIK_SERVICES[FIRMWARE]}/install":
-        return [MOCK_UPDATE_INFO]
+        return [UPDATE_INSTALLED_INFO]
 
 
 async def test_update_available(hass: HomeAssistant) -> None:
@@ -21,7 +23,7 @@ async def test_update_available(hass: HomeAssistant) -> None:
 
     await setup_mikrotik_entry(hass)
 
-    update = hass.states.get("update.mikrotik_update")
+    update = hass.states.get("update.firmware")
     assert update is not None
     assert update.state == "on"
     assert update.attributes.get("installed_version") == "1.0"
@@ -37,7 +39,7 @@ async def test_available_update_can_be_installed(hass: HomeAssistant) -> None:
 
     await setup_mikrotik_entry(hass)
 
-    update = hass.states.get("update.mikrotik_update")
+    update = hass.states.get("update.firmware")
     assert update is not None
     assert update.state == "on"
     assert update.attributes.get("installed_version") == "1.0"
@@ -47,20 +49,17 @@ async def test_available_update_can_be_installed(hass: HomeAssistant) -> None:
         == "https://mikrotik.com/download/changelogs"
     )
 
-    MOCK_UPDATE_INFO["installed-version"] = "2.0"
-    MOCK_UPDATE_INFO["status"] = "System is already up to date"
-
     with patch(
         "homeassistant.components.mikrotik.hub.MikrotikData.command", new=mock_command
     ):
         assert await hass.services.async_call(
             UPDATE_DOMAIN,
             SERVICE_INSTALL,
-            {"entity_id": "update.mikrotik_update"},
+            {"entity_id": "update.firmware"},
             blocking=True,
         )
 
-    update = hass.states.get("update.mikrotik_update")
+    update = hass.states.get("update.firmware")
     assert update is not None
     assert update.state == "off"
     assert update.attributes.get("installed_version") == "2.0"

--- a/tests/components/mikrotik/test_update.py
+++ b/tests/components/mikrotik/test_update.py
@@ -1,0 +1,67 @@
+"""Tests for Fritz!Tools update platform."""
+
+from unittest.mock import patch
+
+from homeassistant.components.mikrotik.const import FIRMWARE, MIKROTIK_SERVICES
+from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
+from homeassistant.components.update.const import SERVICE_INSTALL
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_UPDATE_INFO, setup_mikrotik_entry
+
+
+def mock_command(self, cmd, params=None):
+    """Mock the Mikrotik command method."""
+    if cmd == f"{MIKROTIK_SERVICES[FIRMWARE]}/install":
+        return [MOCK_UPDATE_INFO]
+
+
+async def test_update_available(hass: HomeAssistant) -> None:
+    """Test update entities."""
+
+    await setup_mikrotik_entry(hass)
+
+    update = hass.states.get("update.mikrotik_update")
+    assert update is not None
+    assert update.state == "on"
+    assert update.attributes.get("installed_version") == "1.0"
+    assert update.attributes.get("latest_version") == "2.0"
+    assert (
+        update.attributes.get("release_url")
+        == "https://mikrotik.com/download/changelogs"
+    )
+
+
+async def test_available_update_can_be_installed(hass: HomeAssistant) -> None:
+    """Test installing update."""
+
+    await setup_mikrotik_entry(hass)
+
+    update = hass.states.get("update.mikrotik_update")
+    assert update is not None
+    assert update.state == "on"
+    assert update.attributes.get("installed_version") == "1.0"
+    assert update.attributes.get("latest_version") == "2.0"
+    assert (
+        update.attributes.get("release_url")
+        == "https://mikrotik.com/download/changelogs"
+    )
+
+    MOCK_UPDATE_INFO["installed-version"] = "2.0"
+    MOCK_UPDATE_INFO["status"] = "System is already up to date"
+
+    with patch(
+        "homeassistant.components.mikrotik.hub.MikrotikData.command", new=mock_command
+    ):
+        assert await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {"entity_id": "update.mikrotik_update"},
+            blocking=True,
+        )
+
+    update = hass.states.get("update.mikrotik_update")
+    assert update is not None
+    assert update.state == "off"
+    assert update.attributes.get("installed_version") == "2.0"
+    assert update.attributes.get("latest_version") == "2.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add update entity to the mikrotik hub.
- `installed-version` and `latest-version` are now pull from `/system/package/update`.
- Mikrotik doesn't check for updates automatically so an hourly call for `check-for-updates` is done to check for new version.
- When checking for update or installing the new update the response is a list of dictionaiers each including the current status (like 'Downloading' or 'System is already up to date'. We look at the last element of the reposne list for the firmware version details.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
