### PR TITLE
Add a context variable holding a HomeAssistant reference

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -100,7 +100,6 @@ async def async_setup_hass(
 ) -> core.HomeAssistant | None:
     """Set up Home Assistant."""
     hass = core.HomeAssistant()
-    core._cv_hass.set(hass)  # pylint: disable=protected-access
     hass.config.config_dir = runtime_config.config_dir
 
     async_enable_logging(

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -100,6 +100,7 @@ async def async_setup_hass(
 ) -> core.HomeAssistant | None:
     """Set up Home Assistant."""
     hass = core.HomeAssistant()
+    core._cv_hass.set(hass)  # pylint: disable=protected-access
     hass.config.config_dir = runtime_config.config_dir
 
     async_enable_logging(
@@ -165,7 +166,6 @@ async def async_setup_hass(
         old_config = hass.config
         old_logging = hass.data.get(DATA_LOGGING)
 
-        core._cv_hass.reset(hass._context_token)  # pylint: disable=protected-access
         hass = core.HomeAssistant()
         if old_logging:
             hass.data[DATA_LOGGING] = old_logging

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -100,7 +100,6 @@ async def async_setup_hass(
 ) -> core.HomeAssistant | None:
     """Set up Home Assistant."""
     hass = core.HomeAssistant()
-    core._cv_hass.set(hass)  # pylint: disable=protected-access
     hass.config.config_dir = runtime_config.config_dir
 
     async_enable_logging(
@@ -166,6 +165,7 @@ async def async_setup_hass(
         old_config = hass.config
         old_logging = hass.data.get(DATA_LOGGING)
 
+        core._cv_hass.reset(hass._context_token)  # pylint: disable=protected-access
         hass = core.HomeAssistant()
         if old_logging:
             hass.data[DATA_LOGGING] = old_logging

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -100,6 +100,7 @@ async def async_setup_hass(
 ) -> core.HomeAssistant | None:
     """Set up Home Assistant."""
     hass = core.HomeAssistant()
+    core._cv_hass.set(hass)  # pylint: disable=protected-access
     hass.config.config_dir = runtime_config.config_dir
 
     async_enable_logging(
@@ -186,8 +187,6 @@ async def async_setup_hass(
 
     if runtime_config.open_ui:
         hass.add_job(open_hass_ui, hass)
-
-    core._cv_hass.set(hass)  # pylint: disable=protected-access
 
     return hass
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -187,6 +187,8 @@ async def async_setup_hass(
     if runtime_config.open_ui:
         hass.add_job(open_hass_ui, hass)
 
+    core._cv_hass.set(hass)  # pylint: disable=protected-access
+
     return hass
 
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -251,6 +251,12 @@ class HomeAssistant:
     http: HomeAssistantHTTP = None  # type: ignore[assignment]
     config_entries: ConfigEntries = None  # type: ignore[assignment]
 
+    def __new__(cls) -> HomeAssistant:
+        """Set the _cv_hass context variable."""
+        hass = super().__new__(cls)
+        _cv_hass.set(hass)
+        return hass
+
     def __init__(self) -> None:
         """Initialize new Home Assistant object."""
         self.loop = asyncio.get_running_loop()

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -180,7 +180,11 @@ def is_callback(func: Callable[..., Any]) -> bool:
 
 @callback
 def async_get_hass() -> HomeAssistant:
-    """Return the HomeAssistant instance."""
+    """Return the HomeAssistant instance.
+
+    This should be used where it's very cumbersome or downright impossible to pass
+    hass to the code which needs it.
+    """
     return _cv_hass.get()
 
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -182,6 +182,8 @@ def is_callback(func: Callable[..., Any]) -> bool:
 def async_get_hass() -> HomeAssistant:
     """Return the HomeAssistant instance.
 
+    Raises LookupError if no HomeAssistant instance is available.
+
     This should be used where it's very cumbersome or downright impossible to pass
     hass to the code which needs it.
     """

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -15,6 +15,7 @@ from collections.abc import (
     Iterable,
     Mapping,
 )
+from contextvars import ContextVar
 import datetime
 import enum
 import functools
@@ -138,6 +139,8 @@ MAX_EXPECTED_ENTITY_IDS = 16384
 
 _LOGGER = logging.getLogger(__name__)
 
+_cv_hass: ContextVar[HomeAssistant] = ContextVar("current_entry")
+
 
 @functools.lru_cache(MAX_EXPECTED_ENTITY_IDS)
 def split_entity_id(entity_id: str) -> tuple[str, str]:
@@ -173,6 +176,12 @@ def callback(func: _CallableT) -> _CallableT:
 def is_callback(func: Callable[..., Any]) -> bool:
     """Check if function is safe to be called in the event loop."""
     return getattr(func, "_hass_callback", False) is True
+
+
+@callback
+def async_get_hass() -> HomeAssistant:
+    """Return the HomeAssistant instance."""
+    return _cv_hass.get()
 
 
 @enum.unique

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -15,7 +15,7 @@ from collections.abc import (
     Iterable,
     Mapping,
 )
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 import datetime
 import enum
 import functools
@@ -178,12 +178,6 @@ def is_callback(func: Callable[..., Any]) -> bool:
     return getattr(func, "_hass_callback", False) is True
 
 
-@callback
-def async_get_hass() -> HomeAssistant:
-    """Return the HomeAssistant instance."""
-    return _cv_hass.get()
-
-
 @enum.unique
 class HassJobType(enum.Enum):
     """Represent a job type."""
@@ -250,9 +244,23 @@ class HomeAssistant:
     auth: AuthManager
     http: HomeAssistantHTTP = None  # type: ignore[assignment]
     config_entries: ConfigEntries = None  # type: ignore[assignment]
+    _initialized: bool = False
+    _context_token: Token[HomeAssistant]
+
+    def __new__(cls) -> HomeAssistant:
+        """Return the existing HA instance if it exists, otherwise create one."""
+        try:
+            return _cv_hass.get()
+        except LookupError:
+            hass = super().__new__(cls)
+            hass._context_token = _cv_hass.set(hass)
+            return hass
 
     def __init__(self) -> None:
         """Initialize new Home Assistant object."""
+        if self._initialized:
+            return
+        self._initialized = True
         self.loop = asyncio.get_running_loop()
         self._pending_tasks: list[asyncio.Future[Any]] = []
         self._track_task = True

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -501,6 +501,8 @@ async def test_setup_hass(
     assert len(mock_ensure_config_exists.mock_calls) == 1
     assert len(mock_process_ha_config_upgrade.mock_calls) == 1
 
+    assert hass == core.async_get_hass()
+
 
 async def test_setup_hass_takes_longer_than_log_slow_startup(
     mock_enable_logging,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -501,7 +501,7 @@ async def test_setup_hass(
     assert len(mock_ensure_config_exists.mock_calls) == 1
     assert len(mock_process_ha_config_upgrade.mock_calls) == 1
 
-    assert hass == core.HomeAssistant()
+    assert hass == core.async_get_hass()
 
 
 async def test_setup_hass_takes_longer_than_log_slow_startup(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -501,7 +501,7 @@ async def test_setup_hass(
     assert len(mock_ensure_config_exists.mock_calls) == 1
     assert len(mock_process_ha_config_upgrade.mock_calls) == 1
 
-    assert hass == core.async_get_hass()
+    assert hass == core.HomeAssistant()
 
 
 async def test_setup_hass_takes_longer_than_log_slow_startup(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a context variable holding a `HomeAssistant` reference

The value of the context variable can be accessed by calling `core.async_get_hass`.

Although this means it's no longer strictly necessary to pass `hass` around, the recommendation is still only use `core.async_get_hass` where it's very cumbersome or downright impossible to pass `hass` to the code which needs it.
An example is voluptuous validators, which today has no access to `hass` because voluptuous doesn't enable that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
