### PR TITLE
Do not make Life360 entities unavailable for server errors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -643,6 +643,7 @@ omit =
     homeassistant/components/lg_netcast/media_player.py
     homeassistant/components/lg_soundbar/media_player.py
     homeassistant/components/life360/__init__.py
+    homeassistant/components/life360/binary_sensor.py
     homeassistant/components/life360/const.py
     homeassistant/components/life360/coordinator.py
     homeassistant/components/life360/device_tracker.py

--- a/homeassistant/components/life360/__init__.py
+++ b/homeassistant/components/life360/__init__.py
@@ -39,7 +39,7 @@ from .const import (
 )
 from .coordinator import Life360DataUpdateCoordinator, MissingLocReason
 
-PLATFORMS = [Platform.DEVICE_TRACKER]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
 
 CONF_ACCOUNTS = "accounts"
 

--- a/homeassistant/components/life360/binary_sensor.py
+++ b/homeassistant/components/life360/binary_sensor.py
@@ -1,0 +1,73 @@
+"""Support for Life360 binary sensor."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_USERNAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+
+from .const import DOMAIN
+
+ATTR_REASON = "reason"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the binary sensor platform."""
+    coordinator = hass.data[DOMAIN].coordinators[entry.entry_id]
+    name = f"Life360 Online ({entry.data[CONF_USERNAME]})"
+    async_add_entities([Life360BinarySensor(coordinator, name)])
+
+
+class Life360BinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Life360 Binary Sensor."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, name: str) -> None:
+        """Initialize entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = cast(ConfigEntry, coordinator.config_entry).entry_id
+        self._attr_name = name
+        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+        self._attr_is_on = self.online
+
+    @property
+    def online(self) -> bool:
+        """Return if online."""
+        return super().available
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return True
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_is_on = self.online
+        super()._handle_coordinator_update()
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return entity specific state attributes."""
+        attrs = {}
+        if not self.online:
+            if isinstance(self.coordinator.last_exception, ConfigEntryAuthFailed):
+                attrs[ATTR_REASON] = "Authorization failure"
+            elif isinstance(self.coordinator.last_exception, UpdateFailed):
+                attrs[ATTR_REASON] = "Server communication failure"
+        return attrs


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Converting the Life360 integration from a "legacy" tracker to a new entity-based one,
and using the standard DataUpdateCoordinator and corresponding CoordinatorEntity
classes, had an unexpected and unintentional side-effect when there are errors
retrieving data from the Life360 server. This now causes the state of the corresponding
device_tracker entities to become `unavailable` which did not happen before.

This can (and has) caused user automations to fire when they shouldn't (because the
devices no longer appear "Home", or in some other zone the automation cares about.)

This change prevents the entities from changing to `unavailable`, but rather to retain their
current state, just as they did before, and as other device tracker integrations do in a
similar scenario.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75956, fixes #76105
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
