### PR TITLE
More explicitly call out special cases with SimpliSafe authorization code

### DIFF
--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -83,10 +83,11 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
 
-        # SimpliSafe authorization codes are 45 characters in length; check for that:
         if len(user_input[CONF_AUTH_CODE]) != 45:
+            # SimpliSafe authorization codes are 45 characters in length:
             errors = {CONF_AUTH_CODE: "invalid_auth_code_length"}
         elif user_input[CONF_AUTH_CODE].startswith("="):
+            # Ensure the user isn't including the "=" from the URL query param:
             errors = {CONF_AUTH_CODE: "invalid_auth_code_start"}
 
         if errors:

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -83,10 +83,10 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
 
-        if len(user_input[CONF_AUTH_CODE]) != 45:
+        if len(auth_code := user_input[CONF_AUTH_CODE]) != 45:
             # SimpliSafe authorization codes are 45 characters in length:
             errors = {CONF_AUTH_CODE: "invalid_auth_code_length"}
-        elif user_input[CONF_AUTH_CODE].startswith("="):
+        elif auth_code.startswith("="):
             # Ensure the user isn't including the "=" from the URL query param:
             errors = {CONF_AUTH_CODE: "invalid_auth_code_start"}
 
@@ -101,7 +101,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         session = aiohttp_client.async_get_clientsession(self.hass)
         try:
             simplisafe = await API.async_from_auth(
-                user_input[CONF_AUTH_CODE],
+                auth_code,
                 self._oauth_values.code_verifier,
                 session=session,
             )

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and input the authorization code from the SimpliSafe web app URL.",
+        "description": "SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. If you've already logged into SimpliSafe in your browser, you may want to open a new tab, then copy/paste the above URL into that tab.\n\nWhen the process is complete, return here and input the authorization code from the `com.simplisafe.mobile` URL.",
         "data": {
           "auth_code": "Authorization Code"
         }
@@ -11,6 +11,8 @@
     "error": {
       "identifier_exists": "Account already registered",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_auth_code_length": "SimpliSafe authorization codes are 45 characters in length",
+      "invalid_auth_code_start": "SimpliSafe authorization codes do not start with \"=\"",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -12,7 +12,6 @@
       "identifier_exists": "Account already registered",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_auth_code_length": "SimpliSafe authorization codes are 45 characters in length",
-      "invalid_auth_code_start": "SimpliSafe authorization codes do not start with \"=\"",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -9,7 +9,6 @@
             "identifier_exists": "Account already registered",
             "invalid_auth": "Invalid authentication",
             "invalid_auth_code_length": "SimpliSafe authorization codes are 45 characters in length",
-            "invalid_auth_code_start": "SimpliSafe authorization codes do not start with \"=\"",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -2,39 +2,22 @@
     "config": {
         "abort": {
             "already_configured": "This SimpliSafe account is already in use.",
-            "email_2fa_timed_out": "Timed out while waiting for email-based two-factor authentication.",
             "reauth_successful": "Re-authentication was successful",
             "wrong_account": "The user credentials provided do not match this SimpliSafe account."
         },
         "error": {
             "identifier_exists": "Account already registered",
             "invalid_auth": "Invalid authentication",
+            "invalid_auth_code_length": "SimpliSafe authorization codes are 45 characters in length",
+            "invalid_auth_code_start": "SimpliSafe authorization codes do not start with \"=\"",
             "unknown": "Unexpected error"
         },
-        "progress": {
-            "email_2fa": "Check your email for a verification link from Simplisafe."
-        },
         "step": {
-            "reauth_confirm": {
-                "data": {
-                    "password": "Password"
-                },
-                "description": "Please re-enter the password for {username}.",
-                "title": "Reauthenticate Integration"
-            },
-            "sms_2fa": {
-                "data": {
-                    "code": "Code"
-                },
-                "description": "Input the two-factor authentication code sent to you via SMS."
-            },
             "user": {
                 "data": {
-                    "auth_code": "Authorization Code",
-                    "password": "Password",
-                    "username": "Username"
+                    "auth_code": "Authorization Code"
                 },
-                "description": "SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and input the authorization code from the SimpliSafe web app URL."
+                "description": "SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. If you've already logged into SimpliSafe in your browser, you may want to open a new tab, then copy/paste the above URL into that tab.\n\nWhen the process is complete, return here and input the authorization code from the `com.simplisafe.mobile` URL."
             }
         }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/issues/75596 shows that some users are struggling to figure out where to get the SimpliSafe auth code from during the config flow. This PR adds two cases to watch for:

1. Ensure the entered code is the correct length.
2. Ensure the entered code doesn't begin with `=` (I think some people might be including that from the URL query param).

It also adjusts the config flow copy with additional instructions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/issues/75596
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
