### PR TITLE
Update HomeKit PM2.5 mappings to US AQI

### DIFF
--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -56,7 +56,6 @@ from .util import (
     convert_to_float,
     density_to_air_quality,
     density_to_air_quality_pm10,
-    density_to_air_quality_pm25,
     temperature_to_homekit,
 )
 
@@ -239,7 +238,7 @@ class PM25Sensor(AirQualitySensor):
         if self.char_density.value != density:
             self.char_density.set_value(density)
             _LOGGER.debug("%s: Set density to %d", self.entity_id, density)
-        air_quality = density_to_air_quality_pm25(density)
+        air_quality = density_to_air_quality(density)
         if self.char_quality.value != air_quality:
             self.char_quality.set_value(air_quality)
             _LOGGER.debug("%s: Set air_quality to %d", self.entity_id, air_quality)

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -401,15 +401,15 @@ def temperature_to_states(temperature: float | int, unit: str) -> float:
 
 def density_to_air_quality(density: float) -> int:
     """Map PM2.5 µg/m3 density to HomeKit AirQuality level."""
-    if density <= 12: # US AQI 0-50 (HomeKit: Excellent)
+    if density <= 12:  # US AQI 0-50 (HomeKit: Excellent)
         return 1
-    if density <= 35.4: # US AQI 51-100 (HomeKit: Good)
+    if density <= 35.4:  # US AQI 51-100 (HomeKit: Good)
         return 2
-    if density <= 55.4: # US AQI 101-150 (HomeKit: Fair)
+    if density <= 55.4:  # US AQI 101-150 (HomeKit: Fair)
         return 3
-    if density <= 150.4: # US AQI 151-200 (HomeKit: Inferior)
+    if density <= 150.4:  # US AQI 151-200 (HomeKit: Inferior)
         return 4
-    return 5 # US AQI 201+ (HomeKit: Poor)
+    return 5  # US AQI 201+ (HomeKit: Poor)
 
 
 def density_to_air_quality_pm10(density: float) -> int:

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -400,16 +400,16 @@ def temperature_to_states(temperature: float | int, unit: str) -> float:
 
 
 def density_to_air_quality(density: float) -> int:
-    """Map PM2.5 density to HomeKit AirQuality level."""
-    if density <= 35:
+    """Map PM2.5 µg/m3 density to HomeKit AirQuality level."""
+    if density <= 12: # US AQI 0-50 (HomeKit: Excellent)
         return 1
-    if density <= 75:
+    if density <= 35.4: # US AQI 51-100 (HomeKit: Good)
         return 2
-    if density <= 115:
+    if density <= 55.4: # US AQI 101-150 (HomeKit: Fair)
         return 3
-    if density <= 150:
+    if density <= 150.4: # US AQI 151-200 (HomeKit: Inferior)
         return 4
-    return 5
+    return 5 # US AQI 201+ (HomeKit: Poor)
 
 
 def density_to_air_quality_pm10(density: float) -> int:

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -425,19 +425,6 @@ def density_to_air_quality_pm10(density: float) -> int:
     return 5
 
 
-def density_to_air_quality_pm25(density: float) -> int:
-    """Map PM2.5 density to HomeKit AirQuality level."""
-    if density <= 25:
-        return 1
-    if density <= 50:
-        return 2
-    if density <= 100:
-        return 3
-    if density <= 300:
-        return 4
-    return 5
-
-
 def get_persist_filename_for_entry_id(entry_id: str) -> str:
     """Determine the filename of the homekit state file."""
     return f"{DOMAIN}.{entry_id}.state"

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -126,7 +126,7 @@ async def test_air_quality(hass, hk_driver):
     hass.states.async_set(entity_id, "34")
     await hass.async_block_till_done()
     assert acc.char_density.value == 34
-    assert acc.char_quality.value == 1
+    assert acc.char_quality.value == 2
 
     hass.states.async_set(entity_id, "200")
     await hass.async_block_till_done()
@@ -205,7 +205,7 @@ async def test_pm25(hass, hk_driver):
     hass.states.async_set(entity_id, "23")
     await hass.async_block_till_done()
     assert acc.char_density.value == 23
-    assert acc.char_quality.value == 1
+    assert acc.char_quality.value == 2
 
     hass.states.async_set(entity_id, "34")
     await hass.async_block_till_done()
@@ -215,12 +215,12 @@ async def test_pm25(hass, hk_driver):
     hass.states.async_set(entity_id, "90")
     await hass.async_block_till_done()
     assert acc.char_density.value == 90
-    assert acc.char_quality.value == 3
+    assert acc.char_quality.value == 4
 
     hass.states.async_set(entity_id, "200")
     await hass.async_block_till_done()
     assert acc.char_density.value == 200
-    assert acc.char_quality.value == 4
+    assert acc.char_quality.value == 5
 
     hass.states.async_set(entity_id, "400")
     await hass.async_block_till_done()

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -224,12 +224,15 @@ def test_temperature_to_states():
 def test_density_to_air_quality():
     """Test map PM2.5 density to HomeKit AirQuality level."""
     assert density_to_air_quality(0) == 1
-    assert density_to_air_quality(35) == 1
-    assert density_to_air_quality(35.1) == 2
-    assert density_to_air_quality(75) == 2
-    assert density_to_air_quality(115) == 3
-    assert density_to_air_quality(150) == 4
-    assert density_to_air_quality(300) == 5
+    assert density_to_air_quality(12) == 1
+    assert density_to_air_quality(12.1) == 2
+    assert density_to_air_quality(35.4) == 2
+    assert density_to_air_quality(35.5) == 3
+    assert density_to_air_quality(55.4) == 3
+    assert density_to_air_quality(55.5) == 4
+    assert density_to_air_quality(150.4) == 4
+    assert density_to_air_quality(150.5) == 5
+    assert density_to_air_quality(200) == 5
 
 
 async def test_async_show_setup_msg(hass, hk_driver, mock_get_source_ip):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR changes the PM2.5 µg/m3 mappings in the HomeKit integration to use the values based on the US AQI set by the EPA.

| HomeKit | Current PM2.5 µg/m3 | Proposed PM2.5 µg/m3 |
|---|---|---|
| Excellent | <= 25 | <= 12 |
| Good | <= 50 | <= 35.4 |
| Fair | <= 100 | <= 55.4 |
| Inferior | <= 300 | <= 150.4 |
| Poor | > 300 | > 150.4 |

US EPA AQI:
- https://www.epa.gov/sites/default/files/2016-04/documents/2012_aqi_factsheet.pdf
- https://www.airnow.gov/sites/default/files/2020-05/aqi-technical-assistance-document-sept2018.pdf

<img width="680" alt="image" src="https://user-images.githubusercontent.com/4297171/183257363-1f4eb2bf-81a1-441f-8176-91901c6631b0.png">

HomeKit Enum: https://developer.apple.com/documentation/homekit/hmcharacteristicvalueairquality

This PR also removes a redundant PM2.5 mapping function which had different cutoffs for PM2.5.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21926
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
