### PR TITLE
Improve Life360 address attribute

### DIFF
--- a/homeassistant/components/life360/coordinator.py
+++ b/homeassistant/components/life360/coordinator.py
@@ -64,10 +64,7 @@ class Life360Circle:
 class Life360Member:
     """Life360 Member data."""
 
-    # Don't include address field in eq comparison because it often changes (back and
-    # forth) between updates. If it was included there would be way more state changes
-    # and database updates than is useful.
-    address: str | None = field(compare=False)
+    address: str | None
     at_loc_since: datetime
     battery_charging: bool
     battery_level: int
@@ -203,15 +200,12 @@ class Life360DataUpdateCoordinator(DataUpdateCoordinator[Life360Data]):
 
                 place = loc["name"] or None
 
-                if place:
-                    address: str | None = place
+                address1: str | None = loc["address1"] or None
+                address2: str | None = loc["address2"] or None
+                if address1 and address2:
+                    address: str | None = ", ".join([address1, address2])
                 else:
-                    address1 = loc["address1"] or None
-                    address2 = loc["address2"] or None
-                    if address1 and address2:
-                        address = ", ".join([address1, address2])
-                    else:
-                        address = address1 or address2
+                    address = address1 or address2
 
                 speed = max(0, float(loc["speed"]) * SPEED_FACTOR_MPH)
                 if self._hass.config.units.is_metric:

--- a/homeassistant/components/life360/device_tracker.py
+++ b/homeassistant/components/life360/device_tracker.py
@@ -171,7 +171,6 @@ class Life360DeviceTracker(
                 # Overwrite new location related data with previous values.
                 for attr in _LOC_ATTRS:
                     setattr(self._data, attr, getattr(self._prev_data, attr))
-                self._addresses = []
 
             else:
                 # Process address field.

--- a/homeassistant/components/life360/device_tracker.py
+++ b/homeassistant/components/life360/device_tracker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import suppress
 from typing import Any, cast
 
 from homeassistant.components.device_tracker import SourceType
@@ -114,6 +115,17 @@ class Life360DeviceTracker(
         self._attr_name = self._data.name
         self._attr_entity_picture = self._data.entity_picture
 
+        # Server sends a pair of address values on alternate updates. Keep the pair of
+        # values so they can be combined into the one address attribute.
+        # The pair will either be two different address values, or one address and a
+        # copy of the Place value (if the Member is in a Place.) In the latter case we
+        # won't duplicate the Place name, but rather just use one the address value. Use
+        # the value of None to hold one of the "slots" in the list so we'll know not to
+        # expect another address value.
+        if (address := self._data.address) == self._data.place:
+            address = None
+        self._addresses = [address]
+
     @property
     def _options(self) -> Mapping[str, Any]:
         """Shortcut to config entry options."""
@@ -159,6 +171,31 @@ class Life360DeviceTracker(
                 # Overwrite new location related data with previous values.
                 for attr in _LOC_ATTRS:
                     setattr(self._data, attr, getattr(self._prev_data, attr))
+                self._addresses = []
+
+            else:
+                # Process address field.
+                # Check if we got the name of a Place, which we won't use.
+                if (address := self._data.address) == self._data.place:
+                    address = None
+                if last_seen != prev_seen:
+                    # We have new location data, so we might have a new pair of address
+                    # values.
+                    if address not in self._addresses:
+                        # We do.
+                        # Replace the old values with the first value of the new pair.
+                        self._addresses = [address]
+                elif self._data.address != self._prev_data.address:
+                    # Location data didn't change in general, but the address field did.
+                    # There are three possibilities:
+                    # 1. The new value is one of the pair we've already seen before.
+                    # 2. The new value is the second of the pair we haven't seen yet.
+                    # 3. The new value is the first of a new pair of values.
+                    if address not in self._addresses:
+                        if len(self._addresses) < 2:
+                            self._addresses.append(address)
+                        else:
+                            self._addresses = [address]
 
             self._prev_data = self._data
 
@@ -246,8 +283,26 @@ class Life360DeviceTracker(
                 ATTR_SPEED: None,
                 ATTR_WIFI_ON: None,
             }
+
+        # Generate address attribute from pair of address values.
+        # There may be two, one or no values. If there are two, sort the strings since
+        # one value is typically a numbered street address and the other is a street,
+        # town or state name, and it's helpful to start with the more detailed address
+        # value. Also, sorting helps to generate the same result if we get a location
+        # update, and the same pair is sent afterwards, but where the value that comes
+        # first is swapped vs the order they came in before the update.
+        address1: str | None = None
+        address2: str | None = None
+        with suppress(IndexError):
+            address1 = self._addresses[0]
+            address2 = self._addresses[1]
+        if address1 and address2:
+            address: str | None = " / ".join(sorted([address1, address2]))
+        else:
+            address = address1 or address2
+
         return {
-            ATTR_ADDRESS: self._data.address,
+            ATTR_ADDRESS: address,
             ATTR_AT_LOC_SINCE: self._data.at_loc_since,
             ATTR_BATTERY_CHARGING: self._data.battery_charging,
             ATTR_DRIVING: self.driving,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After more detailed observation of the address values sent by the Life360 server,
it became obvious that it sends two values on alternate updates. E.g., it might send:

"123 Elm St" then "Hometown, XYZ"

Or, if the Member happens to be in a Life360 Place (e.g., Work), it might send that
Place name as one of the strings:

"Elm St, Hometown" then "Work"

This change keeps track of the pair of values and generates a more informative value
for the `address` attribute.

E.g., before it might have just happened to grab and use:

"Hometown, XYZ"

whereas now the `address` attribute would be:

"123 Elm St / Hometown, XYZ"

Note that if one of the values is the name of the Place, that will not be used, since that
value is already in the `place` attribute.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
