### PR TITLE
Fix serialization of Xiaomi BLE reauth flow

### DIFF
--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -260,7 +260,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         assert entry is not None
 
-        device: DeviceData = self.context["device"]
+        device: DeviceData = entry_data["device"]
         self._discovered_device = device
 
         self._discovery_info = device.last_service_info

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -181,7 +181,7 @@ def process_service_info(
         and data.encryption_scheme != EncryptionScheme.NONE
         and not data.bindkey_verified
     ):
-        entry.async_start_reauth(hass, context={"device": data})
+        entry.async_start_reauth(hass, data={"device": data})
 
     return sensor_update_to_bluetooth_data_update(update)
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -641,7 +641,10 @@ class ConfigEntry:
 
     @callback
     def async_start_reauth(
-        self, hass: HomeAssistant, context: dict[str, Any] | None = None
+        self,
+        hass: HomeAssistant,
+        context: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
     ) -> None:
         """Start a reauth flow."""
         flow_context = {
@@ -662,7 +665,7 @@ class ConfigEntry:
             hass.config_entries.flow.async_init(
                 self.domain,
                 context=flow_context,
-                data=self.data,
+                data=self.data | (data or {}),
             )
         )
 

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -1033,9 +1033,8 @@ async def test_async_step_reauth_abort_early(hass):
             "entry_id": entry.entry_id,
             "title_placeholders": {"name": entry.title},
             "unique_id": entry.unique_id,
-            "device": device,
         },
-        data=entry.data,
+        data=entry.data | {"device": device},
     )
 
     assert result["type"] == FlowResultType.ABORT

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3286,7 +3286,9 @@ async def test_reauth(hass):
     await entry.async_setup(hass)
     await hass.async_block_till_done()
 
-    entry.async_start_reauth(hass, {"extra_context": "some_extra_context"})
+    entry.async_start_reauth(
+        hass, context={"extra_context": "some_extra_context"}, data={"extra_data": 1234}
+    )
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()


### PR DESCRIPTION
## Proposed change

Use `data` instead of `context` in the Xiaomi BLE reauth flow. Fixes this:

```
2022-08-02 19:28:25.668 ERROR (MainThread) [homeassistant.components.websocket_api.messages] Unable to serialize to JSON. Bad data found at $.result[1].context.device=<xiaomi_ble.parser.XiaomiBluetoothDeviceData object at 0x118ea00a0>(<class 'xiaomi_ble.parser.XiaomiBluetoothDeviceData'>
```

If backporting, pick https://github.com/home-assistant/core/pull/76077 first to avoid conflicts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
