### PR TITLE
Support polling the MiFlora battery

### DIFF
--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -11,8 +11,8 @@ from homeassistant.components.bluetooth import (
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
 )
-from homeassistant.components.bluetooth.passive_update_processor import (
-    PassiveBluetoothProcessorCoordinator,
+from homeassistant.components.bluetooth.active_update_coordinator import (
+    ActiveBluetoothProcessorCoordinator,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -56,9 +56,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         kwargs["bindkey"] = bytes.fromhex(bindkey)
     data = XiaomiBluetoothDeviceData(**kwargs)
 
+    def _needs_poll(
+        service_info: BluetoothServiceInfoBleak, last_poll: float | None
+    ) -> bool:
+        return data.poll_needed(service_info, last_poll)
+
+    async def _async_poll(service_info: BluetoothServiceInfoBleak):
+        # BluetoothServiceInfoBleak is defined in HA, otherwise would just pass it
+        # directly to the Xiaomi code
+        return await data.async_poll(service_info.device)
+
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator(
+    ] = ActiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
         address=address,
@@ -66,6 +76,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_method=lambda service_info: process_service_info(
             hass, entry, data, service_info
         ),
+        needs_poll_method=_needs_poll,
+        poll_method=_async_poll,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -8,7 +8,7 @@
       "service_data_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.8.0"],
+  "requirements": ["xiaomi-ble==0.8.1"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -8,7 +8,7 @@
       "service_data_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.6.4"],
+  "requirements": ["xiaomi-ble==0.8.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2480,7 +2480,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.6.4
+xiaomi-ble==0.8.0
 
 # homeassistant.components.knx
 xknx==0.22.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2480,7 +2480,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.8.0
+xiaomi-ble==0.8.1
 
 # homeassistant.components.knx
 xknx==0.22.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1678,7 +1678,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.8.0
+xiaomi-ble==0.8.1
 
 # homeassistant.components.knx
 xknx==0.22.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1678,7 +1678,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.6.4
+xiaomi-ble==0.8.0
 
 # homeassistant.components.knx
 xknx==0.22.1

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -1,21 +1,26 @@
 """Tests for the SensorPush integration."""
 
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
 
-from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
-NOT_SENSOR_PUSH_SERVICE_INFO = BluetoothServiceInfo(
+NOT_SENSOR_PUSH_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="Not it",
     address="00:00:00:00:00:00",
+    device=BLEDevice("00:00:00:00:00:00", None),
     rssi=-63,
     manufacturer_data={3234: b"\x00\x01"},
     service_data={},
     service_uuids=[],
     source="local",
+    advertisement=AdvertisementData(local_name="Not it"),
 )
 
-LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfo(
+LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="LYWSDCGQ",
     address="58:2D:34:35:93:21",
+    device=BLEDevice("00:00:00:00:00:00", None),
     rssi=-63,
     manufacturer_data={},
     service_data={
@@ -23,11 +28,13 @@ LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfo(
     },
     service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
     source="local",
+    advertisement=AdvertisementData(local_name="Not it"),
 )
 
-MMC_T201_1_SERVICE_INFO = BluetoothServiceInfo(
+MMC_T201_1_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="MMC_T201_1",
     address="00:81:F9:DD:6F:C1",
+    device=BLEDevice("00:00:00:00:00:00", None),
     rssi=-56,
     manufacturer_data={},
     service_data={
@@ -35,11 +42,13 @@ MMC_T201_1_SERVICE_INFO = BluetoothServiceInfo(
     },
     service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
     source="local",
+    advertisement=AdvertisementData(local_name="Not it"),
 )
 
-JTYJGD03MI_SERVICE_INFO = BluetoothServiceInfo(
+JTYJGD03MI_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="JTYJGD03MI",
     address="54:EF:44:E3:9C:BC",
+    device=BLEDevice("00:00:00:00:00:00", None),
     rssi=-56,
     manufacturer_data={},
     service_data={
@@ -47,11 +56,13 @@ JTYJGD03MI_SERVICE_INFO = BluetoothServiceInfo(
     },
     service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
     source="local",
+    advertisement=AdvertisementData(local_name="Not it"),
 )
 
-YLKG07YL_SERVICE_INFO = BluetoothServiceInfo(
+YLKG07YL_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="YLKG07YL",
     address="F8:24:41:C5:98:8B",
+    device=BLEDevice("00:00:00:00:00:00", None),
     rssi=-56,
     manufacturer_data={},
     service_data={
@@ -59,11 +70,13 @@ YLKG07YL_SERVICE_INFO = BluetoothServiceInfo(
     },
     service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
     source="local",
+    advertisement=AdvertisementData(local_name="Not it"),
 )
 
-MISSING_PAYLOAD_ENCRYPTED = BluetoothServiceInfo(
+MISSING_PAYLOAD_ENCRYPTED = BluetoothServiceInfoBleak(
     name="LYWSD02MMC",
     address="A4:C1:38:56:53:84",
+    device=BLEDevice("00:00:00:00:00:00", None),
     rssi=-56,
     manufacturer_data={},
     service_data={
@@ -71,14 +84,16 @@ MISSING_PAYLOAD_ENCRYPTED = BluetoothServiceInfo(
     },
     service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
     source="local",
+    advertisement=AdvertisementData(local_name="Not it"),
 )
 
 
-def make_advertisement(address: str, payload: bytes) -> BluetoothServiceInfo:
+def make_advertisement(address: str, payload: bytes) -> BluetoothServiceInfoBleak:
     """Make a dummy advertisement."""
-    return BluetoothServiceInfo(
+    return BluetoothServiceInfoBleak(
         name="Test Device",
         address=address,
+        device=BLEDevice(address, None),
         rssi=-56,
         manufacturer_data={},
         service_data={
@@ -86,4 +101,5 @@ def make_advertisement(address: str, payload: bytes) -> BluetoothServiceInfo:
         },
         service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
         source="local",
+        advertisement=AdvertisementData(local_name="Test Device"),
     )

--- a/tests/components/xiaomi_ble/conftest.py
+++ b/tests/components/xiaomi_ble/conftest.py
@@ -1,8 +1,55 @@
 """Session fixtures."""
 
+from unittest import mock
+
 import pytest
+
+
+class MockServices:
+    """Mock GATTServicesCollection."""
+
+    def get_characteristic(self, key: str) -> str:
+        """Mock GATTServicesCollection.get_characteristic."""
+        return key
+
+
+class MockBleakClient:
+    """Mock BleakClient."""
+
+    services = MockServices()
+
+    def __init__(self, *args, **kwargs):
+        """Mock BleakClient."""
+        pass
+
+    async def __aenter__(self, *args, **kwargs):
+        """Mock BleakClient.__aenter__."""
+        return self
+
+    async def __aexit__(self, *args, **kwargs):
+        """Mock BleakClient.__aexit__."""
+        pass
+
+    async def connect(self, *args, **kwargs):
+        """Mock BleakClient.connect."""
+        pass
+
+    async def disconnect(self, *args, **kwargs):
+        """Mock BleakClient.disconnect."""
+        pass
+
+
+class MockBleakClientBattery5(MockBleakClient):
+    """Mock BleakClient that returns a battery level of 5."""
+
+    async def read_gatt_char(self, *args, **kwargs) -> bytes:
+        """Mock BleakClient.read_gatt_char."""
+        return b"\x05\x001.2.3"
 
 
 @pytest.fixture(autouse=True)
 def mock_bluetooth(enable_bluetooth):
     """Auto mock bluetooth."""
+
+    with mock.patch("xiaomi_ble.parser.BleakClient", MockBleakClientBattery5):
+        yield

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -78,7 +78,7 @@ async def test_xiaomi_formaldeyhde(hass):
     # obj type is 0x1010, payload len is 0x2 and payload is 0xf400
     saved_callback(
         make_advertisement(
-            "C4:7C:8D:6A:3E:7A", b"q \x98\x00iz>j\x8d|\xc4\r\x10\x10\x02\xf4\x00"
+            "C4:7C:8D:6A:3E:7A", b"q \x5d\x01iz>j\x8d|\xc4\r\x10\x10\x02\xf4\x00"
         ),
         BluetoothChange.ADVERTISEMENT,
     )
@@ -125,7 +125,7 @@ async def test_xiaomi_consumable(hass):
     # obj type is 0x1310, payload len is 0x2 and payload is 0x6000
     saved_callback(
         make_advertisement(
-            "C4:7C:8D:6A:3E:7A", b"q \x98\x00iz>j\x8d|\xc4\r\x13\x10\x02\x60\x00"
+            "C4:7C:8D:6A:3E:7A", b"q \x5d\x01iz>j\x8d|\xc4\r\x13\x10\x02\x60\x00"
         ),
         BluetoothChange.ADVERTISEMENT,
     )
@@ -172,7 +172,7 @@ async def test_xiaomi_battery_voltage(hass):
     # obj type is 0x0a10, payload len is 0x2 and payload is 0x6400
     saved_callback(
         make_advertisement(
-            "C4:7C:8D:6A:3E:7A", b"q \x98\x00iz>j\x8d|\xc4\r\x0a\x10\x02\x64\x00"
+            "C4:7C:8D:6A:3E:7A", b"q \x5d\x01iz>j\x8d|\xc4\r\x0a\x10\x02\x64\x00"
         ),
         BluetoothChange.ADVERTISEMENT,
     )
@@ -246,7 +246,7 @@ async def test_xiaomi_HHCCJCY01(hass):
         BluetoothChange.ADVERTISEMENT,
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 5
 
     illum_sensor = hass.states.get("sensor.test_device_illuminance")
     illum_sensor_attr = illum_sensor.attributes
@@ -275,6 +275,13 @@ async def test_xiaomi_HHCCJCY01(hass):
     assert temp_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Test Device Temperature"
     assert temp_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "°C"
     assert temp_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
+
+    batt_sensor = hass.states.get("sensor.test_device_battery")
+    batt_sensor_attribtes = batt_sensor.attributes
+    assert batt_sensor.state == "5"
+    assert batt_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Test Device Battery"
+    assert batt_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "%"
+    assert batt_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change

Add support for the MiFlora battery sensor. Unlike the other sensors, we cannot collect this passively. We only poll it once a day to conserve battery use. We also only poll it when we have recently seen an advertisement for it.

![Screenshot 2022-08-05 at 22 59 16](https://user-images.githubusercontent.com/11544/183216974-dc714134-c992-422c-b5ec-e00c79d35696.png)

Extends the PassiveBluetoothProcessorCoordinator in the bluetooth integration to support polling, adding a new ActiveBluetoothProcessorCoordinator for devices that predominately use PassiveBluetoothProcessorCoordinator but need to do a bit of polling as well.

https://github.com/Bluetooth-Devices/xiaomi-ble/compare/v0.6.4...v0.8.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
