### PR TITLE
2022.8.1

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -388,6 +388,7 @@ omit =
     homeassistant/components/flume/__init__.py
     homeassistant/components/flume/sensor.py
     homeassistant/components/flunearyou/__init__.py
+    homeassistant/components/flunearyou/repairs.py
     homeassistant/components/flunearyou/sensor.py
     homeassistant/components/folder/sensor.py
     homeassistant/components/folder_watcher/*

--- a/.strict-typing
+++ b/.strict-typing
@@ -128,6 +128,7 @@ homeassistant.components.homekit.util
 homeassistant.components.homekit_controller
 homeassistant.components.homekit_controller.alarm_control_panel
 homeassistant.components.homekit_controller.button
+homeassistant.components.homekit_controller.config_flow
 homeassistant.components.homekit_controller.const
 homeassistant.components.homekit_controller.lock
 homeassistant.components.homekit_controller.select

--- a/homeassistant/components/aladdin_connect/manifest.json
+++ b/homeassistant/components/aladdin_connect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "aladdin_connect",
   "name": "Aladdin Connect",
   "documentation": "https://www.home-assistant.io/integrations/aladdin_connect",
-  "requirements": ["AIOAladdinConnect==0.1.39"],
+  "requirements": ["AIOAladdinConnect==0.1.41"],
   "codeowners": ["@mkmer"],
   "iot_class": "cloud_polling",
   "loggers": ["aladdin_connect"],

--- a/homeassistant/components/alexa/const.py
+++ b/homeassistant/components/alexa/const.py
@@ -68,16 +68,19 @@ API_TEMP_UNITS = {TEMP_FAHRENHEIT: "FAHRENHEIT", TEMP_CELSIUS: "CELSIUS"}
 # back to HA state.
 API_THERMOSTAT_MODES = OrderedDict(
     [
-        (climate.HVAC_MODE_HEAT, "HEAT"),
-        (climate.HVAC_MODE_COOL, "COOL"),
-        (climate.HVAC_MODE_HEAT_COOL, "AUTO"),
-        (climate.HVAC_MODE_AUTO, "AUTO"),
-        (climate.HVAC_MODE_OFF, "OFF"),
-        (climate.HVAC_MODE_FAN_ONLY, "OFF"),
-        (climate.HVAC_MODE_DRY, "CUSTOM"),
+        (climate.HVACMode.HEAT, "HEAT"),
+        (climate.HVACMode.COOL, "COOL"),
+        (climate.HVACMode.HEAT_COOL, "AUTO"),
+        (climate.HVACMode.AUTO, "AUTO"),
+        (climate.HVACMode.OFF, "OFF"),
+        (climate.HVACMode.FAN_ONLY, "CUSTOM"),
+        (climate.HVACMode.DRY, "CUSTOM"),
     ]
 )
-API_THERMOSTAT_MODES_CUSTOM = {climate.HVAC_MODE_DRY: "DEHUMIDIFY"}
+API_THERMOSTAT_MODES_CUSTOM = {
+    climate.HVACMode.DRY: "DEHUMIDIFY",
+    climate.HVACMode.FAN_ONLY: "FAN",
+}
 API_THERMOSTAT_PRESETS = {climate.PRESET_ECO: "ECO"}
 
 # AlexaModeController does not like a single mode for the fan preset, we add PRESET_MODE_NA if a fan has only one preset_mode

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -188,7 +188,7 @@ async def async_process_advertisements(
     def _async_discovered_device(
         service_info: BluetoothServiceInfoBleak, change: BluetoothChange
     ) -> None:
-        if callback(service_info):
+        if not done.done() and callback(service_info):
             done.set_result(service_info)
 
     unload = async_register_callback(hass, _async_discovered_device, match_dict, mode)

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/bluetooth",
   "dependencies": ["websocket_api"],
   "quality_scale": "internal",
-  "requirements": ["bleak==0.15.0", "bluetooth-adapters==0.1.3"],
+  "requirements": ["bleak==0.15.1", "bluetooth-adapters==0.1.3"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "iot_class": "local_push"

--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -9,6 +9,7 @@ from typing import Any
 from pyflunearyou import Client
 from pyflunearyou.errors import FluNearYouError
 
+from homeassistant.components.repairs import IssueSeverity, async_create_issue
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
@@ -26,6 +27,15 @@ PLATFORMS = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Flu Near You as config entry."""
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "integration_removal",
+        is_fixable=True,
+        severity=IssueSeverity.ERROR,
+        translation_key="integration_removal",
+    )
+
     websession = aiohttp_client.async_get_clientsession(hass)
     client = Client(session=websession)
 

--- a/homeassistant/components/flunearyou/manifest.json
+++ b/homeassistant/components/flunearyou/manifest.json
@@ -3,6 +3,7 @@
   "name": "Flu Near You",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flunearyou",
+  "dependencies": ["repairs"],
   "requirements": ["pyflunearyou==2.0.2"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",

--- a/homeassistant/components/flunearyou/repairs.py
+++ b/homeassistant/components/flunearyou/repairs.py
@@ -1,0 +1,42 @@
+"""Repairs platform for the Flu Near You integration."""
+from __future__ import annotations
+
+import asyncio
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+class FluNearYouFixFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            removal_tasks = [
+                self.hass.config_entries.async_remove(entry.entry_id)
+                for entry in self.hass.config_entries.async_entries(DOMAIN)
+            ]
+            await asyncio.gather(*removal_tasks)
+            return self.async_create_entry(title="Fixed issue", data={})
+        return self.async_show_form(step_id="confirm", data_schema=vol.Schema({}))
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str
+) -> FluNearYouFixFlow:
+    """Create flow."""
+    return FluNearYouFixFlow()

--- a/homeassistant/components/flunearyou/strings.json
+++ b/homeassistant/components/flunearyou/strings.json
@@ -16,5 +16,18 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_location%]"
     }
+  },
+  "issues": {
+    "integration_removal": {
+      "title": "Flu Near You is no longer available",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Remove Flu Near You",
+            "description": "The external data source powering the Flu Near You integration is no longer available; thus, the integration no longer works.\n\nPress SUBMIT to remove Flu Near You from your Home Assistant instance."
+          }
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/flunearyou/translations/en.json
+++ b/homeassistant/components/flunearyou/translations/en.json
@@ -16,5 +16,18 @@
                 "title": "Configure Flu Near You"
             }
         }
+    },
+    "issues": {
+        "integration_removal": {
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "description": "The data source that powered the Flu Near You integration is no longer available. Press SUBMIT to remove all configured instances of the integration from Home Assistant.",
+                        "title": "Remove Flu Near You"
+                    }
+                }
+            },
+            "title": "Flu Near You is no longer available"
+        }
     }
 }

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -105,27 +105,33 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         assert mac_address is not None
         mac = dr.format_mac(mac_address)
         await self.async_set_unique_id(mac)
-        for entry in self._async_current_entries(include_ignore=False):
-            if entry.data[CONF_HOST] == device[ATTR_IPADDR] or (
-                entry.unique_id
-                and ":" in entry.unique_id
-                and mac_matches_by_one(entry.unique_id, mac)
+        for entry in self._async_current_entries(include_ignore=True):
+            if not (
+                entry.data.get(CONF_HOST) == device[ATTR_IPADDR]
+                or (
+                    entry.unique_id
+                    and ":" in entry.unique_id
+                    and mac_matches_by_one(entry.unique_id, mac)
+                )
             ):
-                if (
-                    async_update_entry_from_discovery(
-                        self.hass, entry, device, None, allow_update_mac
-                    )
-                    or entry.state == config_entries.ConfigEntryState.SETUP_RETRY
-                ):
-                    self.hass.async_create_task(
-                        self.hass.config_entries.async_reload(entry.entry_id)
-                    )
-                else:
-                    async_dispatcher_send(
-                        self.hass,
-                        FLUX_LED_DISCOVERY_SIGNAL.format(entry_id=entry.entry_id),
-                    )
+                continue
+            if entry.source == config_entries.SOURCE_IGNORE:
                 raise AbortFlow("already_configured")
+            if (
+                async_update_entry_from_discovery(
+                    self.hass, entry, device, None, allow_update_mac
+                )
+                or entry.state == config_entries.ConfigEntryState.SETUP_RETRY
+            ):
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(entry.entry_id)
+                )
+            else:
+                async_dispatcher_send(
+                    self.hass,
+                    FLUX_LED_DISCOVERY_SIGNAL.format(entry_id=entry.entry_id),
+                )
+            raise AbortFlow("already_configured")
 
     async def _async_handle_discovery(self) -> FlowResult:
         """Handle any discovery."""

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -223,10 +223,22 @@ HARDWARE_INTEGRATIONS = {
 async def async_get_addon_info(hass: HomeAssistant, slug: str) -> dict:
     """Return add-on info.
 
+    The add-on must be installed.
     The caller of the function should handle HassioAPIError.
     """
     hassio = hass.data[DOMAIN]
     return await hassio.get_addon_info(slug)
+
+
+@api_data
+async def async_get_addon_store_info(hass: HomeAssistant, slug: str) -> dict:
+    """Return add-on store info.
+
+    The caller of the function should handle HassioAPIError.
+    """
+    hassio: HassIO = hass.data[DOMAIN]
+    command = f"/store/addons/{slug}"
+    return await hassio.send_command(command, method="get")
 
 
 @bind_hass

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.typing import ConfigType
 from .config_flow import normalize_hkid
 from .connection import HKDevice, valid_serial_number
 from .const import ENTITY_MAP, KNOWN_DEVICES, TRIGGERS
-from .storage import async_get_entity_storage
+from .storage import EntityMapStorage, async_get_entity_storage
 from .utils import async_get_controller, folded_name
 
 _LOGGER = logging.getLogger(__name__)
@@ -269,7 +269,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hkid = entry.data["AccessoryPairingID"]
 
     if hkid in hass.data[KNOWN_DEVICES]:
-        connection = hass.data[KNOWN_DEVICES][hkid]
+        connection: HKDevice = hass.data[KNOWN_DEVICES][hkid]
         await connection.async_unload()
 
     return True
@@ -280,7 +280,8 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     hkid = entry.data["AccessoryPairingID"]
 
     # Remove cached type data from .storage/homekit_controller-entity-map
-    hass.data[ENTITY_MAP].async_delete_map(hkid)
+    entity_map_storage: EntityMapStorage = hass.data[ENTITY_MAP]
+    entity_map_storage.async_delete_map(hkid)
 
     controller = await async_get_controller(hass)
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -1,14 +1,17 @@
 """Config flow to configure homekit_controller."""
 from __future__ import annotations
 
-from collections.abc import Awaitable
 import logging
 import re
 from typing import TYPE_CHECKING, Any, cast
 
 import aiohomekit
 from aiohomekit import Controller, const as aiohomekit_const
-from aiohomekit.controller.abstract import AbstractDiscovery, AbstractPairing
+from aiohomekit.controller.abstract import (
+    AbstractDiscovery,
+    AbstractPairing,
+    FinishPairing,
+)
 from aiohomekit.exceptions import AuthenticationError
 from aiohomekit.model.categories import Categories
 from aiohomekit.model.status_flags import StatusFlags
@@ -17,7 +20,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import device_registry as dr
 
@@ -78,7 +81,9 @@ def formatted_category(category: Categories) -> str:
 
 
 @callback
-def find_existing_host(hass, serial: str) -> config_entries.ConfigEntry | None:
+def find_existing_host(
+    hass: HomeAssistant, serial: str
+) -> config_entries.ConfigEntry | None:
     """Return a set of the configured hosts."""
     for entry in hass.config_entries.async_entries(DOMAIN):
         if entry.data.get("AccessoryPairingID") == serial:
@@ -115,15 +120,17 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.category: Categories | None = None
         self.devices: dict[str, AbstractDiscovery] = {}
         self.controller: Controller | None = None
-        self.finish_pairing: Awaitable[AbstractPairing] | None = None
+        self.finish_pairing: FinishPairing | None = None
 
-    async def _async_setup_controller(self):
+    async def _async_setup_controller(self) -> None:
         """Create the controller."""
         self.controller = await async_get_controller(self.hass)
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow start."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             key = user_input["device"]
@@ -141,6 +148,8 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if self.controller is None:
             await self._async_setup_controller()
+
+        assert self.controller
 
         self.devices = {}
 
@@ -167,7 +176,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    async def async_step_unignore(self, user_input):
+    async def async_step_unignore(self, user_input: dict[str, Any]) -> FlowResult:
         """Rediscover a previously ignored discover."""
         unique_id = user_input["unique_id"]
         await self.async_set_unique_id(unique_id)
@@ -175,19 +184,21 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if self.controller is None:
             await self._async_setup_controller()
 
+        assert self.controller
+
         try:
             discovery = await self.controller.async_find(unique_id)
         except aiohomekit.AccessoryNotFoundError:
             return self.async_abort(reason="accessory_not_found_error")
 
         self.name = discovery.description.name
-        self.model = discovery.description.model
+        self.model = getattr(discovery.description, "model", BLE_DEFAULT_NAME)
         self.category = discovery.description.category
         self.hkid = discovery.description.id
 
         return self._async_step_pair_show_form()
 
-    async def _hkid_is_homekit(self, hkid):
+    async def _hkid_is_homekit(self, hkid: str) -> bool:
         """Determine if the device is a homekit bridge or accessory."""
         dev_reg = dr.async_get(self.hass)
         device = dev_reg.async_get_device(
@@ -410,7 +421,9 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self._async_step_pair_show_form()
 
-    async def async_step_pair(self, pair_info=None):
+    async def async_step_pair(
+        self, pair_info: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Pair with a new HomeKit accessory."""
         # If async_step_pair is called with no pairing code then we do the M1
         # phase of pairing. If this is successful the device enters pairing
@@ -428,10 +441,15 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # callable. We call the callable with the pin that the user has typed
         # in.
 
+        # Should never call this step without setting self.hkid
+        assert self.hkid
+
         errors = {}
 
         if self.controller is None:
             await self._async_setup_controller()
+
+        assert self.controller
 
         if pair_info and self.finish_pairing:
             self.context["pairing"] = True
@@ -507,21 +525,27 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self._async_step_pair_show_form(errors)
 
-    async def async_step_busy_error(self, user_input=None):
+    async def async_step_busy_error(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Retry pairing after the accessory is busy."""
         if user_input is not None:
             return await self.async_step_pair()
 
         return self.async_show_form(step_id="busy_error")
 
-    async def async_step_max_tries_error(self, user_input=None):
+    async def async_step_max_tries_error(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Retry pairing after the accessory has reached max tries."""
         if user_input is not None:
             return await self.async_step_pair()
 
         return self.async_show_form(step_id="max_tries_error")
 
-    async def async_step_protocol_error(self, user_input=None):
+    async def async_step_protocol_error(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Retry pairing after the accessory has a protocol error."""
         if user_input is not None:
             return await self.async_step_pair()
@@ -529,7 +553,11 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(step_id="protocol_error")
 
     @callback
-    def _async_step_pair_show_form(self, errors=None):
+    def _async_step_pair_show_form(
+        self, errors: dict[str, str] | None = None
+    ) -> FlowResult:
+        assert self.category
+
         placeholders = self.context["title_placeholders"] = {
             "name": self.name,
             "category": formatted_category(self.category),

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -569,7 +569,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         entity_storage = await async_get_entity_storage(self.hass)
         assert self.unique_id is not None
         entity_storage.async_create_or_update_map(
-            self.unique_id,
+            pairing.id,
             accessories_state.config_num,
             accessories_state.accessories.serialize(),
         )

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -107,9 +107,9 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         return ColorMode.ONOFF
 
     @property
-    def supported_color_modes(self) -> set[ColorMode | str] | None:
+    def supported_color_modes(self) -> set[ColorMode]:
         """Flag supported color modes."""
-        color_modes: set[ColorMode | str] = set()
+        color_modes: set[ColorMode] = set()
 
         if self.service.has(CharacteristicsTypes.HUE) or self.service.has(
             CharacteristicsTypes.SATURATION

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==1.2.3"],
+  "requirements": ["aiohomekit==1.2.4"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
   "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_start": [6] }],
   "dependencies": ["bluetooth", "zeroconf"],

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==1.2.4"],
+  "requirements": ["aiohomekit==1.2.5"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
   "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_start": [6] }],
   "dependencies": ["bluetooth", "zeroconf"],

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -223,6 +223,7 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
                 == SensorDeviceClass.POWER
             ):
                 self._attr_device_class = SensorDeviceClass.ENERGY
+                self._attr_icon = None
                 update_state = True
 
             if update_state:

--- a/homeassistant/components/life360/coordinator.py
+++ b/homeassistant/components/life360/coordinator.py
@@ -91,8 +91,10 @@ class Life360Data:
     members: dict[str, Life360Member] = field(init=False, default_factory=dict)
 
 
-class Life360DataUpdateCoordinator(DataUpdateCoordinator):
+class Life360DataUpdateCoordinator(DataUpdateCoordinator[Life360Data]):
     """Life360 data update coordinator."""
+
+    config_entry: ConfigEntry
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize data update coordinator."""

--- a/homeassistant/components/luci/manifest.json
+++ b/homeassistant/components/luci/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "luci",
-  "name": "OpenWRT (luci)",
+  "name": "OpenWrt (luci)",
   "documentation": "https://www.home-assistant.io/integrations/luci",
   "requirements": ["openwrt-luci-rpc==1.1.11"],
   "codeowners": ["@mzdrale"],

--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -116,7 +116,7 @@ class MikrotikDataUpdateCoordinatorTracker(
         return self.device.mac
 
     @property
-    def ip_address(self) -> str:
+    def ip_address(self) -> str | None:
         """Return the mac address of the client."""
         return self.device.ip_address
 

--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -60,9 +60,9 @@ class Device:
         return self._params.get("host-name", self.mac)
 
     @property
-    def ip_address(self) -> str:
+    def ip_address(self) -> str | None:
         """Return device primary ip address."""
-        return self._params["address"]
+        return self._params.get("address")
 
     @property
     def mac(self) -> str:

--- a/homeassistant/components/nextdns/manifest.json
+++ b/homeassistant/components/nextdns/manifest.json
@@ -3,7 +3,7 @@
   "name": "NextDNS",
   "documentation": "https://www.home-assistant.io/integrations/nextdns",
   "codeowners": ["@bieniu"],
-  "requirements": ["nextdns==1.0.1"],
+  "requirements": ["nextdns==1.0.2"],
   "config_flow": true,
   "iot_class": "cloud_polling",
   "loggers": ["nextdns"]

--- a/homeassistant/components/risco/manifest.json
+++ b/homeassistant/components/risco/manifest.json
@@ -3,7 +3,7 @@
   "name": "Risco",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/risco",
-  "requirements": ["pyrisco==0.5.0"],
+  "requirements": ["pyrisco==0.5.2"],
   "codeowners": ["@OnFreund"],
   "quality_scale": "platinum",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/rpi_power/binary_sensor.py
+++ b/homeassistant/components/rpi_power/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ class RaspberryChargerBinarySensor(BinarySensorEntity):
     """Binary sensor representing the rpi power status."""
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:raspberry-pi"
     _attr_name = "RPi Power status"
     _attr_unique_id = "rpi_power"  # only one sensor possible

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -81,17 +81,34 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 description_placeholders={CONF_URL: self._oauth_values.auth_url},
             )
 
+        auth_code = user_input[CONF_AUTH_CODE]
+
+        if auth_code.startswith("="):
+            # Sometimes, users may include the "=" from the URL query param; in that
+            # case, strip it off and proceed:
+            LOGGER.debug('Stripping "=" from the start of the authorization code')
+            auth_code = auth_code[1:]
+
+        if len(auth_code) != 45:
+            # SimpliSafe authorization codes are 45 characters in length; if the user
+            # provides something different, stop them here:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=STEP_USER_SCHEMA,
+                errors={CONF_AUTH_CODE: "invalid_auth_code_length"},
+                description_placeholders={CONF_URL: self._oauth_values.auth_url},
+            )
+
         errors = {}
         session = aiohttp_client.async_get_clientsession(self.hass)
-
         try:
             simplisafe = await API.async_from_auth(
-                user_input[CONF_AUTH_CODE],
+                auth_code,
                 self._oauth_values.code_verifier,
                 session=session,
             )
         except InvalidCredentialsError:
-            errors = {"base": "invalid_auth"}
+            errors = {CONF_AUTH_CODE: "invalid_auth"}
         except SimplipyError as err:
             LOGGER.error("Unknown error while logging into SimpliSafe: %s", err)
             errors = {"base": "unknown"}

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and input the authorization code from the SimpliSafe web app URL.",
+        "description": "SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. If you've already logged into SimpliSafe in your browser, you may want to open a new tab, then copy/paste the above URL into that tab.\n\nWhen the process is complete, return here and input the authorization code from the `com.simplisafe.mobile` URL.",
         "data": {
           "auth_code": "Authorization Code"
         }
@@ -11,6 +11,7 @@
     "error": {
       "identifier_exists": "Account already registered",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_auth_code_length": "SimpliSafe authorization codes are 45 characters in length",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -2,39 +2,21 @@
     "config": {
         "abort": {
             "already_configured": "This SimpliSafe account is already in use.",
-            "email_2fa_timed_out": "Timed out while waiting for email-based two-factor authentication.",
             "reauth_successful": "Re-authentication was successful",
             "wrong_account": "The user credentials provided do not match this SimpliSafe account."
         },
         "error": {
             "identifier_exists": "Account already registered",
             "invalid_auth": "Invalid authentication",
+            "invalid_auth_code_length": "SimpliSafe authorization codes are 45 characters in length",
             "unknown": "Unexpected error"
         },
-        "progress": {
-            "email_2fa": "Check your email for a verification link from Simplisafe."
-        },
         "step": {
-            "reauth_confirm": {
-                "data": {
-                    "password": "Password"
-                },
-                "description": "Please re-enter the password for {username}.",
-                "title": "Reauthenticate Integration"
-            },
-            "sms_2fa": {
-                "data": {
-                    "code": "Code"
-                },
-                "description": "Input the two-factor authentication code sent to you via SMS."
-            },
             "user": {
                 "data": {
-                    "auth_code": "Authorization Code",
-                    "password": "Password",
-                    "username": "Username"
+                    "auth_code": "Authorization Code"
                 },
-                "description": "SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and input the authorization code from the SimpliSafe web app URL."
+                "description": "SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. If you've already logged into SimpliSafe in your browser, you may want to open a new tab, then copy/paste the above URL into that tab.\n\nWhen the process is complete, return here and input the authorization code from the `com.simplisafe.mobile` URL."
             }
         }
     },

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from .backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 8
-PATCH_VERSION: Final = "0"
+PATCH_VERSION: Final = "1"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -10,7 +10,7 @@ atomicwrites-homeassistant==1.4.1
 attrs==21.2.0
 awesomeversion==22.6.0
 bcrypt==3.1.7
-bleak==0.15.0
+bleak==0.15.1
 bluetooth-adapters==0.1.3
 certifi>=2021.5.30
 ciso8601==2.2.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1131,6 +1131,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.homekit_controller.config_flow]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.homekit_controller.const]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2022.8.0"
+version     = "2022.8.1"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1784,7 +1784,7 @@ pyrecswitch==1.0.2
 pyrepetierng==0.1.0
 
 # homeassistant.components.risco
-pyrisco==0.5.0
+pyrisco==0.5.2
 
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -168,7 +168,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.2.3
+aiohomekit==1.2.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1103,7 +1103,7 @@ nextcloudmonitor==1.1.0
 nextcord==2.0.0a8
 
 # homeassistant.components.nextdns
-nextdns==1.0.1
+nextdns==1.0.2
 
 # homeassistant.components.niko_home_control
 niko-home-control==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,7 +5,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.39
+AIOAladdinConnect==0.1.41
 
 # homeassistant.components.adax
 Adax-local==0.1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -168,7 +168,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.2.4
+aiohomekit==1.2.5
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -405,7 +405,7 @@ bimmer_connected==0.10.1
 bizkaibus==0.1.1
 
 # homeassistant.components.bluetooth
-bleak==0.15.0
+bleak==0.15.1
 
 # homeassistant.components.blebox
 blebox_uniapi==2.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.39
+AIOAladdinConnect==0.1.41
 
 # homeassistant.components.adax
 Adax-local==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.2.3
+aiohomekit==1.2.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.2.4
+aiohomekit==1.2.5
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1228,7 +1228,7 @@ pyps4-2ndscreen==1.3.1
 pyqwikswitch==0.93
 
 # homeassistant.components.risco
-pyrisco==0.5.0
+pyrisco==0.5.2
 
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -784,7 +784,7 @@ nexia==2.0.2
 nextcord==2.0.0a8
 
 # homeassistant.components.nextdns
-nextdns==1.0.1
+nextdns==1.0.2
 
 # homeassistant.components.nfandroidtv
 notifications-android-tv==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -326,7 +326,7 @@ bellows==0.31.2
 bimmer_connected==0.10.1
 
 # homeassistant.components.bluetooth
-bleak==0.15.0
+bleak==0.15.1
 
 # homeassistant.components.blebox
 blebox_uniapi==2.0.2

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -590,7 +590,7 @@ async def test_report_climate_state(hass):
             {"value": 34.0, "scale": "CELSIUS"},
         )
 
-    for off_modes in (climate.HVAC_MODE_OFF, climate.HVAC_MODE_FAN_ONLY):
+    for off_modes in [climate.HVAC_MODE_OFF]:
         hass.states.async_set(
             "climate.downstairs",
             off_modes,
@@ -624,6 +624,23 @@ async def test_report_climate_state(hass):
     properties.assert_equal("Alexa.ThermostatController", "thermostatMode", "CUSTOM")
     properties.assert_equal(
         "Alexa.TemperatureSensor", "temperature", {"value": 34.0, "scale": "CELSIUS"}
+    )
+
+    # assert fan_only is reported as CUSTOM
+    hass.states.async_set(
+        "climate.downstairs",
+        "fan_only",
+        {
+            "friendly_name": "Climate Downstairs",
+            "supported_features": 91,
+            climate.ATTR_CURRENT_TEMPERATURE: 31,
+            ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
+        },
+    )
+    properties = await reported_properties(hass, "climate.downstairs")
+    properties.assert_equal("Alexa.ThermostatController", "thermostatMode", "CUSTOM")
+    properties.assert_equal(
+        "Alexa.TemperatureSensor", "temperature", {"value": 31.0, "scale": "CELSIUS"}
     )
 
     hass.states.async_set(

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2030,7 +2030,7 @@ async def test_thermostat(hass):
             "current_temperature": 75.0,
             "friendly_name": "Test Thermostat",
             "supported_features": 1 | 2 | 4 | 128,
-            "hvac_modes": ["off", "heat", "cool", "auto", "dry"],
+            "hvac_modes": ["off", "heat", "cool", "auto", "dry", "fan_only"],
             "preset_mode": None,
             "preset_modes": ["eco"],
             "min_temp": 50,
@@ -2220,7 +2220,7 @@ async def test_thermostat(hass):
     properties = ReportedProperties(msg["context"]["properties"])
     properties.assert_equal("Alexa.ThermostatController", "thermostatMode", "HEAT")
 
-    # Assert we can call custom modes
+    # Assert we can call custom modes for dry and fan_only
     call, msg = await assert_request_calls_service(
         "Alexa.ThermostatController",
         "SetThermostatMode",
@@ -2230,6 +2230,18 @@ async def test_thermostat(hass):
         payload={"thermostatMode": {"value": "CUSTOM", "customName": "DEHUMIDIFY"}},
     )
     assert call.data["hvac_mode"] == "dry"
+    properties = ReportedProperties(msg["context"]["properties"])
+    properties.assert_equal("Alexa.ThermostatController", "thermostatMode", "CUSTOM")
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.ThermostatController",
+        "SetThermostatMode",
+        "climate#test_thermostat",
+        "climate.set_hvac_mode",
+        hass,
+        payload={"thermostatMode": {"value": "CUSTOM", "customName": "FAN"}},
+    )
+    assert call.data["hvac_mode"] == "fan_only"
     properties = ReportedProperties(msg["context"]["properties"])
     properties.assert_equal("Alexa.ThermostatController", "thermostatMode", "CUSTOM")
 

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -856,6 +856,9 @@ async def test_process_advertisements_bail_on_good_advertisement(
         )
 
         _get_underlying_scanner()._callback(device, adv)
+        _get_underlying_scanner()._callback(device, adv)
+        _get_underlying_scanner()._callback(device, adv)
+
         await asyncio.sleep(0)
 
     result = await handle

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -8,7 +8,12 @@ import pytest
 from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.components import frontend
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.hassio import ADDONS_COORDINATOR, DOMAIN, STORAGE_KEY
+from homeassistant.components.hassio import (
+    ADDONS_COORDINATOR,
+    DOMAIN,
+    STORAGE_KEY,
+    async_get_addon_store_info,
+)
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.helpers.device_registry import async_get
@@ -748,3 +753,16 @@ async def test_setup_hardware_integration(hass, aioclient_mock, integration):
 
     assert aioclient_mock.call_count == 15
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_get_store_addon_info(hass, hassio_stubs, aioclient_mock):
+    """Test get store add-on info from Supervisor API."""
+    aioclient_mock.clear_requests()
+    aioclient_mock.get(
+        "http://127.0.0.1/store/addons/test",
+        json={"result": "ok", "data": {"name": "bla"}},
+    )
+
+    data = await async_get_addon_store_info(hass, "test")
+    assert data["name"] == "bla"
+    assert aioclient_mock.call_count == 1

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -14,6 +14,7 @@ from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
+from homeassistant.components.homekit_controller.storage import async_get_entity_storage
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
     RESULT_TYPE_FORM,
@@ -1071,6 +1072,8 @@ async def test_bluetooth_valid_device_discovery_paired(hass, controller):
 async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
     """Test bluetooth discovery with a homekit device and discovery works."""
     setup_mock_accessory(controller)
+    storage = await async_get_entity_storage(hass)
+
     with patch(
         "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
         True,
@@ -1083,6 +1086,7 @@ async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
 
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "pair"
+    assert storage.get_map("00:00:00:00:00:00") is None
 
     assert get_flow_context(hass, result) == {
         "source": config_entries.SOURCE_BLUETOOTH,
@@ -1098,3 +1102,5 @@ async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
     assert result3["type"] == FlowResultType.CREATE_ENTRY
     assert result3["title"] == "Koogeek-LS1-20833F"
     assert result3["data"] == {}
+
+    assert storage.get_map("00:00:00:00:00:00") is not None

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -88,10 +88,12 @@ async def test_temperature_sensor_not_added_twice(hass, utcnow):
         hass, create_temperature_sensor_service, suffix="temperature"
     )
 
+    created_sensors = set()
     for state in hass.states.async_all():
-        if state.entity_id.startswith("button"):
-            continue
-        assert state.entity_id == helper.entity_id
+        if state.attributes.get("device_class") == SensorDeviceClass.TEMPERATURE:
+            created_sensors.add(state.entity_id)
+
+    assert created_sensors == {helper.entity_id}
 
 
 async def test_humidity_sensor_read_state(hass, utcnow):

--- a/tests/components/nextdns/test_diagnostics.py
+++ b/tests/components/nextdns/test_diagnostics.py
@@ -48,11 +48,13 @@ async def test_entry_diagnostics(
     }
     assert result["protocols_coordinator_data"] == {
         "doh_queries": 20,
+        "doh3_queries": 0,
         "doq_queries": 10,
         "dot_queries": 30,
         "tcp_queries": 0,
         "udp_queries": 40,
         "doh_queries_ratio": 20.0,
+        "doh3_queries_ratio": 0.0,
         "doq_queries_ratio": 10.0,
         "dot_queries_ratio": 30.0,
         "tcp_queries_ratio": 0.0,

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -1,4 +1,5 @@
 """Define tests for the SimpliSafe config flow."""
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -9,6 +10,8 @@ from homeassistant.components.simplisafe import DOMAIN
 from homeassistant.components.simplisafe.config_flow import CONF_AUTH_CODE
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
+
+VALID_AUTH_CODE = "code12345123451234512345123451234512345123451"
 
 
 async def test_duplicate_error(config_entry, hass, setup_simplisafe):
@@ -23,10 +26,25 @@ async def test_duplicate_error(config_entry, hass, setup_simplisafe):
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
+            result["flow_id"], user_input={CONF_AUTH_CODE: VALID_AUTH_CODE}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "already_configured"
+
+
+async def test_invalid_auth_code_length(hass):
+    """Test that an invalid auth code length show the correct error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_AUTH_CODE: "too_short_code"}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_AUTH_CODE: "invalid_auth_code_length"}
 
 
 async def test_invalid_credentials(hass):
@@ -42,10 +60,11 @@ async def test_invalid_credentials(hass):
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
+            result["flow_id"],
+            user_input={CONF_AUTH_CODE: VALID_AUTH_CODE},
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": "invalid_auth"}
+        assert result["errors"] == {CONF_AUTH_CODE: "invalid_auth"}
 
 
 async def test_options_flow(config_entry, hass):
@@ -80,7 +99,7 @@ async def test_step_reauth(config_entry, hass, setup_simplisafe):
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
     ), patch("homeassistant.config_entries.ConfigEntries.async_reload"):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
+            result["flow_id"], user_input={CONF_AUTH_CODE: VALID_AUTH_CODE}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "reauth_successful"
@@ -104,14 +123,29 @@ async def test_step_reauth_wrong_account(config_entry, hass, setup_simplisafe):
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
     ), patch("homeassistant.config_entries.ConfigEntries.async_reload"):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
+            result["flow_id"], user_input={CONF_AUTH_CODE: VALID_AUTH_CODE}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "wrong_account"
 
 
-async def test_step_user(hass, setup_simplisafe):
-    """Test the user step."""
+@pytest.mark.parametrize(
+    "auth_code,log_statement",
+    [
+        (
+            VALID_AUTH_CODE,
+            None,
+        ),
+        (
+            f"={VALID_AUTH_CODE}",
+            'Stripping "=" from the start of the authorization code',
+        ),
+    ],
+)
+async def test_step_user(auth_code, caplog, hass, log_statement, setup_simplisafe):
+    """Test successfully completion of the user step."""
+    caplog.set_level = logging.DEBUG
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -121,9 +155,12 @@ async def test_step_user(hass, setup_simplisafe):
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
     ), patch("homeassistant.config_entries.ConfigEntries.async_reload"):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
+            result["flow_id"], user_input={CONF_AUTH_CODE: auth_code}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    if log_statement:
+        assert any(m for m in caplog.messages if log_statement in m)
 
     assert len(hass.config_entries.async_entries()) == 1
     [config_entry] = hass.config_entries.async_entries(DOMAIN)
@@ -143,7 +180,7 @@ async def test_unknown_error(hass, setup_simplisafe):
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
+            result["flow_id"], user_input={CONF_AUTH_CODE: VALID_AUTH_CODE}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {"base": "unknown"}

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -38,18 +38,56 @@ def mock_addon_info(addon_info_side_effect):
         yield addon_info
 
 
+@pytest.fixture(name="addon_store_info_side_effect")
+def addon_store_info_side_effect_fixture():
+    """Return the add-on store info side effect."""
+    return None
+
+
+@pytest.fixture(name="addon_store_info")
+def mock_addon_store_info(addon_store_info_side_effect):
+    """Mock Supervisor add-on info."""
+    with patch(
+        "homeassistant.components.zwave_js.addon.async_get_addon_store_info",
+        side_effect=addon_store_info_side_effect,
+    ) as addon_store_info:
+        addon_store_info.return_value = {
+            "installed": None,
+            "state": None,
+            "version": "1.0.0",
+        }
+        yield addon_store_info
+
+
 @pytest.fixture(name="addon_running")
-def mock_addon_running(addon_info):
+def mock_addon_running(addon_store_info, addon_info):
     """Mock add-on already running."""
+    addon_store_info.return_value = {
+        "installed": "1.0.0",
+        "state": "started",
+        "version": "1.0.0",
+    }
     addon_info.return_value["state"] = "started"
+    addon_info.return_value["version"] = "1.0.0"
     return addon_info
 
 
 @pytest.fixture(name="addon_installed")
-def mock_addon_installed(addon_info):
+def mock_addon_installed(addon_store_info, addon_info):
     """Mock add-on already installed but not running."""
+    addon_store_info.return_value = {
+        "installed": "1.0.0",
+        "state": "stopped",
+        "version": "1.0.0",
+    }
     addon_info.return_value["state"] = "stopped"
-    addon_info.return_value["version"] = "1.0"
+    addon_info.return_value["version"] = "1.0.0"
+    return addon_info
+
+
+@pytest.fixture(name="addon_not_installed")
+def mock_addon_not_installed(addon_store_info, addon_info):
+    """Mock add-on not installed."""
     return addon_info
 
 
@@ -81,13 +119,18 @@ def mock_set_addon_options(set_addon_options_side_effect):
 
 
 @pytest.fixture(name="install_addon_side_effect")
-def install_addon_side_effect_fixture(addon_info):
+def install_addon_side_effect_fixture(addon_store_info, addon_info):
     """Return the install add-on side effect."""
 
     async def install_addon(hass, slug):
         """Mock install add-on."""
+        addon_store_info.return_value = {
+            "installed": "1.0.0",
+            "state": "stopped",
+            "version": "1.0.0",
+        }
         addon_info.return_value["state"] = "stopped"
-        addon_info.return_value["version"] = "1.0"
+        addon_info.return_value["version"] = "1.0.0"
 
     return install_addon
 
@@ -112,11 +155,16 @@ def mock_update_addon():
 
 
 @pytest.fixture(name="start_addon_side_effect")
-def start_addon_side_effect_fixture(addon_info):
+def start_addon_side_effect_fixture(addon_store_info, addon_info):
     """Return the start add-on options side effect."""
 
     async def start_addon(hass, slug):
         """Mock start add-on."""
+        addon_store_info.return_value = {
+            "installed": "1.0.0",
+            "state": "started",
+            "version": "1.0.0",
+        }
         addon_info.return_value["state"] = "started"
 
     return start_addon

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -422,7 +422,7 @@ async def test_abort_discovery_with_existing_entry(
 
 
 async def test_abort_hassio_discovery_with_existing_flow(
-    hass, supervisor, addon_options
+    hass, supervisor, addon_installed, addon_options
 ):
     """Test hassio discovery flow is aborted when another discovery has happened."""
     result = await hass.config_entries.flow.async_init(
@@ -701,15 +701,13 @@ async def test_discovery_addon_not_running(
 async def test_discovery_addon_not_installed(
     hass,
     supervisor,
-    addon_installed,
+    addon_not_installed,
     install_addon,
     addon_options,
     set_addon_options,
     start_addon,
 ):
     """Test discovery with add-on not installed."""
-    addon_installed.return_value["version"] = None
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
@@ -1443,7 +1441,7 @@ async def test_addon_installed_already_configured(
 async def test_addon_not_installed(
     hass,
     supervisor,
-    addon_installed,
+    addon_not_installed,
     install_addon,
     addon_options,
     set_addon_options,
@@ -1451,8 +1449,6 @@ async def test_addon_not_installed(
     get_addon_discovery_info,
 ):
     """Test add-on not installed."""
-    addon_installed.return_value["version"] = None
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -1533,9 +1529,10 @@ async def test_addon_not_installed(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_install_addon_failure(hass, supervisor, addon_installed, install_addon):
+async def test_install_addon_failure(
+    hass, supervisor, addon_not_installed, install_addon
+):
     """Test add-on install failure."""
-    addon_installed.return_value["version"] = None
     install_addon.side_effect = HassioAPIError()
 
     result = await hass.config_entries.flow.async_init(
@@ -2292,7 +2289,7 @@ async def test_options_addon_not_installed(
     hass,
     client,
     supervisor,
-    addon_installed,
+    addon_not_installed,
     install_addon,
     integration,
     addon_options,
@@ -2306,7 +2303,6 @@ async def test_options_addon_not_installed(
     disconnect_calls,
 ):
     """Test options flow and add-on not installed on Supervisor."""
-    addon_installed.return_value["version"] = None
     addon_options.update(old_addon_options)
     entry = integration
     entry.unique_id = "1234"

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -432,10 +432,14 @@ async def test_start_addon(
 
 
 async def test_install_addon(
-    hass, addon_installed, install_addon, addon_options, set_addon_options, start_addon
+    hass,
+    addon_not_installed,
+    install_addon,
+    addon_options,
+    set_addon_options,
+    start_addon,
 ):
     """Test install and start the Z-Wave JS add-on during entry setup."""
-    addon_installed.return_value["version"] = None
     device = "/test"
     s0_legacy_key = "s0_legacy"
     s2_access_control_key = "s2_access_control"
@@ -583,10 +587,10 @@ async def test_addon_options_changed(
     "addon_version, update_available, update_calls, backup_calls, "
     "update_addon_side_effect, create_backup_side_effect",
     [
-        ("1.0", True, 1, 1, None, None),
-        ("1.0", False, 0, 0, None, None),
-        ("1.0", True, 1, 1, HassioAPIError("Boom"), None),
-        ("1.0", True, 0, 1, None, HassioAPIError("Boom")),
+        ("1.0.0", True, 1, 1, None, None),
+        ("1.0.0", False, 0, 0, None, None),
+        ("1.0.0", True, 1, 1, HassioAPIError("Boom"), None),
+        ("1.0.0", True, 0, 1, None, HassioAPIError("Boom")),
     ],
 )
 async def test_update_addon(
@@ -720,7 +724,7 @@ async def test_remove_entry(
     assert create_backup.call_count == 1
     assert create_backup.call_args == call(
         hass,
-        {"name": "addon_core_zwave_js_1.0", "addons": ["core_zwave_js"]},
+        {"name": "addon_core_zwave_js_1.0.0", "addons": ["core_zwave_js"]},
         partial=True,
     )
     assert uninstall_addon.call_count == 1
@@ -762,7 +766,7 @@ async def test_remove_entry(
     assert create_backup.call_count == 1
     assert create_backup.call_args == call(
         hass,
-        {"name": "addon_core_zwave_js_1.0", "addons": ["core_zwave_js"]},
+        {"name": "addon_core_zwave_js_1.0.0", "addons": ["core_zwave_js"]},
         partial=True,
     )
     assert uninstall_addon.call_count == 0
@@ -786,7 +790,7 @@ async def test_remove_entry(
     assert create_backup.call_count == 1
     assert create_backup.call_args == call(
         hass,
-        {"name": "addon_core_zwave_js_1.0", "addons": ["core_zwave_js"]},
+        {"name": "addon_core_zwave_js_1.0.0", "addons": ["core_zwave_js"]},
         partial=True,
     )
     assert uninstall_addon.call_count == 1


### PR DESCRIPTION
- Fix zwave_js addon info ([@MartinHjelmare] - [#76044]) ([hassio docs]) ([zwave_js docs])
- Bump bleak to 0.15.1 ([@bdraco] - [#76136]) ([bluetooth docs])
- Allow climate operation mode fan_only as custom mode in Alexa ([@jbouwh] - [#76148]) ([alexa docs])
- Remove icon attribute if device class is set ([@dgomes] - [#76161]) ([integration docs])
- Fix flux_led ignored entries not being respected ([@bdraco] - [#76173]) ([flux_led docs])
- Fix race in bluetooth async_process_advertisements ([@bdraco] - [#76176]) ([bluetooth docs])
- Add repair item to remove no-longer-functioning Flu Near You integration ([@bachya] - [#76177]) ([flunearyou docs]) (deprecation)
- Fix arm away in Risco ([@OnFreund] - [#76188]) ([risco docs])
- Fix nullable ip_address in mikrotik ([@engrbm87] - [#76197]) ([mikrotik docs])
- Mark RPI Power binary sensor as diagnostic ([@frenck] - [#76198]) ([rpi_power docs])
- BLE pairing reliablity fixes for HomeKit Controller ([@bdraco] - [#76199]) ([homekit_controller docs]) (dependency)
- Bump NextDNS library ([@bieniu] - [#76207]) ([nextdns docs])
- Bump AIOAladdin Connect to 0.1.41 ([@mkmer] - [#76217]) ([aladdin_connect docs]) (dependency)
- Fix spelling of OpenWrt in luci integration manifest ([@frenck] - [#76219]) ([luci docs])
- Fix Life360 recovery from server errors ([@pnbruckner] - [#76231]) ([life360 docs])
- More explicitly call out special cases with SimpliSafe authorization code ([@bachya] - [#76232]) ([simplisafe docs])
- Enable strict typing for HomeKit Controller config flow module ([@Jc2k] - [#76233]) ([homekit_controller docs])
- Fix some homekit_controller pylint warnings and (local only) test failures ([@Jc2k] - [#76122]) ([homekit_controller docs])

[#76044]: https://github.com/home-assistant/core/pull/76044
[#76122]: https://github.com/home-assistant/core/pull/76122
[#76136]: https://github.com/home-assistant/core/pull/76136
[#76148]: https://github.com/home-assistant/core/pull/76148
[#76161]: https://github.com/home-assistant/core/pull/76161
[#76173]: https://github.com/home-assistant/core/pull/76173
[#76176]: https://github.com/home-assistant/core/pull/76176
[#76177]: https://github.com/home-assistant/core/pull/76177
[#76188]: https://github.com/home-assistant/core/pull/76188
[#76197]: https://github.com/home-assistant/core/pull/76197
[#76198]: https://github.com/home-assistant/core/pull/76198
[#76199]: https://github.com/home-assistant/core/pull/76199
[#76207]: https://github.com/home-assistant/core/pull/76207
[#76217]: https://github.com/home-assistant/core/pull/76217
[#76219]: https://github.com/home-assistant/core/pull/76219
[#76231]: https://github.com/home-assistant/core/pull/76231
[#76232]: https://github.com/home-assistant/core/pull/76232
[#76233]: https://github.com/home-assistant/core/pull/76233
[@Jc2k]: https://github.com/Jc2k
[@MartinHjelmare]: https://github.com/MartinHjelmare
[@OnFreund]: https://github.com/OnFreund
[@bachya]: https://github.com/bachya
[@bdraco]: https://github.com/bdraco
[@bieniu]: https://github.com/bieniu
[@dgomes]: https://github.com/dgomes
[@engrbm87]: https://github.com/engrbm87
[@frenck]: https://github.com/frenck
[@jbouwh]: https://github.com/jbouwh
[@mkmer]: https://github.com/mkmer
[@pnbruckner]: https://github.com/pnbruckner
[aladdin_connect docs]: https://www.home-assistant.io/integrations/aladdin_connect/
[alexa docs]: https://www.home-assistant.io/integrations/alexa/
[bluetooth docs]: https://www.home-assistant.io/integrations/bluetooth/
[flunearyou docs]: https://www.home-assistant.io/integrations/flunearyou/
[flux_led docs]: https://www.home-assistant.io/integrations/flux_led/
[hassio docs]: https://www.home-assistant.io/integrations/hassio/
[homekit_controller docs]: https://www.home-assistant.io/integrations/homekit_controller/
[integration docs]: https://www.home-assistant.io/integrations/integration/
[life360 docs]: https://www.home-assistant.io/integrations/life360/
[luci docs]: https://www.home-assistant.io/integrations/luci/
[mikrotik docs]: https://www.home-assistant.io/integrations/mikrotik/
[nextdns docs]: https://www.home-assistant.io/integrations/nextdns/
[risco docs]: https://www.home-assistant.io/integrations/risco/
[rpi_power docs]: https://www.home-assistant.io/integrations/rpi_power/
[simplisafe docs]: https://www.home-assistant.io/integrations/simplisafe/
[zwave_js docs]: https://www.home-assistant.io/integrations/zwave_js/