### PR TITLE
Fix Xiaomi BLE UI string issues

### DIFF
--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -189,7 +189,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Ack that device is slow."""
-        if user_input is not None or not onboarding.async_is_onboarded(self.hass):
+        if user_input is not None:
             return self._async_get_or_create_entry()
 
         self._set_confirm_only()

--- a/homeassistant/components/xiaomi_ble/strings.json
+++ b/homeassistant/components/xiaomi_ble/strings.json
@@ -11,7 +11,7 @@
       "bluetooth_confirm": {
         "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]"
       },
-      "slow_confirm": {
+      "confirm_slow": {
         "description": "There hasn't been a broadcast from this device in the last minute so we aren't sure if this device uses encryption or not. This may be because the device uses a slow broadcast interval. Confirm to add this device anyway, then the next time a broadcast is received you will be prompted to enter its bindkey if it's needed."
       },
       "get_encryption_key_legacy": {
@@ -27,14 +27,16 @@
         }
       }
     },
+    "error": {
+      "decryption_failed": "The provided bindkey did not work, sensor data could not be decrypted. Please check it and try again.",
+      "expected_24_characters": "Expected a 24 character hexadecimal bindkey.",
+      "expected_32_characters": "Expected a 32 character hexadecimal bindkey."
+    },
     "abort": {
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "decryption_failed": "The provided bindkey did not work, sensor data could not be decrypted. Please check it and try again.",
-      "expected_24_characters": "Expected a 24 character hexadecimal bindkey.",
-      "expected_32_characters": "Expected a 32 character hexadecimal bindkey."
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }

--- a/homeassistant/components/xiaomi_ble/translations/en.json
+++ b/homeassistant/components/xiaomi_ble/translations/en.json
@@ -3,16 +3,21 @@
         "abort": {
             "already_configured": "Device is already configured",
             "already_in_progress": "Configuration flow is already in progress",
-            "decryption_failed": "The provided bindkey did not work, sensor data could not be decrypted. Please check it and try again.",
-            "expected_24_characters": "Expected a 24 character hexadecimal bindkey.",
-            "expected_32_characters": "Expected a 32 character hexadecimal bindkey.",
             "no_devices_found": "No devices found on the network",
             "reauth_successful": "Re-authentication was successful"
+        },
+        "error": {
+            "decryption_failed": "The provided bindkey did not work, sensor data could not be decrypted. Please check it and try again.",
+            "expected_24_characters": "Expected a 24 character hexadecimal bindkey.",
+            "expected_32_characters": "Expected a 32 character hexadecimal bindkey."
         },
         "flow_title": "{name}",
         "step": {
             "bluetooth_confirm": {
                 "description": "Do you want to setup {name}?"
+            },
+            "confirm_slow": {
+                "description": "There hasn't been a broadcast from this device in the last minute so we aren't sure if this device uses encryption or not. This may be because the device uses a slow broadcast interval. Confirm to add this device anyway, then the next time a broadcast is received you will be prompted to enter its bindkey if it's needed."
             },
             "get_encryption_key_4_5": {
                 "data": {
@@ -25,9 +30,6 @@
                     "bindkey": "Bindkey"
                 },
                 "description": "The sensor data broadcast by the sensor is encrypted. In order to decrypt it we need a 24 character hexadecimal bindkey."
-            },
-            "slow_confirm": {
-                "description": "There hasn't been a broadcast from this device in the last minute so we aren't sure if this device uses encryption or not. This may be because the device uses a slow broadcast interval. Confirm to add this device anyway, then the next time a broadcast is received you will be prompted to enter its bindkey if it's needed."
             },
             "user": {
                 "data": {


### PR DESCRIPTION
## Proposed change

Fix a couple of annoying screwups in strings.json in flows I can't test by hand until my LYWSD03MMC arrives (currently on a boat).

Also remove a call to async_is_onboarded that was included by accident when copying `async_step_bluetooth_confirm` that I noticed while testing. Can pull this into a seperate PR if needed.

(Have tested these by hacking my dev instance to make it think my MiFlora was an encrypted device, so should be right now).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
