### PR TITLE
Remove deprecated `send_if_off` option for MQTT climate

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -181,7 +181,6 @@ ABBREVIATIONS = {
     "rgbww_stat_t": "rgbww_state_topic",
     "rgbww_val_tpl": "rgbww_value_template",
     "send_cmd_t": "send_command_topic",
-    "send_if_off": "send_if_off",
     "set_fan_spd_t": "set_fan_speed_topic",
     "set_pos_tpl": "set_position_template",
     "set_pos_t": "set_position_topic",

--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -181,6 +181,7 @@ ABBREVIATIONS = {
     "rgbww_stat_t": "rgbww_state_topic",
     "rgbww_val_tpl": "rgbww_value_template",
     "send_cmd_t": "send_command_topic",
+    "send_if_off": "send_if_off",
     "set_fan_spd_t": "set_fan_speed_topic",
     "set_pos_tpl": "set_position_template",
     "set_pos_t": "set_position_topic",

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -99,8 +99,6 @@ CONF_PRESET_MODE_COMMAND_TOPIC = "preset_mode_command_topic"
 CONF_PRESET_MODE_VALUE_TEMPLATE = "preset_mode_value_template"
 CONF_PRESET_MODE_COMMAND_TEMPLATE = "preset_mode_command_template"
 CONF_PRESET_MODES_LIST = "preset_modes"
-# CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-CONF_SEND_IF_OFF = "send_if_off"
 CONF_SWING_MODE_COMMAND_TEMPLATE = "swing_mode_command_template"
 CONF_SWING_MODE_COMMAND_TOPIC = "swing_mode_command_topic"
 CONF_SWING_MODE_LIST = "swing_modes"
@@ -284,8 +282,6 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
             [PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]
         ),
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
-        # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        vol.Optional(CONF_SEND_IF_OFF): cv.boolean,
         vol.Optional(CONF_ACTION_TEMPLATE): cv.template,
         vol.Optional(CONF_ACTION_TOPIC): valid_subscribe_topic,
         # CONF_PRESET_MODE_COMMAND_TOPIC and CONF_PRESET_MODES_LIST must be used together
@@ -334,8 +330,6 @@ PLATFORM_SCHEMA_MODERN = vol.All(
 # Configuring MQTT Climate under the climate platform key is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
-    # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-    cv.deprecated(CONF_SEND_IF_OFF),
     # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
     cv.deprecated(CONF_AWAY_MODE_COMMAND_TOPIC),
     cv.deprecated(CONF_AWAY_MODE_STATE_TEMPLATE),
@@ -353,8 +347,6 @@ _DISCOVERY_SCHEMA_BASE = _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA
 
 DISCOVERY_SCHEMA = vol.All(
     _DISCOVERY_SCHEMA_BASE,
-    # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-    cv.deprecated(CONF_SEND_IF_OFF),
     # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
     cv.deprecated(CONF_AWAY_MODE_COMMAND_TOPIC),
     cv.deprecated(CONF_AWAY_MODE_STATE_TEMPLATE),
@@ -437,8 +429,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
         self._feature_preset_mode = False
         self._optimistic_preset_mode = None
 
-        # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        self._send_if_off = True
         # AWAY and HOLD mode topics and templates are deprecated,
         # support will be removed with release 2022.9
         self._hold_list = []
@@ -510,10 +500,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
             ).async_render
 
         self._command_templates = command_templates
-
-        # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        if CONF_SEND_IF_OFF in config:
-            self._send_if_off = config[CONF_SEND_IF_OFF]
 
         # AWAY and HOLD mode topics and templates are deprecated,
         # support will be removed with release 2022.9
@@ -871,10 +857,8 @@ class MqttClimate(MqttEntity, ClimateEntity):
                 # optimistic mode
                 setattr(self, attr, temp)
 
-            # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-            if self._send_if_off or self._current_operation != HVACMode.OFF:
-                payload = self._command_templates[cmnd_template](temp)
-                await self._publish(cmnd_topic, payload)
+            payload = self._command_templates[cmnd_template](temp)
+            await self._publish(cmnd_topic, payload)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""
@@ -910,12 +894,8 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new swing mode."""
-        # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        if self._send_if_off or self._current_operation != HVACMode.OFF:
-            payload = self._command_templates[CONF_SWING_MODE_COMMAND_TEMPLATE](
-                swing_mode
-            )
-            await self._publish(CONF_SWING_MODE_COMMAND_TOPIC, payload)
+        payload = self._command_templates[CONF_SWING_MODE_COMMAND_TEMPLATE](swing_mode)
+        await self._publish(CONF_SWING_MODE_COMMAND_TOPIC, payload)
 
         if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None:
             self._current_swing_mode = swing_mode
@@ -923,10 +903,8 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target temperature."""
-        # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        if self._send_if_off or self._current_operation != HVACMode.OFF:
-            payload = self._command_templates[CONF_FAN_MODE_COMMAND_TEMPLATE](fan_mode)
-            await self._publish(CONF_FAN_MODE_COMMAND_TOPIC, payload)
+        payload = self._command_templates[CONF_FAN_MODE_COMMAND_TEMPLATE](fan_mode)
+        await self._publish(CONF_FAN_MODE_COMMAND_TOPIC, payload)
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
             self._current_fan_mode = fan_mode

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -99,6 +99,8 @@ CONF_PRESET_MODE_COMMAND_TOPIC = "preset_mode_command_topic"
 CONF_PRESET_MODE_VALUE_TEMPLATE = "preset_mode_value_template"
 CONF_PRESET_MODE_COMMAND_TEMPLATE = "preset_mode_command_template"
 CONF_PRESET_MODES_LIST = "preset_modes"
+# Support CONF_SEND_IF_OFF is removed with release 2022.9
+CONF_SEND_IF_OFF = "send_if_off"
 CONF_SWING_MODE_COMMAND_TEMPLATE = "swing_mode_command_template"
 CONF_SWING_MODE_COMMAND_TOPIC = "swing_mode_command_topic"
 CONF_SWING_MODE_LIST = "swing_modes"
@@ -330,6 +332,8 @@ PLATFORM_SCHEMA_MODERN = vol.All(
 # Configuring MQTT Climate under the climate platform key is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
+    # Support CONF_SEND_IF_OFF is removed with release 2022.9
+    cv.removed(CONF_SEND_IF_OFF),
     # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
     cv.deprecated(CONF_AWAY_MODE_COMMAND_TOPIC),
     cv.deprecated(CONF_AWAY_MODE_STATE_TEMPLATE),
@@ -347,6 +351,8 @@ _DISCOVERY_SCHEMA_BASE = _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA
 
 DISCOVERY_SCHEMA = vol.All(
     _DISCOVERY_SCHEMA_BASE,
+    # Support CONF_SEND_IF_OFF is removed with release 2022.9
+    cv.removed(CONF_SEND_IF_OFF),
     # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
     cv.deprecated(CONF_AWAY_MODE_COMMAND_TOPIC),
     cv.deprecated(CONF_AWAY_MODE_STATE_TEMPLATE),

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -349,44 +349,6 @@ async def test_set_fan_mode(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("fan_mode") == "high"
 
 
-# CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-@pytest.mark.parametrize(
-    "send_if_off,assert_async_publish",
-    [
-        ({}, [call("fan-mode-topic", "low", 0, False)]),
-        ({"send_if_off": True}, [call("fan-mode-topic", "low", 0, False)]),
-        ({"send_if_off": False}, []),
-    ],
-)
-async def test_set_fan_mode_send_if_off(
-    hass, mqtt_mock_entry_with_yaml_config, send_if_off, assert_async_publish
-):
-    """Test setting of fan mode if the hvac is off."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
-    config[CLIMATE_DOMAIN].update(send_if_off)
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-    assert hass.states.get(ENTITY_CLIMATE) is not None
-
-    # Turn on HVAC
-    await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.reset_mock()
-    # Updates for fan_mode should be sent when the device is turned on
-    await common.async_set_fan_mode(hass, "high", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.assert_called_once_with("fan-mode-topic", "high", 0, False)
-
-    # Turn off HVAC
-    await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.state == "off"
-
-    # Updates for fan_mode should be sent if SEND_IF_OFF is not set or is True
-    mqtt_mock.async_publish.reset_mock()
-    await common.async_set_fan_mode(hass, "low", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.assert_has_calls(assert_async_publish)
-
-
 async def test_set_swing_mode_bad_attr(hass, mqtt_mock_entry_with_yaml_config, caplog):
     """Test setting swing mode without required attribute."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
@@ -442,44 +404,6 @@ async def test_set_swing(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("swing_mode") == "on"
 
 
-# CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-@pytest.mark.parametrize(
-    "send_if_off,assert_async_publish",
-    [
-        ({}, [call("swing-mode-topic", "on", 0, False)]),
-        ({"send_if_off": True}, [call("swing-mode-topic", "on", 0, False)]),
-        ({"send_if_off": False}, []),
-    ],
-)
-async def test_set_swing_mode_send_if_off(
-    hass, mqtt_mock_entry_with_yaml_config, send_if_off, assert_async_publish
-):
-    """Test setting of swing mode if the hvac is off."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
-    config[CLIMATE_DOMAIN].update(send_if_off)
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-    assert hass.states.get(ENTITY_CLIMATE) is not None
-
-    # Turn on HVAC
-    await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.reset_mock()
-    # Updates for swing_mode should be sent when the device is turned on
-    await common.async_set_swing_mode(hass, "off", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.assert_called_once_with("swing-mode-topic", "off", 0, False)
-
-    # Turn off HVAC
-    await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.state == "off"
-
-    # Updates for swing_mode should be sent if SEND_IF_OFF is not set or is True
-    mqtt_mock.async_publish.reset_mock()
-    await common.async_set_swing_mode(hass, "on", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.assert_has_calls(assert_async_publish)
-
-
 async def test_set_target_temperature(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting the target temperature."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
@@ -515,46 +439,6 @@ async def test_set_target_temperature(hass, mqtt_mock_entry_with_yaml_config):
         ]
     )
     mqtt_mock.async_publish.reset_mock()
-
-
-# CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-@pytest.mark.parametrize(
-    "send_if_off,assert_async_publish",
-    [
-        ({}, [call("temperature-topic", "21.0", 0, False)]),
-        ({"send_if_off": True}, [call("temperature-topic", "21.0", 0, False)]),
-        ({"send_if_off": False}, []),
-    ],
-)
-async def test_set_target_temperature_send_if_off(
-    hass, mqtt_mock_entry_with_yaml_config, send_if_off, assert_async_publish
-):
-    """Test setting of target temperature if the hvac is off."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
-    config[CLIMATE_DOMAIN].update(send_if_off)
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-    assert hass.states.get(ENTITY_CLIMATE) is not None
-
-    # Turn on HVAC
-    await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.reset_mock()
-    # Updates for target temperature should be sent when the device is turned on
-    await common.async_set_temperature(hass, 16.0, ENTITY_CLIMATE)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "temperature-topic", "16.0", 0, False
-    )
-
-    # Turn off HVAC
-    await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.state == "off"
-
-    # Updates for target temperature sent should be if SEND_IF_OFF is not set or is True
-    mqtt_mock.async_publish.reset_mock()
-    await common.async_set_temperature(hass, 21.0, ENTITY_CLIMATE)
-    mqtt_mock.async_publish.assert_has_calls(assert_async_publish)
 
 
 async def test_set_target_temperature_pessimistic(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `send_if_off` config parameter, which was deprecated in Home Assistant Core 2022.3.0, has been removed from the MQTT climate platform.
This means that an MQTT payload will always be sent when either of `fan_mode` or `swing_mode` is changed or the `temperature` is set, even when the climate is turned off.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT climate config parameters `send_if_off` was deprecated with the HA 2022.3.0 release and will now be removed (HA 2022.9.0).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
