### PR TITLE
Ensure bluetooth recovers if Dbus gets restarted

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
 import logging
+import time
 from typing import TYPE_CHECKING, Final
 
 import async_timeout
@@ -55,6 +56,10 @@ UNAVAILABLE_TRACK_SECONDS: Final = 60 * 5
 START_TIMEOUT = 9
 
 SOURCE_LOCAL: Final = "local"
+
+SCANNER_WATCHDOG_TIMEOUT: Final = 60 * 5
+SCANNER_WATCHDOG_INTERVAL: Final = timedelta(seconds=SCANNER_WATCHDOG_TIMEOUT)
+MONOTONIC_TIME = time.monotonic
 
 
 @dataclass
@@ -252,9 +257,10 @@ async def async_setup_entry(
 ) -> bool:
     """Set up the bluetooth integration from a config entry."""
     manager: BluetoothManager = hass.data[DOMAIN]
-    await manager.async_start(
-        BluetoothScanningMode.ACTIVE, entry.options.get(CONF_ADAPTER)
-    )
+    async with manager.start_stop_lock:
+        await manager.async_start(
+            BluetoothScanningMode.ACTIVE, entry.options.get(CONF_ADAPTER)
+        )
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
 
@@ -263,8 +269,6 @@ async def _async_update_listener(
     hass: HomeAssistant, entry: config_entries.ConfigEntry
 ) -> None:
     """Handle options update."""
-    manager: BluetoothManager = hass.data[DOMAIN]
-    manager.async_start_reload()
     await hass.config_entries.async_reload(entry.entry_id)
 
 
@@ -273,7 +277,9 @@ async def async_unload_entry(
 ) -> bool:
     """Unload a config entry."""
     manager: BluetoothManager = hass.data[DOMAIN]
-    await manager.async_stop()
+    async with manager.start_stop_lock:
+        manager.async_start_reload()
+        await manager.async_stop()
     return True
 
 
@@ -289,13 +295,19 @@ class BluetoothManager:
         self.hass = hass
         self._integration_matcher = integration_matcher
         self.scanner: HaBleakScanner | None = None
+        self.start_stop_lock = asyncio.Lock()
         self._cancel_device_detected: CALLBACK_TYPE | None = None
         self._cancel_unavailable_tracking: CALLBACK_TYPE | None = None
+        self._cancel_stop: CALLBACK_TYPE | None = None
+        self._cancel_watchdog: CALLBACK_TYPE | None = None
         self._unavailable_callbacks: dict[str, list[Callable[[str], None]]] = {}
         self._callbacks: list[
             tuple[BluetoothCallback, BluetoothCallbackMatcher | None]
         ] = []
+        self._last_detection = 0.0
         self._reloading = False
+        self._adapter: str | None = None
+        self._scanning_mode = BluetoothScanningMode.ACTIVE
 
     @hass_callback
     def async_setup(self) -> None:
@@ -317,6 +329,8 @@ class BluetoothManager:
     ) -> None:
         """Set up BT Discovery."""
         assert self.scanner is not None
+        self._adapter = adapter
+        self._scanning_mode = scanning_mode
         if self._reloading:
             # On reload, we need to reset the scanner instance
             # since the devices in its history may not be reachable
@@ -381,7 +395,29 @@ class BluetoothManager:
             _LOGGER.debug("BleakError while starting bluetooth: %s", ex, exc_info=True)
             raise ConfigEntryNotReady(f"Failed to start Bluetooth: {ex}") from ex
         self.async_setup_unavailable_tracking()
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.async_stop)
+        self._async_setup_scanner_watchdog()
+        self._cancel_stop = self.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STOP, self._async_hass_stopping
+        )
+
+    @hass_callback
+    def _async_setup_scanner_watchdog(self) -> None:
+        """If Dbus gets restarted or updated, we need to restart the scanner."""
+        self._last_detection = MONOTONIC_TIME()
+        self._cancel_watchdog = async_track_time_interval(
+            self.hass, self._async_scanner_watchdog, SCANNER_WATCHDOG_INTERVAL
+        )
+
+    async def _async_scanner_watchdog(self, now: datetime) -> None:
+        """Check if the scanner is running."""
+        time_since_last_detection = MONOTONIC_TIME() - self._last_detection
+        if time_since_last_detection < SCANNER_WATCHDOG_TIMEOUT:
+            return
+        _LOGGER.debug("Bluetooth scanner not running, restarting")
+        async with self.start_stop_lock:
+            self.async_start_reload()
+            await self.async_stop()
+            await self.async_start(self._scanning_mode, self._adapter)
 
     @hass_callback
     def async_setup_unavailable_tracking(self) -> None:
@@ -416,6 +452,7 @@ class BluetoothManager:
         self, device: BLEDevice, advertisement_data: AdvertisementData
     ) -> None:
         """Handle a detected device."""
+        self._last_detection = MONOTONIC_TIME()
         matched_domains = self._integration_matcher.match_domains(
             device, advertisement_data
         )
@@ -528,14 +565,26 @@ class BluetoothManager:
             for device_adv in self.scanner.history.values()
         ]
 
-    async def async_stop(self, event: Event | None = None) -> None:
+    async def _async_hass_stopping(self, event: Event) -> None:
+        """Stop the Bluetooth integration at shutdown."""
+        self._cancel_stop = None
+        await self.async_stop()
+
+    async def async_stop(self) -> None:
         """Stop bluetooth discovery."""
+        _LOGGER.debug("Stopping bluetooth discovery")
+        if self._cancel_watchdog:
+            self._cancel_watchdog()
+            self._cancel_watchdog = None
         if self._cancel_device_detected:
             self._cancel_device_detected()
             self._cancel_device_detected = None
         if self._cancel_unavailable_tracking:
             self._cancel_unavailable_tracking()
             self._cancel_unavailable_tracking = None
+        if self._cancel_stop:
+            self._cancel_stop()
+            self._cancel_stop = None
         if self.scanner:
             try:
                 await self.scanner.stop()  # type: ignore[no-untyped-call]

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -413,7 +413,10 @@ class BluetoothManager:
         time_since_last_detection = MONOTONIC_TIME() - self._last_detection
         if time_since_last_detection < SCANNER_WATCHDOG_TIMEOUT:
             return
-        _LOGGER.debug("Bluetooth scanner not running, restarting")
+        _LOGGER.info(
+            "Bluetooth scanner has gone quiet for %s, restarting",
+            SCANNER_WATCHDOG_INTERVAL,
+        )
         async with self.start_stop_lock:
             self.async_start_reload()
             await self.async_stop()


### PR DESCRIPTION
Until this merging, manually reloading the bluetooth integration should work around the issue.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If Dbus gets restarted out from under us everything will fail to connect with `Method "Connect" with signature "" on interface "org.bluez.Device1" doesn't exist` because the devices will no longer be available on the bus.  We need to restart the scanner so it reconnects the devices to the bus if everything has gone quiet.

This should fix the issues were users reporting bluetooth stops working overnight when the host installs updates and restarts services.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #76319 fixes #75962
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
