### PR TITLE
Add Shelly support for sleeping devices Part 1

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -68,6 +68,7 @@ from .utils import (
     get_coap_context,
     get_device_entry_gen,
     get_rpc_device_name,
+    get_ws_context,
 )
 
 BLOCK_PLATFORMS: Final = [
@@ -243,11 +244,13 @@ async def async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool
         entry.data.get(CONF_PASSWORD),
     )
 
+    ws_context = await get_ws_context(hass)
+
     LOGGER.debug("Setting up online RPC device %s", entry.title)
     try:
         async with async_timeout.timeout(AIOSHELLY_DEVICE_TIMEOUT_SEC):
             device = await RpcDevice.create(
-                aiohttp_client.async_get_clientsession(hass), options
+                aiohttp_client.async_get_clientsession(hass), ws_context, options
             )
     except asyncio.TimeoutError as err:
         raise ConfigEntryNotReady(str(err) or "Timeout during device setup") from err

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -28,6 +28,8 @@ from .utils import (
     get_info_gen,
     get_model_name,
     get_rpc_device_name,
+    get_rpc_device_sleep_period,
+    get_ws_context,
 )
 
 HOST_SCHEMA: Final = vol.Schema({vol.Required(CONF_HOST): str})
@@ -53,8 +55,10 @@ async def validate_input(
 
     async with async_timeout.timeout(AIOSHELLY_DEVICE_TIMEOUT_SEC):
         if get_info_gen(info) == 2:
+            ws_context = await get_ws_context(hass)
             rpc_device = await RpcDevice.create(
                 aiohttp_client.async_get_clientsession(hass),
+                ws_context,
                 options,
             )
             await rpc_device.shutdown()
@@ -62,7 +66,7 @@ async def validate_input(
 
             return {
                 "title": get_rpc_device_name(rpc_device),
-                CONF_SLEEP_PERIOD: 0,
+                CONF_SLEEP_PERIOD: get_rpc_device_sleep_period(rpc_device.config),
                 "model": rpc_device.shelly.get("model"),
                 "gen": 2,
             }

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -18,6 +18,8 @@ RPC_POLL: Final = "rpc_poll"
 
 CONF_COAP_PORT: Final = "coap_port"
 DEFAULT_COAP_PORT: Final = 5683
+CONF_WS_PORT: Final = "ws_port"
+DEFAULT_WS_PORT: Final = 5683
 FIRMWARE_PATTERN: Final = re.compile(r"^(\d{8})")
 
 # Firmware 1.11.0 release date, this firmware supports light transition

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "requirements": ["aioshelly==2.0.1"],
+  "requirements": ["aioshelly==3.0.0"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from aioshelly.block_device import BLOCK_VALUE_UNIT, COAP, Block, BlockDevice
 from aioshelly.const import MODEL_NAMES
-from aioshelly.rpc_device import RpcDevice
+from aioshelly.rpc_device import RpcDevice, WsServer
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS, TEMP_FAHRENHEIT
@@ -18,7 +18,9 @@ from homeassistant.util.dt import utcnow
 from .const import (
     BASIC_INPUTS_EVENTS_TYPES,
     CONF_COAP_PORT,
+    CONF_WS_PORT,
     DEFAULT_COAP_PORT,
+    DEFAULT_WS_PORT,
     DOMAIN,
     LOGGER,
     MAX_RPC_KEY_INSTANCES,
@@ -213,13 +215,33 @@ def get_shbtn_input_triggers() -> list[tuple[str, str]]:
 
 @singleton.singleton("shelly_coap")
 async def get_coap_context(hass: HomeAssistant) -> COAP:
-    """Get CoAP context to be used in all Shelly devices."""
+    """Get CoAP context to be used in all Shelly Gen1 devices."""
     context = COAP()
     if DOMAIN in hass.data:
         port = hass.data[DOMAIN].get(CONF_COAP_PORT, DEFAULT_COAP_PORT)
     else:
         port = DEFAULT_COAP_PORT
     LOGGER.info("Starting CoAP context with UDP port %s", port)
+    await context.initialize(port)
+
+    @callback
+    def shutdown_listener(ev: EventType) -> None:
+        context.close()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown_listener)
+
+    return context
+
+
+@singleton.singleton("shelly_ws_server")
+async def get_ws_context(hass: HomeAssistant) -> WsServer:
+    """Get websocket server context to be used in all Shelly Gen2 devices."""
+    context = WsServer()
+    if DOMAIN in hass.data:
+        port = hass.data[DOMAIN].get(CONF_WS_PORT, DEFAULT_WS_PORT)
+    else:
+        port = DEFAULT_WS_PORT
+    LOGGER.info("Starting websocket server context with TCP port %s", port)
     await context.initialize(port)
 
     @callback
@@ -241,6 +263,11 @@ def get_block_device_sleep_period(settings: dict[str, Any]) -> int:
             sleep_period *= 60  # hours to minutes
 
     return sleep_period * 60  # minutes to seconds
+
+
+def get_rpc_device_sleep_period(config: dict[str, Any]) -> int:
+    """Return the device sleep period in seconds or 0 for non sleeping devices."""
+    return cast(int, config["sys"].get("sleep", {}).get("wakeup_period", 0))
 
 
 def get_info_auth(info: dict[str, Any]) -> bool:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -247,7 +247,7 @@ aiosenseme==0.6.1
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==2.0.1
+aioshelly==3.0.0
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -219,7 +219,7 @@ aiosenseme==0.6.1
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==2.0.1
+aioshelly==3.0.0
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -96,9 +96,16 @@ MOCK_STATUS_RPC = {
 
 
 @pytest.fixture(autouse=True)
-def mock_coap():
-    """Mock out coap."""
+def mock_coap_context():
+    """Mock out coap context."""
     with patch("homeassistant.components.shelly.utils.get_coap_context"):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_ws_context():
+    """Mock out ws context."""
+    with patch("homeassistant.components.shelly.utils.get_ws_context"):
         yield
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Part 1 for adding support for Shelly Gen2 sleeping (battery operated) devices.
This PR mainly bump `aioshelly` to `3.0.0` and adjust to upstream changes.
Does not add support yet and doesn't break/change any existing functionality.

Bump `aioshelly` to 3.0.0: https://github.com/home-assistant-libs/aioshelly/releases/tag/3.0.0

Diff: https://github.com/home-assistant-libs/aioshelly/compare/2.0.1...3.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/76062
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23697

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
