### PR TITLE
Some minor deCONZ clean up

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -48,7 +48,7 @@ def get_alarm_system_id_for_unique_id(
     gateway: DeconzGateway, unique_id: str
 ) -> str | None:
     """Retrieve alarm system ID the unique ID is registered to."""
-    for alarm_system in gateway.api.alarmsystems.values():
+    for alarm_system in gateway.api.alarm_systems.values():
         if unique_id in alarm_system.devices:
             return alarm_system.resource_id
     return None
@@ -122,27 +122,27 @@ class DeconzAlarmControlPanel(DeconzDevice[AncillaryControl], AlarmControlPanelE
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         if code:
-            await self.gateway.api.alarmsystems.arm(
+            await self.gateway.api.alarm_systems.arm(
                 self.alarm_system_id, AlarmSystemArmAction.AWAY, code
             )
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         if code:
-            await self.gateway.api.alarmsystems.arm(
+            await self.gateway.api.alarm_systems.arm(
                 self.alarm_system_id, AlarmSystemArmAction.STAY, code
             )
 
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
         if code:
-            await self.gateway.api.alarmsystems.arm(
+            await self.gateway.api.alarm_systems.arm(
                 self.alarm_system_id, AlarmSystemArmAction.NIGHT, code
             )
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         if code:
-            await self.gateway.api.alarmsystems.arm(
+            await self.gateway.api.alarm_systems.arm(
                 self.alarm_system_id, AlarmSystemArmAction.DISARM, code
             )

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -159,7 +159,7 @@ ENTITY_DESCRIPTIONS = {
     ],
 }
 
-BINARY_SENSOR_DESCRIPTIONS = [
+COMMON_BINARY_SENSOR_DESCRIPTIONS = [
     DeconzBinarySensorDescription(
         key="tampered",
         value_fn=lambda device: device.tampered,
@@ -215,7 +215,8 @@ async def async_setup_entry(
         sensor = gateway.api.sensors[sensor_id]
 
         for description in (
-            ENTITY_DESCRIPTIONS.get(type(sensor), []) + BINARY_SENSOR_DESCRIPTIONS
+            ENTITY_DESCRIPTIONS.get(type(sensor), [])
+            + COMMON_BINARY_SENSOR_DESCRIPTIONS
         ):
             if (
                 not hasattr(sensor, description.key)

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -283,8 +283,8 @@ class DeconzBinarySensor(DeconzDevice[SensorResources], BinarySensorEntity):
         if self._device.on is not None:
             attr[ATTR_ON] = self._device.on
 
-        if self._device.secondary_temperature is not None:
-            attr[ATTR_TEMPERATURE] = self._device.secondary_temperature
+        if self._device.internal_temperature is not None:
+            attr[ATTR_TEMPERATURE] = self._device.internal_temperature
 
         if isinstance(self._device, Presence):
 

--- a/homeassistant/components/deconz/diagnostics.py
+++ b/homeassistant/components/deconz/diagnostics.py
@@ -26,7 +26,7 @@ async def async_get_config_entry_diagnostics(
         gateway.api.config.raw, REDACT_DECONZ_CONFIG
     )
     diag["websocket_state"] = (
-        gateway.api.websocket.state if gateway.api.websocket else "Unknown"
+        gateway.api.websocket.state.value if gateway.api.websocket else "Unknown"
     )
     diag["deconz_ids"] = gateway.deconz_ids
     diag["entities"] = gateway.entities

--- a/homeassistant/components/deconz/diagnostics.py
+++ b/homeassistant/components/deconz/diagnostics.py
@@ -37,7 +37,7 @@ async def async_get_config_entry_diagnostics(
         }
         for event in gateway.events
     }
-    diag["alarm_systems"] = {k: v.raw for k, v in gateway.api.alarmsystems.items()}
+    diag["alarm_systems"] = {k: v.raw for k, v in gateway.api.alarm_systems.items()}
     diag["groups"] = {k: v.raw for k, v in gateway.api.groups.items()}
     diag["lights"] = {k: v.raw for k, v in gateway.api.lights.items()}
     diag["scenes"] = {k: v.raw for k, v in gateway.api.scenes.items()}

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -169,7 +169,7 @@ class DeconzGateway:
             )
         )
 
-        for device_id in deconz_device_interface:
+        for device_id in sorted(deconz_device_interface, key=int):
             async_add_device(EventType.ADDED, device_id)
 
         initializing = False

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==102"],
+  "requirements": ["pydeconz==103"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from pydeconz.models.event import EventType
-from pydeconz.models.sensor.presence import PRESENCE_DELAY, Presence
+from pydeconz.models.sensor.presence import Presence
 
 from homeassistant.components.number import (
     DOMAIN,
@@ -42,7 +42,7 @@ ENTITY_DESCRIPTIONS = {
             key="delay",
             value_fn=lambda device: device.delay,
             suffix="Delay",
-            update_key=PRESENCE_DELAY,
+            update_key="delay",
             native_max_value=65535,
             native_min_value=0,
             native_step=1,

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -221,8 +221,8 @@ SENSOR_DESCRIPTIONS = [
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     DeconzSensorDescription(
-        key="secondary_temperature",
-        value_fn=lambda device: device.secondary_temperature,
+        key="internal_temperature",
+        value_fn=lambda device: device.internal_temperature,
         suffix="Temperature",
         update_key="temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -341,8 +341,8 @@ class DeconzSensor(DeconzDevice[SensorResources], SensorEntity):
         if self._device.on is not None:
             attr[ATTR_ON] = self._device.on
 
-        if self._device.secondary_temperature is not None:
-            attr[ATTR_TEMPERATURE] = self._device.secondary_temperature
+        if self._device.internal_temperature is not None:
+            attr[ATTR_TEMPERATURE] = self._device.internal_temperature
 
         if isinstance(self._device, Consumption):
             attr[ATTR_POWER] = self._device.power

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -383,13 +383,13 @@ class DeconzBatteryTracker:
         self.sensor = gateway.api.sensors[sensor_id]
         self.gateway = gateway
         self.async_add_entities = async_add_entities
-        self.unsub = self.sensor.subscribe(self.async_update_callback)
+        self.unsubscribe = self.sensor.subscribe(self.async_update_callback)
 
     @callback
     def async_update_callback(self) -> None:
         """Update the device's state."""
         if "battery" in self.sensor.changed_keys:
-            self.unsub()
+            self.unsubscribe()
             known_entities = set(self.gateway.entities[DOMAIN])
             entity = DeconzSensor(
                 self.sensor, self.gateway, COMMON_SENSOR_DESCRIPTIONS[0]

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -209,7 +209,7 @@ ENTITY_DESCRIPTIONS = {
 }
 
 
-SENSOR_DESCRIPTIONS = [
+COMMON_SENSOR_DESCRIPTIONS = [
     DeconzSensorDescription(
         key="battery",
         value_fn=lambda device: device.battery,
@@ -253,7 +253,7 @@ async def async_setup_entry(
         known_entities = set(gateway.entities[DOMAIN])
 
         for description in (
-            ENTITY_DESCRIPTIONS.get(type(sensor), []) + SENSOR_DESCRIPTIONS
+            ENTITY_DESCRIPTIONS.get(type(sensor), []) + COMMON_SENSOR_DESCRIPTIONS
         ):
             if (
                 not hasattr(sensor, description.key)
@@ -391,6 +391,8 @@ class DeconzBatteryTracker:
         if "battery" in self.sensor.changed_keys:
             self.unsub()
             known_entities = set(self.gateway.entities[DOMAIN])
-            entity = DeconzSensor(self.sensor, self.gateway, SENSOR_DESCRIPTIONS[0])
+            entity = DeconzSensor(
+                self.sensor, self.gateway, COMMON_SENSOR_DESCRIPTIONS[0]
+            )
             if entity.unique_id not in known_entities:
                 self.async_add_entities([entity])

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1461,7 +1461,7 @@ pydaikin==2.7.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==102
+pydeconz==103
 
 # homeassistant.components.delijn
 pydelijn==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1004,7 +1004,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.7.0
 
 # homeassistant.components.deconz
-pydeconz==102
+pydeconz==103
 
 # homeassistant.components.dexcom
 pydexcom==0.2.3

--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from pydeconz.websocket import SIGNAL_CONNECTION_STATE, SIGNAL_DATA
+from pydeconz.websocket import Signal
 import pytest
 
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
@@ -20,10 +20,10 @@ def mock_deconz_websocket():
 
             if data:
                 mock.return_value.data = data
-                await pydeconz_gateway_session_handler(signal=SIGNAL_DATA)
+                await pydeconz_gateway_session_handler(signal=Signal.DATA)
             elif state:
                 mock.return_value.state = state
-                await pydeconz_gateway_session_handler(signal=SIGNAL_CONNECTION_STATE)
+                await pydeconz_gateway_session_handler(signal=Signal.CONNECTION_STATE)
             else:
                 raise NotImplementedError
 

--- a/tests/components/deconz/test_diagnostics.py
+++ b/tests/components/deconz/test_diagnostics.py
@@ -1,6 +1,6 @@
 """Test deCONZ diagnostics."""
 
-from pydeconz.websocket import STATE_RUNNING
+from pydeconz.websocket import State
 
 from homeassistant.components.deconz.const import CONF_MASTER_GATEWAY
 from homeassistant.components.diagnostics import REDACTED
@@ -17,7 +17,7 @@ async def test_entry_diagnostics(
     """Test config entry diagnostics."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
-    await mock_deconz_websocket(state=STATE_RUNNING)
+    await mock_deconz_websocket(state=State.RUNNING)
     await hass.async_block_till_done()
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
@@ -44,7 +44,7 @@ async def test_entry_diagnostics(
             "uuid": "1234",
             "websocketport": 1234,
         },
-        "websocket_state": STATE_RUNNING,
+        "websocket_state": State.RUNNING.value,
         "deconz_ids": {},
         "entities": {
             str(Platform.ALARM_CONTROL_PANEL): [],

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from unittest.mock import patch
 
 import pydeconz
-from pydeconz.websocket import STATE_RETRYING, STATE_RUNNING
+from pydeconz.websocket import State
 import pytest
 
 from homeassistant.components import ssdp
@@ -223,12 +223,12 @@ async def test_connection_status_signalling(
 
     assert hass.states.get("binary_sensor.presence").state == STATE_OFF
 
-    await mock_deconz_websocket(state=STATE_RETRYING)
+    await mock_deconz_websocket(state=State.RETRYING)
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.presence").state == STATE_UNAVAILABLE
 
-    await mock_deconz_websocket(state=STATE_RUNNING)
+    await mock_deconz_websocket(state=State.RUNNING)
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.presence").state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some isolated changes bundled together into one PR, improvements identified from other future PRs in the works.

Rename secondary_temperature to more correct internal_temperature https://github.com/Kane610/deconz/pull/351
Prefix binary_/sensor_descriptions to common/_binary/_sensor_descriptions
Make sure to create entities in a deterministic order
Rename api.alarmsystems to api.alarm_systems https://github.com/Kane610/deconz/pull/353
Use pydeconz web socket enums https://github.com/Kane610/deconz/pull/354
Don't use presence legacy string constant https://github.com/Kane610/deconz/pull/352

https://github.com/Kane610/deconz/compare/v102...v103

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
