### PR TITLE
Remove deprecated utility_meter entity

### DIFF
--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -13,7 +13,6 @@ from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.helpers import discovery, entity_registry as er
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -27,7 +26,6 @@ from .const import (
     CONF_TARIFF,
     CONF_TARIFF_ENTITY,
     CONF_TARIFFS,
-    DATA_LEGACY_COMPONENT,
     DATA_TARIFF_SENSORS,
     DATA_UTILITY,
     DOMAIN,
@@ -101,8 +99,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up an Utility Meter."""
-    hass.data[DATA_LEGACY_COMPONENT] = EntityComponent(_LOGGER, DOMAIN, hass)
-
     hass.data[DATA_UTILITY] = {}
 
     async def async_reset_meters(service_call):

--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -47,5 +47,4 @@ SIGNAL_START_PAUSE_METER = "utility_meter_start_pause"
 SIGNAL_RESET_METER = "utility_meter_reset"
 
 SERVICE_RESET = "reset"
-SERVICE_SELECT_TARIFF = "select_tariff"
 SERVICE_CALIBRATE_METER = "calibrate"

--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -25,7 +25,6 @@ METER_TYPES = [
 
 DATA_UTILITY = "utility_meter_data"
 DATA_TARIFF_SENSORS = "utility_meter_sensors"
-DATA_LEGACY_COMPONENT = "utility_meter_legacy_component"
 
 CONF_METER = "meter"
 CONF_SOURCE_SENSOR = "source"
@@ -49,5 +48,4 @@ SIGNAL_RESET_METER = "utility_meter_reset"
 
 SERVICE_RESET = "reset"
 SERVICE_SELECT_TARIFF = "select_tariff"
-SERVICE_SELECT_NEXT_TARIFF = "next_tariff"
 SERVICE_CALIBRATE_METER = "calibrate"

--- a/homeassistant/components/utility_meter/select.py
+++ b/homeassistant/components/utility_meter/select.py
@@ -3,41 +3,15 @@ from __future__ import annotations
 
 import logging
 
-import voluptuous as vol
-
 from homeassistant.components.select import SelectEntity
-from homeassistant.components.select.const import (
-    ATTR_OPTION,
-    ATTR_OPTIONS,
-    DOMAIN as SELECT_DOMAIN,
-    SERVICE_SELECT_OPTION,
-)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_FRIENDLY_NAME,
-    CONF_UNIQUE_ID,
-    STATE_UNAVAILABLE,
-)
-from homeassistant.core import Event, HomeAssistant, callback, split_entity_id
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity import Entity
+from homeassistant.const import CONF_UNIQUE_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import (
-    ATTR_TARIFF,
-    ATTR_TARIFFS,
-    CONF_METER,
-    CONF_TARIFFS,
-    DATA_LEGACY_COMPONENT,
-    DATA_UTILITY,
-    SERVICE_SELECT_NEXT_TARIFF,
-    SERVICE_SELECT_TARIFF,
-    TARIFF_ICON,
-)
+from .const import CONF_METER, CONF_TARIFFS, DATA_UTILITY, TARIFF_ICON
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,9 +25,8 @@ async def async_setup_entry(
     name = config_entry.title
     tariffs = config_entry.options[CONF_TARIFFS]
 
-    legacy_add_entities = None
     unique_id = config_entry.entry_id
-    tariff_select = TariffSelect(name, tariffs, legacy_add_entities, unique_id)
+    tariff_select = TariffSelect(name, tariffs, unique_id)
     async_add_entities([tariff_select])
 
 
@@ -71,7 +44,6 @@ async def async_setup_platform(
         )
         return
 
-    legacy_component = hass.data[DATA_LEGACY_COMPONENT]
     meter: str = discovery_info[CONF_METER]
     conf_meter_unique_id: str | None = hass.data[DATA_UTILITY][meter].get(
         CONF_UNIQUE_ID
@@ -82,27 +54,16 @@ async def async_setup_platform(
             TariffSelect(
                 discovery_info[CONF_METER],
                 discovery_info[CONF_TARIFFS],
-                legacy_component.async_add_entities,
                 conf_meter_unique_id,
             )
         ]
-    )
-
-    legacy_component.async_register_entity_service(
-        SERVICE_SELECT_TARIFF,
-        {vol.Required(ATTR_TARIFF): cv.string},
-        "async_select_tariff",
-    )
-
-    legacy_component.async_register_entity_service(
-        SERVICE_SELECT_NEXT_TARIFF, {}, "async_next_tariff"
     )
 
 
 class TariffSelect(SelectEntity, RestoreEntity):
     """Representation of a Tariff selector."""
 
-    def __init__(self, name, tariffs, add_legacy_entities, unique_id):
+    def __init__(self, name, tariffs, unique_id):
         """Initialize a tariff selector."""
         self._attr_name = name
         self._attr_unique_id = unique_id
@@ -110,7 +71,6 @@ class TariffSelect(SelectEntity, RestoreEntity):
         self._tariffs = tariffs
         self._attr_icon = TARIFF_ICON
         self._attr_should_poll = False
-        self._add_legacy_entities = add_legacy_entities
 
     @property
     def options(self):
@@ -126,9 +86,6 @@ class TariffSelect(SelectEntity, RestoreEntity):
         """Run when entity about to be added."""
         await super().async_added_to_hass()
 
-        if self._add_legacy_entities:
-            await self._add_legacy_entities([LegacyTariffSelect(self.entity_id)])
-
         state = await self.async_get_last_state()
         if not state or state.state not in self._tariffs:
             self._current_tariff = self._tariffs[0]
@@ -139,81 +96,3 @@ class TariffSelect(SelectEntity, RestoreEntity):
         """Select new tariff (option)."""
         self._current_tariff = option
         self.async_write_ha_state()
-
-
-class LegacyTariffSelect(Entity):
-    """Backwards compatibility for deprecated utility_meter select entity."""
-
-    def __init__(self, tracked_entity_id):
-        """Initialize the entity."""
-        self._attr_icon = TARIFF_ICON
-        # Set name to influence entity_id
-        self._attr_name = split_entity_id(tracked_entity_id)[1]
-        self.tracked_entity_id = tracked_entity_id
-
-    @callback
-    def async_state_changed_listener(self, event: Event | None = None) -> None:
-        """Handle child updates."""
-        if (
-            state := self.hass.states.get(self.tracked_entity_id)
-        ) is None or state.state == STATE_UNAVAILABLE:
-            self._attr_available = False
-            return
-
-        self._attr_available = True
-
-        self._attr_name = state.attributes.get(ATTR_FRIENDLY_NAME)
-        self._attr_state = state.state
-        self._attr_extra_state_attributes = {
-            ATTR_TARIFFS: state.attributes.get(ATTR_OPTIONS)
-        }
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-
-        @callback
-        def _async_state_changed_listener(event: Event | None = None) -> None:
-            """Handle child updates."""
-            self.async_state_changed_listener(event)
-            self.async_write_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, [self.tracked_entity_id], _async_state_changed_listener
-            )
-        )
-
-        # Call once on adding
-        _async_state_changed_listener()
-
-    async def async_select_tariff(self, tariff):
-        """Select new option."""
-        _LOGGER.warning(
-            "The 'utility_meter.select_tariff' service has been deprecated and will "
-            "be removed in HA Core 2022.7. Please use 'select.select_option' instead",
-        )
-        await self.hass.services.async_call(
-            SELECT_DOMAIN,
-            SERVICE_SELECT_OPTION,
-            {ATTR_ENTITY_ID: self.tracked_entity_id, ATTR_OPTION: tariff},
-            blocking=True,
-            context=self._context,
-        )
-
-    async def async_next_tariff(self):
-        """Offset current index."""
-        _LOGGER.warning(
-            "The 'utility_meter.next_tariff' service has been deprecated and will "
-            "be removed in HA Core 2022.7. Please use 'select.select_option' instead",
-        )
-        if (
-            not self.available
-            or (state := self.hass.states.get(self.tracked_entity_id)) is None
-        ):
-            return
-        tariffs = state.attributes.get(ATTR_OPTIONS)
-        current_tariff = state.state
-        current_index = tariffs.index(current_tariff)
-        new_index = (current_index + 1) % len(tariffs)
-
-        await self.async_select_tariff(tariffs[new_index])

--- a/homeassistant/components/utility_meter/services.yaml
+++ b/homeassistant/components/utility_meter/services.yaml
@@ -7,28 +7,6 @@ reset:
     entity:
       domain: select
 
-next_tariff:
-  name: Next Tariff
-  description: Changes the tariff to the next one.
-  target:
-    entity:
-      domain: utility_meter
-
-select_tariff:
-  name: Select Tariff
-  description: Selects the current tariff of a utility meter.
-  target:
-    entity:
-      domain: utility_meter
-  fields:
-    tariff:
-      name: Tariff
-      description: Name of the tariff to switch to
-      example: "offpeak"
-      required: true
-      selector:
-        text:
-
 calibrate:
   name: Calibrate
   description: Calibrates a utility meter sensor.

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -7,16 +7,11 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.select.const import (
+    ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.components.utility_meter.const import (
-    DOMAIN,
-    SERVICE_RESET,
-    SERVICE_SELECT_NEXT_TARIFF,
-    SERVICE_SELECT_TARIFF,
-    SIGNAL_RESET_METER,
-)
+from homeassistant.components.utility_meter.const import DOMAIN, SERVICE_RESET
 import homeassistant.components.utility_meter.select as um_select
 import homeassistant.components.utility_meter.sensor as um_sensor
 from homeassistant.const import (
@@ -28,9 +23,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, State
-from homeassistant.exceptions import ServiceNotFound
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -71,8 +64,6 @@ async def test_restore_state(hass):
     (
         ["select.energy_bill"],
         "select.energy_bill",
-        ["utility_meter.energy_bill"],
-        "utility_meter.energy_bill",
     ),
 )
 async def test_services(hass, meter):
@@ -119,9 +110,9 @@ async def test_services(hass, meter):
     state = hass.states.get("sensor.energy_bill_offpeak")
     assert state.state == "0"
 
-    # Next tariff - only supported on legacy entity
-    data = {ATTR_ENTITY_ID: "utility_meter.energy_bill"}
-    await hass.services.async_call(DOMAIN, SERVICE_SELECT_NEXT_TARIFF, data)
+    # Change tariff
+    data = {ATTR_ENTITY_ID: "select.energy_bill", ATTR_OPTION: "offpeak"}
+    await hass.services.async_call(SELECT_DOMAIN, SERVICE_SELECT_OPTION, data)
     await hass.async_block_till_done()
 
     now += timedelta(seconds=10)
@@ -242,12 +233,6 @@ async def test_services_config_entry(hass):
 
     state = hass.states.get("sensor.energy_bill_offpeak")
     assert state.state == "0"
-
-    # Next tariff - only supported on legacy entity
-    with pytest.raises(ServiceNotFound):
-        data = {ATTR_ENTITY_ID: "utility_meter.energy_bill"}
-        await hass.services.async_call(DOMAIN, SERVICE_SELECT_NEXT_TARIFF, data)
-        await hass.async_block_till_done()
 
     # Change tariff
     data = {ATTR_ENTITY_ID: "select.energy_bill", "option": "offpeak"}
@@ -392,88 +377,6 @@ async def test_setup_missing_discovery(hass):
     """Test setup with configuration missing discovery_info."""
     assert not await um_select.async_setup_platform(hass, {CONF_PLATFORM: DOMAIN}, None)
     assert not await um_sensor.async_setup_platform(hass, {CONF_PLATFORM: DOMAIN}, None)
-
-
-async def test_legacy_support(hass):
-    """Test legacy entity support."""
-    config = {
-        "utility_meter": {
-            "energy_bill": {
-                "source": "sensor.energy",
-                "cycle": "hourly",
-                "tariffs": ["peak", "offpeak"],
-            },
-        }
-    }
-
-    assert await async_setup_component(hass, DOMAIN, config)
-    assert await async_setup_component(hass, Platform.SENSOR, config)
-    await hass.async_block_till_done()
-
-    select_state = hass.states.get("select.energy_bill")
-    legacy_state = hass.states.get("utility_meter.energy_bill")
-
-    assert select_state.state == legacy_state.state == "peak"
-    select_attributes = select_state.attributes
-    legacy_attributes = legacy_state.attributes
-    assert select_attributes.keys() == {
-        "friendly_name",
-        "icon",
-        "options",
-    }
-    assert legacy_attributes.keys() == {"friendly_name", "icon", "tariffs"}
-    assert select_attributes["friendly_name"] == legacy_attributes["friendly_name"]
-    assert select_attributes["icon"] == legacy_attributes["icon"]
-    assert select_attributes["options"] == legacy_attributes["tariffs"]
-
-    # Change tariff on the select
-    data = {ATTR_ENTITY_ID: "select.energy_bill", "option": "offpeak"}
-    await hass.services.async_call(SELECT_DOMAIN, SERVICE_SELECT_OPTION, data)
-    await hass.async_block_till_done()
-
-    select_state = hass.states.get("select.energy_bill")
-    legacy_state = hass.states.get("utility_meter.energy_bill")
-    assert select_state.state == legacy_state.state == "offpeak"
-
-    # Change tariff on the legacy entity
-    data = {ATTR_ENTITY_ID: "utility_meter.energy_bill", "tariff": "offpeak"}
-    await hass.services.async_call(DOMAIN, SERVICE_SELECT_TARIFF, data)
-    await hass.async_block_till_done()
-
-    select_state = hass.states.get("select.energy_bill")
-    legacy_state = hass.states.get("utility_meter.energy_bill")
-    assert select_state.state == legacy_state.state == "offpeak"
-
-    # Cycle tariffs on the select - not supported
-    data = {ATTR_ENTITY_ID: "select.energy_bill"}
-    await hass.services.async_call(DOMAIN, SERVICE_SELECT_NEXT_TARIFF, data)
-    await hass.async_block_till_done()
-
-    select_state = hass.states.get("select.energy_bill")
-    legacy_state = hass.states.get("utility_meter.energy_bill")
-    assert select_state.state == legacy_state.state == "offpeak"
-
-    # Cycle tariffs on the legacy entity
-    data = {ATTR_ENTITY_ID: "utility_meter.energy_bill"}
-    await hass.services.async_call(DOMAIN, SERVICE_SELECT_NEXT_TARIFF, data)
-    await hass.async_block_till_done()
-
-    select_state = hass.states.get("select.energy_bill")
-    legacy_state = hass.states.get("utility_meter.energy_bill")
-    assert select_state.state == legacy_state.state == "peak"
-
-    # Reset the legacy entity
-    reset_calls = []
-
-    def async_reset_meter(entity_id):
-        reset_calls.append(entity_id)
-
-    async_dispatcher_connect(hass, SIGNAL_RESET_METER, async_reset_meter)
-
-    data = {ATTR_ENTITY_ID: "utility_meter.energy_bill"}
-    await hass.services.async_call(DOMAIN, SERVICE_RESET, data)
-    await hass.async_block_till_done()
-    assert reset_calls == ["select.energy_bill"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Legacy utility_meter entity used to change tariffs has been removed (was due for removal on 2022.7)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
