### PR TITLE
Improve type hints in harmony

### DIFF
--- a/homeassistant/components/harmony/select.py
+++ b/homeassistant/components/harmony/select.py
@@ -40,7 +40,7 @@ class HarmonyActivitySelect(HarmonyEntity, SelectEntity):
         self._attr_name = name
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return a representative icon."""
         if not self.available or self.current_option == ACTIVITY_POWER_OFF:
             return "mdi:remote-tv-off"
@@ -52,7 +52,7 @@ class HarmonyActivitySelect(HarmonyEntity, SelectEntity):
         return [ACTIVITY_POWER_OFF] + sorted(self._data.activity_names)
 
     @property
-    def current_option(self):
+    def current_option(self) -> str | None:
         """Return the current activity."""
         _, activity_name = self._data.current_activity
         return activity_name
@@ -61,18 +61,19 @@ class HarmonyActivitySelect(HarmonyEntity, SelectEntity):
         """Change the current activity."""
         await self._data.async_start_activity(option)
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
-
-        callbacks = {
-            "connected": self.async_got_connected,
-            "disconnected": self.async_got_disconnected,
-            "activity_starting": self._async_activity_update,
-            "activity_started": self._async_activity_update,
-            "config_updated": None,
-        }
-
-        self.async_on_remove(self._data.async_subscribe(HarmonyCallback(**callbacks)))
+        self.async_on_remove(
+            self._data.async_subscribe(
+                HarmonyCallback(
+                    connected=self.async_got_connected,
+                    disconnected=self.async_got_disconnected,
+                    activity_starting=self._async_activity_update,
+                    activity_started=self._async_activity_update,
+                    config_updated=None,
+                )
+            )
+        )
 
     @callback
     def _async_activity_update(self, activity_info: tuple):

--- a/homeassistant/components/harmony/subscriber.py
+++ b/homeassistant/components/harmony/subscriber.py
@@ -7,12 +7,12 @@ import logging
 # https://bugs.python.org/issue42965
 from typing import Any, Callable, NamedTuple, Optional
 
-from homeassistant.core import callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 
 _LOGGER = logging.getLogger(__name__)
 
-NoParamCallback = Optional[Callable[[object], Any]]
-ActivityCallback = Optional[Callable[[object, tuple], Any]]
+NoParamCallback = Optional[Callable[[], Any]]
+ActivityCallback = Optional[Callable[[tuple], Any]]
 
 
 class HarmonyCallback(NamedTuple):
@@ -28,11 +28,11 @@ class HarmonyCallback(NamedTuple):
 class HarmonySubscriberMixin:
     """Base implementation for a subscriber."""
 
-    def __init__(self, hass):
+    def __init__(self, hass: HomeAssistant) -> None:
         """Initialize an subscriber."""
         super().__init__()
         self._hass = hass
-        self._subscriptions = []
+        self._subscriptions: list[HarmonyCallback] = []
         self._activity_lock = asyncio.Lock()
 
     async def async_lock_start_activity(self):
@@ -40,23 +40,23 @@ class HarmonySubscriberMixin:
         await self._activity_lock.acquire()
 
     @callback
-    def async_unlock_start_activity(self):
+    def async_unlock_start_activity(self) -> None:
         """Release the lock."""
         if self._activity_lock.locked():
             self._activity_lock.release()
 
     @callback
-    def async_subscribe(self, update_callbacks: HarmonyCallback) -> Callable:
+    def async_subscribe(self, update_callbacks: HarmonyCallback) -> CALLBACK_TYPE:
         """Add a callback subscriber."""
         self._subscriptions.append(update_callbacks)
 
-        def _unsubscribe():
+        def _unsubscribe() -> None:
             self.async_unsubscribe(update_callbacks)
 
         return _unsubscribe
 
     @callback
-    def async_unsubscribe(self, update_callback: HarmonyCallback):
+    def async_unsubscribe(self, update_callback: HarmonyCallback) -> None:
         """Remove a callback subscriber."""
         self._subscriptions.remove(update_callback)
 
@@ -85,7 +85,7 @@ class HarmonySubscriberMixin:
         self.async_unlock_start_activity()
         self._call_callbacks("activity_started", activity_info)
 
-    def _call_callbacks(self, callback_func_name: str, argument: tuple = None):
+    def _call_callbacks(self, callback_func_name: str, argument: tuple = None) -> None:
         for subscription in self._subscriptions:
             current_callback = getattr(subscription, callback_func_name)
             if current_callback:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve type hints in harmony
Linked to #76439

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
