### PR TITLE
Add homekit_controller thread node capabilties diagnostic sensor

### DIFF
--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -88,6 +88,7 @@ CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.DENSITY_SO2: "sensor",
     CharacteristicsTypes.DENSITY_VOC: "sensor",
     CharacteristicsTypes.IDENTIFY: "button",
+    CharacteristicsTypes.THREAD_NODE_CAPABILITIES: "sensor",
 }
 
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -42,10 +42,10 @@ class HomeKitSensorEntityDescription(SensorEntityDescription):
     """Describes Homekit sensor."""
 
     probe: Callable[[Characteristic], bool] | None = None
-    format: Callable[[Characteristic], str | None] | None = None
+    format: Callable[[Characteristic], str] | None = None
 
 
-def thread_node_capability_to_str(char: Characteristic) -> str | None:
+def thread_node_capability_to_str(char: Characteristic) -> str :
     """
     Return the thread device type as a string.
 
@@ -79,8 +79,8 @@ def thread_node_capability_to_str(char: Characteristic) -> str | None:
         # normally disabled, wakes on occasion to poll for messages from its parent
         return "sleepy"
 
-    # Device has the characteristic but its not a known device type
-    return None
+    # Device has no known thread capabilities
+    return "none"
 
 
 SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -42,10 +42,10 @@ class HomeKitSensorEntityDescription(SensorEntityDescription):
     """Describes Homekit sensor."""
 
     probe: Callable[[Characteristic], bool] | None = None
-    format: Callable[[Characteristic], str] | None = None
+    format: Callable[[Characteristic], str | None] | None = None
 
 
-def thread_node_capability_to_str(char: Characteristic) -> str:
+def thread_node_capability_to_str(char: Characteristic) -> str | None:
     """
     Return the thread device type as a string.
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -45,7 +45,7 @@ class HomeKitSensorEntityDescription(SensorEntityDescription):
     format: Callable[[Characteristic], str] | None = None
 
 
-def thread_node_capability_to_str(char: Characteristic) -> str :
+def thread_node_capability_to_str(char: Characteristic) -> str:
     """
     Return the thread device type as a string.
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
+from aiohomekit.model.characteristics.const import ThreadNodeCapabilities
 from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.components.sensor import (
@@ -27,6 +28,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
@@ -40,6 +42,45 @@ class HomeKitSensorEntityDescription(SensorEntityDescription):
     """Describes Homekit sensor."""
 
     probe: Callable[[Characteristic], bool] | None = None
+    format: Callable[[Characteristic], str] | None = None
+
+
+def thread_node_capability_to_str(char: Characteristic) -> str:
+    """
+    Return the thread device type as a string.
+
+    The underlying value is a bitmask, but we want to turn that to
+    a human readable string. Some devices will have multiple capabilities.
+    For example, an NL55 is SLEEPY | MINIMAL. In that case we return the
+    "best" capability.
+
+    https://openthread.io/guides/thread-primer/node-roles-and-types
+    """
+
+    val = ThreadNodeCapabilities(char.value)
+
+    if val & ThreadNodeCapabilities.BORDER_ROUTER_CAPABLE:
+        # can act as a bridge between thread network and e.g. WiFi
+        return "border_router_capable"
+
+    if val & ThreadNodeCapabilities.ROUTER_ELIGIBLE:
+        # radio always on, can be a router
+        return "router_eligible"
+
+    if val & ThreadNodeCapabilities.FULL:
+        # radio always on, but can't be a router
+        return "full"
+
+    if val & ThreadNodeCapabilities.MINIMAL:
+        # transceiver always on, does not need to poll for messages from its parent
+        return "minimal"
+
+    if val & ThreadNodeCapabilities.SLEEPY:
+        # normally disabled, wakes on occasion to poll for messages from its parent
+        return "sleepy"
+
+    # Device has the characteristic but its not a known device type
+    return None
 
 
 SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {
@@ -194,6 +235,13 @@ SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    ),
+    CharacteristicsTypes.THREAD_NODE_CAPABILITIES: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.THREAD_NODE_CAPABILITIES,
+        name="Thread Capabilities",
+        device_class="homekit_controller__thread_node_capabilities",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        format=thread_node_capability_to_str,
     ),
 }
 
@@ -399,7 +447,10 @@ class SimpleSensor(CharacteristicEntity, SensorEntity):
     @property
     def native_value(self) -> str | int | float:
         """Return the current sensor value."""
-        return self._char.value
+        val = self._char.value
+        if self.entity_description.format:
+            return self.entity_description.format(val)
+        return val
 
 
 ENTITY_TYPES = {

--- a/homeassistant/components/homekit_controller/strings.sensor.json
+++ b/homeassistant/components/homekit_controller/strings.sensor.json
@@ -1,0 +1,12 @@
+{
+    "state": {
+        "homekit_controller__thread_node_capabilities": {
+            "border_router_capable": "Border Router Capable",
+            "router_eligible": "Router Eligible End Device",
+            "full": "Full End Device",
+            "minimal": "Minimal End Device",
+            "sleepy": "Sleepy End Device",
+            "none": "None"
+        }
+    }
+}

--- a/homeassistant/components/homekit_controller/translations/sensor.en.json
+++ b/homeassistant/components/homekit_controller/translations/sensor.en.json
@@ -1,0 +1,12 @@
+{
+    "state": {
+        "homekit_controller__thread_node_capabilities": {
+            "border_router_capable": "Border Router Capable",
+            "full": "Full End Device",
+            "minimal": "Minimal End Device",
+            "none": "None",
+            "router_eligible": "Router Eligible End Device",
+            "sleepy": "Sleepy End Device"
+        }
+    }
+}

--- a/tests/components/homekit_controller/specific_devices/test_nanoleaf_strip_nl55.py
+++ b/tests/components/homekit_controller/specific_devices/test_nanoleaf_strip_nl55.py
@@ -50,6 +50,13 @@ async def test_nanoleaf_nl55_setup(hass):
                     entity_category=EntityCategory.DIAGNOSTIC,
                     state="unknown",
                 ),
+                EntityTestInfo(
+                    entity_id="sensor.nanoleaf_strip_3b32_thread_node_capabilities",
+                    friendly_name="Nanoleaf Strip 3B32 Thread Node Capabilities",
+                    unique_id="homekit-AAAA011111111111-aid:1-sid:31-cid:115",
+                    entity_category=EntityCategory.DIAGNOSTIC,
+                    state="border_router_capable",
+                ),
             ],
         ),
     )

--- a/tests/components/homekit_controller/specific_devices/test_nanoleaf_strip_nl55.py
+++ b/tests/components/homekit_controller/specific_devices/test_nanoleaf_strip_nl55.py
@@ -51,8 +51,8 @@ async def test_nanoleaf_nl55_setup(hass):
                     state="unknown",
                 ),
                 EntityTestInfo(
-                    entity_id="sensor.nanoleaf_strip_3b32_thread_node_capabilities",
-                    friendly_name="Nanoleaf Strip 3B32 Thread Node Capabilities",
+                    entity_id="sensor.nanoleaf_strip_3b32_thread_capabilities",
+                    friendly_name="Nanoleaf Strip 3B32 Thread Capabilities",
                     unique_id="homekit-AAAA011111111111-aid:1-sid:31-cid:115",
                     entity_category=EntityCategory.DIAGNOSTIC,
                     state="border_router_capable",

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -1,8 +1,12 @@
 """Basic checks for HomeKit sensor."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics.const import ThreadNodeCapabilities
 from aiohomekit.model.services import ServicesTypes
 from aiohomekit.protocol.statuscodes import HapStatusCode
 
+from homeassistant.components.homekit_controller.sensor import (
+    thread_node_capability_to_str,
+)
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
 from tests.components.homekit_controller.common import Helper, setup_test_component
@@ -315,3 +319,18 @@ async def test_sensor_unavailable(hass, utcnow):
     # Energy sensor has non-responsive characteristics so should be unavailable
     state = await energy_helper.poll_and_get_state()
     assert state.state == "unavailable"
+
+
+def test_thread_node_caps_to_str():
+    assert (
+        thread_node_capability_to_str(ThreadNodeCapabilities.BORDER_ROUTER_CAPABLE)
+        == "border_router_capable"
+    )
+    assert (
+        thread_node_capability_to_str(ThreadNodeCapabilities.ROUTER_ELIGIBLE)
+        == "router_eligible"
+    )
+    assert thread_node_capability_to_str(ThreadNodeCapabilities.FULL) == "full"
+    assert thread_node_capability_to_str(ThreadNodeCapabilities.MINIMAL) == "minimal"
+    assert thread_node_capability_to_str(ThreadNodeCapabilities.SLEEPY) == "sleepy"
+    assert thread_node_capability_to_str(ThreadNodeCapabilities(128)) == "none"

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -322,6 +322,7 @@ async def test_sensor_unavailable(hass, utcnow):
 
 
 def test_thread_node_caps_to_str():
+    """Test all values of this enum get a translatable string."""
     assert (
         thread_node_capability_to_str(ThreadNodeCapabilities.BORDER_ROUTER_CAPABLE)
         == "border_router_capable"


### PR DESCRIPTION
## Proposed change

In order to diagnose HomeKit over Thread issues it is useful to know what thread capabilities your devices have. This adds a translatable diagnostic sensor for that.

![Screenshot 2022-08-03 at 11 56 35](https://user-images.githubusercontent.com/11544/182591892-d27f93c5-777f-420e-8f77-b412f720c646.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
