### PR TITLE
Handle additional bluetooth start exceptions

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -345,16 +345,21 @@ class BluetoothManager:
                 await self.scanner.start()  # type: ignore[no-untyped-call]
         except InvalidMessageError as ex:
             self._cancel_device_detected()
+            _LOGGER.debug("Invalid DBus message received: %s", ex, exc_info=True)
             raise ConfigEntryNotReady(
-                f"Invalid DBus message received: {ex}; try restarting DBus"
+                f"Invalid DBus message received: {ex}; try restarting `dbus`"
             ) from ex
         except BrokenPipeError as ex:
             self._cancel_device_detected()
+            _LOGGER.debug("DBus connection broken: %s", ex, exc_info=True)
             raise ConfigEntryNotReady(
-                f"DBus connection broken: {ex}; try restarting DBus"
+                f"DBus connection broken: {ex}; try restarting `bluetooth` and `dbus`"
             ) from ex
         except FileNotFoundError as ex:
             self._cancel_device_detected()
+            _LOGGER.debug(
+                "FileNotFoundError while starting bluetooth: %s", ex, exc_info=True
+            )
             if is_docker_env():
                 raise ConfigEntryNotReady(
                     f"DBus service not found; docker config may be missing `-v /run/dbus:/run/dbus:ro`: {ex}"
@@ -369,6 +374,7 @@ class BluetoothManager:
             ) from ex
         except BleakError as ex:
             self._cancel_device_detected()
+            _LOGGER.debug("BleakError while starting bluetooth: %s", ex, exc_info=True)
             raise ConfigEntryNotReady(f"Failed to start Bluetooth: {ex}") from ex
         self.async_setup_unavailable_tracking()
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.async_stop)

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Final
 
 import async_timeout
 from bleak import BleakError
+from dbus_next import InvalidMessageError
 
 from homeassistant import config_entries
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -26,6 +27,7 @@ from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 from homeassistant.loader import async_get_bluetooth
+from homeassistant.util.package import is_docker_env
 
 from . import models
 from .const import CONF_ADAPTER, DEFAULT_ADAPTERS, DOMAIN
@@ -341,12 +343,31 @@ class BluetoothManager:
         try:
             async with async_timeout.timeout(START_TIMEOUT):
                 await self.scanner.start()  # type: ignore[no-untyped-call]
+        except InvalidMessageError as ex:
+            self._cancel_device_detected()
+            raise ConfigEntryNotReady(
+                f"Invalid D-bus message received: {ex}; try restarting D-bus"
+            ) from ex
+        except BrokenPipeError as ex:
+            self._cancel_device_detected()
+            raise ConfigEntryNotReady(
+                f"D-bus connection broken: {ex}; try restarting D-bus"
+            ) from ex
+        except FileNotFoundError as ex:
+            self._cancel_device_detected()
+            if is_docker_env():
+                raise ConfigEntryNotReady(
+                    f"D-bus service not found; docker config may be missing `-v /run/dbus:/run/dbus:ro`: {ex}"
+                ) from ex
+            raise ConfigEntryNotReady(
+                f"D-bus service not found; make sure the D-bus socket is available to Home Assistant: {ex}"
+            ) from ex
         except asyncio.TimeoutError as ex:
             self._cancel_device_detected()
             raise ConfigEntryNotReady(
                 f"Timed out starting Bluetooth after {START_TIMEOUT} seconds"
             ) from ex
-        except (FileNotFoundError, BleakError) as ex:
+        except BleakError as ex:
             self._cancel_device_detected()
             raise ConfigEntryNotReady(f"Failed to start Bluetooth: {ex}") from ex
         self.async_setup_unavailable_tracking()

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -352,6 +352,10 @@ class BluetoothManager:
         except BrokenPipeError as ex:
             self._cancel_device_detected()
             _LOGGER.debug("DBus connection broken: %s", ex, exc_info=True)
+            if is_docker_env():
+                raise ConfigEntryNotReady(
+                    f"DBus connection broken: {ex}; try restarting `bluetooth`, `dbus`, and finally the docker container"
+                ) from ex
             raise ConfigEntryNotReady(
                 f"DBus connection broken: {ex}; try restarting `bluetooth` and `dbus`"
             ) from ex

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -346,21 +346,21 @@ class BluetoothManager:
         except InvalidMessageError as ex:
             self._cancel_device_detected()
             raise ConfigEntryNotReady(
-                f"Invalid D-bus message received: {ex}; try restarting D-bus"
+                f"Invalid DBus message received: {ex}; try restarting DBus"
             ) from ex
         except BrokenPipeError as ex:
             self._cancel_device_detected()
             raise ConfigEntryNotReady(
-                f"D-bus connection broken: {ex}; try restarting D-bus"
+                f"DBus connection broken: {ex}; try restarting DBus"
             ) from ex
         except FileNotFoundError as ex:
             self._cancel_device_detected()
             if is_docker_env():
                 raise ConfigEntryNotReady(
-                    f"D-bus service not found; docker config may be missing `-v /run/dbus:/run/dbus:ro`: {ex}"
+                    f"DBus service not found; docker config may be missing `-v /run/dbus:/run/dbus:ro`: {ex}"
                 ) from ex
             raise ConfigEntryNotReady(
-                f"D-bus service not found; make sure the D-bus socket is available to Home Assistant: {ex}"
+                f"DBus service not found; make sure the DBus socket is available to Home Assistant: {ex}"
             ) from ex
         except asyncio.TimeoutError as ex:
             self._cancel_device_detected()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improves the error reporting so the user has a better chance
of fixing out what is wrong

There are a few upstream PRs that will help as well but they likely won't be out the door in time for release
https://github.com/hbldh/bleak/pull/919
https://github.com/hbldh/bleak/pull/918
https://github.com/hbldh/bleak/pull/920

The following exceptions are now handled
```
2022-08-02 09:23:42.854 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Bluetooth for bluetooth
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 357, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 253, in async_setup_entry
    await manager.async_start(
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 343, in async_start
    await self.scanner.start()  # type: ignore[no-untyped-call]
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/scanner.py", line 128, in start
    manager = await get_global_bluez_manager()
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/manager.py", line 808, in get_global_bluez_manager
    await instance.async_init()
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/manager.py", line 324, in async_init
    reply = await self._bus.call(
  File "/usr/local/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 305, in call
    await future
  File "/usr/local/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 365, in _message_reader
    if self._unmarshaller.unmarshall():
  File "/usr/local/lib/python3.10/site-packages/dbus_next/_private/unmarshaller.py", line 289, in unmarshall
    self._unmarshall()
  File "/usr/local/lib/python3.10/site-packages/dbus_next/_private/unmarshaller.py", line 242, in _unmarshall
    raise InvalidMessageError("Expecting endianness as the first byte")
dbus_next.errors.InvalidMessageError: Expecting endianness as the first byte
```
```
2022-08-02 09:29:00.722 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Bluetooth for bluetooth
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 357, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 253, in async_setup_entry
    await manager.async_start(
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 343, in async_start
    await self.scanner.start()  # type: ignore[no-untyped-call]
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/scanner.py", line 128, in start
    manager = await get_global_bluez_manager()
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/manager.py", line 808, in get_global_bluez_manager
    await instance.async_init()
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/manager.py", line 290, in async_init
    await self._bus.connect()
  File "/usr/local/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 149, in connect
    await self._authenticate()
  File "/usr/local/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 380, in _authenticate
    await self._loop.sock_sendall(self._sock, b0)
  File "/usr/local/lib/python3.10/asyncio/selector_events.py", line 441, in sock_sendall
    n = sock.send(data)
BrokenPipeError: [Errno 32] Broken pipe
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
