### PR TITLE
Replace two RainMachine binary sensors with config switches

### DIFF
--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 
 from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -11,17 +12,16 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import RainMachineData, RainMachineEntity
-from .const import (
-    DATA_PROVISION_SETTINGS,
-    DATA_RESTRICTIONS_CURRENT,
-    DATA_RESTRICTIONS_UNIVERSAL,
-    DOMAIN,
-)
+from .const import DATA_PROVISION_SETTINGS, DATA_RESTRICTIONS_CURRENT, DOMAIN
 from .model import (
     RainMachineEntityDescription,
     RainMachineEntityDescriptionMixinDataKey,
 )
-from .util import key_exists
+from .util import (
+    EntityDomainReplacementStrategy,
+    async_finish_entity_domain_replacements,
+    key_exists,
+)
 
 TYPE_FLOW_SENSOR = "flow_sensor"
 TYPE_FREEZE = "freeze"
@@ -58,22 +58,6 @@ BINARY_SENSOR_DESCRIPTIONS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         api_category=DATA_RESTRICTIONS_CURRENT,
         data_key="freeze",
-    ),
-    RainMachineBinarySensorDescription(
-        key=TYPE_FREEZE_PROTECTION,
-        name="Freeze protection",
-        icon="mdi:weather-snowy",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        api_category=DATA_RESTRICTIONS_UNIVERSAL,
-        data_key="freezeProtectEnabled",
-    ),
-    RainMachineBinarySensorDescription(
-        key=TYPE_HOT_DAYS,
-        name="Extra water on hot days",
-        icon="mdi:thermometer-lines",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        api_category=DATA_RESTRICTIONS_UNIVERSAL,
-        data_key="hotDaysExtraWatering",
     ),
     RainMachineBinarySensorDescription(
         key=TYPE_HOURLY,
@@ -118,6 +102,11 @@ BINARY_SENSOR_DESCRIPTIONS = (
     ),
 )
 
+ENTITY_UNIQUE_ID_SUFFIXES_TO_REMOVE = (
+    "extra_water_on_hot_days",
+    "freeze_protection",
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -125,10 +114,30 @@ async def async_setup_entry(
     """Set up RainMachine binary sensors based on a config entry."""
     data: RainMachineData = hass.data[DOMAIN][entry.entry_id]
 
+    async_finish_entity_domain_replacements(
+        hass,
+        entry,
+        (
+            EntityDomainReplacementStrategy(
+                BINARY_SENSOR_DOMAIN,
+                f"{data.controller.mac}_freeze_protection",
+                f"switch.{data.controller.name.lower()}_freeze_protect_enabled",
+                breaks_in_ha_version="2022.12.0",
+                remove_old_entity=False,
+            ),
+            EntityDomainReplacementStrategy(
+                BINARY_SENSOR_DOMAIN,
+                f"{data.controller.mac}_extra_water_on_hot_days",
+                f"switch.{data.controller.name.lower()}_hot_days_extra_watering",
+                breaks_in_ha_version="2022.12.0",
+                remove_old_entity=False,
+            ),
+        ),
+    )
+
     api_category_sensor_map = {
         DATA_PROVISION_SETTINGS: ProvisionSettingsBinarySensor,
         DATA_RESTRICTIONS_CURRENT: CurrentRestrictionsBinarySensor,
-        DATA_RESTRICTIONS_UNIVERSAL: UniversalRestrictionsBinarySensor,
     }
 
     async_add_entities(

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -12,7 +12,12 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import RainMachineData, RainMachineEntity
-from .const import DATA_PROVISION_SETTINGS, DATA_RESTRICTIONS_CURRENT, DOMAIN
+from .const import (
+    DATA_PROVISION_SETTINGS,
+    DATA_RESTRICTIONS_CURRENT,
+    DATA_RESTRICTIONS_UNIVERSAL,
+    DOMAIN,
+)
 from .model import (
     RainMachineEntityDescription,
     RainMachineEntityDescriptionMixinDataKey,
@@ -60,6 +65,22 @@ BINARY_SENSOR_DESCRIPTIONS = (
         data_key="freeze",
     ),
     RainMachineBinarySensorDescription(
+        key=TYPE_FREEZE_PROTECTION,
+        name="Freeze protection",
+        icon="mdi:weather-snowy",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="freezeProtectEnabled",
+    ),
+    RainMachineBinarySensorDescription(
+        key=TYPE_HOT_DAYS,
+        name="Extra water on hot days",
+        icon="mdi:thermometer-lines",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="hotDaysExtraWatering",
+    ),
+    RainMachineBinarySensorDescription(
         key=TYPE_HOURLY,
         name="Hourly restrictions",
         icon="mdi:cancel",
@@ -102,11 +123,6 @@ BINARY_SENSOR_DESCRIPTIONS = (
     ),
 )
 
-ENTITY_UNIQUE_ID_SUFFIXES_TO_REMOVE = (
-    "extra_water_on_hot_days",
-    "freeze_protection",
-)
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -138,6 +154,7 @@ async def async_setup_entry(
     api_category_sensor_map = {
         DATA_PROVISION_SETTINGS: ProvisionSettingsBinarySensor,
         DATA_RESTRICTIONS_CURRENT: CurrentRestrictionsBinarySensor,
+        DATA_RESTRICTIONS_UNIVERSAL: UniversalRestrictionsBinarySensor,
     }
 
     async_add_entities(

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -14,14 +14,20 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import VOLUME_CUBIC_METERS
+from homeassistant.const import TEMP_CELSIUS, VOLUME_CUBIC_METERS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utcnow
 
 from . import RainMachineData, RainMachineEntity
-from .const import DATA_PROGRAMS, DATA_PROVISION_SETTINGS, DATA_ZONES, DOMAIN
+from .const import (
+    DATA_PROGRAMS,
+    DATA_PROVISION_SETTINGS,
+    DATA_RESTRICTIONS_UNIVERSAL,
+    DATA_ZONES,
+    DOMAIN,
+)
 from .model import (
     RainMachineEntityDescription,
     RainMachineEntityDescriptionMixinDataKey,
@@ -41,6 +47,7 @@ TYPE_FLOW_SENSOR_CLICK_M3 = "flow_sensor_clicks_cubic_meter"
 TYPE_FLOW_SENSOR_CONSUMED_LITERS = "flow_sensor_consumed_liters"
 TYPE_FLOW_SENSOR_START_INDEX = "flow_sensor_start_index"
 TYPE_FLOW_SENSOR_WATERING_CLICKS = "flow_sensor_watering_clicks"
+TYPE_FREEZE_TEMP = "freeze_protect_temp"
 TYPE_PROGRAM_RUN_COMPLETION_TIME = "program_run_completion_time"
 TYPE_ZONE_RUN_COMPLETION_TIME = "zone_run_completion_time"
 
@@ -107,6 +114,17 @@ SENSOR_DESCRIPTIONS = (
         api_category=DATA_PROVISION_SETTINGS,
         data_key="flowSensorWateringClicks",
     ),
+    RainMachineSensorDataDescription(
+        key=TYPE_FREEZE_TEMP,
+        name="Freeze protect temperature",
+        icon="mdi:thermometer",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=TEMP_CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="freezeProtectTemp",
+    ),
 )
 
 
@@ -132,11 +150,10 @@ async def async_setup_entry(
 
     api_category_sensor_map = {
         DATA_PROVISION_SETTINGS: ProvisionSettingsSensor,
+        DATA_RESTRICTIONS_UNIVERSAL: UniversalRestrictionsSensor,
     }
 
-    sensors: list[
-        ProgramTimeRemainingSensor | ProvisionSettingsSensor | TimeRemainingSensor
-    ] = [
+    sensors = [
         api_category_sensor_map[description.api_category](entry, data, description)
         for description in SENSOR_DESCRIPTIONS
         if (
@@ -300,6 +317,18 @@ class ProvisionSettingsSensor(RainMachineEntity, SensorEntity):
             self._attr_native_value = self.coordinator.data.get("system", {}).get(
                 "flowSensorWateringClicks"
             )
+
+
+class UniversalRestrictionsSensor(RainMachineEntity, SensorEntity):
+    """Define a sensor that handles universal restrictions data."""
+
+    entity_description: RainMachineSensorDataDescription
+
+    @callback
+    def update_from_latest_data(self) -> None:
+        """Update the state."""
+        if self.entity_description.key == TYPE_FREEZE_TEMP:
+            self._attr_native_value = self.coordinator.data.get("freezeProtectTemp")
 
 
 class ZoneTimeRemainingSensor(TimeRemainingSensor):

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -109,8 +109,6 @@ SENSOR_DESCRIPTIONS = (
     ),
 )
 
-ENTITY_UNIQUE_ID_SUFFIXES_TO_REMOVE = ("freeze_protect_temp",)
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -136,7 +136,9 @@ async def async_setup_entry(
         DATA_PROVISION_SETTINGS: ProvisionSettingsSensor,
     }
 
-    sensors = [
+    sensors: list[
+        ProgramTimeRemainingSensor | ProvisionSettingsSensor | TimeRemainingSensor
+    ] = [
         api_category_sensor_map[description.api_category](entry, data, description)
         for description in SENSOR_DESCRIPTIONS
         if (

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -14,20 +14,14 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS, VOLUME_CUBIC_METERS
+from homeassistant.const import VOLUME_CUBIC_METERS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utcnow
 
 from . import RainMachineData, RainMachineEntity
-from .const import (
-    DATA_PROGRAMS,
-    DATA_PROVISION_SETTINGS,
-    DATA_RESTRICTIONS_UNIVERSAL,
-    DATA_ZONES,
-    DOMAIN,
-)
+from .const import DATA_PROGRAMS, DATA_PROVISION_SETTINGS, DATA_ZONES, DOMAIN
 from .model import (
     RainMachineEntityDescription,
     RainMachineEntityDescriptionMixinDataKey,
@@ -47,7 +41,6 @@ TYPE_FLOW_SENSOR_CLICK_M3 = "flow_sensor_clicks_cubic_meter"
 TYPE_FLOW_SENSOR_CONSUMED_LITERS = "flow_sensor_consumed_liters"
 TYPE_FLOW_SENSOR_START_INDEX = "flow_sensor_start_index"
 TYPE_FLOW_SENSOR_WATERING_CLICKS = "flow_sensor_watering_clicks"
-TYPE_FREEZE_TEMP = "freeze_protect_temp"
 TYPE_PROGRAM_RUN_COMPLETION_TIME = "program_run_completion_time"
 TYPE_ZONE_RUN_COMPLETION_TIME = "zone_run_completion_time"
 
@@ -114,18 +107,9 @@ SENSOR_DESCRIPTIONS = (
         api_category=DATA_PROVISION_SETTINGS,
         data_key="flowSensorWateringClicks",
     ),
-    RainMachineSensorDataDescription(
-        key=TYPE_FREEZE_TEMP,
-        name="Freeze protect temperature",
-        icon="mdi:thermometer",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement=TEMP_CELSIUS,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        api_category=DATA_RESTRICTIONS_UNIVERSAL,
-        data_key="freezeProtectTemp",
-    ),
 )
+
+ENTITY_UNIQUE_ID_SUFFIXES_TO_REMOVE = ("freeze_protect_temp",)
 
 
 async def async_setup_entry(
@@ -150,7 +134,6 @@ async def async_setup_entry(
 
     api_category_sensor_map = {
         DATA_PROVISION_SETTINGS: ProvisionSettingsSensor,
-        DATA_RESTRICTIONS_UNIVERSAL: UniversalRestrictionsSensor,
     }
 
     sensors = [
@@ -317,18 +300,6 @@ class ProvisionSettingsSensor(RainMachineEntity, SensorEntity):
             self._attr_native_value = self.coordinator.data.get("system", {}).get(
                 "flowSensorWateringClicks"
             )
-
-
-class UniversalRestrictionsSensor(RainMachineEntity, SensorEntity):
-    """Define a sensor that handles universal restrictions data."""
-
-    entity_description: RainMachineSensorDataDescription
-
-    @callback
-    def update_from_latest_data(self) -> None:
-        """Update the state."""
-        if self.entity_description.key == TYPE_FREEZE_TEMP:
-            self._attr_native_value = self.coordinator.data.get("freezeProtectTemp")
 
 
 class ZoneTimeRemainingSensor(TimeRemainingSensor):

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -24,11 +24,16 @@ from . import RainMachineData, RainMachineEntity, async_update_programs_and_zone
 from .const import (
     CONF_ZONE_RUN_TIME,
     DATA_PROGRAMS,
+    DATA_RESTRICTIONS_UNIVERSAL,
     DATA_ZONES,
     DEFAULT_ZONE_RUN,
     DOMAIN,
 )
-from .model import RainMachineEntityDescription, RainMachineEntityDescriptionMixinUid
+from .model import (
+    RainMachineEntityDescription,
+    RainMachineEntityDescriptionMixinDataKey,
+    RainMachineEntityDescriptionMixinUid,
+)
 from .util import RUN_STATE_MAP
 
 ATTR_AREA = "area"
@@ -128,11 +133,50 @@ def raise_on_request_error(
 
 @dataclass
 class RainMachineSwitchDescription(
-    SwitchEntityDescription,
-    RainMachineEntityDescription,
-    RainMachineEntityDescriptionMixinUid,
+    SwitchEntityDescription, RainMachineEntityDescription
 ):
     """Describe a RainMachine switch."""
+
+
+@dataclass
+class RainMachineActivitySwitchDescription(
+    RainMachineSwitchDescription, RainMachineEntityDescriptionMixinUid
+):
+    """Describe a RainMachine activity (program/zone) switch."""
+
+
+@dataclass
+class RainMachineRestrictionSwitchDescription(
+    RainMachineSwitchDescription, RainMachineEntityDescriptionMixinDataKey
+):
+    """Describe a RainMachine restriction switch."""
+
+
+TYPE_RESTRICTIONS_FREEZE_PROTECT_ENABLED = "freeze_protect_enabled"
+TYPE_RESTRICTIONS_HOT_DAYS_EXTRA_WATERING = "hot_days_extra_watering"
+
+RESTRICTIONS_SWITCH_DESCRIPTIONS = (
+    RainMachineRestrictionSwitchDescription(
+        key=TYPE_RESTRICTIONS_FREEZE_PROTECT_ENABLED,
+        name="Freeze protection",
+        icon="mdi:snowflake-alert",
+        entity_category=EntityCategory.CONFIG,
+        api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="freezeProtectEnabled",
+    ),
+    RainMachineRestrictionSwitchDescription(
+        key=TYPE_RESTRICTIONS_HOT_DAYS_EXTRA_WATERING,
+        name="Extra watering on hot days",
+        icon="mdi:heat-wave",
+        entity_category=EntityCategory.CONFIG,
+        api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="hotDaysExtraWatering",
+    ),
+)
+
+
+class SwitchUpdateError(HomeAssistantError):
+    """Define an error when a switch update fails."""
 
 
 async def async_setup_entry(
@@ -158,8 +202,9 @@ async def async_setup_entry(
         platform.async_register_entity_service(service_name, schema, method)
 
     data: RainMachineData = hass.data[DOMAIN][entry.entry_id]
-
     entities: list[RainMachineActivitySwitch | RainMachineEnabledSwitch] = []
+
+    # Add switches for programs and zones (plus associated switches to enable/disable):
     for kind, api_category, switch_class, switch_enabled_class in (
         ("program", DATA_PROGRAMS, RainMachineProgram, RainMachineProgramEnabled),
         ("zone", DATA_ZONES, RainMachineZone, RainMachineZoneEnabled),
@@ -173,7 +218,7 @@ async def async_setup_entry(
                 switch_class(
                     entry,
                     data,
-                    RainMachineSwitchDescription(
+                    RainMachineActivitySwitchDescription(
                         key=f"{kind}_{uid}",
                         name=name,
                         icon="mdi:water",
@@ -188,7 +233,7 @@ async def async_setup_entry(
                 switch_enabled_class(
                     entry,
                     data,
-                    RainMachineSwitchDescription(
+                    RainMachineActivitySwitchDescription(
                         key=f"{kind}_{uid}_enabled",
                         name=f"{name} enabled",
                         entity_category=EntityCategory.CONFIG,
@@ -198,6 +243,10 @@ async def async_setup_entry(
                     ),
                 )
             )
+
+    # Add switches to control restrictions:
+    for description in RESTRICTIONS_SWITCH_DESCRIPTIONS:
+        entities.append(RainMachineRestriction(entry, data, description))
 
     async_add_entities(entities)
 
@@ -358,6 +407,29 @@ class RainMachineProgramEnabled(RainMachineEnabledSwitch):
         """Enable the program."""
         await self._data.controller.programs.enable(self.entity_description.uid)
         self._update_activities()
+
+
+class RainMachineRestriction(RainMachineBaseSwitch):
+    """Define a RainMachine restriction setting."""
+
+    @raise_on_request_error
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the restriction."""
+        await self._data.controller.restrictions.set_universal(
+            {self.entity_description.data_key: False}
+        )
+
+    @raise_on_request_error
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the restriction."""
+        await self._data.controller.restrictions.set_universal(
+            {self.entity_description.data_key: True}
+        )
+
+    @callback
+    def update_from_latest_data(self) -> None:
+        """Update the entity when new data is received."""
+        self._attr_is_on = self.coordinator.data[self.entity_description.data_key]
 
 
 class RainMachineZone(RainMachineActivitySwitch):

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -166,7 +166,7 @@ RESTRICTIONS_SWITCH_DESCRIPTIONS = (
     ),
     RainMachineRestrictionSwitchDescription(
         key=TYPE_RESTRICTIONS_HOT_DAYS_EXTRA_WATERING,
-        name="Extra watering on hot days",
+        name="Extra water on hot days",
         icon="mdi:heat-wave",
         entity_category=EntityCategory.CONFIG,
         api_category=DATA_RESTRICTIONS_UNIVERSAL,

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -24,11 +24,16 @@ from . import RainMachineData, RainMachineEntity, async_update_programs_and_zone
 from .const import (
     CONF_ZONE_RUN_TIME,
     DATA_PROGRAMS,
+    DATA_RESTRICTIONS_UNIVERSAL,
     DATA_ZONES,
     DEFAULT_ZONE_RUN,
     DOMAIN,
 )
-from .model import RainMachineEntityDescription, RainMachineEntityDescriptionMixinUid
+from .model import (
+    RainMachineEntityDescription,
+    RainMachineEntityDescriptionMixinDataKey,
+    RainMachineEntityDescriptionMixinUid,
+)
 from .util import RUN_STATE_MAP
 
 ATTR_AREA = "area"
@@ -130,9 +135,43 @@ def raise_on_request_error(
 class RainMachineSwitchDescription(
     SwitchEntityDescription,
     RainMachineEntityDescription,
-    RainMachineEntityDescriptionMixinUid,
 ):
     """Describe a RainMachine switch."""
+
+
+@dataclass
+class RainMachineActivitySwitchDescription(
+    RainMachineSwitchDescription, RainMachineEntityDescriptionMixinUid
+):
+    """Describe a RainMachine activity (program/zone) switch."""
+
+
+@dataclass
+class RainMachineRestrictionSwitchDescription(
+    RainMachineSwitchDescription, RainMachineEntityDescriptionMixinDataKey
+):
+    """Describe a RainMachine restriction switch."""
+
+
+TYPE_RESTRICTIONS_FREEZE_PROTECT_ENABLED = "freeze_protect_enabled"
+TYPE_RESTRICTIONS_HOT_DAYS_EXTRA_WATERING = "hot_days_extra_watering"
+
+RESTRICTIONS_SWITCH_DESCRIPTIONS = (
+    RainMachineRestrictionSwitchDescription(
+        key=TYPE_RESTRICTIONS_FREEZE_PROTECT_ENABLED,
+        name="Freeze protection",
+        icon="mdi:snowflake-alert",
+        api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="freezeProtectEnabled",
+    ),
+    RainMachineRestrictionSwitchDescription(
+        key=TYPE_RESTRICTIONS_HOT_DAYS_EXTRA_WATERING,
+        name="Extra water on hot days",
+        icon="mdi:heat-wave",
+        api_category=DATA_RESTRICTIONS_UNIVERSAL,
+        data_key="hotDaysExtraWatering",
+    ),
+)
 
 
 async def async_setup_entry(
@@ -173,10 +212,9 @@ async def async_setup_entry(
                 switch_class(
                     entry,
                     data,
-                    RainMachineSwitchDescription(
+                    RainMachineActivitySwitchDescription(
                         key=f"{kind}_{uid}",
                         name=name,
-                        icon="mdi:water",
                         api_category=api_category,
                         uid=uid,
                     ),
@@ -188,11 +226,9 @@ async def async_setup_entry(
                 switch_enabled_class(
                     entry,
                     data,
-                    RainMachineSwitchDescription(
+                    RainMachineActivitySwitchDescription(
                         key=f"{kind}_{uid}_enabled",
                         name=f"{name} enabled",
-                        entity_category=EntityCategory.CONFIG,
-                        icon="mdi:cog",
                         api_category=api_category,
                         uid=uid,
                     ),
@@ -246,6 +282,9 @@ class RainMachineBaseSwitch(RainMachineEntity, SwitchEntity):
 class RainMachineActivitySwitch(RainMachineBaseSwitch):
     """Define a RainMachine switch to start/stop an activity (program or zone)."""
 
+    _attr_icon = "mdi:water"
+    entity_description: RainMachineActivitySwitchDescription
+
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off.
 
@@ -283,6 +322,10 @@ class RainMachineActivitySwitch(RainMachineBaseSwitch):
 
 class RainMachineEnabledSwitch(RainMachineBaseSwitch):
     """Define a RainMachine switch to enable/disable an activity (program or zone)."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:cog"
+    entity_description: RainMachineActivitySwitchDescription
 
     @callback
     def update_from_latest_data(self) -> None:
@@ -358,6 +401,36 @@ class RainMachineProgramEnabled(RainMachineEnabledSwitch):
         """Enable the program."""
         await self._data.controller.programs.enable(self.entity_description.uid)
         self._update_activities()
+
+
+class RainMachineRestriction(RainMachineBaseSwitch):
+    """Define a RainMachine restriction setting."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    entity_description: RainMachineRestrictionSwitchDescription
+
+    @raise_on_request_error
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the restriction."""
+        await self._data.controller.restrictions.set_universal(
+            {self.entity_description.data_key: False}
+        )
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    @raise_on_request_error
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the restriction."""
+        await self._data.controller.restrictions.set_universal(
+            {self.entity_description.data_key: True}
+        )
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    @callback
+    def update_from_latest_data(self) -> None:
+        """Update the entity when new data is received."""
+        self._attr_is_on = self.coordinator.data[self.entity_description.data_key]
 
 
 class RainMachineZone(RainMachineActivitySwitch):

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -237,7 +237,7 @@ async def async_setup_entry(
 
     # Add switches to control restrictions:
     for description in RESTRICTIONS_SWITCH_DESCRIPTIONS:
-        entities.append(RainMachineRestriction(entry, data, description))
+        entities.append(RainMachineRestrictionSwitch(entry, data, description))
 
     async_add_entities(entities)
 
@@ -407,7 +407,7 @@ class RainMachineProgramEnabled(RainMachineEnabledSwitch):
         self._update_activities()
 
 
-class RainMachineRestriction(RainMachineBaseSwitch):
+class RainMachineRestrictionSwitch(RainMachineBaseSwitch):
     """Define a RainMachine restriction setting."""
 
     _attr_entity_category = EntityCategory.CONFIG

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -197,8 +197,8 @@ async def async_setup_entry(
         platform.async_register_entity_service(service_name, schema, method)
 
     data: RainMachineData = hass.data[DOMAIN][entry.entry_id]
+    entities: list[RainMachineBaseSwitch] = []
 
-    entities: list[RainMachineActivitySwitch | RainMachineEnabledSwitch] = []
     for kind, api_category, switch_class, switch_enabled_class in (
         ("program", DATA_PROGRAMS, RainMachineProgram, RainMachineProgramEnabled),
         ("zone", DATA_ZONES, RainMachineZone, RainMachineZoneEnabled),
@@ -234,6 +234,10 @@ async def async_setup_entry(
                     ),
                 )
             )
+
+    # Add switches to control restrictions:
+    for description in RESTRICTIONS_SWITCH_DESCRIPTIONS:
+        entities.append(RainMachineRestriction(entry, data, description))
 
     async_add_entities(entities)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Before entity categories existed, RainMachine provided several binary sensor/sensor entities to show "restrictions" (i.e., whether the user had restricted watering activities in any way). Now that we have config entity categories, these values are better represented as other entities that allow the user to control the values, not only read them.

This PR replaces the `extra_water_on_hot_days` and `freeze_protection` binary sensors with switches:

![CleanShot 2022-08-08 at 11 45 15](https://user-images.githubusercontent.com/47216/183480675-35051007-d1f5-4ba2-a5a9-1396576117e2.png)

![CleanShot 2022-08-08 at 11 45 18](https://user-images.githubusercontent.com/47216/183480688-b1229622-95b8-484b-8fec-09a7e29c96e6.png)

The PR adds a Repair entry to inform the user about the old entities' deprecation and future removal.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
