### PR TITLE
Fix Life360 recovery from server errors

### DIFF
--- a/homeassistant/components/life360/coordinator.py
+++ b/homeassistant/components/life360/coordinator.py
@@ -91,8 +91,10 @@ class Life360Data:
     members: dict[str, Life360Member] = field(init=False, default_factory=dict)
 
 
-class Life360DataUpdateCoordinator(DataUpdateCoordinator):
+class Life360DataUpdateCoordinator(DataUpdateCoordinator[Life360Data]):
     """Life360 data update coordinator."""
+
+    config_entry: ConfigEntry
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize data update coordinator."""

--- a/homeassistant/components/life360/device_tracker.py
+++ b/homeassistant/components/life360/device_tracker.py
@@ -11,10 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_BATTERY_CHARGING
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_ADDRESS,
@@ -31,6 +28,7 @@ from .const import (
     LOGGER,
     SHOW_DRIVING,
 )
+from .coordinator import Life360DataUpdateCoordinator, Life360Member
 
 _LOC_ATTRS = (
     "address",
@@ -95,22 +93,26 @@ async def async_setup_entry(
     entry.async_on_unload(coordinator.async_add_listener(process_data))
 
 
-class Life360DeviceTracker(CoordinatorEntity, TrackerEntity):
+class Life360DeviceTracker(
+    CoordinatorEntity[Life360DataUpdateCoordinator], TrackerEntity
+):
     """Life360 Device Tracker."""
 
     _attr_attribution = ATTRIBUTION
+    _attr_unique_id: str
 
-    def __init__(self, coordinator: DataUpdateCoordinator, member_id: str) -> None:
+    def __init__(
+        self, coordinator: Life360DataUpdateCoordinator, member_id: str
+    ) -> None:
         """Initialize Life360 Entity."""
         super().__init__(coordinator)
         self._attr_unique_id = member_id
 
-        self._data = coordinator.data.members[self.unique_id]
+        self._data: Life360Member | None = coordinator.data.members[member_id]
+        self._prev_data = self._data
 
         self._attr_name = self._data.name
         self._attr_entity_picture = self._data.entity_picture
-
-        self._prev_data = self._data
 
     @property
     def _options(self) -> Mapping[str, Any]:
@@ -124,7 +126,7 @@ class Life360DeviceTracker(CoordinatorEntity, TrackerEntity):
         # coordinator provides a new Life360Member object each time, and it's possible
         # that there is no data for this Member on some updates.
         if self.available:
-            self._data = self.coordinator.data.members.get(self.unique_id)
+            self._data = self.coordinator.data.members.get(self._attr_unique_id)
         else:
             self._data = None
 
@@ -170,11 +172,9 @@ class Life360DeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
-        if self.available:
+        if self._data:
             self._attr_entity_picture = self._data.entity_picture
         return super().entity_picture
-
-    # All of the following will only be called if self.available is True.
 
     @property
     def battery_level(self) -> int | None:
@@ -182,6 +182,8 @@ class Life360DeviceTracker(CoordinatorEntity, TrackerEntity):
 
         Percentage from 0-100.
         """
+        if not self._data:
+            return None
         return self._data.battery_level
 
     @property
@@ -195,11 +197,15 @@ class Life360DeviceTracker(CoordinatorEntity, TrackerEntity):
 
         Value in meters.
         """
+        if not self._data:
+            return 0
         return self._data.gps_accuracy
 
     @property
     def driving(self) -> bool:
         """Return if driving."""
+        if not self._data:
+            return False
         if (driving_speed := self._options.get(CONF_DRIVING_SPEED)) is not None:
             if self._data.speed >= driving_speed:
                 return True
@@ -215,23 +221,38 @@ class Life360DeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
+        if not self._data:
+            return None
         return self._data.latitude
 
     @property
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
+        if not self._data:
+            return None
         return self._data.longitude
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return entity specific state attributes."""
-        attrs = {}
-        attrs[ATTR_ADDRESS] = self._data.address
-        attrs[ATTR_AT_LOC_SINCE] = self._data.at_loc_since
-        attrs[ATTR_BATTERY_CHARGING] = self._data.battery_charging
-        attrs[ATTR_DRIVING] = self.driving
-        attrs[ATTR_LAST_SEEN] = self._data.last_seen
-        attrs[ATTR_PLACE] = self._data.place
-        attrs[ATTR_SPEED] = self._data.speed
-        attrs[ATTR_WIFI_ON] = self._data.wifi_on
-        return attrs
+        if not self._data:
+            return {
+                ATTR_ADDRESS: None,
+                ATTR_AT_LOC_SINCE: None,
+                ATTR_BATTERY_CHARGING: None,
+                ATTR_DRIVING: None,
+                ATTR_LAST_SEEN: None,
+                ATTR_PLACE: None,
+                ATTR_SPEED: None,
+                ATTR_WIFI_ON: None,
+            }
+        return {
+            ATTR_ADDRESS: self._data.address,
+            ATTR_AT_LOC_SINCE: self._data.at_loc_since,
+            ATTR_BATTERY_CHARGING: self._data.battery_charging,
+            ATTR_DRIVING: self.driving,
+            ATTR_LAST_SEEN: self._data.last_seen,
+            ATTR_PLACE: self._data.place,
+            ATTR_SPEED: self._data.speed,
+            ATTR_WIFI_ON: self._data.wifi_on,
+        }

--- a/homeassistant/components/life360/device_tracker.py
+++ b/homeassistant/components/life360/device_tracker.py
@@ -125,7 +125,6 @@ class Life360DeviceTracker(CoordinatorEntity, TrackerEntity):
         # that there is no data for this Member on some updates.
         if self.available:
             self._data = self.coordinator.data.members.get(self.unique_id)
-            assert self._data is None or self._data is not self._prev_data
         else:
             self._data = None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If communication with the Life360 is interrupted for any reason, the state of
all the entities become `unavailable`. However, after communication is restored,
the state of the entities does not return to normal right away like it should.
Eventually, when the server has new data for an entity it will update and return
to normal.

This change makes the entities return to normal as soon as communication with
the server is restored.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #76105
- This PR is related to issue: #75956 and PR #76141
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
