### PR TITLE
Fix nina warning state

### DIFF
--- a/homeassistant/components/nina/__init__.py
+++ b/homeassistant/components/nina/__init__.py
@@ -1,6 +1,7 @@
 """The Nina integration."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from async_timeout import timeout
@@ -12,22 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    _LOGGER,
-    ATTR_DESCRIPTION,
-    ATTR_EXPIRES,
-    ATTR_HEADLINE,
-    ATTR_ID,
-    ATTR_SENDER,
-    ATTR_SENT,
-    ATTR_SEVERITY,
-    ATTR_START,
-    CONF_FILTER_CORONA,
-    CONF_REGIONS,
-    CONST_WARNING_ACTIVE,
-    DOMAIN,
-    SCAN_INTERVAL,
-)
+from .const import _LOGGER, CONF_FILTER_CORONA, CONF_REGIONS, DOMAIN, SCAN_INTERVAL
 
 PLATFORMS: list[str] = [Platform.BINARY_SENSOR]
 
@@ -62,6 +48,21 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     await hass.config_entries.async_reload(entry.entry_id)
 
 
+@dataclass
+class NinaWarningData:
+    """Class to hold the warning data."""
+
+    id: str
+    headline: str
+    description: str
+    sender: str
+    severity: str
+    sent: str
+    start: str
+    expires: str
+    is_valid: bool
+
+
 class NINADataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching NINA data API."""
 
@@ -94,24 +95,24 @@ class NINADataUpdateCoordinator(DataUpdateCoordinator):
         return_data: dict[str, Any] = {}
 
         for region_id, raw_warnings in self._nina.warnings.items():
-            warnings_for_regions: list[Any] = []
+            warnings_for_regions: list[NinaWarningData] = []
 
             for raw_warn in raw_warnings:
                 if "corona" in raw_warn.headline.lower() and self.corona_filter:
                     continue
 
-                warn_obj: dict[str, Any] = {
-                    ATTR_ID: raw_warn.id,
-                    ATTR_HEADLINE: raw_warn.headline,
-                    ATTR_DESCRIPTION: raw_warn.description,
-                    ATTR_SENDER: raw_warn.sender,
-                    ATTR_SEVERITY: raw_warn.severity,
-                    ATTR_SENT: raw_warn.sent or "",
-                    ATTR_START: raw_warn.start or "",
-                    ATTR_EXPIRES: raw_warn.expires or "",
-                    CONST_WARNING_ACTIVE: raw_warn.isValid(),
-                }
-                warnings_for_regions.append(warn_obj)
+                warning_data: NinaWarningData = NinaWarningData(
+                    raw_warn.id,
+                    raw_warn.headline,
+                    raw_warn.description,
+                    raw_warn.sender,
+                    raw_warn.severity,
+                    raw_warn.sent or "",
+                    raw_warn.start or "",
+                    raw_warn.expires or "",
+                    raw_warn.isValid(),
+                )
+                warnings_for_regions.append(warning_data)
 
             return_data[region_id] = warnings_for_regions
 

--- a/homeassistant/components/nina/__init__.py
+++ b/homeassistant/components/nina/__init__.py
@@ -24,6 +24,7 @@ from .const import (
     ATTR_START,
     CONF_FILTER_CORONA,
     CONF_REGIONS,
+    CONST_WARNING_ACTIVE,
     DOMAIN,
     SCAN_INTERVAL,
 )
@@ -108,6 +109,7 @@ class NINADataUpdateCoordinator(DataUpdateCoordinator):
                     ATTR_SENT: raw_warn.sent or "",
                     ATTR_START: raw_warn.start or "",
                     ATTR_EXPIRES: raw_warn.expires or "",
+                    CONST_WARNING_ACTIVE: raw_warn.isValid(),
                 }
                 warnings_for_regions.append(warn_obj)
 

--- a/homeassistant/components/nina/binary_sensor.py
+++ b/homeassistant/components/nina/binary_sensor.py
@@ -82,9 +82,7 @@ class NINAMessage(CoordinatorEntity[NINADataUpdateCoordinator], BinarySensorEnti
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes of the sensor."""
-        if (
-            not len(self.coordinator.data[self._region]) > self._warning_index
-        ) or not self.is_on:
+        if not self.is_on:
             return {}
 
         data: NinaWarningData = self.coordinator.data[self._region][self._warning_index]

--- a/homeassistant/components/nina/binary_sensor.py
+++ b/homeassistant/components/nina/binary_sensor.py
@@ -24,6 +24,7 @@ from .const import (
     ATTR_START,
     CONF_MESSAGE_SLOTS,
     CONF_REGIONS,
+    CONST_WARNING_ACTIVE,
     DOMAIN,
 )
 
@@ -72,7 +73,12 @@ class NINAMessage(CoordinatorEntity[NINADataUpdateCoordinator], BinarySensorEnti
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return len(self.coordinator.data[self._region]) > self._warning_index
+        if not len(self.coordinator.data[self._region]) > self._warning_index:
+            return False
+
+        data: dict[str, Any] = self.coordinator.data[self._region][self._warning_index]
+
+        return data[CONST_WARNING_ACTIVE]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/nina/binary_sensor.py
+++ b/homeassistant/components/nina/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import NINADataUpdateCoordinator
+from . import NINADataUpdateCoordinator, NinaWarningData
 from .const import (
     ATTR_DESCRIPTION,
     ATTR_EXPIRES,
@@ -24,7 +24,6 @@ from .const import (
     ATTR_START,
     CONF_MESSAGE_SLOTS,
     CONF_REGIONS,
-    CONST_WARNING_ACTIVE,
     DOMAIN,
 )
 
@@ -76,9 +75,9 @@ class NINAMessage(CoordinatorEntity[NINADataUpdateCoordinator], BinarySensorEnti
         if not len(self.coordinator.data[self._region]) > self._warning_index:
             return False
 
-        data: dict[str, Any] = self.coordinator.data[self._region][self._warning_index]
+        data: NinaWarningData = self.coordinator.data[self._region][self._warning_index]
 
-        return data[CONST_WARNING_ACTIVE]
+        return data.is_valid
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -88,15 +87,15 @@ class NINAMessage(CoordinatorEntity[NINADataUpdateCoordinator], BinarySensorEnti
         ) or not self.is_on:
             return {}
 
-        data: dict[str, Any] = self.coordinator.data[self._region][self._warning_index]
+        data: NinaWarningData = self.coordinator.data[self._region][self._warning_index]
 
         return {
-            ATTR_HEADLINE: data[ATTR_HEADLINE],
-            ATTR_DESCRIPTION: data[ATTR_DESCRIPTION],
-            ATTR_SENDER: data[ATTR_SENDER],
-            ATTR_SEVERITY: data[ATTR_SEVERITY],
-            ATTR_ID: data[ATTR_ID],
-            ATTR_SENT: data[ATTR_SENT],
-            ATTR_START: data[ATTR_START],
-            ATTR_EXPIRES: data[ATTR_EXPIRES],
+            ATTR_HEADLINE: data.headline,
+            ATTR_DESCRIPTION: data.description,
+            ATTR_SENDER: data.sender,
+            ATTR_SEVERITY: data.severity,
+            ATTR_ID: data.id,
+            ATTR_SENT: data.sent,
+            ATTR_START: data.start,
+            ATTR_EXPIRES: data.expires,
         }

--- a/homeassistant/components/nina/const.py
+++ b/homeassistant/components/nina/const.py
@@ -24,6 +24,8 @@ ATTR_SENT: str = "sent"
 ATTR_START: str = "start"
 ATTR_EXPIRES: str = "expires"
 
+CONST_WARNING_ACTIVE: str = "active"
+
 CONST_LIST_A_TO_D: list[str] = ["A", "Ä", "B", "C", "D"]
 CONST_LIST_E_TO_H: list[str] = ["E", "F", "G", "H"]
 CONST_LIST_I_TO_L: list[str] = ["I", "J", "K", "L"]

--- a/homeassistant/components/nina/const.py
+++ b/homeassistant/components/nina/const.py
@@ -24,8 +24,6 @@ ATTR_SENT: str = "sent"
 ATTR_START: str = "start"
 ATTR_EXPIRES: str = "expires"
 
-CONST_WARNING_ACTIVE: str = "active"
-
 CONST_LIST_A_TO_D: list[str] = ["A", "Ä", "B", "C", "D"]
 CONST_LIST_E_TO_H: list[str] = ["E", "F", "G", "H"]
 CONST_LIST_I_TO_L: list[str] = ["I", "J", "K", "L"]

--- a/tests/components/nina/fixtures/sample_warning_details.json
+++ b/tests/components/nina/fixtures/sample_warning_details.json
@@ -157,5 +157,52 @@
         ]
       }
     ]
+  },
+  "biw.BIWAPP-69634": {
+    "identifier": "biw.BIWAPP-69634",
+    "sender": "CAP@biwapp.de",
+    "sent": "1999-08-07T10:59:00+02:00",
+    "status": "Actual",
+    "msgType": "Alert",
+    "scope": "Public",
+    "code": ["DVN:2", "BIWAPP"],
+    "info": [
+      {
+        "language": "DE",
+        "category": ["Other"],
+        "event": "4",
+        "urgency": "Unknown",
+        "severity": "Minor",
+        "certainty": "Unknown",
+        "expires": "2002-08-07T10:59:00+02:00",
+        "headline": "Geflügelpest im Landkreis Cuxhaven - Teile des Landkreises Osterholz zur Überwachungszone erklärt",
+        "description": "In Beverstedt im Landkreis Cuxhaven ist am 20. Juli 2022 in einer Geflügelhaltung der Ausbruch der Geflügelpest (Vogelgrippe, Aviäre Influenza) amtlich festgestellt worden. Durch die geografische Nähe des Ausbruchsbetriebes zum Gebiet des Landkreises Osterholz musste das Veterinäramt des Landkreises zum Schutz vor einer Ausbreitung der Geflügelpest auch für sein Gebiet ein Restriktionsgebiet festlegen. Rund um den Ausbruchsort wurde eine Überwachungszone ausgewiesen. Eine entsprechende Tierseuchenbehördliche Allgemeinverfügung wurde vom Landkreis Osterholz erlassen und tritt am 23.07.2022 in Kraft.<br>&nbsp;<br>Die Überwachungszone mit einem Radius von mindestens zehn Kilometern um den Ausbruchsbetrieb erstreckt sich im Landkreis Osterholz innerhalb der Samtgemeinde Hambergen auf die Mitgliedsgemeinden Axstedt, Holste und Lübberstedt. Die vorgenannten Gemeinden sind vollständig zur Überwachungszone erklärt worden. Der genaue Grenzverlauf des Gebietes kann auch der interaktiven Karte im Internet entnommen werden.<br>&nbsp;<br>In der Überwachungszone liegen im Landkreis Osterholz rund 70 Geflügelhaltungen mit einem Gesamtbestand von rund 1.800 Tieren. Sie alle unterliegen mit der Allgemeinverfügung der sogenannten amtlichen Beobachtung. Für die Betriebe sind die Biosicherheitsmaßnahmen einzuhalten. Dazu zählen insbesondere Hygienemaßnahmen im laufenden Betrieb und eine ordnungsgemäße Schadnagerbekämpfung.<br>&nbsp;<br>Das Verbringen von Vögeln, Fleisch von Geflügel, Eiern und sonstige Nebenprodukte von Geflügel in und aus Betrieben in der Überwachungszone ist verboten. Auch Geflügeltransporte sind in der Überwachungszone verboten. Jeder Verdacht der Erkrankung auf Geflügelpest ist zudem dem Veterinäramt des Landkreises Osterholz unter der E-Mail-Adresse veterinaeramt@landkreis-osterholz.de sofort zu melden. Alle Hinweise, die innerhalb der Überwachungszone zu beachten sind, sind unter www.landkreis-osterholz.de/gefluegelpest zusammengefasst dargestellt.<br>&nbsp;<br>Die Veterinärbehörde weist zudem darauf hin, dass sämtliche Geflügelhaltungen – Hühner, Enten, Gänse, Fasane, Perlhühner, Rebhühner, Truthühner, Wachteln oder Laufvögel – der zuständigen Behörde angezeigt werden müssen. Wer dies bisher noch nicht gemacht hat und über keine Registriernummer für seinen Geflügelbestand verfügt, sollte die Meldung über das Veterinäramt umgehend nachholen.<br>&nbsp;<br>Das Beobachtungsgebiet kann frühestens 30 Tage nach der Grobreinigung des Ausbruchsbetriebes wieder aufgehoben werden. Hierüber wird der Landkreis Osterholz informieren.<br>&nbsp;<br>Die Allgemeinverfügung, eine Übersicht zur Überwachungszone und weitere Hinweise sind auf der Internetseite unter www.landkreis-osterholz.de/gefluegelpest zu finden.",
+        "parameter": [
+          {
+            "valueName": "sender_langname",
+            "value": "Landkreis Osterholz"
+          },
+          {
+            "valueName": "PHGEM",
+            "value": "740+10,770,792,817,100001"
+          },
+          {
+            "valueName": "GRID",
+            "value": "101346,101954+7,102566+9,103177+13,103774,103790+13,104387+1,104403+13,105000+1,105016+15,105612+2,105630+15,106225+2,106241+18,106838+2,106853+18,107451+1,107464+22,108064+9,108075+23,108677+34,109290+34,109903+35,110516+35,111129+35,111742+35,112355,112357+34,112971+33,113587+30,114200+30,114814,114818+26,115432,115436+22,116050+21,116669+15,117283+5,117290+7,117897+3,117904+6,500001"
+          }
+        ],
+        "area": [
+          {
+            "areaDesc": "Axstedt, Gnarrenburg, Grasberg, Hagen im Bremischen, Hambergen, Hepstedt, Holste, Lilienthal, Lübberstedt, Osterholz-Scharmbeck, Ritterhude, Schwanewede, Vollersode, Worpswede",
+            "geocode": [
+              {
+                "valueName": "AreaId",
+                "value": "0"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   }
 }

--- a/tests/components/nina/fixtures/sample_warnings.json
+++ b/tests/components/nina/fixtures/sample_warnings.json
@@ -40,5 +40,29 @@
     "onset": "2021-11-01T05:20:00+01:00",
     "sent": "2021-10-11T05:20:00+01:00",
     "expires": "3021-11-22T05:19:00+01:00"
+  },
+  {
+    "id": "biw.BIWAPP-69634",
+    "payload": {
+      "version": 2,
+      "type": "ALERT",
+      "id": "biw.BIWAPP-69634",
+      "hash": "fdbafb6b164f549ff60b9adfa5b1c707069cdd178bf55f025066f319451660ad",
+      "data": {
+        "headline": "Geflügelpest im Landkreis Cuxhaven - Teile des Landkreises Osterholz zur Überwachungszone erklärt",
+        "provider": "BIWAPP",
+        "severity": "Minor",
+        "msgType": "Alert",
+        "area": {
+          "type": "GRID",
+          "data": "101346,101954+7,102566+9,103177+13,103774,103790+13,104387+1,104403+13,105000+1,105016+15,105612+2,105630+15,106225+2,106241+18,106838+2,106853+18,107451+1,107464+22,108064+9,108075+23,108677+34,109290+34,109903+35,110516+35,111129+35,111742+35,112355,112357+34,112971+33,113587+30,114200+30,114814,114818+26,115432,115436+22,116050+21,116669+15,117283+5,117290+7,117897+3,117904+6,500001"
+        }
+      }
+    },
+    "i18nTitle": {
+      "de": "Geflügelpest im Landkreis Cuxhaven - Teile des Landkreises Osterholz zur Überwachungszone erklärt"
+    },
+    "sent": "1999-08-07T10:59:00+02:00",
+    "expires": "2002-08-07T10:59:00+02:00"
   }
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the missing check of the expired attribute by which the warning were still shown as active after the date of expiration. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #76248
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
