### PR TITLE
Add resize_keyboard and one_time_keyboard attributes in component "telegram bot"

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -583,13 +583,11 @@ class TelegramNotificationService:
             if ATTR_KEYBOARD in data:
                 keys = data.get(ATTR_KEYBOARD)
                 keys = keys if isinstance(keys, list) else [keys]
-                is_resize_keyboard = data[ATTR_RESIZE_KEYBOARD] if ATTR_RESIZE_KEYBOARD in data else False
-                is_one_time_keyboard = data[ATTR_ONE_TIME_KEYBOARD] if ATTR_ONE_TIME_KEYBOARD in data else False
                 if keys:
                     params[ATTR_REPLYMARKUP] = ReplyKeyboardMarkup(
                         [[key.strip() for key in row.split(",")] for row in keys],
-                        resize_keyboard = is_resize_keyboard,
-                        one_time_keyboard = is_one_time_keyboard
+                        resize_keyboard =  data[ATTR_RESIZE_KEYBOARD] if ATTR_RESIZE_KEYBOARD in data else False,
+                        one_time_keyboard = data[ATTR_ONE_TIME_KEYBOARD] if ATTR_ONE_TIME_KEYBOARD in data else False
                     )
                 else:
                     params[ATTR_REPLYMARKUP] = ReplyKeyboardRemove(True)

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -62,6 +62,8 @@ ATTR_FILE = "file"
 ATTR_FROM_FIRST = "from_first"
 ATTR_FROM_LAST = "from_last"
 ATTR_KEYBOARD = "keyboard"
+ATTR_RESIZE_KEYBOARD = "resize_keyboard"
+ATTR_ONE_TIME_KEYBOARD = "one_time_keyboard"
 ATTR_KEYBOARD_INLINE = "inline_keyboard"
 ATTR_MESSAGEID = "message_id"
 ATTR_MSG = "message"
@@ -157,6 +159,8 @@ BASE_SERVICE_SCHEMA = vol.Schema(
         vol.Optional(ATTR_PARSER): cv.string,
         vol.Optional(ATTR_DISABLE_NOTIF): cv.boolean,
         vol.Optional(ATTR_DISABLE_WEB_PREV): cv.boolean,
+        vol.Optional(ATTR_RESIZE_KEYBOARD): cv.boolean,
+        vol.Optional(ATTR_ONE_TIME_KEYBOARD): cv.boolean,
         vol.Optional(ATTR_KEYBOARD): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(ATTR_KEYBOARD_INLINE): cv.ensure_list,
         vol.Optional(ATTR_TIMEOUT): cv.positive_int,
@@ -579,9 +583,13 @@ class TelegramNotificationService:
             if ATTR_KEYBOARD in data:
                 keys = data.get(ATTR_KEYBOARD)
                 keys = keys if isinstance(keys, list) else [keys]
+                is_resize_keyboard = data[ATTR_RESIZE_KEYBOARD] if ATTR_RESIZE_KEYBOARD in data else False
+                is_one_time_keyboard = data[ATTR_ONE_TIME_KEYBOARD] if ATTR_ONE_TIME_KEYBOARD in data else False
                 if keys:
                     params[ATTR_REPLYMARKUP] = ReplyKeyboardMarkup(
-                        [[key.strip() for key in row.split(",")] for row in keys]
+                        [[key.strip() for key in row.split(",")] for row in keys],
+                        resize_keyboard = is_resize_keyboard,
+                        one_time_keyboard = is_one_time_keyboard
                     )
                 else:
                     params[ATTR_REPLYMARKUP] = ReplyKeyboardRemove(True)


### PR DESCRIPTION
Adding `resize_keyboard` and `one_time_keyboard` attributes in component "telegram bot"


## Proposed change

This change add support new optional attributes in telegram api keyboard:
- resize_keyboard
- one_time_keyboard

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Telegram API documentation: https://docs.python-telegram-bot.org/en/v13.3/telegram.replykeyboardmarkup.html
Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23674

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
