### PR TITLE
Enable the LIFX diagnostic buttons by default

### DIFF
--- a/homeassistant/components/lifx/button.py
+++ b/homeassistant/components/lifx/button.py
@@ -19,14 +19,12 @@ RESTART_BUTTON_DESCRIPTION = ButtonEntityDescription(
     key=RESTART,
     name="Restart",
     device_class=ButtonDeviceClass.RESTART,
-    entity_registry_enabled_default=False,
     entity_category=EntityCategory.DIAGNOSTIC,
 )
 
 IDENTIFY_BUTTON_DESCRIPTION = ButtonEntityDescription(
     key=IDENTIFY,
     name="Identify",
-    entity_registry_enabled_default=False,
     entity_category=EntityCategory.DIAGNOSTIC,
 )
 

--- a/tests/components/lifx/test_button.py
+++ b/tests/components/lifx/test_button.py
@@ -43,17 +43,8 @@ async def test_button_restart(hass: HomeAssistant) -> None:
     entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(entity_id)
     assert entity
-    assert entity.disabled
+    assert not entity.disabled
     assert entity.unique_id == unique_id
-
-    enabled_entity = entity_registry.async_update_entity(entity_id, disabled_by=None)
-    assert not enabled_entity.disabled
-
-    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
-        device=bulb
-    ), _patch_device(device=bulb):
-        await hass.config_entries.async_reload(config_entry.entry_id)
-        await hass.async_block_till_done()
 
     await hass.services.async_call(
         BUTTON_DOMAIN, "press", {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -84,17 +75,8 @@ async def test_button_identify(hass: HomeAssistant) -> None:
     entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(entity_id)
     assert entity
-    assert entity.disabled
+    assert not entity.disabled
     assert entity.unique_id == unique_id
-
-    enabled_entity = entity_registry.async_update_entity(entity_id, disabled_by=None)
-    assert not enabled_entity.disabled
-
-    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
-        device=bulb
-    ), _patch_device(device=bulb):
-        await hass.config_entries.async_reload(config_entry.entry_id)
-        await hass.async_block_till_done()
 
     await hass.services.async_call(
         BUTTON_DOMAIN, "press", {ATTR_ENTITY_ID: entity_id}, blocking=True


### PR DESCRIPTION
## Proposed change

Follow up to #75568 which has already been merged. This PR enables the buttons by default, as per @frenck's review feedback on that PR. Tests updated accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #75568
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23692 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
