### PR TITLE
BLE pairing reliablity fixes for HomeKit Controller

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -285,11 +285,6 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
     controller = await async_get_controller(hass)
 
-    # Delete it from aiohomekit's memory cache
-    # as well to ensure we don't try to reuse it
-    # if they repair the accessory
-    controller.async_delete_cached_map(hkid)
-
     # Remove the pairing on the device, making the device discoverable again.
     # Don't reuse any objects in hass.data as they are already unloaded
     controller.load_pairing(hkid, dict(entry.data))

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.typing import ConfigType
 from .config_flow import normalize_hkid
 from .connection import HKDevice, valid_serial_number
 from .const import ENTITY_MAP, KNOWN_DEVICES, TRIGGERS
-from .storage import async_get_entity_storage
+from .storage import EntityMapStorage, async_get_entity_storage
 from .utils import async_get_controller, folded_name
 
 _LOGGER = logging.getLogger(__name__)
@@ -269,7 +269,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hkid = entry.data["AccessoryPairingID"]
 
     if hkid in hass.data[KNOWN_DEVICES]:
-        connection = hass.data[KNOWN_DEVICES][hkid]
+        connection: HKDevice = hass.data[KNOWN_DEVICES][hkid]
         await connection.async_unload()
 
     return True
@@ -280,9 +280,15 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     hkid = entry.data["AccessoryPairingID"]
 
     # Remove cached type data from .storage/homekit_controller-entity-map
-    hass.data[ENTITY_MAP].async_delete_map(hkid)
+    entity_map_storage: EntityMapStorage = hass.data[ENTITY_MAP]
+    entity_map_storage.async_delete_map(hkid)
 
     controller = await async_get_controller(hass)
+
+    # Delete it from aiohomekit's memory cache
+    # as well to ensure we don't try to reuse it
+    # if they repair the accessory
+    controller.async_delete_cached_map(hkid)
 
     # Remove the pairing on the device, making the device discoverable again.
     # Don't reuse any objects in hass.data as they are already unloaded

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -597,7 +597,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         entity_storage = await async_get_entity_storage(self.hass)
         assert self.unique_id is not None
         entity_storage.async_create_or_update_map(
-            pairing_data["AccessoryPairingID"],
+            pairing.id,
             accessories_state.config_num,
             accessories_state.accessories.serialize(),
         )

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -569,7 +569,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         entity_storage = await async_get_entity_storage(self.hass)
         assert self.unique_id is not None
         entity_storage.async_create_or_update_map(
-            self.unique_id,
+            pairing_data["AccessoryPairingID"],
             accessories_state.config_num,
             accessories_state.accessories.serialize(),
         )

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==1.2.3"],
+  "requirements": ["aiohomekit==1.2.4"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
   "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_start": [6] }],
   "dependencies": ["bluetooth", "zeroconf"],

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -85,6 +85,11 @@ class EntityMapStorage:
 
         _LOGGER.debug("Deleting entity map for %s", homekit_id)
         self.storage_data.pop(homekit_id)
+
+        # If the lowercased version was accidentally cached, delete it too
+        lower_homekit_id = homekit_id.lower()
+        if lower_homekit_id in self.storage_data:
+            self.storage_data.pop(lower_homekit_id)
         self._async_schedule_save()
 
     @callback

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, TypedDict
 
 from homeassistant.core import HomeAssistant, callback
@@ -12,6 +13,7 @@ from .const import DOMAIN, ENTITY_MAP
 ENTITY_MAP_STORAGE_KEY = f"{DOMAIN}-entity-map"
 ENTITY_MAP_STORAGE_VERSION = 1
 ENTITY_MAP_SAVE_DELAY = 10
+_LOGGER = logging.getLogger(__name__)
 
 
 class Pairing(TypedDict):
@@ -77,6 +79,7 @@ class EntityMapStorage:
     def async_delete_map(self, homekit_id: str) -> None:
         """Delete pairing cache."""
         if homekit_id not in self.storage_data:
+            _LOGGER.debug("Tried to delete non-existent pairing %s", homekit_id)
             return
 
         self.storage_data.pop(homekit_id)

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -70,6 +70,7 @@ class EntityMapStorage:
         self, homekit_id: str, config_num: int, accessories: list[Any]
     ) -> Pairing:
         """Create a new pairing cache."""
+        _LOGGER.debug("Creating or updating pairing cache for %s", homekit_id)
         data = Pairing(config_num=config_num, accessories=accessories)
         self.storage_data[homekit_id] = data
         self._async_schedule_save()
@@ -82,6 +83,7 @@ class EntityMapStorage:
             _LOGGER.debug("Tried to delete non-existent pairing %s", homekit_id)
             return
 
+        _LOGGER.debug("Deleting pairing cache for %s", homekit_id)
         self.storage_data.pop(homekit_id)
         self._async_schedule_save()
 

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -70,7 +70,7 @@ class EntityMapStorage:
         self, homekit_id: str, config_num: int, accessories: list[Any]
     ) -> Pairing:
         """Create a new pairing cache."""
-        _LOGGER.debug("Creating or updating pairing cache for %s", homekit_id)
+        _LOGGER.debug("Creating or updating entity map for %s", homekit_id)
         data = Pairing(config_num=config_num, accessories=accessories)
         self.storage_data[homekit_id] = data
         self._async_schedule_save()
@@ -80,10 +80,10 @@ class EntityMapStorage:
     def async_delete_map(self, homekit_id: str) -> None:
         """Delete pairing cache."""
         if homekit_id not in self.storage_data:
-            _LOGGER.debug("Tried to delete non-existent pairing %s", homekit_id)
+            _LOGGER.debug("Tried to delete non-existent entity map %s", homekit_id)
             return
 
-        _LOGGER.debug("Deleting pairing cache for %s", homekit_id)
+        _LOGGER.debug("Deleting entity map for %s", homekit_id)
         self.storage_data.pop(homekit_id)
         self._async_schedule_save()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -168,7 +168,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.2.3
+aiohomekit==1.2.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.2.3
+aiohomekit==1.2.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -14,6 +14,7 @@ from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
+from homeassistant.components.homekit_controller.storage import async_get_entity_storage
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
     RESULT_TYPE_FORM,
@@ -1071,6 +1072,8 @@ async def test_bluetooth_valid_device_discovery_paired(hass, controller):
 async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
     """Test bluetooth discovery with a homekit device and discovery works."""
     setup_mock_accessory(controller)
+    storage = await async_get_entity_storage(hass)
+
     with patch(
         "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
         True,
@@ -1083,6 +1086,7 @@ async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
 
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "pair"
+    assert storage.get_map("00:00:00:00:00:00") is None
 
     assert get_flow_context(hass, result) == {
         "source": config_entries.SOURCE_BLUETOOTH,
@@ -1098,3 +1102,5 @@ async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
     assert result3["type"] == FlowResultType.CREATE_ENTRY
     assert result3["title"] == "Koogeek-LS1-20833F"
     assert result3["data"] == {}
+
+    assert storage.get_map("00:00:00:00:00:00") is not None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Save the entity map from the config flow with the
  correct unique id (speeds up pairing a bit if we
  don't fetch it twice -- once in the flow, and one for
  first setup) 

- Remove the entity map that was stored with the
  wrong unique id when removing the entry to avoid
  leaving cruft behind

- Fixes for accessories that use a config number of
  0

- General reliability improvements to the pairing process
  under the hood of `aiohomekit`


Changelog: https://github.com/Jc2k/aiohomekit/compare/1.2.3...1.2.4


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
