### PR TITLE
Fix ZHA light color temp support

### DIFF
--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -1,7 +1,7 @@
 """Lighting channels module for Zigbee Home Automation."""
 from __future__ import annotations
 
-from contextlib import suppress
+from functools import cached_property
 
 from zigpy.zcl.clusters import lighting
 
@@ -46,17 +46,8 @@ class ColorChannel(ZigbeeChannel):
         "color_loop_active": False,
     }
 
-    @property
-    def color_capabilities(self) -> int:
-        """Return color capabilities of the light."""
-        with suppress(KeyError):
-            return self.cluster["color_capabilities"]
-        if self.cluster.get("color_temperature") is not None:
-            return self.CAPABILITIES_COLOR_XY | self.CAPABILITIES_COLOR_TEMP
-        return self.CAPABILITIES_COLOR_XY
-
-    @property
-    def zcl_color_capabilities(self) -> lighting.Color.ColorCapabilities:
+    @cached_property
+    def color_capabilities(self) -> lighting.Color.ColorCapabilities:
         """Return ZCL color capabilities of the light."""
         color_capabilities = self.cluster.get("color_capabilities")
         if color_capabilities is None:
@@ -117,43 +108,41 @@ class ColorChannel(ZigbeeChannel):
     def hs_supported(self) -> bool:
         """Return True if the channel supports hue and saturation."""
         return (
-            self.zcl_color_capabilities is not None
+            self.color_capabilities is not None
             and lighting.Color.ColorCapabilities.Hue_and_saturation
-            in self.zcl_color_capabilities
+            in self.color_capabilities
         )
 
     @property
     def enhanced_hue_supported(self) -> bool:
         """Return True if the channel supports enhanced hue and saturation."""
         return (
-            self.zcl_color_capabilities is not None
-            and lighting.Color.ColorCapabilities.Enhanced_hue
-            in self.zcl_color_capabilities
+            self.color_capabilities is not None
+            and lighting.Color.ColorCapabilities.Enhanced_hue in self.color_capabilities
         )
 
     @property
     def xy_supported(self) -> bool:
         """Return True if the channel supports xy."""
         return (
-            self.zcl_color_capabilities is not None
+            self.color_capabilities is not None
             and lighting.Color.ColorCapabilities.XY_attributes
-            in self.zcl_color_capabilities
+            in self.color_capabilities
         )
 
     @property
     def color_temp_supported(self) -> bool:
         """Return True if the channel supports color temperature."""
         return (
-            self.zcl_color_capabilities is not None
+            self.color_capabilities is not None
             and lighting.Color.ColorCapabilities.Color_temperature
-            in self.zcl_color_capabilities
-        )
+            in self.color_capabilities
+        ) or self.color_temperature is not None
 
     @property
     def color_loop_supported(self) -> bool:
         """Return True if the channel supports color loop."""
         return (
-            self.zcl_color_capabilities is not None
-            and lighting.Color.ColorCapabilities.Color_loop
-            in self.zcl_color_capabilities
+            self.color_capabilities is not None
+            and lighting.Color.ColorCapabilities.Color_loop in self.color_capabilities
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR modifies the check for color temperature support to better support manufacturers that don't follow the Zigbee specification. It restores previous functionality that checks the `color_temperature` attribute for a value instead of solely relying on `color_capabilities`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #76154
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
