### PR TITLE
Use Callback protocol for AutomationActionType

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -1,9 +1,9 @@
 """Allow to set up simple automation rules via the config file."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 import logging
-from typing import Any, TypedDict, cast
+from typing import Any, Protocol, TypedDict, cast
 
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
@@ -110,7 +110,18 @@ ATTR_VARIABLES = "variables"
 SERVICE_TRIGGER = "trigger"
 
 _LOGGER = logging.getLogger(__name__)
-AutomationActionType = Callable[[HomeAssistant, TemplateVarsType], Awaitable[None]]
+
+
+class AutomationActionType(Protocol):
+    """Protocol type for automation action callback."""
+
+    async def __call__(
+        self,
+        run_variables: dict[str, Any],
+        context: Context | None = None,
+        skip_condition: bool = False,
+    ) -> None:
+        """Define action callback type."""
 
 
 class AutomationTriggerData(TypedDict):
@@ -437,7 +448,12 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         else:
             await self.async_disable()
 
-    async def async_trigger(self, run_variables, context=None, skip_condition=False):
+    async def async_trigger(
+        self,
+        run_variables: dict[str, Any],
+        context: Context | None = None,
+        skip_condition: bool = False,
+    ) -> None:
         """Trigger automation.
 
         This method is a coroutine.
@@ -462,7 +478,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             this = None
             if state := self.hass.states.get(self.entity_id):
                 this = state.as_dict()
-            variables = {"this": this, **(run_variables or {})}
+            variables: dict[str, Any] = {"this": this, **(run_variables or {})}
             if self._variables:
                 try:
                     variables = self._variables.async_render(self.hass, variables)

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -119,7 +119,6 @@ class AutomationActionType(Protocol):
         self,
         run_variables: dict[str, Any],
         context: Context | None = None,
-        skip_condition: bool = False,
     ) -> None:
         """Define action callback type."""
 

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -1,6 +1,7 @@
 """Offer calendar automation rules."""
 from __future__ import annotations
 
+from collections.abc import Coroutine
 import datetime
 import logging
 from typing import Any
@@ -47,7 +48,7 @@ class CalendarEventListener:
     def __init__(
         self,
         hass: HomeAssistant,
-        job: HassJob,
+        job: HassJob[..., Coroutine[Any, Any, None]],
         trigger_data: dict[str, Any],
         entity: CalendarEntity,
         event_type: str,

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -66,7 +66,7 @@ class DeviceTriggerAccessory(HomeAccessory):
 
     async def async_trigger(
         self,
-        run_variables: dict,
+        run_variables: dict[str, Any],
         context: Context | None = None,
         skip_condition: bool = False,
     ) -> None:

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Coroutine, Mapping
 from datetime import timedelta
 import logging
 from typing import Any
@@ -77,7 +77,9 @@ class PluggableAction:
     def __init__(self, update: Callable[[], None]) -> None:
         """Initialize."""
         self._update = update
-        self._actions: dict[Any, tuple[HassJob, dict[str, Any]]] = {}
+        self._actions: dict[
+            Any, tuple[HassJob[..., Coroutine[Any, Any, None]], dict[str, Any]]
+        ] = {}
 
     def __bool__(self):
         """Return if we have something attached."""

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -1,7 +1,7 @@
 """Support for LG webOS Smart TV."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from contextlib import suppress
 import logging
 from typing import Any
@@ -170,7 +170,10 @@ class PluggableAction:
 
     def __init__(self) -> None:
         """Initialize."""
-        self._actions: dict[Callable[[], None], tuple[HassJob, dict[str, Any]]] = {}
+        self._actions: dict[
+            Callable[[], None],
+            tuple[HassJob[..., Coroutine[Any, Any, None]], dict[str, Any]],
+        ] = {}
 
     def __bool__(self) -> bool:
         """Return if we have something attached."""


### PR DESCRIPTION
## Proposed change
Fix `AutomationActionType` and convert it to a Callback protocol.

AFAICT it is only ever used in the context of device triggers. More specifically, `AutomationEntity.async_trigger` is passed as `action` to `async_attach_trigger`.
https://github.com/home-assistant/core/blob/3eafe13085444a5f29b57c3a43740eff5be36f35/homeassistant/components/automation/__init__.py#L440-L444 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
