### PR TITLE
Add support for SwitchBot Plug Mini

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1046,8 +1046,8 @@ build.json @home-assistant/supervisor
 /tests/components/switch/ @home-assistant/core
 /homeassistant/components/switch_as_x/ @home-assistant/core
 /tests/components/switch_as_x/ @home-assistant/core
-/homeassistant/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas
-/tests/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas
+/homeassistant/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas @Eloston
+/tests/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas @Eloston
 /homeassistant/components/switcher_kis/ @tomerfi @thecode
 /tests/components/switcher_kis/ @tomerfi @thecode
 /homeassistant/components/switchmate/ @danielhiversen @qiz-li

--- a/homeassistant/components/switchbot/__init__.py
+++ b/homeassistant/components/switchbot/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     ATTR_CONTACT,
     ATTR_CURTAIN,
     ATTR_HYGROMETER,
+    ATTR_PLUG,
     CONF_RETRY_COUNT,
     DEFAULT_RETRY_COUNT,
     DOMAIN,
@@ -30,6 +31,7 @@ from .coordinator import SwitchbotDataUpdateCoordinator
 
 PLATFORMS_BY_TYPE = {
     ATTR_BOT: [Platform.SWITCH, Platform.SENSOR],
+    ATTR_PLUG: [Platform.SWITCH, Platform.SENSOR],
     ATTR_CURTAIN: [Platform.COVER, Platform.BINARY_SENSOR, Platform.SENSOR],
     ATTR_HYGROMETER: [Platform.SENSOR],
     ATTR_CONTACT: [Platform.BINARY_SENSOR, Platform.SENSOR],
@@ -37,6 +39,7 @@ PLATFORMS_BY_TYPE = {
 CLASS_BY_DEVICE = {
     ATTR_CURTAIN: switchbot.SwitchbotCurtain,
     ATTR_BOT: switchbot.Switchbot,
+    ATTR_PLUG: switchbot.SwitchbotPlugMini,
 }
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/switchbot/const.py
+++ b/homeassistant/components/switchbot/const.py
@@ -7,12 +7,14 @@ ATTR_BOT = "bot"
 ATTR_CURTAIN = "curtain"
 ATTR_HYGROMETER = "hygrometer"
 ATTR_CONTACT = "contact"
+ATTR_PLUG = "plug"
 DEFAULT_NAME = "Switchbot"
 SUPPORTED_MODEL_TYPES = {
     "WoHand": ATTR_BOT,
     "WoCurtain": ATTR_CURTAIN,
     "WoSensorTH": ATTR_HYGROMETER,
     "WoContact": ATTR_CONTACT,
+    "WoPlug": ATTR_PLUG,
 }
 
 # Config Defaults

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.16.0"],
+  "requirements": ["PySwitchbot==0.17.1"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "codeowners": [

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -5,7 +5,13 @@
   "requirements": ["PySwitchbot==0.16.0"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
-  "codeowners": ["@bdraco", "@danielhiversen", "@RenierM26", "@murtas"],
+  "codeowners": [
+    "@bdraco",
+    "@danielhiversen",
+    "@RenierM26",
+    "@murtas",
+    "@Eloston"
+  ],
   "bluetooth": [
     {
       "service_data_uuid": "0000fd3d-0000-1000-8000-00805f9b34fb"

--- a/homeassistant/components/switchbot/sensor.py
+++ b/homeassistant/components/switchbot/sensor.py
@@ -33,6 +33,13 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    "wifi_rssi": SensorEntityDescription(
+        key="wifi_rssi",
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     "battery": SensorEntityDescription(
         key="battery",
         native_unit_of_measurement=PERCENTAGE,

--- a/homeassistant/components/switchbot/sensor.py
+++ b/homeassistant/components/switchbot/sensor.py
@@ -105,7 +105,7 @@ class SwitchBotSensor(SwitchbotEntity, SensorEntity):
         super().__init__(coordinator, unique_id, address, name=switchbot_name)
         self._sensor = sensor
         self._attr_unique_id = f"{unique_id}-{sensor}"
-        self._attr_name = f"{switchbot_name} {sensor.title()}"
+        self._attr_name = f"{switchbot_name} {sensor.replace('_', ' ').title()}"
         self.entity_description = SENSOR_TYPES[sensor]
 
     @property

--- a/homeassistant/components/switchbot/switch.py
+++ b/homeassistant/components/switchbot/switch.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
     assert unique_id is not None
     async_add_entities(
         [
-            SwitchBotBotEntity(
+            SwitchBotSwitch(
                 coordinator,
                 unique_id,
                 entry.data[CONF_ADDRESS],
@@ -44,8 +44,8 @@ async def async_setup_entry(
     )
 
 
-class SwitchBotBotEntity(SwitchbotEntity, SwitchEntity, RestoreEntity):
-    """Representation of a Switchbot."""
+class SwitchBotSwitch(SwitchbotEntity, SwitchEntity, RestoreEntity):
+    """Representation of a Switchbot switch."""
 
     _attr_device_class = SwitchDeviceClass.SWITCH
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -37,7 +37,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.16.0
+PySwitchbot==0.17.1
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -33,7 +33,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.16.0
+PySwitchbot==0.17.1
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds support for the SwitchBot Plug Mini

Support for the Plug Mini was introduced in https://github.com/Danielhiversen/pySwitchbot/pull/53

Bumped pySwitchbot to 0.17.1 to fix WiFi RSSI: https://github.com/Danielhiversen/pySwitchbot/compare/0.16.0...0.17.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23606

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
