### PR TITLE
Add a Thread network status sensor to homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -104,7 +104,7 @@ def thread_status_to_str(char: Characteristic) -> str:
     if val & ThreadStatus.LEADER:
         # Device has joined the Thread network and is participating
         # in routing between mesh nodes.
-        # It's also the leader. Theres only one leader and it manages
+        # It's also the leader. There's only one leader and it manages
         # which nodes are routers.
         return "leader"
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
-from aiohomekit.model.characteristics.const import ThreadNodeCapabilities
+from aiohomekit.model.characteristics.const import ThreadNodeCapabilities, ThreadStatus
 from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.components.sensor import (
@@ -81,6 +81,54 @@ def thread_node_capability_to_str(char: Characteristic) -> str:
 
     # Device has no known thread capabilities
     return "none"
+
+
+def thread_status_to_str(char: Characteristic) -> str:
+    """
+    Return the thread status as a string.
+
+    The underlying value is a bitmask, but we want to turn that to
+    a human readable string. So we check the flags in order. E.g. BORDER_ROUTER implies
+    ROUTER, so its more important to show that value.
+    """
+
+    val = ThreadStatus(char.value)
+
+    if val & ThreadStatus.BORDER_ROUTER:
+        # Device has joined the Thread network and is participating
+        # in routing between mesh nodes.
+        # It's also the border router - bridging the thread network
+        # to WiFI/Ethernet/etc
+        return "border_router"
+
+    if val & ThreadStatus.LEADER:
+        # Device has joined the Thread network and is participating
+        # in routing between mesh nodes.
+        # It's also the leader. Theres only one leader and it manages
+        # which nodes are routers.
+        return "leader"
+
+    if val & ThreadStatus.ROUTER:
+        # Device has joined the Thread network and is participating
+        # in routing between mesh nodes.
+        return "router"
+
+    if val & ThreadStatus.CHILD:
+        # Device has joined the Thread network as a child
+        # It's not participating in routing between mesh nodes
+        return "child"
+
+    if val & ThreadStatus.JOINING:
+        # Device is currently joining its Thread network
+        return "joining"
+
+    if val & ThreadStatus.DETACHED:
+        # Device is currently unable to reach its Thread network
+        return "detached"
+
+    # Must be ThreadStatus.DISABLED
+    # Device is not currently connected to Thread and will not try to.
+    return "disabled"
 
 
 SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {
@@ -242,6 +290,13 @@ SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {
         device_class="homekit_controller__thread_node_capabilities",
         entity_category=EntityCategory.DIAGNOSTIC,
         format=thread_node_capability_to_str,
+    ),
+    CharacteristicsTypes.THREAD_STATUS: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.THREAD_STATUS,
+        name="Thread Status",
+        device_class="homekit_controller__thread_status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        format=thread_status_to_str,
     ),
 }
 

--- a/homeassistant/components/homekit_controller/strings.sensor.json
+++ b/homeassistant/components/homekit_controller/strings.sensor.json
@@ -7,6 +7,15 @@
       "minimal": "Minimal End Device",
       "sleepy": "Sleepy End Device",
       "none": "None"
+    },
+    "homekit_controller__thread_status": {
+      "border_router": "Border Router Capable",
+      "leader": "Router Eligible End Device",
+      "router": "Full End Device",
+      "child": "Minimal End Device",
+      "joining": "Sleepy End Device",
+      "detached": "None",
+      "disabled": "Disabled"
     }
   }
 }

--- a/homeassistant/components/homekit_controller/strings.sensor.json
+++ b/homeassistant/components/homekit_controller/strings.sensor.json
@@ -9,12 +9,12 @@
       "none": "None"
     },
     "homekit_controller__thread_status": {
-      "border_router": "Border Router Capable",
-      "leader": "Router Eligible End Device",
-      "router": "Full End Device",
-      "child": "Minimal End Device",
-      "joining": "Sleepy End Device",
-      "detached": "None",
+      "border_router": "Border Router",
+      "leader": "Leader",
+      "router": "Router",
+      "child": "Child",
+      "joining": "Joining",
+      "detached": "Detached",
       "disabled": "Disabled"
     }
   }

--- a/homeassistant/components/homekit_controller/translations/sensor.en.json
+++ b/homeassistant/components/homekit_controller/translations/sensor.en.json
@@ -9,13 +9,13 @@
             "sleepy": "Sleepy End Device"
         },
         "homekit_controller__thread_status": {
-            "border_router": "Border Router Capable",
-            "child": "Minimal End Device",
-            "detached": "None",
+            "border_router": "Border Router",
+            "child": "Child",
+            "detached": "Detached",
             "disabled": "Disabled",
-            "joining": "Sleepy End Device",
-            "leader": "Router Eligible End Device",
-            "router": "Full End Device"
+            "joining": "Joining",
+            "leader": "Leader",
+            "router": "Router"
         }
     }
 }

--- a/homeassistant/components/homekit_controller/translations/sensor.en.json
+++ b/homeassistant/components/homekit_controller/translations/sensor.en.json
@@ -7,6 +7,15 @@
             "none": "None",
             "router_eligible": "Router Eligible End Device",
             "sleepy": "Sleepy End Device"
+        },
+        "homekit_controller__thread_status": {
+            "border_router": "Border Router Capable",
+            "child": "Minimal End Device",
+            "detached": "None",
+            "disabled": "Disabled",
+            "joining": "Sleepy End Device",
+            "leader": "Router Eligible End Device",
+            "router": "Full End Device"
         }
     }
 }

--- a/tests/components/homekit_controller/specific_devices/test_nanoleaf_strip_nl55.py
+++ b/tests/components/homekit_controller/specific_devices/test_nanoleaf_strip_nl55.py
@@ -57,6 +57,13 @@ async def test_nanoleaf_nl55_setup(hass):
                     entity_category=EntityCategory.DIAGNOSTIC,
                     state="border_router_capable",
                 ),
+                EntityTestInfo(
+                    entity_id="sensor.nanoleaf_strip_3b32_thread_status",
+                    friendly_name="Nanoleaf Strip 3B32 Thread Status",
+                    unique_id="homekit-AAAA011111111111-aid:1-sid:31-cid:117",
+                    entity_category=EntityCategory.DIAGNOSTIC,
+                    state="border_router",
+                ),
             ],
         ),
     )

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -1,11 +1,12 @@
 """Basic checks for HomeKit sensor."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.characteristics.const import ThreadNodeCapabilities
+from aiohomekit.model.characteristics.const import ThreadNodeCapabilities, ThreadStatus
 from aiohomekit.model.services import ServicesTypes
 from aiohomekit.protocol.statuscodes import HapStatusCode
 
 from homeassistant.components.homekit_controller.sensor import (
     thread_node_capability_to_str,
+    thread_status_to_str,
 )
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
@@ -337,3 +338,14 @@ def test_thread_node_caps_to_str():
     assert thread_node_capability_to_str(ThreadNodeCapabilities.MINIMAL) == "minimal"
     assert thread_node_capability_to_str(ThreadNodeCapabilities.SLEEPY) == "sleepy"
     assert thread_node_capability_to_str(ThreadNodeCapabilities(128)) == "none"
+
+
+def test_thread_status_to_str():
+    """Test all values of this enum get a translatable string."""
+    assert thread_status_to_str(ThreadStatus.BORDER_ROUTER) == "border_router"
+    assert thread_status_to_str(ThreadStatus.LEADER) == "leader"
+    assert thread_status_to_str(ThreadStatus.ROUTER) == "router"
+    assert thread_status_to_str(ThreadStatus.CHILD) == "child"
+    assert thread_status_to_str(ThreadStatus.JOINING) == "joining"
+    assert thread_status_to_str(ThreadStatus.DETACHED) == "detached"
+    assert thread_status_to_str(ThreadStatus.DISABLED) == "disabled"


### PR DESCRIPTION
## Proposed change

Another Thread diagnostic sensor (like https://github.com/home-assistant/core/pull/76120). This is the more interesting of the 2 as it lets you see see which devices are currently routers, border routers, etc, and whether they are disconnected or joining (only useful when querying with the non-thread homekit backend).

![Screenshot 2022-08-04 at 10 36 26](https://user-images.githubusercontent.com/11544/182815328-e284c3b0-d691-44b0-a1ef-eec3d3eb725a.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
