### PR TITLE
Add device_tracker checks to pylint plugin

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -1135,6 +1135,79 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
             ],
         ),
     ],
+    "device_tracker": [
+        ClassTypeHintMatch(
+            base_class="Entity",
+            matches=_ENTITY_MATCH,
+        ),
+        ClassTypeHintMatch(
+            base_class="BaseTrackerEntity",
+            matches=[
+                TypeHintMatch(
+                    function_name="battery_level",
+                    return_type=["int", None],
+                ),
+                TypeHintMatch(
+                    function_name="source_type",
+                    return_type=["SourceType", "str"],
+                ),
+            ],
+        ),
+        ClassTypeHintMatch(
+            base_class="TrackerEntity",
+            matches=[
+                TypeHintMatch(
+                    function_name="force_update",
+                    return_type="bool",
+                ),
+                TypeHintMatch(
+                    function_name="location_accuracy",
+                    return_type="int",
+                ),
+                TypeHintMatch(
+                    function_name="location_name",
+                    return_type=["str", None],
+                ),
+                TypeHintMatch(
+                    function_name="latitude",
+                    return_type=["float", None],
+                ),
+                TypeHintMatch(
+                    function_name="longitude",
+                    return_type=["float", None],
+                ),
+                TypeHintMatch(
+                    function_name="state",
+                    return_type=["str", None],
+                ),
+            ],
+        ),
+        ClassTypeHintMatch(
+            base_class="ScannerEntity",
+            matches=[
+                TypeHintMatch(
+                    function_name="ip_address",
+                    return_type=["str", None],
+                ),
+                TypeHintMatch(
+                    function_name="mac_address",
+                    return_type=["str", None],
+                ),
+                TypeHintMatch(
+                    function_name="hostname",
+                    return_type=["str", None],
+                ),
+                TypeHintMatch(
+                    function_name="state",
+                    return_type="str",
+                ),
+                TypeHintMatch(
+                    function_name="is_connected",
+                    return_type="bool",
+                ),
+            ],
+        ),
+    ],
     "fan": [
         ClassTypeHintMatch(
             base_class="Entity",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add device_tracker checks to pylint plugin

```console
pylint homeassistant/components/**/device_tracker.py --disable=all --enable=hass_enforce_type_hints

************* Module homeassistant.components.bmw_connected_drive.device_tracker
homeassistant/components/bmw_connected_drive/device_tracker.py:59:4: W7432: Return type should be ['Mapping[str, Any]', None] in extra_state_attributes (hass-return-type)
************* Module homeassistant.components.freebox.device_tracker
homeassistant/components/freebox/device_tracker.py:96:4: W7432: Return type should be bool in is_connected (hass-return-type)
homeassistant/components/freebox/device_tracker.py:126:4: W7432: Return type should be None in async_added_to_hass (hass-return-type)
************* Module homeassistant.components.geofency.device_tracker
homeassistant/components/geofency/device_tracker.py:79:4: W7432: Return type should be ['str', None] in location_name (hass-return-type)
homeassistant/components/geofency/device_tracker.py:69:4: W7432: Return type should be ['float', None] in latitude (hass-return-type)
homeassistant/components/geofency/device_tracker.py:74:4: W7432: Return type should be ['float', None] in longitude (hass-return-type)
homeassistant/components/geofency/device_tracker.py:89:4: W7432: Return type should be ['str', None] in unique_id (hass-return-type)
homeassistant/components/geofency/device_tracker.py:84:4: W7432: Return type should be ['str', None] in name (hass-return-type)
homeassistant/components/geofency/device_tracker.py:64:4: W7432: Return type should be ['Mapping[str, Any]', None] in extra_state_attributes (hass-return-type)
homeassistant/components/geofency/device_tracker.py:103:4: W7432: Return type should be None in async_added_to_hass (hass-return-type)
homeassistant/components/geofency/device_tracker.py:120:4: W7432: Return type should be None in async_will_remove_from_hass (hass-return-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
