### PR TITLE
Remove MQTT climate support for hold and away modes

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -19,7 +19,6 @@ from homeassistant.components.climate.const import (
     FAN_HIGH,
     FAN_LOW,
     FAN_MEDIUM,
-    PRESET_AWAY,
     PRESET_NONE,
     SWING_OFF,
     SWING_ON,
@@ -68,10 +67,11 @@ CONF_ACTION_TOPIC = "action_topic"
 CONF_AUX_COMMAND_TOPIC = "aux_command_topic"
 CONF_AUX_STATE_TEMPLATE = "aux_state_template"
 CONF_AUX_STATE_TOPIC = "aux_state_topic"
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
+# AWAY and HOLD mode topics and templates are no longer supported, support was removed with release 2022.9
 CONF_AWAY_MODE_COMMAND_TOPIC = "away_mode_command_topic"
 CONF_AWAY_MODE_STATE_TEMPLATE = "away_mode_state_template"
 CONF_AWAY_MODE_STATE_TOPIC = "away_mode_state_topic"
+
 CONF_CURRENT_TEMP_TEMPLATE = "current_temperature_template"
 CONF_CURRENT_TEMP_TOPIC = "current_temperature_topic"
 CONF_FAN_MODE_COMMAND_TEMPLATE = "fan_mode_command_template"
@@ -79,12 +79,13 @@ CONF_FAN_MODE_COMMAND_TOPIC = "fan_mode_command_topic"
 CONF_FAN_MODE_LIST = "fan_modes"
 CONF_FAN_MODE_STATE_TEMPLATE = "fan_mode_state_template"
 CONF_FAN_MODE_STATE_TOPIC = "fan_mode_state_topic"
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
+# AWAY and HOLD mode topics and templates are no longer supported, support was removed with release 2022.9
 CONF_HOLD_COMMAND_TEMPLATE = "hold_command_template"
 CONF_HOLD_COMMAND_TOPIC = "hold_command_topic"
 CONF_HOLD_STATE_TEMPLATE = "hold_state_template"
 CONF_HOLD_STATE_TOPIC = "hold_state_topic"
 CONF_HOLD_LIST = "hold_modes"
+
 CONF_MODE_COMMAND_TEMPLATE = "mode_command_template"
 CONF_MODE_COMMAND_TOPIC = "mode_command_topic"
 CONF_MODE_LIST = "modes"
@@ -150,12 +151,8 @@ MQTT_CLIMATE_ATTRIBUTES_BLOCKED = frozenset(
 
 VALUE_TEMPLATE_KEYS = (
     CONF_AUX_STATE_TEMPLATE,
-    # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-    CONF_AWAY_MODE_STATE_TEMPLATE,
     CONF_CURRENT_TEMP_TEMPLATE,
     CONF_FAN_MODE_STATE_TEMPLATE,
-    # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-    CONF_HOLD_STATE_TEMPLATE,
     CONF_MODE_STATE_TEMPLATE,
     CONF_POWER_STATE_TEMPLATE,
     CONF_ACTION_TEMPLATE,
@@ -168,8 +165,6 @@ VALUE_TEMPLATE_KEYS = (
 
 COMMAND_TEMPLATE_KEYS = {
     CONF_FAN_MODE_COMMAND_TEMPLATE,
-    # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-    CONF_HOLD_COMMAND_TEMPLATE,
     CONF_MODE_COMMAND_TEMPLATE,
     CONF_PRESET_MODE_COMMAND_TEMPLATE,
     CONF_SWING_MODE_COMMAND_TEMPLATE,
@@ -178,32 +173,14 @@ COMMAND_TEMPLATE_KEYS = {
     CONF_TEMP_LOW_COMMAND_TEMPLATE,
 }
 
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-DEPRECATED_INVALID = [
-    CONF_AWAY_MODE_COMMAND_TOPIC,
-    CONF_AWAY_MODE_STATE_TEMPLATE,
-    CONF_AWAY_MODE_STATE_TOPIC,
-    CONF_HOLD_COMMAND_TEMPLATE,
-    CONF_HOLD_COMMAND_TOPIC,
-    CONF_HOLD_STATE_TEMPLATE,
-    CONF_HOLD_STATE_TOPIC,
-    CONF_HOLD_LIST,
-]
-
 
 TOPIC_KEYS = (
     CONF_ACTION_TOPIC,
     CONF_AUX_COMMAND_TOPIC,
     CONF_AUX_STATE_TOPIC,
-    # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-    CONF_AWAY_MODE_COMMAND_TOPIC,
-    CONF_AWAY_MODE_STATE_TOPIC,
     CONF_CURRENT_TEMP_TOPIC,
     CONF_FAN_MODE_COMMAND_TOPIC,
     CONF_FAN_MODE_STATE_TOPIC,
-    # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-    CONF_HOLD_COMMAND_TOPIC,
-    CONF_HOLD_STATE_TOPIC,
     CONF_MODE_COMMAND_TOPIC,
     CONF_MODE_STATE_TOPIC,
     CONF_POWER_COMMAND_TOPIC,
@@ -225,12 +202,6 @@ def valid_preset_mode_configuration(config):
     """Validate that the preset mode reset payload is not one of the preset modes."""
     if PRESET_NONE in config.get(CONF_PRESET_MODES_LIST):
         raise ValueError("preset_modes must not include preset mode 'none'")
-    if config.get(CONF_PRESET_MODE_COMMAND_TOPIC):
-        for config_parameter in DEPRECATED_INVALID:
-            if config.get(config_parameter):
-                raise vol.MultipleInvalid(
-                    "preset_modes cannot be used with deprecated away or hold mode config options"
-                )
     return config
 
 
@@ -239,10 +210,6 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_AUX_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_AUX_STATE_TEMPLATE): cv.template,
         vol.Optional(CONF_AUX_STATE_TOPIC): valid_subscribe_topic,
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        vol.Optional(CONF_AWAY_MODE_COMMAND_TOPIC): valid_publish_topic,
-        vol.Optional(CONF_AWAY_MODE_STATE_TEMPLATE): cv.template,
-        vol.Optional(CONF_AWAY_MODE_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_CURRENT_TEMP_TEMPLATE): cv.template,
         vol.Optional(CONF_CURRENT_TEMP_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_FAN_MODE_COMMAND_TEMPLATE): cv.template,
@@ -253,12 +220,6 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
         ): cv.ensure_list,
         vol.Optional(CONF_FAN_MODE_STATE_TEMPLATE): cv.template,
         vol.Optional(CONF_FAN_MODE_STATE_TOPIC): valid_subscribe_topic,
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        vol.Optional(CONF_HOLD_COMMAND_TEMPLATE): cv.template,
-        vol.Optional(CONF_HOLD_COMMAND_TOPIC): valid_publish_topic,
-        vol.Optional(CONF_HOLD_STATE_TEMPLATE): cv.template,
-        vol.Optional(CONF_HOLD_STATE_TOPIC): valid_subscribe_topic,
-        vol.Optional(CONF_HOLD_LIST): cv.ensure_list,
         vol.Optional(CONF_MODE_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_MODE_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(
@@ -334,15 +295,15 @@ PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
     # Support CONF_SEND_IF_OFF is removed with release 2022.9
     cv.removed(CONF_SEND_IF_OFF),
-    # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-    cv.deprecated(CONF_AWAY_MODE_COMMAND_TOPIC),
-    cv.deprecated(CONF_AWAY_MODE_STATE_TEMPLATE),
-    cv.deprecated(CONF_AWAY_MODE_STATE_TOPIC),
-    cv.deprecated(CONF_HOLD_COMMAND_TEMPLATE),
-    cv.deprecated(CONF_HOLD_COMMAND_TOPIC),
-    cv.deprecated(CONF_HOLD_STATE_TEMPLATE),
-    cv.deprecated(CONF_HOLD_STATE_TOPIC),
-    cv.deprecated(CONF_HOLD_LIST),
+    # AWAY and HOLD mode topics and templates are no longer supported, support was removed with release 2022.9
+    cv.removed(CONF_AWAY_MODE_COMMAND_TOPIC),
+    cv.removed(CONF_AWAY_MODE_STATE_TEMPLATE),
+    cv.removed(CONF_AWAY_MODE_STATE_TOPIC),
+    cv.removed(CONF_HOLD_COMMAND_TEMPLATE),
+    cv.removed(CONF_HOLD_COMMAND_TOPIC),
+    cv.removed(CONF_HOLD_STATE_TEMPLATE),
+    cv.removed(CONF_HOLD_STATE_TOPIC),
+    cv.removed(CONF_HOLD_LIST),
     valid_preset_mode_configuration,
     warn_for_legacy_schema(climate.DOMAIN),
 )
@@ -353,15 +314,15 @@ DISCOVERY_SCHEMA = vol.All(
     _DISCOVERY_SCHEMA_BASE,
     # Support CONF_SEND_IF_OFF is removed with release 2022.9
     cv.removed(CONF_SEND_IF_OFF),
-    # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-    cv.deprecated(CONF_AWAY_MODE_COMMAND_TOPIC),
-    cv.deprecated(CONF_AWAY_MODE_STATE_TEMPLATE),
-    cv.deprecated(CONF_AWAY_MODE_STATE_TOPIC),
-    cv.deprecated(CONF_HOLD_COMMAND_TEMPLATE),
-    cv.deprecated(CONF_HOLD_COMMAND_TOPIC),
-    cv.deprecated(CONF_HOLD_STATE_TEMPLATE),
-    cv.deprecated(CONF_HOLD_STATE_TOPIC),
-    cv.deprecated(CONF_HOLD_LIST),
+    # AWAY and HOLD mode topics and templates are no longer supported, support was removed with release 2022.9
+    cv.removed(CONF_AWAY_MODE_COMMAND_TOPIC),
+    cv.removed(CONF_AWAY_MODE_STATE_TEMPLATE),
+    cv.removed(CONF_AWAY_MODE_STATE_TOPIC),
+    cv.removed(CONF_HOLD_COMMAND_TEMPLATE),
+    cv.removed(CONF_HOLD_COMMAND_TOPIC),
+    cv.removed(CONF_HOLD_STATE_TEMPLATE),
+    cv.removed(CONF_HOLD_STATE_TOPIC),
+    cv.removed(CONF_HOLD_LIST),
     valid_preset_mode_configuration,
 )
 
@@ -419,12 +380,10 @@ class MqttClimate(MqttEntity, ClimateEntity):
         """Initialize the climate device."""
         self._action = None
         self._aux = False
-        self._away = False
         self._current_fan_mode = None
         self._current_operation = None
         self._current_swing_mode = None
         self._current_temp = None
-        self._hold = None
         self._preset_mode = None
         self._target_temp = None
         self._target_temp_high = None
@@ -434,10 +393,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
         self._command_templates = None
         self._feature_preset_mode = False
         self._optimistic_preset_mode = None
-
-        # AWAY and HOLD mode topics and templates are deprecated,
-        # support will be removed with release 2022.9
-        self._hold_list = []
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
@@ -477,9 +432,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
             self._preset_modes = []
         self._optimistic_preset_mode = CONF_PRESET_MODE_STATE_TOPIC not in config
         self._action = None
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        self._away = False
-        self._hold = None
         self._aux = False
 
         value_templates = {}
@@ -506,11 +458,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
             ).async_render
 
         self._command_templates = command_templates
-
-        # AWAY and HOLD mode topics and templates are deprecated,
-        # support will be removed with release 2022.9
-        if CONF_HOLD_LIST in config:
-            self._hold_list = config[CONF_HOLD_LIST]
 
     def _prepare_subscribe_topics(self):  # noqa: C901
         """(Re)Subscribe to topics."""
@@ -682,15 +629,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
             self.async_write_ha_state()
 
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        @callback
-        @log_messages(self.hass, self.entity_id)
-        def handle_away_mode_received(msg):
-            """Handle receiving away mode via MQTT."""
-            handle_onoff_mode_received(msg, CONF_AWAY_MODE_STATE_TEMPLATE, "_away")
-
-        add_subscription(topics, CONF_AWAY_MODE_STATE_TOPIC, handle_away_mode_received)
-
         @callback
         @log_messages(self.hass, self.entity_id)
         def handle_aux_mode_received(msg):
@@ -698,22 +636,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
             handle_onoff_mode_received(msg, CONF_AUX_STATE_TEMPLATE, "_aux")
 
         add_subscription(topics, CONF_AUX_STATE_TOPIC, handle_aux_mode_received)
-
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        @callback
-        @log_messages(self.hass, self.entity_id)
-        def handle_hold_mode_received(msg):
-            """Handle receiving hold mode via MQTT."""
-            payload = render_template(msg, CONF_HOLD_STATE_TEMPLATE)
-
-            if payload == "off":
-                payload = None
-
-            self._hold = payload
-            self._preset_mode = None
-            self.async_write_ha_state()
-
-        add_subscription(topics, CONF_HOLD_STATE_TOPIC, handle_hold_mode_received)
 
         @callback
         @log_messages(self.hass, self.entity_id)
@@ -802,11 +724,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
         """Return preset mode."""
         if self._feature_preset_mode and self._preset_mode is not None:
             return self._preset_mode
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        if self._hold:
-            return self._hold
-        if self._away:
-            return PRESET_AWAY
         return PRESET_NONE
 
     @property
@@ -814,17 +731,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
         """Return preset modes."""
         presets = []
         presets.extend(self._preset_modes)
-
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        if (self._topic[CONF_AWAY_MODE_STATE_TOPIC] is not None) or (
-            self._topic[CONF_AWAY_MODE_COMMAND_TOPIC] is not None
-        ):
-            presets.append(PRESET_AWAY)
-
-        # AWAY and HOLD mode topics and templates are deprecated,
-        # support will be removed with release 2022.9
-        presets.extend(self._hold_list)
-
         if presets:
             presets.insert(0, PRESET_NONE)
 
@@ -895,7 +801,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
             "_target_temp_high",
         )
 
-        # Always optimistic?
         self.async_write_ha_state()
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
@@ -962,49 +867,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
             return
 
-        # Update hold or away mode: Track if we should optimistic update the state
-        optimistic_update = await self._set_away_mode(preset_mode == PRESET_AWAY)
-        hold_mode: str | None = preset_mode
-        if preset_mode in [PRESET_NONE, PRESET_AWAY]:
-            hold_mode = None
-        optimistic_update = await self._set_hold_mode(hold_mode) or optimistic_update
-
-        if optimistic_update:
-            self.async_write_ha_state()
-
-    # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-    async def _set_away_mode(self, state):
-        """Set away mode.
-
-        Returns if we should optimistically write the state.
-        """
-        await self._publish(
-            CONF_AWAY_MODE_COMMAND_TOPIC,
-            self._config[CONF_PAYLOAD_ON] if state else self._config[CONF_PAYLOAD_OFF],
-        )
-
-        if self._topic[CONF_AWAY_MODE_STATE_TOPIC] is not None:
-            return False
-
-        self._away = state
-        return True
-
-    async def _set_hold_mode(self, hold_mode):
-        """Set hold mode.
-
-        Returns if we should optimistically write the state.
-        """
-        payload = self._command_templates[CONF_HOLD_COMMAND_TEMPLATE](
-            hold_mode or "off"
-        )
-        await self._publish(CONF_HOLD_COMMAND_TOPIC, payload)
-
-        if self._topic[CONF_HOLD_STATE_TOPIC] is not None:
-            return False
-
-        self._hold = hold_mode
-        return True
-
     async def _set_aux_heat(self, state):
         await self._publish(
             CONF_AUX_COMMAND_TOPIC,
@@ -1053,14 +915,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
         ):
             support |= ClimateEntityFeature.SWING_MODE
 
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        if (
-            self._feature_preset_mode
-            or (self._topic[CONF_AWAY_MODE_STATE_TOPIC] is not None)
-            or (self._topic[CONF_AWAY_MODE_COMMAND_TOPIC] is not None)
-            or (self._topic[CONF_HOLD_STATE_TOPIC] is not None)
-            or (self._topic[CONF_HOLD_COMMAND_TOPIC] is not None)
-        ):
+        if self._feature_preset_mode:
             support |= ClimateEntityFeature.PRESET_MODE
 
         if (self._topic[CONF_AUX_STATE_TOPIC] is not None) or (

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -13,15 +13,12 @@ from homeassistant.components.climate.const import (
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
     ATTR_HVAC_ACTION,
-    ATTR_PRESET_MODE,
     ATTR_SWING_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     CURRENT_HVAC_ACTIONS,
     DOMAIN as CLIMATE_DOMAIN,
-    PRESET_AWAY,
     PRESET_ECO,
-    PRESET_NONE,
     ClimateEntityFeature,
     HVACMode,
 )
@@ -86,23 +83,6 @@ DEFAULT_CONFIG = {
             "sleep",
             "activity",
         ],
-    }
-}
-
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-DEFAULT_LEGACY_CONFIG = {
-    CLIMATE_DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "mode_command_topic": "mode-topic",
-        "temperature_command_topic": "temperature-topic",
-        "temperature_low_command_topic": "temperature-low-topic",
-        "temperature_high_command_topic": "temperature-high-topic",
-        "fan_mode_command_topic": "fan-mode-topic",
-        "swing_mode_command_topic": "swing-mode-topic",
-        "aux_command_topic": "aux-topic",
-        "away_mode_command_topic": "away-mode-topic",
-        "hold_command_topic": "hold-topic",
     }
 }
 
@@ -654,241 +634,6 @@ async def test_set_preset_mode_pessimistic(
     assert state.attributes.get("preset_mode") == "home"
 
 
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-async def test_set_away_mode_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
-    """Test setting of the away mode."""
-    config = copy.deepcopy(DEFAULT_LEGACY_CONFIG)
-    config["climate"]["away_mode_state_topic"] = "away-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-
-    await common.async_set_preset_mode(hass, "away", ENTITY_CLIMATE)
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-
-    async_fire_mqtt_message(hass, "away-state", "ON")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "away"
-
-    async_fire_mqtt_message(hass, "away-state", "OFF")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-
-    async_fire_mqtt_message(hass, "away-state", "nonsense")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-
-
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-async def test_set_away_mode(hass, mqtt_mock_entry_with_yaml_config):
-    """Test setting of the away mode."""
-    config = copy.deepcopy(DEFAULT_LEGACY_CONFIG)
-    config["climate"]["payload_on"] = "AN"
-    config["climate"]["payload_off"] = "AUS"
-
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-
-    mqtt_mock.async_publish.reset_mock()
-    await common.async_set_preset_mode(hass, "away", ENTITY_CLIMATE)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "AN", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "off", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "away"
-
-    await common.async_set_preset_mode(hass, PRESET_NONE, ENTITY_CLIMATE)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "AUS", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "off", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-
-    await common.async_set_preset_mode(hass, "hold-on", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.reset_mock()
-
-    await common.async_set_preset_mode(hass, "away", ENTITY_CLIMATE)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "AN", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "off", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "away"
-
-
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-async def test_set_hold_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
-    """Test setting the hold mode in pessimistic mode."""
-    config = copy.deepcopy(DEFAULT_LEGACY_CONFIG)
-    config["climate"]["hold_state_topic"] = "hold-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("hold_mode") is None
-
-    await common.async_set_preset_mode(hass, "hold", ENTITY_CLIMATE)
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("hold_mode") is None
-
-    async_fire_mqtt_message(hass, "hold-state", "on")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "on"
-
-    async_fire_mqtt_message(hass, "hold-state", "off")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-
-
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-async def test_set_hold(hass, mqtt_mock_entry_with_yaml_config):
-    """Test setting the hold mode."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_LEGACY_CONFIG)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-    await common.async_set_preset_mode(hass, "hold-on", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "hold-on", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "hold-on"
-
-    await common.async_set_preset_mode(hass, PRESET_ECO, ENTITY_CLIMATE)
-    mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "eco", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == PRESET_ECO
-
-    await common.async_set_preset_mode(hass, PRESET_NONE, ENTITY_CLIMATE)
-    mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "off", 0, False)
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-
-
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-async def test_set_preset_away(hass, mqtt_mock_entry_with_yaml_config):
-    """Test setting the hold mode and away mode."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_LEGACY_CONFIG)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == PRESET_NONE
-
-    await common.async_set_preset_mode(hass, "hold-on", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "hold-on", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "hold-on"
-
-    await common.async_set_preset_mode(hass, PRESET_AWAY, ENTITY_CLIMATE)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "ON", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "off", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == PRESET_AWAY
-
-    await common.async_set_preset_mode(hass, "hold-on-again", ENTITY_CLIMATE)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "hold-on-again", 0, False)
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "hold-on-again"
-
-
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-async def test_set_preset_away_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
-    """Test setting the hold mode and away mode in pessimistic mode."""
-    config = copy.deepcopy(DEFAULT_LEGACY_CONFIG)
-    config["climate"]["hold_state_topic"] = "hold-state"
-    config["climate"]["away_mode_state_topic"] = "away-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == PRESET_NONE
-
-    await common.async_set_preset_mode(hass, "hold-on", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "hold-on", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == PRESET_NONE
-
-    async_fire_mqtt_message(hass, "hold-state", "hold-on")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "hold-on"
-
-    await common.async_set_preset_mode(hass, PRESET_AWAY, ENTITY_CLIMATE)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "ON", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "off", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "hold-on"
-
-    async_fire_mqtt_message(hass, "away-state", "ON")
-    async_fire_mqtt_message(hass, "hold-state", "off")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == PRESET_AWAY
-
-    await common.async_set_preset_mode(hass, "hold-on-again", ENTITY_CLIMATE)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "hold-on-again", 0, False)
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == PRESET_AWAY
-
-    async_fire_mqtt_message(hass, "hold-state", "hold-on-again")
-    async_fire_mqtt_message(hass, "away-state", "OFF")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "hold-on-again"
-
-
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-async def test_set_preset_mode_twice(hass, mqtt_mock_entry_with_yaml_config):
-    """Test setting of the same mode twice only publishes once."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_LEGACY_CONFIG)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-    await common.async_set_preset_mode(hass, "hold-on", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "hold-on", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "hold-on"
-
-
 async def test_set_aux_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting of the aux heating in pessimistic mode."""
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -1103,57 +848,6 @@ async def test_get_with_templates(hass, mqtt_mock_entry_with_yaml_config, caplog
     )
 
 
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-async def test_get_with_hold_and_away_mode_and_templates(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
-    """Test getting various for hold and away mode attributes with templates."""
-    config = copy.deepcopy(DEFAULT_LEGACY_CONFIG)
-    config["climate"]["mode_state_topic"] = "mode-state"
-    # By default, just unquote the JSON-strings
-    config["climate"]["value_template"] = "{{ value_json }}"
-    # Something more complicated for hold mode
-    config["climate"]["hold_state_template"] = "{{ value_json.attribute }}"
-    config["climate"]["away_mode_state_topic"] = "away-state"
-    config["climate"]["hold_state_topic"] = "hold-state"
-
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
-
-    # Operation Mode
-    state = hass.states.get(ENTITY_CLIMATE)
-    async_fire_mqtt_message(hass, "mode-state", '"cool"')
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.state == "cool"
-
-    # Away Mode
-    assert state.attributes.get("preset_mode") == "none"
-    async_fire_mqtt_message(hass, "away-state", '"ON"')
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "away"
-
-    # Away Mode with JSON values
-    async_fire_mqtt_message(hass, "away-state", "false")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
-
-    async_fire_mqtt_message(hass, "away-state", "true")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "away"
-
-    # Hold Mode
-    async_fire_mqtt_message(
-        hass,
-        "hold-state",
-        """
-        { "attribute": "somemode" }
-    """,
-    )
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "somemode"
-
-
 async def test_set_and_templates(hass, mqtt_mock_entry_with_yaml_config, caplog):
     """Test setting various attributes with templates."""
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -1230,29 +924,6 @@ async def test_set_and_templates(hass, mqtt_mock_entry_with_yaml_config, caplog)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("target_temp_low") == 20
     assert state.attributes.get("target_temp_high") == 23
-
-
-# AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-async def test_set_with_away_and_hold_modes_and_templates(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
-    """Test setting various attributes on hold and away mode with templates."""
-    config = copy.deepcopy(DEFAULT_LEGACY_CONFIG)
-    # Create simple templates
-    config["climate"]["hold_command_template"] = "hold: {{ value }}"
-
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-
-    # Hold Mode
-    await common.async_set_preset_mode(hass, PRESET_ECO, ENTITY_CLIMATE)
-    mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("away-mode-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.assert_any_call("hold-topic", "hold: eco", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == PRESET_ECO
 
 
 async def test_min_temp_custom(hass, mqtt_mock_entry_with_yaml_config):
@@ -1404,12 +1075,8 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
         ("action_topic", "heating", ATTR_HVAC_ACTION, "heating"),
         ("action_topic", "cooling", ATTR_HVAC_ACTION, "cooling"),
         ("aux_state_topic", "ON", ATTR_AUX_HEAT, "on"),
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        ("away_mode_state_topic", "ON", ATTR_PRESET_MODE, "away"),
         ("current_temperature_topic", "22.1", ATTR_CURRENT_TEMPERATURE, 22.1),
         ("fan_mode_state_topic", "low", ATTR_FAN_MODE, "low"),
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-        ("hold_state_topic", "mode1", ATTR_PRESET_MODE, "mode1"),
         ("mode_state_topic", "cool", None, None),
         ("mode_state_topic", "fan_only", None, None),
         ("swing_mode_state_topic", "on", ATTR_SWING_MODE, "on"),
@@ -1429,11 +1096,6 @@ async def test_encoding_subscribable_topics(
 ):
     """Test handling of incoming encoded payload."""
     config = copy.deepcopy(DEFAULT_CONFIG[CLIMATE_DOMAIN])
-    # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
-    if topic in ["hold_state_topic", "away_mode_state_topic"]:
-        config["hold_modes"] = ["mode1", "mode2"]
-        del config["preset_modes"]
-        del config["preset_mode_command_topic"]
     await help_test_encoding_subscribable_topics(
         hass,
         mqtt_mock_entry_with_yaml_config,
@@ -1637,27 +1299,6 @@ async def test_precision_whole(hass, mqtt_mock_entry_with_yaml_config):
             {"preset_mode": "sleep"},
             "sleep",
             "preset_mode_command_template",
-        ),
-        (
-            climate.SERVICE_SET_PRESET_MODE,
-            "away_mode_command_topic",
-            {"preset_mode": "away"},
-            "ON",
-            None,
-        ),
-        (
-            climate.SERVICE_SET_PRESET_MODE,
-            "hold_command_topic",
-            {"preset_mode": "eco"},
-            "eco",
-            "hold_command_template",
-        ),
-        (
-            climate.SERVICE_SET_PRESET_MODE,
-            "hold_command_topic",
-            {"preset_mode": "comfort"},
-            "comfort",
-            "hold_command_template",
         ),
         (
             climate.SERVICE_SET_FAN_MODE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Support for MQTT climate `hold` and `away` modes, which was deprecated in Home Assistant Core 2022.3.0, has been removed. The `hold` and `away` modes are replaced by `preset_mode`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT Hold and Away modes were replaced by `preset_mode` with #66062 and deprecated with HA 2022.3. They will be removed with this PR.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
