### PR TITLE
Add new Bluetooth coordinator helper for polling mostly passive devices

### DIFF
--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -94,7 +94,7 @@ class ActiveBluetoothProcessorCoordinator(
             poll_age = time.monotonic() - self._last_poll
         return self._needs_poll_method(service_info, poll_age)
 
-    async def _async_update_data(
+    async def _async_poll_data(
         self, last_service_info: BluetoothServiceInfoBleak
     ) -> _T:
         """Fetch the latest data from the source."""
@@ -107,7 +107,7 @@ class ActiveBluetoothProcessorCoordinator(
         assert self._last_service_info
 
         try:
-            update = await self._async_update_data(self._last_service_info)
+            update = await self._async_poll_data(self._last_service_info)
         except Exception:  # pylint: disable=broad-except
             if self.last_poll_successful:
                 self.logger.exception("%s: Failure while polling", self.address)

--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -1,0 +1,132 @@
+"""A Bluetooth passive coordinator that collects data from advertisements but can also poll."""
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+import logging
+import time
+from typing import Any, TypeVar
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.debounce import Debouncer
+
+from . import BluetoothChange, BluetoothScanningMode, BluetoothServiceInfoBleak
+from .passive_update_processor import (
+    PassiveBluetoothDataUpdate,
+    PassiveBluetoothProcessorCoordinator,
+)
+
+POLL_DEFAULT_COOLDOWN = 10
+POLL_DEFAULT_IMMEDIATE = True
+
+_T = TypeVar("_T")
+
+
+class ActiveBluetoothProcessorCoordinator(PassiveBluetoothProcessorCoordinator):
+    """
+    A coordinator that parses passive data from advertisements but can also poll.
+
+    Every time an advertisement is received, needs_poll_method is called to work
+    out if a poll is needed. This should return True if it is and False if it is
+    not needed.
+
+    def needs_poll_method(svc_info: BluetoothServiceInfoBleak, last_poll: float | None) -> bool:
+        return True
+
+    If there has been no poll since HA started, `last_poll` will be None. Otherwise it is
+    the number of seconds since one was last attempted.
+
+    If a poll is needed, the coordinator will call poll_method. This is a coroutine.
+    It should return the same type of data as your update_method. The expectation is that
+    data from advertisements and from polling are being parsed and fed into a shared
+    object that represents the current state of the device.
+
+    async def poll_method(svc_info: BluetoothServiceInfoBleak) -> YourDataType:
+        return YourDataType(....)
+
+    BluetoothServiceInfoBleak.device contains a BLEDevice. You should use this in
+    your poll function, as it is the most efficient way to get a BleakClient.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: logging.Logger,
+        address: str,
+        mode: BluetoothScanningMode,
+        update_method: Callable[[BluetoothServiceInfoBleak], _T],
+        needs_poll_method: Callable[[BluetoothServiceInfoBleak, float | None], bool],
+        poll_method: Callable[
+            [BluetoothServiceInfoBleak],
+            Coroutine[Any, Any, PassiveBluetoothDataUpdate[_T]],
+        ],
+        poll_debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None,
+    ) -> None:
+        """Initialize the processor."""
+        super().__init__(hass, logger, address, mode, update_method)
+
+        self._needs_poll_method = needs_poll_method
+        self._poll_method = poll_method
+        self._last_poll: float | None = None
+        self._last_poll_successful = True
+
+        # We keep the last service info in case the poller needs to refer to
+        # e.g. its BLEDevice
+        self._last_service_info: BluetoothServiceInfoBleak | None = None
+
+        if poll_debouncer is None:
+            poll_debouncer = Debouncer(
+                hass,
+                logger,
+                cooldown=POLL_DEFAULT_COOLDOWN,
+                immediate=POLL_DEFAULT_IMMEDIATE,
+                function=self._async_poll,
+            )
+        else:
+            poll_debouncer.function = self._async_poll
+
+        self._debounced_poll = poll_debouncer
+
+    def needs_poll(self, service_info: BluetoothServiceInfoBleak) -> bool:
+        """Return true if time to try and poll."""
+        poll_age: float | None = None
+        if self._last_poll:
+            poll_age = time.monotonic() - self._last_poll
+        return self._needs_poll_method(service_info, poll_age)
+
+    async def _async_poll(self) -> None:
+        """Poll the device to retrieve any extra data."""
+        assert self._last_service_info
+
+        try:
+            update = await self._poll_method(self._last_service_info)
+        except Exception:  # pylint: disable=broad-except
+            if self._last_poll_successful:
+                self.logger.exception("%s: Failure while polling", self.address)
+                self._last_poll_successful = False
+                return
+        finally:
+            self._last_poll = time.monotonic()
+
+        if not self._last_poll_successful:
+            self.logger.debug("%s: Polling recovered")
+            self._last_poll_successful = True
+
+        for processor in self._processors:
+            processor.async_handle_update(update)
+
+    @callback
+    def _async_handle_bluetooth_event(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Handle a Bluetooth event."""
+        super()._async_handle_bluetooth_event(service_info, change)
+
+        self._last_service_info = service_info
+
+        # See if its time to poll
+        # We use bluetooth events to trigger the poll so that we scan as soon as
+        # possible after a device comes online or back in range, if a poll is due
+        if self.needs_poll(service_info):
+            self.hass.async_create_task(self._debounced_poll.async_call())

--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -51,6 +51,7 @@ class ActiveBluetoothProcessorCoordinator(PassiveBluetoothProcessorCoordinator):
         self,
         hass: HomeAssistant,
         logger: logging.Logger,
+        *,
         address: str,
         mode: BluetoothScanningMode,
         update_method: Callable[[BluetoothServiceInfoBleak], _T],

--- a/tests/components/bluetooth/test_active_update_coordinator.py
+++ b/tests/components/bluetooth/test_active_update_coordinator.py
@@ -51,11 +51,11 @@ async def test_basic_usage(hass: HomeAssistant, mock_bleak_scanner_start):
     coordinator = ActiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
-        "aa:bb:cc:dd:ee:ff",
-        BluetoothScanningMode.ACTIVE,
-        _update_method,
-        _poll_needed,
-        _poll,
+        address="aa:bb:cc:dd:ee:ff",
+        mode=BluetoothScanningMode.ACTIVE,
+        update_method=_update_method,
+        needs_poll_method=_poll_needed,
+        poll_method=_poll,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -111,12 +111,12 @@ async def test_poll_can_be_skipped(hass: HomeAssistant, mock_bleak_scanner_start
     coordinator = ActiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
-        "aa:bb:cc:dd:ee:ff",
-        BluetoothScanningMode.ACTIVE,
-        _update_method,
-        _poll_needed,
-        _poll,
-        Debouncer(
+        address="aa:bb:cc:dd:ee:ff",
+        mode=BluetoothScanningMode.ACTIVE,
+        update_method=_update_method,
+        needs_poll_method=_poll_needed,
+        poll_method=_poll,
+        poll_debouncer=Debouncer(
             hass,
             _LOGGER,
             cooldown=0,
@@ -183,12 +183,12 @@ async def test_poll_failure_and_recover(hass: HomeAssistant, mock_bleak_scanner_
     coordinator = ActiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
-        "aa:bb:cc:dd:ee:ff",
-        BluetoothScanningMode.ACTIVE,
-        _update_method,
-        _poll_needed,
-        _poll,
-        Debouncer(
+        address="aa:bb:cc:dd:ee:ff",
+        mode=BluetoothScanningMode.ACTIVE,
+        update_method=_update_method,
+        needs_poll_method=_poll_needed,
+        poll_method=_poll,
+        poll_debouncer=Debouncer(
             hass,
             _LOGGER,
             cooldown=0,
@@ -251,11 +251,11 @@ async def test_second_poll_needed(hass: HomeAssistant, mock_bleak_scanner_start)
     coordinator = ActiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
-        "aa:bb:cc:dd:ee:ff",
-        BluetoothScanningMode.ACTIVE,
-        _update_method,
-        _poll_needed,
-        _poll,
+        address="aa:bb:cc:dd:ee:ff",
+        mode=BluetoothScanningMode.ACTIVE,
+        update_method=_update_method,
+        needs_poll_method=_poll_needed,
+        poll_method=_poll,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None
@@ -309,11 +309,11 @@ async def test_rate_limit(hass: HomeAssistant, mock_bleak_scanner_start):
     coordinator = ActiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
-        "aa:bb:cc:dd:ee:ff",
-        BluetoothScanningMode.ACTIVE,
-        _update_method,
-        _poll_needed,
-        _poll,
+        address="aa:bb:cc:dd:ee:ff",
+        mode=BluetoothScanningMode.ACTIVE,
+        update_method=_update_method,
+        needs_poll_method=_poll_needed,
+        poll_method=_poll,
     )
     assert coordinator.available is False  # no data yet
     saved_callback = None

--- a/tests/components/bluetooth/test_active_update_coordinator.py
+++ b/tests/components/bluetooth/test_active_update_coordinator.py
@@ -1,0 +1,348 @@
+"""Tests for the Bluetooth integration PassiveBluetoothDataUpdateCoordinator."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock, call, patch
+
+from homeassistant.components.bluetooth import (
+    DOMAIN,
+    BluetoothChange,
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+)
+from homeassistant.components.bluetooth.active_update_coordinator import (
+    ActiveBluetoothProcessorCoordinator,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
+from homeassistant.setup import async_setup_component
+
+_LOGGER = logging.getLogger(__name__)
+
+
+GENERIC_BLUETOOTH_SERVICE_INFO = BluetoothServiceInfo(
+    name="Generic",
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-95,
+    manufacturer_data={
+        1: b"\x01\x01\x01\x01\x01\x01\x01\x01",
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+
+
+async def test_basic_usage(hass: HomeAssistant, mock_bleak_scanner_start):
+    """Test basic usage of the ActiveBluetoothProcessorCoordinator."""
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    def _update_method(service_info: BluetoothServiceInfoBleak):
+        return {"testdata": 0}
+
+    def _poll_needed(*args, **kwargs):
+        return True
+
+    async def _poll(*args, **kwargs):
+        return {"testdata": 1}
+
+    coordinator = ActiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _update_method,
+        _poll_needed,
+        _poll,
+    )
+    assert coordinator.available is False  # no data yet
+    saved_callback = None
+
+    processor = MagicMock()
+    coordinator.async_register_processor(processor)
+    async_handle_update = processor.async_handle_update
+
+    def _async_register_callback(_hass, _callback, _matcher, _mode):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        cancel = coordinator.async_start()
+
+    assert saved_callback is not None
+
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+
+    assert coordinator.available is True
+
+    # async_handle_update should have been called twice
+    # The first time, it was passed the data from parsing the advertisement
+    # The second time, it was passed the data from polling
+    assert len(async_handle_update.mock_calls) == 2
+    assert async_handle_update.mock_calls[0] == call({"testdata": 0})
+    assert async_handle_update.mock_calls[1] == call({"testdata": 1})
+
+    cancel()
+
+
+async def test_poll_can_be_skipped(hass: HomeAssistant, mock_bleak_scanner_start):
+    """Test need_poll callback works and can skip a poll if its not needed."""
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    flag = True
+
+    def _update_method(service_info: BluetoothServiceInfoBleak):
+        return {"testdata": None}
+
+    def _poll_needed(*args, **kwargs):
+        nonlocal flag
+        return flag
+
+    async def _poll(*args, **kwargs):
+        return {"testdata": flag}
+
+    coordinator = ActiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _update_method,
+        _poll_needed,
+        _poll,
+        Debouncer(
+            hass,
+            _LOGGER,
+            cooldown=0,
+            immediate=True,
+        ),
+    )
+    assert coordinator.available is False  # no data yet
+    saved_callback = None
+
+    processor = MagicMock()
+    coordinator.async_register_processor(processor)
+    async_handle_update = processor.async_handle_update
+
+    def _async_register_callback(_hass, _callback, _matcher, _mode):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        cancel = coordinator.async_start()
+
+    assert saved_callback is not None
+
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+    assert async_handle_update.mock_calls[-1] == call({"testdata": True})
+
+    flag = False
+
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+    assert async_handle_update.mock_calls[-1] == call({"testdata": None})
+
+    flag = True
+
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+    assert async_handle_update.mock_calls[-1] == call({"testdata": True})
+
+    cancel()
+
+
+async def test_poll_failure_and_recover(hass: HomeAssistant, mock_bleak_scanner_start):
+    """Test error handling and recovery."""
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    flag = True
+
+    def _update_method(service_info: BluetoothServiceInfoBleak):
+        return {"testdata": None}
+
+    def _poll_needed(*args, **kwargs):
+        return True
+
+    async def _poll(*args, **kwargs):
+        nonlocal flag
+        if flag:
+            raise RuntimeError("Poll failure")
+        return {"testdata": flag}
+
+    coordinator = ActiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _update_method,
+        _poll_needed,
+        _poll,
+        Debouncer(
+            hass,
+            _LOGGER,
+            cooldown=0,
+            immediate=True,
+        ),
+    )
+    assert coordinator.available is False  # no data yet
+    saved_callback = None
+
+    processor = MagicMock()
+    coordinator.async_register_processor(processor)
+    async_handle_update = processor.async_handle_update
+
+    def _async_register_callback(_hass, _callback, _matcher, _mode):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        cancel = coordinator.async_start()
+
+    assert saved_callback is not None
+
+    # First poll fails
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+    assert async_handle_update.mock_calls[-1] == call({"testdata": None})
+
+    # Second poll works
+    flag = False
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+    assert async_handle_update.mock_calls[-1] == call({"testdata": False})
+
+    cancel()
+
+
+async def test_second_poll_needed(hass: HomeAssistant, mock_bleak_scanner_start):
+    """If a poll is queued, by the time it starts it may no longer be needed."""
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    count = 0
+
+    def _update_method(service_info: BluetoothServiceInfoBleak):
+        return {"testdata": None}
+
+    # Only poll once
+    def _poll_needed(*args, **kwargs):
+        nonlocal count
+        return count == 0
+
+    async def _poll(*args, **kwargs):
+        nonlocal count
+        count += 1
+        return {"testdata": count}
+
+    coordinator = ActiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _update_method,
+        _poll_needed,
+        _poll,
+    )
+    assert coordinator.available is False  # no data yet
+    saved_callback = None
+
+    processor = MagicMock()
+    coordinator.async_register_processor(processor)
+    async_handle_update = processor.async_handle_update
+
+    def _async_register_callback(_hass, _callback, _matcher, _mode):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        cancel = coordinator.async_start()
+
+    assert saved_callback is not None
+
+    # First poll gets queued
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    # Second poll gets stuck behind first poll
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+
+    await hass.async_block_till_done()
+    assert async_handle_update.mock_calls[-1] == call({"testdata": 1})
+
+    cancel()
+
+
+async def test_rate_limit(hass: HomeAssistant, mock_bleak_scanner_start):
+    """Test error handling and recovery."""
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    count = 0
+
+    def _update_method(service_info: BluetoothServiceInfoBleak):
+        return {"testdata": None}
+
+    def _poll_needed(*args, **kwargs):
+        return True
+
+    async def _poll(*args, **kwargs):
+        nonlocal count
+        count += 1
+        await asyncio.sleep(0)
+        return {"testdata": count}
+
+    coordinator = ActiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        "aa:bb:cc:dd:ee:ff",
+        BluetoothScanningMode.ACTIVE,
+        _update_method,
+        _poll_needed,
+        _poll,
+    )
+    assert coordinator.available is False  # no data yet
+    saved_callback = None
+
+    processor = MagicMock()
+    coordinator.async_register_processor(processor)
+    async_handle_update = processor.async_handle_update
+
+    def _async_register_callback(_hass, _callback, _matcher, _mode):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        cancel = coordinator.async_start()
+
+    assert saved_callback is not None
+
+    # First poll gets queued
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    # Second poll gets stuck behind first poll
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    # Third poll gets stuck behind first poll doesn't get queued
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+
+    await hass.async_block_till_done()
+    assert async_handle_update.mock_calls[-1] == call({"testdata": 1})
+
+    cancel()


### PR DESCRIPTION
## Proposed change

This adds a subclass of PassiveBluetoothProcessorCoordinator which has some hooks to help poll devices.

This is really for infrequently polled sensors, like the battery sensor on a Xiaomi MiFlora Flower Care sensor.

Originally part of https://github.com/home-assistant/core/pull/76342, pulled into seperate PR by request of @bdraco

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
