### PR TITLE
Add schedule helper

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -213,6 +213,7 @@ homeassistant.components.rpi_power.*
 homeassistant.components.rtsp_to_webrtc.*
 homeassistant.components.samsungtv.*
 homeassistant.components.scene.*
+homeassistant.components.schedule.*
 homeassistant.components.select.*
 homeassistant.components.sensibo.*
 homeassistant.components.sensor.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -921,6 +921,8 @@ build.json @home-assistant/supervisor
 /tests/components/samsungtv/ @chemelli74 @epenet
 /homeassistant/components/scene/ @home-assistant/core
 /tests/components/scene/ @home-assistant/core
+/homeassistant/components/schedule/ @home-assistant/core
+/tests/components/schedule/ @home-assistant/core
 /homeassistant/components/schluter/ @prairieapps
 /homeassistant/components/scrape/ @fabaff
 /tests/components/scrape/ @fabaff

--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -27,6 +27,7 @@
     "network",
     "person",
     "scene",
+    "schedule",
     "script",
     "ssdp",
     "sun",

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -15,6 +15,8 @@ from homeassistant.const import (
     CONF_ID,
     CONF_NAME,
     SERVICE_RELOAD,
+    STATE_OFF,
+    STATE_ON,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.collection import (
@@ -43,8 +45,6 @@ from .const import (
     CONF_TO,
     DOMAIN,
     LOGGER,
-    STATE_ACTIVE,
-    STATE_INACTIVE,
     WEEKDAY_TO_CONF,
 )
 
@@ -212,7 +212,7 @@ class Schedule(Entity):
 
     _attr_has_entity_name = True
     _attr_should_poll = False
-    _attr_state: Literal["active", "inactive"]
+    _attr_state: Literal["on", "off"]
     _config: ConfigType
     _next: datetime
     _unsub_update: Callable[[], None] | None = None
@@ -261,11 +261,11 @@ class Schedule(Entity):
         # Determine current schedule state
         self._attr_state = next(
             (
-                STATE_ACTIVE
+                STATE_ON
                 for time_range in todays_schedule
                 if time_range[CONF_FROM] <= now.time() <= time_range[CONF_TO]
             ),
-            STATE_INACTIVE,
+            STATE_OFF,
         )
 
         # Find next event in the schedule, loop over each day (starting with

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -291,8 +291,6 @@ class Schedule(Entity):
                 break
 
         self._attr_extra_state_attributes = {
-            day: self._config[day] for day in CONF_ALL_DAYS
-        } | {
             ATTR_NEXT_EVENT: next_event,
         }
         self.async_write_ha_state()

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -204,21 +204,20 @@ class Schedule(Entity):
     _config: ConfigType
     _next: datetime
     _unsub_update: Callable[[], None] | None = None
-    editable = True
 
-    def __init__(self, config: ConfigType) -> None:
+    def __init__(self, config: ConfigType, editable: bool = True) -> None:
         """Initialize a schedule."""
         self._config = STORAGE_SCHEMA(config)
-        self._attr_unique_id = self._config[CONF_ID]
+        self._attr_capability_attributes = {ATTR_EDITABLE: editable}
         self._attr_icon = self._config.get(CONF_ICON)
         self._attr_name = self._config[CONF_NAME]
+        self._attr_unique_id = self._config[CONF_ID]
 
     @classmethod
     def from_yaml(cls, config: ConfigType) -> Schedule:
         """Return entity instance initialized from yaml storage."""
-        schedule = cls(config)
+        schedule = cls(config, editable=False)
         schedule.entity_id = f"{DOMAIN}.{config[CONF_ID]}"
-        schedule.editable = False
         return schedule
 
     async def async_update_config(self, config: ConfigType) -> None:
@@ -228,13 +227,6 @@ class Schedule(Entity):
         self._attr_name = config[CONF_NAME]
         self._clean_up_listener()
         self._update()
-
-    @property
-    def capability_attributes(self) -> dict:
-        """Return the capability attributes."""
-        return {
-            ATTR_EDITABLE: self.editable,
-        }
 
     @callback
     def _clean_up_listener(self) -> None:

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -54,9 +54,11 @@ STORAGE_VERSION_MINOR = 1
 
 def has_no_overlap(schedule: list[dict[str, str]]) -> list[dict[str, str]]:
     """Test the time ranges don't overlap."""
+    # Make a list of all start and end times
     times = itertools.chain(
         *[[time_range[CONF_FROM], time_range[CONF_TO]] for time_range in schedule]
     )
+    # Check if any time falls within the range of another time
     if any(
         time_range[CONF_FROM] < time < time_range[CONF_TO]
         for time_range in schedule

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -271,13 +271,12 @@ class Schedule(Entity):
         # Find next event in the schedule
         next_event = None
         for day in range(7):
+            day_schedule = self._config.get(WEEKDAY_TO_CONF[(now.weekday() + day) % 7], [])
             times = sorted(
                 itertools.chain(
                     *[
                         [time_range[CONF_FROM], time_range[CONF_TO]]
-                        for time_range in self._config.get(
-                            WEEKDAY_TO_CONF[(now.weekday() + day) % 7], []
-                        )
+                        for time_range in day_schedule
                     ]
                 )
             )

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -1,0 +1,304 @@
+"""Support for schedules in Home Assistant."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timedelta
+import itertools
+import logging
+from typing import Literal
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_EDITABLE,
+    CONF_ICON,
+    CONF_ID,
+    CONF_NAME,
+    SERVICE_RELOAD,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers.collection import (
+    IDManager,
+    StorageCollection,
+    StorageCollectionWebsocket,
+    YamlCollection,
+    sync_entity_lifecycle,
+)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.helpers.integration_platform import (
+    async_process_integration_platform_for_component,
+)
+from homeassistant.helpers.service import async_register_admin_service
+from homeassistant.helpers.storage import Store
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    ATTR_NEXT_EVENT,
+    CONF_ALL_DAYS,
+    CONF_FROM,
+    CONF_TO,
+    DOMAIN,
+    LOGGER,
+    WEEKDAY_TO_CONF,
+)
+
+STORAGE_VERSION = 1
+STORAGE_VERSION_MINOR = 1
+
+
+def has_no_overlap(schedule: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Test the time ranges don't overlap."""
+    times = itertools.chain(
+        *[[time_range[CONF_FROM], time_range[CONF_TO]] for time_range in schedule]
+    )
+    if any(
+        time_range[CONF_FROM] < time < time_range[CONF_TO]
+        for time_range in schedule
+        for time in times
+    ):
+        raise vol.Invalid("Overlapping times found in schedule")
+
+    return schedule
+
+
+BASE_SCHEMA = {
+    vol.Required(CONF_NAME): vol.All(str, vol.Length(min=1)),
+    vol.Optional(CONF_ICON): cv.icon,
+}
+
+TIME_RANGE_SCHEMA = {
+    vol.Required(CONF_FROM): cv.time,
+    vol.Required(CONF_TO): cv.time,
+}
+STORAGE_TIME_RANGE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_FROM): vol.All(cv.time, vol.Coerce(str)),
+        vol.Required(CONF_TO): vol.All(cv.time, vol.Coerce(str)),
+    }
+)
+
+SCHEDULE_SCHEMA = {
+    vol.Optional(day, default=[]): vol.All(
+        cv.ensure_list, [TIME_RANGE_SCHEMA], has_no_overlap
+    )
+    for day in CONF_ALL_DAYS
+}
+STORAGE_SCHEDULE_SCHEMA = {
+    vol.Optional(day, default=[]): vol.All(
+        cv.ensure_list, [TIME_RANGE_SCHEMA], has_no_overlap, [STORAGE_TIME_RANGE_SCHEMA]
+    )
+    for day in CONF_ALL_DAYS
+}
+
+
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: cv.schema_with_slug_keys(vol.All(BASE_SCHEMA | SCHEDULE_SCHEMA))}
+)
+STORAGE_SCHEMA = vol.Schema(
+    {vol.Required(CONF_ID): cv.string} | BASE_SCHEMA | SCHEDULE_SCHEMA
+)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up an input select."""
+    component = EntityComponent(LOGGER, DOMAIN, hass)
+
+    # Process integration platforms right away since
+    # we will create entities before firing EVENT_COMPONENT_LOADED
+    await async_process_integration_platform_for_component(hass, DOMAIN)
+
+    id_manager = IDManager()
+
+    yaml_collection = YamlCollection(LOGGER, id_manager)
+    sync_entity_lifecycle(
+        hass, DOMAIN, DOMAIN, component, yaml_collection, Schedule.from_yaml
+    )
+
+    storage_collection = ScheduleStorageCollection(
+        Store(
+            hass,
+            key=DOMAIN,
+            version=STORAGE_VERSION,
+            minor_version=STORAGE_VERSION_MINOR,
+        ),
+        logging.getLogger(f"{__name__}.storage_collection"),
+        id_manager,
+    )
+    sync_entity_lifecycle(hass, DOMAIN, DOMAIN, component, storage_collection, Schedule)
+
+    await yaml_collection.async_load(
+        [{CONF_ID: id_, **cfg} for id_, cfg in config.get(DOMAIN, {}).items()]
+    )
+    await storage_collection.async_load()
+
+    StorageCollectionWebsocket(
+        storage_collection,
+        DOMAIN,
+        DOMAIN,
+        BASE_SCHEMA | STORAGE_SCHEDULE_SCHEMA,
+        BASE_SCHEMA | STORAGE_SCHEDULE_SCHEMA,
+    ).async_setup(hass)
+
+    async def reload_service_handler(service_call: ServiceCall) -> None:
+        """Reload yaml entities."""
+        conf = await component.async_prepare_reload(skip_reset=True)
+        if conf is None:
+            conf = {DOMAIN: {}}
+        await yaml_collection.async_load(
+            [{CONF_ID: id_, **cfg} for id_, cfg in conf.get(DOMAIN, {}).items()]
+        )
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_RELOAD,
+        reload_service_handler,
+    )
+
+    return True
+
+
+class ScheduleStorageCollection(StorageCollection):
+    """Schedules stored in storage."""
+
+    SCHEMA = vol.Schema(BASE_SCHEMA | STORAGE_SCHEDULE_SCHEMA)
+
+    async def _process_create_data(self, data: dict) -> dict:
+        """Validate the config is valid."""
+        self.SCHEMA(data)
+        return data
+
+    @callback
+    def _get_suggested_id(self, info: dict) -> str:
+        """Suggest an ID based on the config."""
+        name: str = info[CONF_NAME]
+        return name
+
+    async def _update_data(self, data: dict, update_data: dict) -> dict:
+        """Return a new updated data object."""
+        self.SCHEMA(update_data)
+        return data | update_data
+
+    async def _async_load_data(self) -> dict | None:
+        """Load the data."""
+        if data := await super()._async_load_data():
+            data["items"] = [STORAGE_SCHEMA(item) for item in data["items"]]
+        return data
+
+
+class Schedule(Entity):
+    """Schedule entity."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_state: Literal["on", "off"]
+    _config: ConfigType
+    _next: datetime
+    _unsub_update: Callable[[], None] | None = None
+    editable = True
+
+    def __init__(self, config: ConfigType) -> None:
+        """Initialize a schedule."""
+        self._config = STORAGE_SCHEMA(config)
+        self._attr_unique_id = self._config[CONF_ID]
+        self._attr_icon = self._config.get(CONF_ICON)
+        self._attr_name = self._config[CONF_NAME]
+
+    @classmethod
+    def from_yaml(cls, config: ConfigType) -> Schedule:
+        """Return entity instance initialized from yaml storage."""
+        schedule = cls(config)
+        schedule.entity_id = f"{DOMAIN}.{config[CONF_ID]}"
+        schedule.editable = False
+        return schedule
+
+    async def async_update_config(self, config: ConfigType) -> None:
+        """Handle when the config is updated."""
+        self._config = STORAGE_SCHEMA(config)
+        self._attr_icon = config.get(CONF_ICON)
+        self._attr_name = config[CONF_NAME]
+        self._update()
+
+    @property
+    def capability_attributes(self) -> dict:
+        """Return the capability attributes."""
+        return {
+            ATTR_EDITABLE: self.editable,
+        }
+
+    @callback
+    def _clean_up_listener(self) -> None:
+        """Remove the update timer."""
+        if self._unsub_update is not None:
+            self._unsub_update()
+            self._unsub_update = None
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        self.async_on_remove(self._clean_up_listener)
+        self._update()
+
+    @callback
+    def _update(self, _: datetime | None = None) -> None:
+        """Update the states of the schedule."""
+        now = dt_util.now()
+        todays_schedule = self._config.get(WEEKDAY_TO_CONF[now.weekday()], [])
+
+        # Determine current schedule state
+        self._attr_state = next(
+            (
+                STATE_ON
+                for time_range in todays_schedule
+                if time_range[CONF_FROM] <= now.time() <= time_range[CONF_TO]
+            ),
+            STATE_OFF,
+        )
+
+        # Find next event in the schedule
+        next_event = None
+        for day in range(7):
+            times = sorted(
+                itertools.chain(
+                    *[
+                        [time_range[CONF_FROM], time_range[CONF_TO]]
+                        for time_range in self._config.get(
+                            WEEKDAY_TO_CONF[(now.weekday() + day) % 7], []
+                        )
+                    ]
+                )
+            )
+            if next_event := next(
+                (
+                    possible_next_event
+                    for time in times
+                    if (
+                        possible_next_event := (
+                            datetime.combine(now.date(), time, tzinfo=now.tzinfo)
+                            + timedelta(days=day)
+                        )
+                    )
+                    > now
+                ),
+                None,
+            ):
+                break
+
+        self._attr_extra_state_attributes = {
+            day: self._config[day] for day in CONF_ALL_DAYS
+        } | {
+            ATTR_NEXT_EVENT: next_event,
+        }
+        self.async_write_ha_state()
+
+        if next_event:
+            self._unsub_update = async_track_point_in_utc_time(
+                self.hass,
+                self._update,
+                next_event,
+            )

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -271,7 +271,9 @@ class Schedule(Entity):
         # Find next event in the schedule
         next_event = None
         for day in range(7):
-            day_schedule = self._config.get(WEEKDAY_TO_CONF[(now.weekday() + day) % 7], [])
+            day_schedule = self._config.get(
+                WEEKDAY_TO_CONF[(now.weekday() + day) % 7], []
+            )
             times = sorted(
                 itertools.chain(
                     *[
@@ -280,17 +282,14 @@ class Schedule(Entity):
                     ]
                 )
             )
-            next_event = None
-            
+
             for time in times:
                 if (
-                        possible_next_event := (
-                            datetime.combine(now.date(), time, tzinfo=now.tzinfo)
-                            + timedelta(days=day)
-                        )
+                    possible_next_event := (
+                        datetime.combine(now.date(), time, tzinfo=now.tzinfo)
+                        + timedelta(days=day)
                     )
-                    > now
-                ):
+                ) > now:
                     next_event = possible_next_event
                     break
 

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -15,8 +15,6 @@ from homeassistant.const import (
     CONF_ID,
     CONF_NAME,
     SERVICE_RELOAD,
-    STATE_OFF,
-    STATE_ON,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.collection import (
@@ -45,6 +43,8 @@ from .const import (
     CONF_TO,
     DOMAIN,
     LOGGER,
+    STATE_ACTIVE,
+    STATE_INACTIVE,
     WEEKDAY_TO_CONF,
 )
 
@@ -200,7 +200,7 @@ class Schedule(Entity):
 
     _attr_has_entity_name = True
     _attr_should_poll = False
-    _attr_state: Literal["on", "off"]
+    _attr_state: Literal["active", "inactive"]
     _config: ConfigType
     _next: datetime
     _unsub_update: Callable[[], None] | None = None
@@ -256,11 +256,11 @@ class Schedule(Entity):
         # Determine current schedule state
         self._attr_state = next(
             (
-                STATE_ON
+                STATE_ACTIVE
                 for time_range in todays_schedule
                 if time_range[CONF_FROM] <= now.time() <= time_range[CONF_TO]
             ),
-            STATE_OFF,
+            STATE_INACTIVE,
         )
 
         # Find next event in the schedule

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -226,6 +226,7 @@ class Schedule(Entity):
         self._config = STORAGE_SCHEMA(config)
         self._attr_icon = config.get(CONF_ICON)
         self._attr_name = config[CONF_NAME]
+        self._clean_up_listener()
         self._update()
 
     @property

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -98,7 +98,8 @@ STORAGE_SCHEDULE_SCHEMA = {
 
 
 CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: cv.schema_with_slug_keys(vol.All(BASE_SCHEMA | SCHEDULE_SCHEMA))}
+    {DOMAIN: cv.schema_with_slug_keys(vol.All(BASE_SCHEMA | SCHEDULE_SCHEMA))},
+    extra=vol.ALLOW_EXTRA,
 )
 STORAGE_SCHEMA = vol.Schema(
     {vol.Required(CONF_ID): cv.string} | BASE_SCHEMA | SCHEDULE_SCHEMA

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -280,21 +280,19 @@ class Schedule(Entity):
                     ]
                 )
             )
-            if next_event := next(
-                (
-                    possible_next_event
-                    for time in times
-                    if (
+            next_event = None
+            
+            for time in times:
+                if (
                         possible_next_event := (
                             datetime.combine(now.date(), time, tzinfo=now.tzinfo)
                             + timedelta(days=day)
                         )
                     )
                     > now
-                ),
-                None,
-            ):
-                break
+                ):
+                    next_event = possible_next_event
+                    break
 
         self._attr_extra_state_attributes = {
             ATTR_NEXT_EVENT: next_event,

--- a/homeassistant/components/schedule/const.py
+++ b/homeassistant/components/schedule/const.py
@@ -1,0 +1,46 @@
+"""Constants for the schedule integration."""
+import logging
+from typing import Final
+
+DOMAIN: Final = "schedule"
+LOGGER = logging.getLogger(__package__)
+
+CONF_FRIDAY: Final = "friday"
+CONF_FROM: Final = "from"
+CONF_MONDAY: Final = "monday"
+CONF_SATURDAY: Final = "saturday"
+CONF_SUNDAY: Final = "sunday"
+CONF_THURSDAY: Final = "thursday"
+CONF_TO: Final = "to"
+CONF_TUESDAY: Final = "tuesday"
+CONF_WEDNESDAY: Final = "wednesday"
+CONF_ALL_DAYS: Final = {
+    CONF_MONDAY,
+    CONF_TUESDAY,
+    CONF_WEDNESDAY,
+    CONF_THURSDAY,
+    CONF_FRIDAY,
+    CONF_SATURDAY,
+    CONF_SUNDAY,
+}
+
+ATTR_FRIDAY: Final = "friday"
+ATTR_FROM: Final = "from"
+ATTR_MONDAY: Final = "monday"
+ATTR_SATURDAY: Final = "saturday"
+ATTR_SUNDAY: Final = "sunday"
+ATTR_THURSDAY: Final = "thursday"
+ATTR_TO: Final = "to"
+ATTR_TUESDAY: Final = "tuesday"
+ATTR_WEDNESDAY: Final = "wednesday"
+ATTR_NEXT_EVENT: Final = "next_event"
+
+WEEKDAY_TO_CONF: Final = {
+    0: CONF_MONDAY,
+    1: CONF_TUESDAY,
+    2: CONF_WEDNESDAY,
+    3: CONF_THURSDAY,
+    4: CONF_FRIDAY,
+    5: CONF_SATURDAY,
+    6: CONF_SUNDAY,
+}

--- a/homeassistant/components/schedule/const.py
+++ b/homeassistant/components/schedule/const.py
@@ -35,3 +35,6 @@ WEEKDAY_TO_CONF: Final = {
     5: CONF_SATURDAY,
     6: CONF_SUNDAY,
 }
+
+STATE_ACTIVE: Final = "active"
+STATE_INACTIVE: Final = "inactive"

--- a/homeassistant/components/schedule/const.py
+++ b/homeassistant/components/schedule/const.py
@@ -24,15 +24,6 @@ CONF_ALL_DAYS: Final = {
     CONF_SUNDAY,
 }
 
-ATTR_FRIDAY: Final = "friday"
-ATTR_FROM: Final = "from"
-ATTR_MONDAY: Final = "monday"
-ATTR_SATURDAY: Final = "saturday"
-ATTR_SUNDAY: Final = "sunday"
-ATTR_THURSDAY: Final = "thursday"
-ATTR_TO: Final = "to"
-ATTR_TUESDAY: Final = "tuesday"
-ATTR_WEDNESDAY: Final = "wednesday"
 ATTR_NEXT_EVENT: Final = "next_event"
 
 WEEKDAY_TO_CONF: Final = {

--- a/homeassistant/components/schedule/const.py
+++ b/homeassistant/components/schedule/const.py
@@ -35,6 +35,3 @@ WEEKDAY_TO_CONF: Final = {
     5: CONF_SATURDAY,
     6: CONF_SUNDAY,
 }
-
-STATE_ACTIVE: Final = "active"
-STATE_INACTIVE: Final = "inactive"

--- a/homeassistant/components/schedule/manifest.json
+++ b/homeassistant/components/schedule/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "schedule",
+  "integration_type": "helper",
+  "name": "Schedule",
+  "documentation": "https://www.home-assistant.io/integrations/schedule",
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/schedule/recorder.py
+++ b/homeassistant/components/schedule/recorder.py
@@ -4,16 +4,7 @@ from __future__ import annotations
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant, callback
 
-from .const import (
-    ATTR_FRIDAY,
-    ATTR_MONDAY,
-    ATTR_NEXT_EVENT,
-    ATTR_SATURDAY,
-    ATTR_SUNDAY,
-    ATTR_THURSDAY,
-    ATTR_TUESDAY,
-    ATTR_WEDNESDAY,
-)
+from .const import ATTR_NEXT_EVENT
 
 
 @callback
@@ -21,12 +12,5 @@ def exclude_attributes(hass: HomeAssistant) -> set[str]:
     """Exclude configuration to be recorded in the database."""
     return {
         ATTR_EDITABLE,
-        ATTR_FRIDAY,
-        ATTR_MONDAY,
-        ATTR_SATURDAY,
-        ATTR_SUNDAY,
-        ATTR_THURSDAY,
-        ATTR_TUESDAY,
-        ATTR_WEDNESDAY,
         ATTR_NEXT_EVENT,
     }

--- a/homeassistant/components/schedule/recorder.py
+++ b/homeassistant/components/schedule/recorder.py
@@ -1,0 +1,32 @@
+"""Integration platform for recorder."""
+from __future__ import annotations
+
+from homeassistant.const import ATTR_EDITABLE
+from homeassistant.core import HomeAssistant, callback
+
+from .const import (
+    ATTR_FRIDAY,
+    ATTR_MONDAY,
+    ATTR_NEXT_EVENT,
+    ATTR_SATURDAY,
+    ATTR_SUNDAY,
+    ATTR_THURSDAY,
+    ATTR_TUESDAY,
+    ATTR_WEDNESDAY,
+)
+
+
+@callback
+def exclude_attributes(hass: HomeAssistant) -> set[str]:
+    """Exclude configuration to be recorded in the database."""
+    return {
+        ATTR_EDITABLE,
+        ATTR_FRIDAY,
+        ATTR_MONDAY,
+        ATTR_SATURDAY,
+        ATTR_SUNDAY,
+        ATTR_THURSDAY,
+        ATTR_TUESDAY,
+        ATTR_WEDNESDAY,
+        ATTR_NEXT_EVENT,
+    }

--- a/homeassistant/components/schedule/services.yaml
+++ b/homeassistant/components/schedule/services.yaml
@@ -1,0 +1,3 @@
+reload:
+  name: Reload
+  description: Reload the schedule configuration

--- a/homeassistant/components/schedule/strings.json
+++ b/homeassistant/components/schedule/strings.json
@@ -1,0 +1,9 @@
+{
+  "title": "Schedule",
+  "state": {
+    "_": {
+      "off": "[%key:common::state::off%]",
+      "on": "[%key:common::state::on%]"
+    }
+  }
+}

--- a/homeassistant/components/schedule/strings.json
+++ b/homeassistant/components/schedule/strings.json
@@ -2,8 +2,8 @@
   "title": "Schedule",
   "state": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "active": "[%key:common::state::active%]",
+      "inactive": "[%key:common::state::inactive%]"
     }
   }
 }

--- a/homeassistant/components/schedule/strings.json
+++ b/homeassistant/components/schedule/strings.json
@@ -2,8 +2,8 @@
   "title": "Schedule",
   "state": {
     "_": {
-      "active": "[%key:common::state::active%]",
-      "inactive": "[%key:common::state::inactive%]"
+      "off": "[%key:common::state::off%]",
+      "on": "[%key:common::state::on%]"
     }
   }
 }

--- a/homeassistant/components/schedule/translations/en.json
+++ b/homeassistant/components/schedule/translations/en.json
@@ -1,0 +1,9 @@
+{
+    "state": {
+        "_": {
+            "off": "Off",
+            "on": "On"
+        }
+    },
+    "title": "Schedule"
+}

--- a/homeassistant/components/schedule/translations/en.json
+++ b/homeassistant/components/schedule/translations/en.json
@@ -1,8 +1,8 @@
 {
     "state": {
         "_": {
-            "active": "Active",
-            "inactive": "Inactive"
+            "off": "Off",
+            "on": "On"
         }
     },
     "title": "Schedule"

--- a/homeassistant/components/schedule/translations/en.json
+++ b/homeassistant/components/schedule/translations/en.json
@@ -1,8 +1,8 @@
 {
     "state": {
         "_": {
-            "off": "Off",
-            "on": "On"
+            "active": "Active",
+            "inactive": "Inactive"
         }
     },
     "title": "Schedule"

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -10,7 +10,6 @@
       "locked": "Locked",
       "unlocked": "Unlocked",
       "active": "Active",
-      "inactive": "Inactive",
       "idle": "Idle",
       "standby": "Standby",
       "paused": "Paused",

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -10,6 +10,7 @@
       "locked": "Locked",
       "unlocked": "Unlocked",
       "active": "Active",
+      "inactive": "Inactive",
       "idle": "Idle",
       "standby": "Standby",
       "paused": "Paused",

--- a/mypy.ini
+++ b/mypy.ini
@@ -2066,6 +2066,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.schedule.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.select.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -83,6 +83,7 @@ NO_IOT_CLASS = [
     "raspberry_pi",
     "repairs",
     "safe_mode",
+    "schedule",
     "script",
     "search",
     "system_health",

--- a/tests/components/schedule/__init__.py
+++ b/tests/components/schedule/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the schedule integration."""

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -22,8 +22,6 @@ from homeassistant.components.schedule.const import (
     CONF_TUESDAY,
     CONF_WEDNESDAY,
     DOMAIN,
-    STATE_ACTIVE,
-    STATE_INACTIVE,
 )
 from homeassistant.const import (
     ATTR_EDITABLE,
@@ -34,6 +32,8 @@ from homeassistant.const import (
     CONF_ID,
     CONF_NAME,
     SERVICE_RELOAD,
+    STATE_OFF,
+    STATE_ON,
 )
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -206,7 +206,7 @@ async def test_load(
 
     state = hass.states.get(f"{DOMAIN}.from_storage")
     assert state
-    assert state.state == STATE_INACTIVE
+    assert state.state == STATE_OFF
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
     assert state.attributes[ATTR_EDITABLE] is True
     assert state.attributes[ATTR_ICON] == "mdi:party-popper"
@@ -214,7 +214,7 @@ async def test_load(
 
     state = hass.states.get(f"{DOMAIN}.from_yaml")
     assert state
-    assert state.state == STATE_ACTIVE
+    assert state.state == STATE_ON
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from yaml"
     assert state.attributes[ATTR_EDITABLE] is False
     assert state.attributes[ATTR_ICON] == "mdi:party-pooper"
@@ -231,7 +231,7 @@ async def test_schedule_updates(
 
     state = hass.states.get(f"{DOMAIN}.from_storage")
     assert state
-    assert state.state == STATE_INACTIVE
+    assert state.state == STATE_OFF
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T17:00:00-07:00"
 
     with freeze_time(state.attributes[ATTR_NEXT_EVENT]):
@@ -240,7 +240,7 @@ async def test_schedule_updates(
 
     state = hass.states.get(f"{DOMAIN}.from_storage")
     assert state
-    assert state.state == STATE_ACTIVE
+    assert state.state == STATE_ON
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T23:59:59-07:00"
 
 
@@ -304,7 +304,7 @@ async def test_update(
 
     state = hass.states.get("schedule.from_storage")
     assert state
-    assert state.state == STATE_INACTIVE
+    assert state.state == STATE_OFF
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
     assert state.attributes[ATTR_ICON] == "mdi:party-popper"
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T17:00:00-07:00"
@@ -333,7 +333,7 @@ async def test_update(
 
     state = hass.states.get("schedule.from_storage")
     assert state
-    assert state.state == STATE_ACTIVE
+    assert state.state == STATE_ON
     assert state.attributes[ATTR_FRIENDLY_NAME] == "Party pooper"
     assert state.attributes[ATTR_ICON] == "mdi:party-pooper"
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-10T23:59:59-07:00"
@@ -369,7 +369,7 @@ async def test_ws_create(
 
     state = hass.states.get("schedule.party_mode")
     assert state
-    assert state.state == STATE_INACTIVE
+    assert state.state == STATE_OFF
     assert state.attributes[ATTR_FRIENDLY_NAME] == "Party mode"
     assert state.attributes[ATTR_EDITABLE] is True
     assert state.attributes[ATTR_ICON] == "mdi:party-popper"

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Coroutine
-from datetime import time
 from typing import Any
 from unittest.mock import patch
 
@@ -12,16 +11,7 @@ import pytest
 
 from homeassistant.components.schedule import STORAGE_VERSION, STORAGE_VERSION_MINOR
 from homeassistant.components.schedule.const import (
-    ATTR_FRIDAY,
-    ATTR_FROM,
-    ATTR_MONDAY,
     ATTR_NEXT_EVENT,
-    ATTR_SATURDAY,
-    ATTR_SUNDAY,
-    ATTR_THURSDAY,
-    ATTR_TO,
-    ATTR_TUESDAY,
-    ATTR_WEDNESDAY,
     CONF_FRIDAY,
     CONF_FROM,
     CONF_MONDAY,
@@ -182,19 +172,6 @@ async def test_load(
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
     assert state.attributes[ATTR_EDITABLE] is True
     assert state.attributes[ATTR_ICON] == "mdi:party-popper"
-    assert state.attributes[ATTR_MONDAY] == []
-    assert state.attributes[ATTR_TUESDAY] == []
-    assert state.attributes[ATTR_WEDNESDAY] == []
-    assert state.attributes[ATTR_THURSDAY] == []
-    assert state.attributes[ATTR_FRIDAY] == [
-        {ATTR_FROM: time(17, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_SATURDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_SUNDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T17:00:00-07:00"
 
     state = hass.states.get(f"{DOMAIN}.from_yaml")
@@ -203,27 +180,6 @@ async def test_load(
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from yaml"
     assert state.attributes[ATTR_EDITABLE] is False
     assert state.attributes[ATTR_ICON] == "mdi:party-pooper"
-    assert state.attributes[ATTR_MONDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_TUESDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_WEDNESDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_THURSDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_FRIDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_SATURDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_SUNDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-10T23:59:59-07:00"
 
 
@@ -313,19 +269,6 @@ async def test_update(
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
     assert state.attributes[ATTR_ICON] == "mdi:party-popper"
-    assert state.attributes[ATTR_MONDAY] == []
-    assert state.attributes[ATTR_TUESDAY] == []
-    assert state.attributes[ATTR_WEDNESDAY] == []
-    assert state.attributes[ATTR_THURSDAY] == []
-    assert state.attributes[ATTR_FRIDAY] == [
-        {ATTR_FROM: time(17, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_SATURDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_SUNDAY] == [
-        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T17:00:00-07:00"
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "from_storage") is not None
 
@@ -355,18 +298,10 @@ async def test_update(
     assert state.state == STATE_ON
     assert state.attributes[ATTR_FRIENDLY_NAME] == "Party pooper"
     assert state.attributes[ATTR_ICON] == "mdi:party-pooper"
-    assert state.attributes[ATTR_MONDAY] == []
-    assert state.attributes[ATTR_TUESDAY] == []
-    assert state.attributes[ATTR_WEDNESDAY] == [
-        {ATTR_FROM: time(17, 00, 00), ATTR_TO: time(23, 59, 59)}
-    ]
-    assert state.attributes[ATTR_THURSDAY] == []
-    assert state.attributes[ATTR_FRIDAY] == []
-    assert state.attributes[ATTR_SATURDAY] == []
-    assert state.attributes[ATTR_SUNDAY] == []
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-10T23:59:59-07:00"
 
 
+@pytest.mark.freeze_time("2022-08-11 8:52:00-07:00")
 async def test_ws_create(
     hass: HomeAssistant,
     hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
@@ -400,12 +335,4 @@ async def test_ws_create(
     assert state.attributes[ATTR_FRIENDLY_NAME] == "Party mode"
     assert state.attributes[ATTR_EDITABLE] is True
     assert state.attributes[ATTR_ICON] == "mdi:party-popper"
-    assert state.attributes[ATTR_MONDAY] == [
-        {ATTR_FROM: time(12, 00, 00), ATTR_TO: time(14, 00, 00)}
-    ]
-    assert state.attributes[ATTR_TUESDAY] == []
-    assert state.attributes[ATTR_WEDNESDAY] == []
-    assert state.attributes[ATTR_THURSDAY] == []
-    assert state.attributes[ATTR_FRIDAY] == []
-    assert state.attributes[ATTR_SATURDAY] == []
-    assert state.attributes[ATTR_SUNDAY] == []
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-15T12:00:00-07:00"

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -1,0 +1,411 @@
+"""Test for the Schedule integration."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Coroutine
+from datetime import time
+from typing import Any
+from unittest.mock import patch
+
+from aiohttp import ClientWebSocketResponse
+from freezegun import freeze_time
+import pytest
+
+from homeassistant.components.schedule import STORAGE_VERSION, STORAGE_VERSION_MINOR
+from homeassistant.components.schedule.const import (
+    ATTR_FRIDAY,
+    ATTR_FROM,
+    ATTR_MONDAY,
+    ATTR_NEXT_EVENT,
+    ATTR_SATURDAY,
+    ATTR_SUNDAY,
+    ATTR_THURSDAY,
+    ATTR_TO,
+    ATTR_TUESDAY,
+    ATTR_WEDNESDAY,
+    CONF_FRIDAY,
+    CONF_FROM,
+    CONF_MONDAY,
+    CONF_SATURDAY,
+    CONF_SUNDAY,
+    CONF_THURSDAY,
+    CONF_TO,
+    CONF_TUESDAY,
+    CONF_WEDNESDAY,
+    DOMAIN,
+)
+from homeassistant.const import (
+    ATTR_EDITABLE,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    ATTR_NAME,
+    CONF_ICON,
+    CONF_ID,
+    CONF_NAME,
+    SERVICE_RELOAD,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockUser, async_fire_time_changed
+
+
+@pytest.fixture
+def schedule_setup(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> Callable[..., Coroutine[Any, Any, bool]]:
+    """Schedule setup."""
+
+    async def _schedule_setup(
+        items: dict[str, Any] | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> bool:
+        if items is None:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": STORAGE_VERSION,
+                "minor_version": STORAGE_VERSION_MINOR,
+                "data": {
+                    "items": [
+                        {
+                            CONF_ID: "from_storage",
+                            CONF_NAME: "from storage",
+                            CONF_ICON: "mdi:party-popper",
+                            CONF_FRIDAY: [
+                                {CONF_FROM: "17:00:00", CONF_TO: "23:59:59"},
+                            ],
+                            CONF_SATURDAY: [
+                                {CONF_FROM: "00:00:00", CONF_TO: "23:59:59"},
+                            ],
+                            CONF_SUNDAY: [
+                                {CONF_FROM: "00:00:00", CONF_TO: "23:59:59"},
+                            ],
+                        }
+                    ]
+                },
+            }
+        else:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": 1,
+                "minor_version": STORAGE_VERSION_MINOR,
+                "data": {"items": items},
+            }
+        if config is None:
+            config = {
+                DOMAIN: {
+                    "from_yaml": {
+                        CONF_NAME: "from yaml",
+                        CONF_ICON: "mdi:party-pooper",
+                        CONF_MONDAY: [{CONF_FROM: "00:00:00", CONF_TO: "23:59:59"}],
+                        CONF_TUESDAY: [{CONF_FROM: "00:00:00", CONF_TO: "23:59:59"}],
+                        CONF_WEDNESDAY: [{CONF_FROM: "00:00:00", CONF_TO: "23:59:59"}],
+                        CONF_THURSDAY: [{CONF_FROM: "00:00:00", CONF_TO: "23:59:59"}],
+                        CONF_FRIDAY: [{CONF_FROM: "00:00:00", CONF_TO: "23:59:59"}],
+                        CONF_SATURDAY: [{CONF_FROM: "00:00:00", CONF_TO: "23:59:59"}],
+                        CONF_SUNDAY: [{CONF_FROM: "00:00:00", CONF_TO: "23:59:59"}],
+                    }
+                }
+            }
+        return await async_setup_component(hass, DOMAIN, config)
+
+    return _schedule_setup
+
+
+async def test_invalid_config(hass: HomeAssistant) -> None:
+    """Test invalid configs."""
+    invalid_configs = [
+        None,
+        {},
+        {"name with space": None},
+    ]
+
+    for cfg in invalid_configs:
+        assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
+
+
+async def test_overlapping_time_ranges(
+    hass: HomeAssistant,
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test overlapping time ranges invalidate."""
+    assert not await schedule_setup(
+        config={
+            DOMAIN: {
+                "from_yaml": {
+                    CONF_NAME: "from yaml",
+                    CONF_ICON: "mdi:party-pooper",
+                    CONF_SUNDAY: [
+                        {CONF_FROM: "00:00:00", CONF_TO: "23:59:59"},
+                        {CONF_FROM: "07:00:00", CONF_TO: "08:00:00"},
+                    ],
+                }
+            }
+        }
+    )
+    assert "Overlapping times found in schedule" in caplog.text
+
+
+async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
+    """Test component setup with no config."""
+    count_start = len(hass.states.async_entity_ids())
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file", autospec=True, return_value={}
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )
+        await hass.async_block_till_done()
+
+    assert count_start == len(hass.states.async_entity_ids())
+
+
+@pytest.mark.freeze_time("2022-08-10 20:10:00-07:00")
+async def test_load(
+    hass: HomeAssistant,
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+) -> None:
+    """Test set up from storage and YAML."""
+    assert await schedule_setup()
+
+    state = hass.states.get(f"{DOMAIN}.from_storage")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
+    assert state.attributes[ATTR_EDITABLE] is True
+    assert state.attributes[ATTR_ICON] == "mdi:party-popper"
+    assert state.attributes[ATTR_MONDAY] == []
+    assert state.attributes[ATTR_TUESDAY] == []
+    assert state.attributes[ATTR_WEDNESDAY] == []
+    assert state.attributes[ATTR_THURSDAY] == []
+    assert state.attributes[ATTR_FRIDAY] == [
+        {ATTR_FROM: time(17, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_SATURDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_SUNDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T17:00:00-07:00"
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "from yaml"
+    assert state.attributes[ATTR_EDITABLE] is False
+    assert state.attributes[ATTR_ICON] == "mdi:party-pooper"
+    assert state.attributes[ATTR_MONDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_TUESDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_WEDNESDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_THURSDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_FRIDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_SATURDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_SUNDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-10T23:59:59-07:00"
+
+
+async def test_schedule_updates(
+    hass: HomeAssistant,
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+) -> None:
+    """Test the schedule updates when time changes."""
+    with freeze_time("2022-08-10 20:10:00-07:00"):
+        assert await schedule_setup()
+
+    state = hass.states.get(f"{DOMAIN}.from_storage")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T17:00:00-07:00"
+
+    with freeze_time(state.attributes[ATTR_NEXT_EVENT]):
+        async_fire_time_changed(hass, state.attributes[ATTR_NEXT_EVENT])
+        await hass.async_block_till_done()
+
+    state = hass.states.get(f"{DOMAIN}.from_storage")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T23:59:59-07:00"
+
+
+async def test_ws_list(
+    hass: HomeAssistant,
+    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+) -> None:
+    """Test listing via WS."""
+    assert await schedule_setup()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": f"{DOMAIN}/list"})
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    result = {item["id"]: item for item in resp["result"]}
+
+    assert len(result) == 1
+    assert result["from_storage"][ATTR_NAME] == "from storage"
+    assert "from_yaml" not in result
+
+
+async def test_ws_delete(
+    hass: HomeAssistant,
+    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+) -> None:
+    """Test WS delete cleans up entity registry."""
+    ent_reg = er.async_get(hass)
+
+    assert await schedule_setup()
+
+    state = hass.states.get("schedule.from_storage")
+    assert state is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "from_storage") is not None
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {"id": 1, "type": f"{DOMAIN}/delete", f"{DOMAIN}_id": "from_storage"}
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get("schedule.from_storage")
+    assert state is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "from_storage") is None
+
+
+@pytest.mark.freeze_time("2022-08-10 20:10:00-07:00")
+async def test_update(
+    hass: HomeAssistant,
+    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+) -> None:
+    """Test updating the schedule."""
+    ent_reg = er.async_get(hass)
+
+    assert await schedule_setup()
+
+    state = hass.states.get("schedule.from_storage")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
+    assert state.attributes[ATTR_ICON] == "mdi:party-popper"
+    assert state.attributes[ATTR_MONDAY] == []
+    assert state.attributes[ATTR_TUESDAY] == []
+    assert state.attributes[ATTR_WEDNESDAY] == []
+    assert state.attributes[ATTR_THURSDAY] == []
+    assert state.attributes[ATTR_FRIDAY] == [
+        {ATTR_FROM: time(17, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_SATURDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_SUNDAY] == [
+        {ATTR_FROM: time(00, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T17:00:00-07:00"
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "from_storage") is not None
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": f"{DOMAIN}/update",
+            f"{DOMAIN}_id": "from_storage",
+            CONF_NAME: "Party pooper",
+            CONF_ICON: "mdi:party-pooper",
+            CONF_MONDAY: [],
+            CONF_TUESDAY: [],
+            CONF_WEDNESDAY: [{CONF_FROM: "17:00:00", CONF_TO: "23:59:59"}],
+            CONF_THURSDAY: [],
+            CONF_FRIDAY: [],
+            CONF_SATURDAY: [],
+            CONF_SUNDAY: [],
+        }
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get("schedule.from_storage")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Party pooper"
+    assert state.attributes[ATTR_ICON] == "mdi:party-pooper"
+    assert state.attributes[ATTR_MONDAY] == []
+    assert state.attributes[ATTR_TUESDAY] == []
+    assert state.attributes[ATTR_WEDNESDAY] == [
+        {ATTR_FROM: time(17, 00, 00), ATTR_TO: time(23, 59, 59)}
+    ]
+    assert state.attributes[ATTR_THURSDAY] == []
+    assert state.attributes[ATTR_FRIDAY] == []
+    assert state.attributes[ATTR_SATURDAY] == []
+    assert state.attributes[ATTR_SUNDAY] == []
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-10T23:59:59-07:00"
+
+
+async def test_ws_create(
+    hass: HomeAssistant,
+    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+) -> None:
+    """Test create WS."""
+    ent_reg = er.async_get(hass)
+
+    assert await schedule_setup(items=[])
+
+    state = hass.states.get("schedule.party_mode")
+    assert state is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "party_mode") is None
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": f"{DOMAIN}/create",
+            "name": "Party mode",
+            "icon": "mdi:party-popper",
+            "monday": [{"from": "12:00:00", "to": "14:00:00"}],
+        }
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get("schedule.party_mode")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Party mode"
+    assert state.attributes[ATTR_EDITABLE] is True
+    assert state.attributes[ATTR_ICON] == "mdi:party-popper"
+    assert state.attributes[ATTR_MONDAY] == [
+        {ATTR_FROM: time(12, 00, 00), ATTR_TO: time(14, 00, 00)}
+    ]
+    assert state.attributes[ATTR_TUESDAY] == []
+    assert state.attributes[ATTR_WEDNESDAY] == []
+    assert state.attributes[ATTR_THURSDAY] == []
+    assert state.attributes[ATTR_FRIDAY] == []
+    assert state.attributes[ATTR_SATURDAY] == []
+    assert state.attributes[ATTR_SUNDAY] == []

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -22,6 +22,8 @@ from homeassistant.components.schedule.const import (
     CONF_TUESDAY,
     CONF_WEDNESDAY,
     DOMAIN,
+    STATE_ACTIVE,
+    STATE_INACTIVE,
 )
 from homeassistant.const import (
     ATTR_EDITABLE,
@@ -32,8 +34,6 @@ from homeassistant.const import (
     CONF_ID,
     CONF_NAME,
     SERVICE_RELOAD,
-    STATE_OFF,
-    STATE_ON,
 )
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -168,7 +168,7 @@ async def test_load(
 
     state = hass.states.get(f"{DOMAIN}.from_storage")
     assert state
-    assert state.state == STATE_OFF
+    assert state.state == STATE_INACTIVE
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
     assert state.attributes[ATTR_EDITABLE] is True
     assert state.attributes[ATTR_ICON] == "mdi:party-popper"
@@ -176,7 +176,7 @@ async def test_load(
 
     state = hass.states.get(f"{DOMAIN}.from_yaml")
     assert state
-    assert state.state == STATE_ON
+    assert state.state == STATE_ACTIVE
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from yaml"
     assert state.attributes[ATTR_EDITABLE] is False
     assert state.attributes[ATTR_ICON] == "mdi:party-pooper"
@@ -193,7 +193,7 @@ async def test_schedule_updates(
 
     state = hass.states.get(f"{DOMAIN}.from_storage")
     assert state
-    assert state.state == STATE_OFF
+    assert state.state == STATE_INACTIVE
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T17:00:00-07:00"
 
     with freeze_time(state.attributes[ATTR_NEXT_EVENT]):
@@ -202,7 +202,7 @@ async def test_schedule_updates(
 
     state = hass.states.get(f"{DOMAIN}.from_storage")
     assert state
-    assert state.state == STATE_ON
+    assert state.state == STATE_ACTIVE
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T23:59:59-07:00"
 
 
@@ -266,7 +266,7 @@ async def test_update(
 
     state = hass.states.get("schedule.from_storage")
     assert state
-    assert state.state == STATE_OFF
+    assert state.state == STATE_INACTIVE
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
     assert state.attributes[ATTR_ICON] == "mdi:party-popper"
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-12T17:00:00-07:00"
@@ -295,7 +295,7 @@ async def test_update(
 
     state = hass.states.get("schedule.from_storage")
     assert state
-    assert state.state == STATE_ON
+    assert state.state == STATE_ACTIVE
     assert state.attributes[ATTR_FRIENDLY_NAME] == "Party pooper"
     assert state.attributes[ATTR_ICON] == "mdi:party-pooper"
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-08-10T23:59:59-07:00"
@@ -331,7 +331,7 @@ async def test_ws_create(
 
     state = hass.states.get("schedule.party_mode")
     assert state
-    assert state.state == STATE_OFF
+    assert state.state == STATE_INACTIVE
     assert state.attributes[ATTR_FRIENDLY_NAME] == "Party mode"
     assert state.attributes[ATTR_EDITABLE] is True
     assert state.attributes[ATTR_ICON] == "mdi:party-popper"

--- a/tests/components/schedule/test_recorder.py
+++ b/tests/components/schedule/test_recorder.py
@@ -1,0 +1,94 @@
+"""The tests for recorder platform."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.recorder.db_schema import StateAttributes, States
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.schedule.const import (
+    ATTR_FRIDAY,
+    ATTR_MONDAY,
+    ATTR_NEXT_EVENT,
+    ATTR_SATURDAY,
+    ATTR_SUNDAY,
+    ATTR_THURSDAY,
+    ATTR_TUESDAY,
+    ATTR_WEDNESDAY,
+    DOMAIN,
+)
+from homeassistant.const import ATTR_EDITABLE, ATTR_FRIENDLY_NAME, ATTR_ICON
+from homeassistant.core import HomeAssistant, State
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed
+from tests.components.recorder.common import async_wait_recording_done
+
+
+async def test_exclude_attributes(
+    hass: HomeAssistant,
+    recorder_mock: None,
+    enable_custom_integrations: None,
+) -> None:
+    """Test attributes to be excluded."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "test": {
+                    "name": "Party mode",
+                    "icon": "mdi:party-popper",
+                    "monday": [{"from": "1:00", "to": "2:00"}],
+                    "tuesday": [{"from": "2:00", "to": "3:00"}],
+                    "wednesday": [{"from": "3:00", "to": "4:00"}],
+                    "thursday": [{"from": "5:00", "to": "6:00"}],
+                    "friday": [{"from": "7:00", "to": "8:00"}],
+                    "saturday": [{"from": "9:00", "to": "10:00"}],
+                    "sunday": [{"from": "11:00", "to": "12:00"}],
+                }
+            }
+        },
+    )
+
+    state = hass.states.get("schedule.test")
+    assert state
+    assert state.attributes[ATTR_EDITABLE] is False
+    assert state.attributes[ATTR_FRIDAY]
+    assert state.attributes[ATTR_FRIENDLY_NAME]
+    assert state.attributes[ATTR_ICON]
+    assert state.attributes[ATTR_MONDAY]
+    assert state.attributes[ATTR_NEXT_EVENT]
+    assert state.attributes[ATTR_SATURDAY]
+    assert state.attributes[ATTR_SUNDAY]
+    assert state.attributes[ATTR_THURSDAY]
+    assert state.attributes[ATTR_TUESDAY]
+    assert state.attributes[ATTR_WEDNESDAY]
+
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    await hass.async_block_till_done()
+    await async_wait_recording_done(hass)
+
+    def _fetch_states() -> list[State]:
+        with session_scope(hass=hass) as session:
+            native_states = []
+            for db_state, db_state_attributes in session.query(States, StateAttributes):
+                state = db_state.to_native()
+                state.attributes = db_state_attributes.to_native()
+                native_states.append(state)
+            return native_states
+
+    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    assert len(states) == 1
+    assert ATTR_EDITABLE not in states[0].attributes
+    assert ATTR_FRIDAY not in states[0].attributes
+    assert ATTR_FRIENDLY_NAME in states[0].attributes
+    assert ATTR_ICON in states[0].attributes
+    assert ATTR_MONDAY not in states[0].attributes
+    assert ATTR_NEXT_EVENT not in states[0].attributes
+    assert ATTR_SATURDAY not in states[0].attributes
+    assert ATTR_SUNDAY not in states[0].attributes
+    assert ATTR_THURSDAY not in states[0].attributes
+    assert ATTR_TUESDAY not in states[0].attributes
+    assert ATTR_WEDNESDAY not in states[0].attributes

--- a/tests/components/schedule/test_recorder.py
+++ b/tests/components/schedule/test_recorder.py
@@ -5,17 +5,7 @@ from datetime import timedelta
 
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
-from homeassistant.components.schedule.const import (
-    ATTR_FRIDAY,
-    ATTR_MONDAY,
-    ATTR_NEXT_EVENT,
-    ATTR_SATURDAY,
-    ATTR_SUNDAY,
-    ATTR_THURSDAY,
-    ATTR_TUESDAY,
-    ATTR_WEDNESDAY,
-    DOMAIN,
-)
+from homeassistant.components.schedule.const import ATTR_NEXT_EVENT, DOMAIN
 from homeassistant.const import ATTR_EDITABLE, ATTR_FRIENDLY_NAME, ATTR_ICON
 from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
@@ -54,16 +44,9 @@ async def test_exclude_attributes(
     state = hass.states.get("schedule.test")
     assert state
     assert state.attributes[ATTR_EDITABLE] is False
-    assert state.attributes[ATTR_FRIDAY]
     assert state.attributes[ATTR_FRIENDLY_NAME]
     assert state.attributes[ATTR_ICON]
-    assert state.attributes[ATTR_MONDAY]
     assert state.attributes[ATTR_NEXT_EVENT]
-    assert state.attributes[ATTR_SATURDAY]
-    assert state.attributes[ATTR_SUNDAY]
-    assert state.attributes[ATTR_THURSDAY]
-    assert state.attributes[ATTR_TUESDAY]
-    assert state.attributes[ATTR_WEDNESDAY]
 
     await hass.async_block_till_done()
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
@@ -82,13 +65,6 @@ async def test_exclude_attributes(
     states: list[State] = await hass.async_add_executor_job(_fetch_states)
     assert len(states) == 1
     assert ATTR_EDITABLE not in states[0].attributes
-    assert ATTR_FRIDAY not in states[0].attributes
     assert ATTR_FRIENDLY_NAME in states[0].attributes
     assert ATTR_ICON in states[0].attributes
-    assert ATTR_MONDAY not in states[0].attributes
     assert ATTR_NEXT_EVENT not in states[0].attributes
-    assert ATTR_SATURDAY not in states[0].attributes
-    assert ATTR_SUNDAY not in states[0].attributes
-    assert ATTR_THURSDAY not in states[0].attributes
-    assert ATTR_TUESDAY not in states[0].attributes
-    assert ATTR_WEDNESDAY not in states[0].attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the schedule integration to Home Assistant.

The schedule integration is a helper integration that allows for creating weekly schedules for use in, for example, automations & scripts.

The reason it is a weekly schedule is that we think this will cover most use cases. When in need of a daily schedule, this integration can still be used. When in need of more complex or longer schedules, the use of a calendar integration might be a better fit.

This first iteration brings in support for the basic integration first and provides a collection that supports both YAML and UI configuration (Frontend part needs to be built at this point).

Example YAML configuration:

```yaml
schedule:
  party:
    name: "Party time"
    icon: "mdi:party-popper"
    friday:
      - from: "20:00"
        to: "23:00"
    saturday:
      - from: "20:00"
        to: "23:00"
```

Possible future extensions/ideas, currently out of scope:

- A dedicated trigger for ease of use in automations.
- A dedicated condition for ease of use in automations and scripts. 
- The use of templates in schemas, time ranges, or times.
- The use of referencing other entities providing a time (e.g., a `sun` entity, `input_datetime` or any other entity providing a time that can be used.
- Variables to set on time ranges, make them available in automations when triggering.

Those are top-of-mind things, but not for now, maybe later. Let's make this works nicely first.

This PR is a replacement of #41385, which didn't get adjusted to the review/requirements set by the core dev team. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23721
- Link to brands pull request: https://github.com/home-assistant/brands/pull/3579

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
