### PR TITLE
Add persistent repair items for deprecated Guardian services

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -10,6 +10,7 @@ from aioguardian import Client
 from aioguardian.errors import GuardianError
 import voluptuous as vol
 
+from homeassistant.components.repairs import IssueSeverity, async_create_issue
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     ATTR_DEVICE_ID,
@@ -116,14 +117,34 @@ def async_log_deprecated_service_call(
     call: ServiceCall,
     alternate_service: str,
     alternate_target: str,
+    breaks_in_ha_version: str,
 ) -> None:
     """Log a warning about a deprecated service call."""
+    deprecated_service = f"{call.domain}.{call.service}"
+
+    async_create_issue(
+        hass,
+        DOMAIN,
+        f"deprecated_service_{deprecated_service}",
+        breaks_in_ha_version=breaks_in_ha_version,
+        is_fixable=False,
+        is_persistent=True,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_service",
+        translation_placeholders={
+            "alternate_service": alternate_service,
+            "alternate_target": alternate_target,
+            "deprecated_service": deprecated_service,
+        },
+    )
+
     LOGGER.warning(
         (
-            'The "%s" service is deprecated and will be removed in a future version; '
-            'use the "%s" service and pass it a target entity ID of "%s"'
+            'The "%s" service is deprecated and will be removed in %s; use the "%s" '
+            'service and pass it a target entity ID of "%s"'
         ),
-        f"{call.domain}.{call.service}",
+        deprecated_service,
+        breaks_in_ha_version,
         alternate_service,
         alternate_target,
     )
@@ -235,6 +256,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             call,
             "button.press",
             f"button.guardian_valve_controller_{data.entry.data[CONF_UID]}_reboot",
+            "2022.10.0",
         )
         await data.client.system.reboot()
 
@@ -248,6 +270,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             call,
             "button.press",
             f"button.guardian_valve_controller_{data.entry.data[CONF_UID]}_reset_valve_diagnostics",
+            "2022.10.0",
         )
         await data.client.valve.reset()
 

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -127,7 +127,7 @@ def async_log_deprecated_service_call(
         DOMAIN,
         f"deprecated_service_{deprecated_service}",
         breaks_in_ha_version=breaks_in_ha_version,
-        is_fixable=False,
+        is_fixable=True,
         is_persistent=True,
         severity=IssueSeverity.WARNING,
         translation_key="deprecated_service",

--- a/homeassistant/components/guardian/manifest.json
+++ b/homeassistant/components/guardian/manifest.json
@@ -3,6 +3,7 @@
   "name": "Elexa Guardian",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/guardian",
+  "dependencies": ["repairs"],
   "requirements": ["aioguardian==2022.07.0"],
   "zeroconf": ["_api._udp.local."],
   "codeowners": ["@bachya"],

--- a/homeassistant/components/guardian/strings.json
+++ b/homeassistant/components/guardian/strings.json
@@ -20,8 +20,8 @@
   },
   "issues": {
     "deprecated_service": {
-      "title": "The {deprecated_service} service is deprecated",
-      "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead."
+      "title": "The {deprecated_service} service is being removed",
+      "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved."
     }
   }
 }

--- a/homeassistant/components/guardian/strings.json
+++ b/homeassistant/components/guardian/strings.json
@@ -21,7 +21,7 @@
   "issues": {
     "deprecated_service": {
       "title": "The {deprecated_service} service is deprecated",
-      "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead"
+      "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead."
     }
   }
 }

--- a/homeassistant/components/guardian/strings.json
+++ b/homeassistant/components/guardian/strings.json
@@ -21,7 +21,14 @@
   "issues": {
     "deprecated_service": {
       "title": "The {deprecated_service} service is being removed",
-      "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved."
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "The {deprecated_service} service is being removed",
+            "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved."
+          }
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/guardian/strings.json
+++ b/homeassistant/components/guardian/strings.json
@@ -17,5 +17,11 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
+  },
+  "issues": {
+    "deprecated_service": {
+      "title": "The {deprecated_service} service is deprecated",
+      "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead"
+    }
   }
 }

--- a/homeassistant/components/guardian/translations/en.json
+++ b/homeassistant/components/guardian/translations/en.json
@@ -20,8 +20,8 @@
     },
     "issues": {
         "deprecated_service": {
-            "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead.",
-            "title": "The {deprecated_service} service is deprecated"
+            "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved.",
+            "title": "The {deprecated_service} service is being removed"
         }
     }
 }

--- a/homeassistant/components/guardian/translations/en.json
+++ b/homeassistant/components/guardian/translations/en.json
@@ -20,7 +20,14 @@
     },
     "issues": {
         "deprecated_service": {
-            "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved.",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`. Then, click SUBMIT below to mark this issue as resolved.",
+                        "title": "The {deprecated_service} service is being removed"
+                    }
+                }
+            },
             "title": "The {deprecated_service} service is being removed"
         }
     }

--- a/homeassistant/components/guardian/translations/en.json
+++ b/homeassistant/components/guardian/translations/en.json
@@ -20,7 +20,7 @@
     },
     "issues": {
         "deprecated_service": {
-            "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead",
+            "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead.",
             "title": "The {deprecated_service} service is deprecated"
         }
     }

--- a/homeassistant/components/guardian/translations/en.json
+++ b/homeassistant/components/guardian/translations/en.json
@@ -17,5 +17,11 @@
                 "description": "Configure a local Elexa Guardian device."
             }
         }
+    },
+    "issues": {
+        "deprecated_service": {
+            "description": "This service is deprecated. Use the `{alternate_service}` service and pass it a target entity ID of `{alternate_target}` instead",
+            "title": "The {deprecated_service} service is deprecated"
+        }
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds persistent repair items for Guardian services that were deprecated in https://github.com/home-assistant/core/pull/75028 (`guardian.reboot` and `guardian.reset_valve_diagnostics`). These items will appear anytime the user calls one of the deprecated services (and will hang around until dismissed).

![CleanShot 2022-08-05 at 09 57 50](https://user-images.githubusercontent.com/47216/183116110-ee342de9-eba5-465f-96c6-151fee484d22.png)
![CleanShot 2022-08-05 at 09 58 35](https://user-images.githubusercontent.com/47216/183116123-f4614688-61e2-410b-9122-be83c957a612.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/core/pull/75028

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
