### PR TITLE
Allow parsing to happen in PassiveBluetoothProcessorCoordinator

### DIFF
--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -79,6 +79,11 @@ class PassiveBluetoothProcessorCoordinator(
         self._update_method = update_method
         self.last_update_success = True
 
+    @property
+    def available(self) -> bool:
+        """Return if the device is available."""
+        return super().available and self.last_update_success
+
     @callback
     def async_register_processor(
         self, processor: PassiveBluetoothDataProcessor

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -73,7 +73,9 @@ class PassiveBluetoothProcessorCoordinator(
         logger: logging.Logger,
         address: str,
         mode: BluetoothScanningMode,
-        update_method: Callable[[BluetoothServiceInfoBleak], _T] = _default_update_method,
+        update_method: Callable[
+            [BluetoothServiceInfoBleak], _T
+        ] = _default_update_method,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(hass, logger, address, mode)

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -52,12 +52,6 @@ class PassiveBluetoothDataUpdate(Generic[_T]):
     )
 
 
-def _default_update_method(
-    service_info: BluetoothServiceInfoBleak,
-) -> BluetoothServiceInfoBleak:
-    return service_info
-
-
 class PassiveBluetoothProcessorCoordinator(
     Generic[_T], BasePassiveBluetoothCoordinator
 ):
@@ -73,12 +67,12 @@ class PassiveBluetoothProcessorCoordinator(
         logger: logging.Logger,
         address: str,
         mode: BluetoothScanningMode,
-        update_method: Callable[[BluetoothServiceInfoBleak], _T] | None = None,
+        update_method: Callable[[BluetoothServiceInfoBleak], _T],
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(hass, logger, address, mode)
         self._processors: list[PassiveBluetoothDataProcessor] = []
-        self._update_method = update_method or _default_update_method
+        self._update_method = update_method
 
     @callback
     def async_register_processor(

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -73,14 +73,12 @@ class PassiveBluetoothProcessorCoordinator(
         logger: logging.Logger,
         address: str,
         mode: BluetoothScanningMode,
-        update_method: Callable[
-            [BluetoothServiceInfoBleak], _T
-        ] = _default_update_method,
+        update_method: Callable[[BluetoothServiceInfoBleak], _T] | None = None,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(hass, logger, address, mode)
         self._processors: list[PassiveBluetoothDataProcessor] = []
-        self._update_method = update_method
+        self._update_method = update_method or _default_update_method
 
     @callback
     def async_register_processor(

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -59,6 +59,10 @@ class PassiveBluetoothProcessorCoordinator(
 
     The coordinator is responsible for dispatching the bluetooth data,
     to each processor, and tracking devices.
+
+    The update_method should return the data that is dispatched to each processor.
+    This is normally a parsed form of the data, but you can just forward the
+    BluetoothServiceInfoBleak if needed.
     """
 
     def __init__(
@@ -130,9 +134,8 @@ class PassiveBluetoothDataProcessor(Generic[_T]):
     the appropriate format.
 
     The processor will call the update_method every time the bluetooth device
-    receives a new advertisement data from the coordinator with the following signature:
-
-    update_method(service_info: BluetoothServiceInfoBleak) -> PassiveBluetoothDataUpdate
+    receives a new advertisement data from the coordinator with the data
+    returned by he update_method of the coordinator.
 
     As the size of each advertisement is limited, the update_method should
     return a PassiveBluetoothDataUpdate object that contains only data that

--- a/homeassistant/components/govee_ble/__init__.py
+++ b/homeassistant/components/govee_ble/__init__.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import BluetoothScanningMode
+from homeassistant.components.bluetooth import (
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+)
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -24,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     assert address is not None
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator(
+    ] = PassiveBluetoothProcessorCoordinator[BluetoothServiceInfoBleak](
         hass,
         _LOGGER,
         address=address,

--- a/homeassistant/components/govee_ble/__init__.py
+++ b/homeassistant/components/govee_ble/__init__.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import (
-    BluetoothScanningMode,
-    BluetoothServiceInfoBleak,
-)
+from govee_ble import GoveeBluetoothDeviceData
+
+from homeassistant.components.bluetooth import BluetoothScanningMode
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -25,13 +24,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Govee BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
+    data = GoveeBluetoothDeviceData()
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator[BluetoothServiceInfoBleak](
+    ] = PassiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
         address=address,
         mode=BluetoothScanningMode.ACTIVE,
+        update_method=data.update,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(

--- a/homeassistant/components/govee_ble/sensor.py
+++ b/homeassistant/components/govee_ble/sensor.py
@@ -3,14 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from govee_ble import (
-    DeviceClass,
-    DeviceKey,
-    GoveeBluetoothDeviceData,
-    SensorDeviceInfo,
-    SensorUpdate,
-    Units,
-)
+from govee_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -129,12 +122,7 @@ async def async_setup_entry(
     coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]
-    data = GoveeBluetoothDeviceData()
-    processor = PassiveBluetoothDataProcessor(
-        lambda service_info: sensor_update_to_bluetooth_data_update(
-            data.update(service_info)
-        )
-    )
+    processor = PassiveBluetoothDataProcessor(sensor_update_to_bluetooth_data_update)
     entry.async_on_unload(
         processor.async_add_entities_listener(
             GoveeBluetoothSensorEntity, async_add_entities

--- a/homeassistant/components/inkbird/__init__.py
+++ b/homeassistant/components/inkbird/__init__.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import (
-    BluetoothScanningMode,
-    BluetoothServiceInfoBleak,
-)
+from inkbird_ble import INKBIRDBluetoothDeviceData
+
+from homeassistant.components.bluetooth import BluetoothScanningMode
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -25,10 +24,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up INKBIRD BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
+    data = INKBIRDBluetoothDeviceData()
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator[BluetoothServiceInfoBleak](
-        hass, _LOGGER, address=address, mode=BluetoothScanningMode.ACTIVE
+    ] = PassiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        address=address,
+        mode=BluetoothScanningMode.ACTIVE,
+        update_method=data.update,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(

--- a/homeassistant/components/inkbird/__init__.py
+++ b/homeassistant/components/inkbird/__init__.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import BluetoothScanningMode
+from homeassistant.components.bluetooth import (
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+)
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -24,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     assert address is not None
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator(
+    ] = PassiveBluetoothProcessorCoordinator[BluetoothServiceInfoBleak](
         hass, _LOGGER, address=address, mode=BluetoothScanningMode.ACTIVE
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/inkbird/sensor.py
+++ b/homeassistant/components/inkbird/sensor.py
@@ -3,14 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from inkbird_ble import (
-    DeviceClass,
-    DeviceKey,
-    INKBIRDBluetoothDeviceData,
-    SensorDeviceInfo,
-    SensorUpdate,
-    Units,
-)
+from inkbird_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -129,12 +122,7 @@ async def async_setup_entry(
     coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]
-    data = INKBIRDBluetoothDeviceData()
-    processor = PassiveBluetoothDataProcessor(
-        lambda service_info: sensor_update_to_bluetooth_data_update(
-            data.update(service_info)
-        )
-    )
+    processor = PassiveBluetoothDataProcessor(sensor_update_to_bluetooth_data_update)
     entry.async_on_unload(
         processor.async_add_entities_listener(
             INKBIRDBluetoothSensorEntity, async_add_entities

--- a/homeassistant/components/moat/__init__.py
+++ b/homeassistant/components/moat/__init__.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import BluetoothScanningMode
+from homeassistant.components.bluetooth import (
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+)
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -24,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     assert address is not None
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator(
+    ] = PassiveBluetoothProcessorCoordinator[BluetoothServiceInfoBleak](
         hass, _LOGGER, address=address, mode=BluetoothScanningMode.PASSIVE
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/moat/__init__.py
+++ b/homeassistant/components/moat/__init__.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import (
-    BluetoothScanningMode,
-    BluetoothServiceInfoBleak,
-)
+from moat_ble import MoatBluetoothDeviceData
+
+from homeassistant.components.bluetooth import BluetoothScanningMode
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -25,10 +24,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Moat BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
+    data = MoatBluetoothDeviceData()
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator[BluetoothServiceInfoBleak](
-        hass, _LOGGER, address=address, mode=BluetoothScanningMode.PASSIVE
+    ] = PassiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        address=address,
+        mode=BluetoothScanningMode.PASSIVE,
+        update_method=data.update,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(

--- a/homeassistant/components/moat/sensor.py
+++ b/homeassistant/components/moat/sensor.py
@@ -3,14 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from moat_ble import (
-    DeviceClass,
-    DeviceKey,
-    MoatBluetoothDeviceData,
-    SensorDeviceInfo,
-    SensorUpdate,
-    Units,
-)
+from moat_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -136,12 +129,7 @@ async def async_setup_entry(
     coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]
-    data = MoatBluetoothDeviceData()
-    processor = PassiveBluetoothDataProcessor(
-        lambda service_info: sensor_update_to_bluetooth_data_update(
-            data.update(service_info)
-        )
-    )
+    processor = PassiveBluetoothDataProcessor(sensor_update_to_bluetooth_data_update)
     entry.async_on_unload(
         processor.async_add_entities_listener(
             MoatBluetoothSensorEntity, async_add_entities

--- a/homeassistant/components/sensorpush/__init__.py
+++ b/homeassistant/components/sensorpush/__init__.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import BluetoothScanningMode, BluetoothServiceInfoBleak
+from homeassistant.components.bluetooth import (
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+)
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )

--- a/homeassistant/components/sensorpush/__init__.py
+++ b/homeassistant/components/sensorpush/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import BluetoothScanningMode
+from homeassistant.components.bluetooth import BluetoothScanningMode, BluetoothServiceInfoBleak
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -24,7 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     assert address is not None
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator(
+    ] = PassiveBluetoothProcessorCoordinator[BluetoothServiceInfoBleak](
         hass, _LOGGER, address=address, mode=BluetoothScanningMode.PASSIVE
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/sensorpush/__init__.py
+++ b/homeassistant/components/sensorpush/__init__.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import (
-    BluetoothScanningMode,
-    BluetoothServiceInfoBleak,
-)
+from sensorpush_ble import SensorPushBluetoothDeviceData
+
+from homeassistant.components.bluetooth import BluetoothScanningMode
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -25,10 +24,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SensorPush BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
+    data = SensorPushBluetoothDeviceData()
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
-    ] = PassiveBluetoothProcessorCoordinator[BluetoothServiceInfoBleak](
-        hass, _LOGGER, address=address, mode=BluetoothScanningMode.PASSIVE
+    ] = PassiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        address=address,
+        mode=BluetoothScanningMode.PASSIVE,
+        update_method=data.update,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(

--- a/homeassistant/components/sensorpush/sensor.py
+++ b/homeassistant/components/sensorpush/sensor.py
@@ -3,14 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from sensorpush_ble import (
-    DeviceClass,
-    DeviceKey,
-    SensorDeviceInfo,
-    SensorPushBluetoothDeviceData,
-    SensorUpdate,
-    Units,
-)
+from sensorpush_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -130,12 +123,7 @@ async def async_setup_entry(
     coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]
-    data = SensorPushBluetoothDeviceData()
-    processor = PassiveBluetoothDataProcessor(
-        lambda service_info: sensor_update_to_bluetooth_data_update(
-            data.update(service_info)
-        )
-    )
+    processor = PassiveBluetoothDataProcessor(sensor_update_to_bluetooth_data_update)
     entry.async_on_unload(
         processor.async_add_entities_listener(
             SensorPushBluetoothSensorEntity, async_add_entities

--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.bluetooth import BluetoothScanningMode
+from xiaomi_ble import SensorUpdate, XiaomiBluetoothDeviceData
+from xiaomi_ble.parser import EncryptionScheme
+
+from homeassistant import config_entries
+from homeassistant.components.bluetooth import (
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+)
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -18,14 +25,47 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
 
 
+def process_service_info(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    data: XiaomiBluetoothDeviceData,
+    service_info: BluetoothServiceInfoBleak,
+) -> SensorUpdate:
+    """Process a BluetoothServiceInfoBleak, running side effects and returning sensor data."""
+    update = data.update(service_info)
+
+    # If device isn't pending we know it has seen at least one broadcast with a payload
+    # If that payload was encrypted and the bindkey was not verified then we need to reauth
+    if (
+        not data.pending
+        and data.encryption_scheme != EncryptionScheme.NONE
+        and not data.bindkey_verified
+    ):
+        entry.async_start_reauth(hass, data={"device": data})
+
+    return update
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Xiaomi BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
+
+    kwargs = {}
+    if bindkey := entry.data.get("bindkey"):
+        kwargs["bindkey"] = bytes.fromhex(bindkey)
+    data = XiaomiBluetoothDeviceData(**kwargs)
+
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
     ] = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, address=address, mode=BluetoothScanningMode.PASSIVE
+        hass,
+        _LOGGER,
+        address=address,
+        mode=BluetoothScanningMode.PASSIVE,
+        update_method=lambda service_info: process_service_info(
+            hass, entry, data, service_info
+        ),
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -3,18 +3,9 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from xiaomi_ble import (
-    DeviceClass,
-    DeviceKey,
-    SensorDeviceInfo,
-    SensorUpdate,
-    Units,
-    XiaomiBluetoothDeviceData,
-)
-from xiaomi_ble.parser import EncryptionScheme
+from xiaomi_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
 
 from homeassistant import config_entries
-from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothDataProcessor,
     PassiveBluetoothDataUpdate,
@@ -165,27 +156,6 @@ def sensor_update_to_bluetooth_data_update(
     )
 
 
-def process_service_info(
-    hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
-    data: XiaomiBluetoothDeviceData,
-    service_info: BluetoothServiceInfoBleak,
-) -> PassiveBluetoothDataUpdate:
-    """Process a BluetoothServiceInfoBleak, running side effects and returning sensor data."""
-    update = data.update(service_info)
-
-    # If device isn't pending we know it has seen at least one broadcast with a payload
-    # If that payload was encrypted and the bindkey was not verified then we need to reauth
-    if (
-        not data.pending
-        and data.encryption_scheme != EncryptionScheme.NONE
-        and not data.bindkey_verified
-    ):
-        entry.async_start_reauth(hass, data={"device": data})
-
-    return sensor_update_to_bluetooth_data_update(update)
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: config_entries.ConfigEntry,
@@ -195,13 +165,7 @@ async def async_setup_entry(
     coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]
-    kwargs = {}
-    if bindkey := entry.data.get("bindkey"):
-        kwargs["bindkey"] = bytes.fromhex(bindkey)
-    data = XiaomiBluetoothDeviceData(**kwargs)
-    processor = PassiveBluetoothDataProcessor(
-        lambda service_info: process_service_info(hass, entry, data, service_info)
-    )
+    processor = PassiveBluetoothDataProcessor(sensor_update_to_bluetooth_data_update)
     entry.async_on_unload(
         processor.async_add_entities_listener(
             XiaomiBluetoothSensorEntity, async_add_entities

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -84,14 +84,25 @@ async def test_basic_usage(hass, mock_bleak_scanner_start):
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
     @callback
-    def _async_generate_mock_data(
+    def _mock_update_method(
         service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
+    @callback
+    def _async_generate_mock_data(
+        data: dict[str, str],
     ) -> PassiveBluetoothDataUpdate:
         """Generate mock data."""
+        assert data == {"test": "data"}
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
     coordinator = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -186,14 +197,24 @@ async def test_unavailable_after_no_data(hass, mock_bleak_scanner_start):
         await hass.async_block_till_done()
 
     @callback
-    def _async_generate_mock_data(
+    def _mock_update_method(
         service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
+    @callback
+    def _async_generate_mock_data(
+        data: dict[str, str],
     ) -> PassiveBluetoothDataUpdate:
         """Generate mock data."""
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
     coordinator = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -271,14 +292,24 @@ async def test_no_updates_once_stopping(hass, mock_bleak_scanner_start):
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
     @callback
-    def _async_generate_mock_data(
+    def _mock_update_method(
         service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
+    @callback
+    def _async_generate_mock_data(
+        data: dict[str, str],
     ) -> PassiveBluetoothDataUpdate:
         """Generate mock data."""
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
     coordinator = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -326,8 +357,14 @@ async def test_exception_from_update_method(hass, caplog, mock_bleak_scanner_sta
     run_count = 0
 
     @callback
-    def _async_generate_mock_data(
+    def _mock_update_method(
         service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
+    @callback
+    def _async_generate_mock_data(
+        data: dict[str, str],
     ) -> PassiveBluetoothDataUpdate:
         """Generate mock data."""
         nonlocal run_count
@@ -337,7 +374,11 @@ async def test_exception_from_update_method(hass, caplog, mock_bleak_scanner_sta
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
     coordinator = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -379,8 +420,14 @@ async def test_bad_data_from_update_method(hass, mock_bleak_scanner_start):
     run_count = 0
 
     @callback
-    def _async_generate_mock_data(
+    def _mock_update_method(
         service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
+    @callback
+    def _async_generate_mock_data(
+        data: dict[str, str],
     ) -> PassiveBluetoothDataUpdate:
         """Generate mock data."""
         nonlocal run_count
@@ -390,7 +437,11 @@ async def test_bad_data_from_update_method(hass, mock_bleak_scanner_start):
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
     coordinator = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -721,8 +772,14 @@ async def test_integration_with_entity(hass, mock_bleak_scanner_start):
     update_count = 0
 
     @callback
-    def _async_generate_mock_data(
+    def _mock_update_method(
         service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
+    @callback
+    def _async_generate_mock_data(
+        data: dict[str, str],
     ) -> PassiveBluetoothDataUpdate:
         """Generate mock data."""
         nonlocal update_count
@@ -732,7 +789,11 @@ async def test_integration_with_entity(hass, mock_bleak_scanner_start):
         return GOVEE_B5178_REMOTE_PASSIVE_BLUETOOTH_DATA_UPDATE
 
     coordinator = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -835,14 +896,24 @@ async def test_integration_with_entity_without_a_device(hass, mock_bleak_scanner
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
     @callback
-    def _async_generate_mock_data(
+    def _mock_update_method(
         service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
+    @callback
+    def _async_generate_mock_data(
+        data: dict[str, str],
     ) -> PassiveBluetoothDataUpdate:
         """Generate mock data."""
         return NO_DEVICES_PASSIVE_BLUETOOTH_DATA_UPDATE
 
     coordinator = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -899,14 +970,24 @@ async def test_passive_bluetooth_entity_with_entity_platform(
     entity_platform = MockEntityPlatform(hass)
 
     @callback
-    def _async_generate_mock_data(
+    def _mock_update_method(
         service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
+    @callback
+    def _async_generate_mock_data(
+        data: dict[str, str],
     ) -> PassiveBluetoothDataUpdate:
         """Generate mock data."""
         return NO_DEVICES_PASSIVE_BLUETOOTH_DATA_UPDATE
 
     coordinator = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -992,8 +1073,18 @@ async def test_integration_multiple_entity_platforms(hass, mock_bleak_scanner_st
     """Test integration of PassiveBluetoothProcessorCoordinator with multiple platforms."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
+    @callback
+    def _mock_update_method(
+        service_info: BluetoothServiceInfo,
+    ) -> dict[str, str]:
+        return {"test": "data"}
+
     coordinator = PassiveBluetoothProcessorCoordinator(
-        hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _mock_update_method,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None


### PR DESCRIPTION
## Breaking change

This changes the `PassiveBluetoothProcessorCoordinator` and `PassiveBluetoothDataProcessor` bluetooth API's introduced in 2022.8.

* `PassiveBluetoothProcessorCoordinator` now takes a mandatory `update_method` callback that receives bluetooth advertisements (in the form of `BluetoothServiceInfoBleak`) and returns the data that should be handed off to any subscribed `PassiveBluetoothDataProcessor`.
* `PassiveBluetoothDataProcessor` still takes an `update_method`, but instead of a `BluetoothServiceInfoBleak`, it now takes receives the data from `PassiveBluetoothProcessorCoordinator`'s `update_method`

This change is to help integrations where:

* a single advertisement contains data for multiple platforms and only needs parsing once
* where you need to parse advertisements to know what platforms to load

## Proposed change

As per discussion in #76342, slight refactor so that the bluetooth coordinator can drive the parsers. This is useful:

* Where 2 platforms in an integration use the same parser (e.g. sensor and binary_sensor contained in the same advertisement)
* There is non-platform logic (like encryption and triggering reauth flows) that makes sense to pull out of the platform.
* Where you need to parse the advertisements to know which platforms to load

If i rebase #76342 on top of this then I can implement an `ActiveBluetoothProcessorCoordinator` that polls characteristics at the coordinator and makes the data available to multiple platforms the same way passsive data is handled (DataProcessor.async_update) (in the PR as it is now, I have to do this in the DataProcessor which probhibits sharing collected data between platforms).

Crucially, each platform is still responsible for its own entities - the coordinator does not know about Home Assistant entities.

There is a default update_method for the coordinator - that just passes through the BluetotohServiceInfo, so other integrations carry on working as they are for now. I intend for that to be temporary, unless people think its useful.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
