### PR TITLE
Fix frontier silicon EQ Mode not present on all devices

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -167,17 +167,18 @@ class AFSAPIDevice(MediaPlayerEntity):
 
         if not self._attr_sound_mode_list and self._supports_sound_mode:
             try:
-                self.__sound_modes_by_label = {
-                    sound_mode.label: sound_mode.key
-                    for sound_mode in await afsapi.get_equalisers()
-                }
-                self._attr_sound_mode_list = list(self.__sound_modes_by_label)
+                equalisers = await afsapi.get_equalisers()
             except FSNotImplementedException:
                 self._supports_sound_mode = False
                 # Remove SELECT_SOUND_MODE from the advertised supported features
                 self._attr_supported_features ^= (
                     MediaPlayerEntityFeature.SELECT_SOUND_MODE
                 )
+            else:
+                self.__sound_modes_by_label = {
+                    sound_mode.label: sound_mode.key for sound_mode in equalisers
+                }
+                self._attr_sound_mode_list = list(self.__sound_modes_by_label)
 
         # The API seems to include 'zero' in the number of steps (e.g. if the range is
         # 0-40 then get_volume_steps returns 41) subtract one to get the max volume.
@@ -202,15 +203,15 @@ class AFSAPIDevice(MediaPlayerEntity):
             if self._supports_sound_mode:
                 try:
                     eq_preset = await afsapi.get_eq_preset()
-                    self._attr_sound_mode = (
-                        eq_preset.label if eq_preset is not None else None
-                    )
-
                 except FSNotImplementedException:
                     self._supports_sound_mode = False
                     # Remove SELECT_SOUND_MODE from the advertised supported features
                     self._attr_supported_features ^= (
                         MediaPlayerEntityFeature.SELECT_SOUND_MODE
+                    )
+                else:
+                    self._attr_sound_mode = (
+                        eq_preset.label if eq_preset is not None else None
                     )
 
             volume = await self.fs_device.get_volume()

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -123,11 +123,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         self.__modes_by_label: dict[str, str] | None = None
         self.__sound_modes_by_label: dict[str, str] | None = None
 
-    @property
-    def _supports_sound_mode(self) -> bool:
-        return bool(
-            self._attr_supported_features & MediaPlayerEntityFeature.SELECT_SOUND_MODE
-        )
+        self._supports_sound_mode: bool = True
 
     async def async_update(self):
         """Get the latest date and update device state."""
@@ -177,6 +173,7 @@ class AFSAPIDevice(MediaPlayerEntity):
                 }
                 self._attr_sound_mode_list = list(self.__sound_modes_by_label)
             except FSNotImplementedException:
+                self._supports_sound_mode = False
                 # Remove SELECT_SOUND_MODE from the advertised supported features
                 self._attr_supported_features ^= (
                     MediaPlayerEntityFeature.SELECT_SOUND_MODE
@@ -210,6 +207,7 @@ class AFSAPIDevice(MediaPlayerEntity):
                     )
 
                 except FSNotImplementedException:
+                    self._supports_sound_mode = False
                     # Remove SELECT_SOUND_MODE from the advertised supported features
                     self._attr_supported_features ^= (
                         MediaPlayerEntityFeature.SELECT_SOUND_MODE

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -91,7 +91,7 @@ class AFSAPIDevice(MediaPlayerEntity):
 
     _attr_media_content_type: str = MEDIA_TYPE_MUSIC
 
-    _always_supported_features = (
+    _attr_supported_features = (
         MediaPlayerEntityFeature.PAUSE
         | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_MUTE
@@ -105,6 +105,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.SELECT_SOUND_MODE
     )
 
     def __init__(self, name: str | None, afsapi: AFSAPI) -> None:
@@ -118,10 +119,15 @@ class AFSAPIDevice(MediaPlayerEntity):
         self._attr_name = name
 
         self._max_volume: int | None = None
-        self._supports_sound_mode: bool | None = None
 
         self.__modes_by_label: dict[str, str] | None = None
         self.__sound_modes_by_label: dict[str, str] | None = None
+
+    @property
+    def _supports_sound_mode(self) -> bool:
+        return bool(
+            self._attr_supported_features & MediaPlayerEntityFeature.SELECT_SOUND_MODE
+        )
 
     async def async_update(self):
         """Get the latest date and update device state."""
@@ -163,16 +169,18 @@ class AFSAPIDevice(MediaPlayerEntity):
             }
             self._attr_source_list = list(self.__modes_by_label)
 
-        if self._supports_sound_mode is None or self._supports_sound_mode:
-            if not self._attr_sound_mode_list:
-                try:
-                    self.__sound_modes_by_label = {
-                        sound_mode.label: sound_mode.key
-                        for sound_mode in await afsapi.get_equalisers()
-                    }
-                    self._attr_sound_mode_list = list(self.__sound_modes_by_label)
-                except FSNotImplementedException:
-                    self._supports_sound_mode = False
+        if not self._attr_sound_mode_list and self._supports_sound_mode:
+            try:
+                self.__sound_modes_by_label = {
+                    sound_mode.label: sound_mode.key
+                    for sound_mode in await afsapi.get_equalisers()
+                }
+                self._attr_sound_mode_list = list(self.__sound_modes_by_label)
+            except FSNotImplementedException:
+                # Remove SELECT_SOUND_MODE from the advertised supported features
+                self._attr_supported_features ^= (
+                    MediaPlayerEntityFeature.SELECT_SOUND_MODE
+                )
 
         # The API seems to include 'zero' in the number of steps (e.g. if the range is
         # 0-40 then get_volume_steps returns 41) subtract one to get the max volume.
@@ -194,15 +202,18 @@ class AFSAPIDevice(MediaPlayerEntity):
             self._attr_is_volume_muted = await afsapi.get_mute()
             self._attr_media_image_url = await afsapi.get_play_graphic()
 
-            if self._supports_sound_mode is None or self._supports_sound_mode:
+            if self._supports_sound_mode:
                 try:
                     eq_preset = await afsapi.get_eq_preset()
                     self._attr_sound_mode = (
                         eq_preset.label if eq_preset is not None else None
                     )
-                    self._supports_sound_mode = True
+
                 except FSNotImplementedException:
-                    self._supports_sound_mode = False
+                    # Remove SELECT_SOUND_MODE from the advertised supported features
+                    self._attr_supported_features ^= (
+                        MediaPlayerEntityFeature.SELECT_SOUND_MODE
+                    )
 
             volume = await self.fs_device.get_volume()
 
@@ -220,15 +231,6 @@ class AFSAPIDevice(MediaPlayerEntity):
             self._attr_sound_mode = None
 
             self._attr_volume_level = None
-
-    @property
-    def supported_features(self) -> int:
-        """Return media player features that are supported."""
-        result = self._always_supported_features
-        if self._supports_sound_mode:
-            result |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
-
-        return result
 
     # Management actions
     # power control


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add logic to test if EQ Mode can be retrieved in `frontier_silicon`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #76159
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
