### PR TITLE
Add Rollotron DECT 1213 to fritzbox

### DIFF
--- a/homeassistant/components/fritzbox/const.py
+++ b/homeassistant/components/fritzbox/const.py
@@ -30,4 +30,5 @@ PLATFORMS: Final[list[Platform]] = [
     Platform.LIGHT,
     Platform.SWITCH,
     Platform.SENSOR,
+    Platform.COVER,
 ]

--- a/homeassistant/components/fritzbox/const.py
+++ b/homeassistant/components/fritzbox/const.py
@@ -27,8 +27,8 @@ LOGGER: Final[logging.Logger] = logging.getLogger(__package__)
 PLATFORMS: Final[list[Platform]] = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
-    Platform.LIGHT,
-    Platform.SWITCH,
-    Platform.SENSOR,
     Platform.COVER,
+    Platform.LIGHT,
+    Platform.SENSOR,
+    Platform.SWITCH,
 ]

--- a/homeassistant/components/fritzbox/cover.py
+++ b/homeassistant/components/fritzbox/cover.py
@@ -24,11 +24,9 @@ async def async_setup_entry(
     coordinator = hass.data[FRITZBOX_DOMAIN][entry.entry_id][CONF_COORDINATOR]
 
     async_add_entities(
-        [
-            FritzboxCover(coordinator, ain)
-            for ain, device in coordinator.data.items()
-            if device.has_blind
-        ]
+        FritzboxCover(coordinator, ain)
+        for ain, device in coordinator.data.items()
+        if device.has_blind
     )
 
 

--- a/homeassistant/components/fritzbox/cover.py
+++ b/homeassistant/components/fritzbox/cover.py
@@ -16,12 +16,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import FritzBoxEntity
 from .const import CONF_COORDINATOR, DOMAIN as FRITZBOX_DOMAIN
 
-OPERATION_LIST = [
-    CoverEntityFeature.OPEN,
-    CoverEntityFeature.CLOSE,
-    CoverEntityFeature.STOP,
-]
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -53,17 +47,16 @@ class FritzboxCover(FritzBoxEntity, CoverEntity):
     def current_cover_position(self) -> int | None:
         """Return the current position."""
         position = None
-        if self.device.has_blind and self.device.levelpercentage is not None:
+        if self.device.levelpercentage is not None:
             position = 100 - self.device.levelpercentage
         return position
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
-        closed = False
-        if self.device.has_blind and self.device.levelpercentage is not None:
-            closed = self.device.levelpercentage == 100
-        return closed
+        if self.device.levelpercentage is None:
+            return None
+        return self.device.levelpercentage == 100  # type: ignore [no-any-return]
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
@@ -77,12 +70,9 @@ class FritzboxCover(FritzBoxEntity, CoverEntity):
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        if kwargs.get(ATTR_POSITION) is not None:
-            position = kwargs[ATTR_POSITION]
-            await self.hass.async_add_executor_job(
-                self.device.set_level_percentage, 100 - position
-            )
-        await self.coordinator.async_refresh()
+        await self.hass.async_add_executor_job(
+            self.device.set_level_percentage, 100 - kwargs[ATTR_POSITION]
+        )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""

--- a/homeassistant/components/fritzbox/cover.py
+++ b/homeassistant/components/fritzbox/cover.py
@@ -1,0 +1,90 @@
+"""Support for AVM FRITZ!SmartHome cover devices."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import FritzBoxEntity
+from .const import CONF_COORDINATOR, DOMAIN as FRITZBOX_DOMAIN
+
+OPERATION_LIST = [
+    CoverEntityFeature.OPEN,
+    CoverEntityFeature.CLOSE,
+    CoverEntityFeature.STOP,
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the FRITZ!SmartHome cover from ConfigEntry."""
+    coordinator = hass.data[FRITZBOX_DOMAIN][entry.entry_id][CONF_COORDINATOR]
+
+    async_add_entities(
+        [
+            FritzboxCover(coordinator, ain)
+            for ain, device in coordinator.data.items()
+            if device.has_blind
+        ]
+    )
+
+
+class FritzboxCover(FritzBoxEntity, CoverEntity):
+    """The cover class for FRITZ!SmartHome covers."""
+
+    _attr_device_class = CoverDeviceClass.BLIND
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+    )
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return the current position."""
+        position = None
+        if self.device.has_blind and self.device.levelpercentage is not None:
+            position = 100 - self.device.levelpercentage
+        return position
+
+    @property
+    def is_closed(self) -> bool:
+        """Return if the cover is closed."""
+        closed = False
+        if self.device.has_blind and self.device.levelpercentage is not None:
+            closed = self.device.levelpercentage == 100
+        return closed
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover."""
+        await self.hass.async_add_executor_job(self.device.set_blind_open)
+        await self.coordinator.async_refresh()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the cover."""
+        await self.hass.async_add_executor_job(self.device.set_blind_close)
+        await self.coordinator.async_refresh()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Move the cover to a specific position."""
+        if kwargs.get(ATTR_POSITION) is not None:
+            position = kwargs[ATTR_POSITION]
+            await self.hass.async_add_executor_job(
+                self.device.set_level_percentage, 100 - position
+            )
+        await self.coordinator.async_refresh()
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover."""
+        await self.hass.async_add_executor_job(self.device.set_blind_stop)
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/fritzbox/manifest.json
+++ b/homeassistant/components/fritzbox/manifest.json
@@ -2,7 +2,7 @@
   "domain": "fritzbox",
   "name": "AVM FRITZ!SmartHome",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox",
-  "requirements": ["pyfritzhome==0.6.4"],
+  "requirements": ["pyfritzhome==0.6.5"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:fritzbox:1"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1533,7 +1533,7 @@ pyforked-daapd==0.1.11
 pyfreedompro==1.1.0
 
 # homeassistant.components.fritzbox
-pyfritzhome==0.6.4
+pyfritzhome==0.6.5
 
 # homeassistant.components.fronius
 pyfronius==0.7.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1049,7 +1049,7 @@ pyforked-daapd==0.1.11
 pyfreedompro==1.1.0
 
 # homeassistant.components.fritzbox
-pyfritzhome==0.6.4
+pyfritzhome==0.6.5
 
 # homeassistant.components.fronius
 pyfronius==0.7.1

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -61,6 +61,7 @@ class FritzDeviceBinarySensorMock(FritzDeviceBaseMock):
     has_lightbulb = False
     has_temperature_sensor = False
     has_thermostat = False
+    has_blind = False
     present = True
 
 
@@ -82,6 +83,7 @@ class FritzDeviceClimateMock(FritzDeviceBaseMock):
     has_switch = False
     has_temperature_sensor = True
     has_thermostat = True
+    has_blind = False
     holiday_active = "fake_holiday"
     lock = "fake_locked"
     present = True
@@ -106,6 +108,7 @@ class FritzDeviceSensorMock(FritzDeviceBaseMock):
     has_switch = False
     has_temperature_sensor = True
     has_thermostat = False
+    has_blind = False
     lock = "fake_locked"
     present = True
     temperature = 1.23
@@ -126,6 +129,7 @@ class FritzDeviceSwitchMock(FritzDeviceBaseMock):
     has_switch = True
     has_temperature_sensor = True
     has_thermostat = False
+    has_blind = False
     switch_state = "fake_state"
     lock = "fake_locked"
     power = 5678
@@ -143,6 +147,21 @@ class FritzDeviceLightMock(FritzDeviceBaseMock):
     has_switch = False
     has_temperature_sensor = False
     has_thermostat = False
+    has_blind = False
     level = 100
     present = True
     state = True
+
+
+class FritzDeviceCoverMock(FritzDeviceBaseMock):
+    """Mock of a AVM Fritz!Box cover device."""
+
+    fw_version = "1.2.3"
+    has_alarm = False
+    has_powermeter = False
+    has_lightbulb = False
+    has_switch = False
+    has_temperature_sensor = False
+    has_thermostat = False
+    has_blind = True
+    levelpercentage = 0

--- a/tests/components/fritzbox/test_cover.py
+++ b/tests/components/fritzbox/test_cover.py
@@ -1,0 +1,86 @@
+"""Tests for AVM Fritz!Box switch component."""
+from unittest.mock import Mock, call
+
+from homeassistant.components.cover import ATTR_CURRENT_POSITION, ATTR_POSITION, DOMAIN
+from homeassistant.components.fritzbox.const import DOMAIN as FB_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DEVICES,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_SET_COVER_POSITION,
+    SERVICE_STOP_COVER,
+)
+from homeassistant.core import HomeAssistant
+
+from . import FritzDeviceCoverMock, setup_config_entry
+from .const import CONF_FAKE_NAME, MOCK_CONFIG
+
+ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
+
+
+async def test_setup(hass: HomeAssistant, fritz: Mock):
+    """Test setup of platform."""
+    device = FritzDeviceCoverMock()
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.attributes[ATTR_CURRENT_POSITION] == 100
+
+
+async def test_open_cover(hass: HomeAssistant, fritz: Mock):
+    """Test opening the cover."""
+    device = FritzDeviceCoverMock()
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    assert device.set_blind_open.call_count == 1
+
+
+async def test_close_cover(hass: HomeAssistant, fritz: Mock):
+    """Test closing the device."""
+    device = FritzDeviceCoverMock()
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_CLOSE_COVER, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    assert device.set_blind_close.call_count == 1
+
+
+async def test_set_position_cover(hass: HomeAssistant, fritz: Mock):
+    """Test stopping the device."""
+    device = FritzDeviceCoverMock()
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    assert await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_POSITION: 50},
+        True,
+    )
+    assert device.set_level_percentage.call_args_list == [call(50)]
+
+
+async def test_stop_cover(hass: HomeAssistant, fritz: Mock):
+    """Test stopping the device."""
+    device = FritzDeviceCoverMock()
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_STOP_COVER, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    assert device.set_blind_stop.call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add support for Rollotron DECT 1213.
The pyfritzhome dependency was bumped to a new version to support this. See diff here: [python-fritzhome/compare/0.6.4...0.6.5](https://github.com/hthiery/python-fritzhome/compare/0.6.4...0.6.5)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  home-assistant/home-assistant.io/pull/23694

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
