### PR TITLE
Update offline keys from august cloud for august branded yale locks

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -162,9 +162,8 @@ class AugustData(AugustSubscriberMixin):
             self._hass,
             [
                 lock_detail
-                for lock_detail in self.locks
-                if lock_detail.device_id in self._device_detail_by_id
-                and self.get_device_detail(lock_detail.device_id).offline_key
+                for lock_detail in self._device_detail_by_id.values()
+                if isinstance(lock_detail, LockDetail) and lock_detail.offline_key
             ],
         )
 

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -13,7 +13,8 @@ from yalexs.lock import Lock, LockDetail
 from yalexs.pubnub_activity import activities_from_pubnub_message
 from yalexs.pubnub_async import AugustPubNub, async_create_pubnub
 
-from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY, ConfigEntry
+from homeassistant.components import yalexs_ble
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import (
@@ -99,18 +100,17 @@ def _async_trigger_ble_lock_discovery(
 ):
     """Update keys for the yalexs-ble integration if available."""
     for lock_detail in locks_with_offline_keys:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                "yalexs_ble",
-                context={"source": SOURCE_INTEGRATION_DISCOVERY},
-                data={
+        yalexs_ble.async_discovery(
+            hass,
+            yalexs_ble.YaleXSBLEDiscovery(
+                {
                     "name": lock_detail.device_name,
                     "address": lock_detail.mac_address,
                     "serial": lock_detail.serial_number,
                     "key": lock_detail.offline_key,
                     "slot": lock_detail.offline_slot,
-                },
-            )
+                }
+            ),
         )
 
 

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -13,7 +13,7 @@ from yalexs.lock import Lock, LockDetail
 from yalexs.pubnub_activity import activities_from_pubnub_message
 from yalexs.pubnub_async import AugustPubNub, async_create_pubnub
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY, ConfigEntry
 from homeassistant.const import CONF_PASSWORD
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import (
@@ -93,6 +93,27 @@ async def async_setup_august(
     return True
 
 
+@callback
+def _async_trigger_ble_lock_discovery(
+    hass: HomeAssistant, locks_with_offline_keys: list[LockDetail]
+):
+    """Update keys for the yalexs-ble integration if available."""
+    for lock_detail in locks_with_offline_keys:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                "yalexs_ble",
+                context={"source": SOURCE_INTEGRATION_DISCOVERY},
+                data={
+                    "name": lock_detail.device_name,
+                    "address": lock_detail.mac_address,
+                    "serial": lock_detail.serial_number,
+                    "key": lock_detail.offline_key,
+                    "slot": lock_detail.offline_slot,
+                },
+            )
+        )
+
+
 class AugustData(AugustSubscriberMixin):
     """August data object."""
 
@@ -133,6 +154,20 @@ class AugustData(AugustSubscriberMixin):
         # detail as we cannot determine if they are usable.
         # This also allows us to avoid checking for
         # detail being None all over the place
+
+        # Currently we know how to feed data to yalexe_ble
+        # but we do not know how to send it to homekit_controller
+        # yet
+        _async_trigger_ble_lock_discovery(
+            self._hass,
+            [
+                lock_detail
+                for lock_detail in self.locks
+                if lock_detail.device_id in self._device_detail_by_id
+                and self.get_device_detail(lock_detail.device_id).offline_key
+            ],
+        )
+
         self._remove_inoperative_locks()
         self._remove_inoperative_doorbells()
 

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -24,5 +24,6 @@
   ],
   "config_flow": true,
   "iot_class": "cloud_push",
-  "loggers": ["pubnub", "yalexs"]
+  "loggers": ["pubnub", "yalexs"],
+  "after_dependencies": ["yalexs_ble"]
 }

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TypedDict
 
 import async_timeout
 from yalexs_ble import PushLock, local_name_is_unique
 
 from homeassistant.components import bluetooth
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY, ConfigEntry
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -17,6 +18,28 @@ from .models import YaleXSBLEData
 from .util import async_find_existing_service_info, bluetooth_callback_matcher
 
 PLATFORMS: list[Platform] = [Platform.LOCK]
+
+
+class YaleXSBLEDiscovery(TypedDict):
+    """A validated discovery of a Yale XS BLE device."""
+
+    name: str
+    address: str
+    serial: str
+    key: str
+    slot: int
+
+
+@callback
+def async_discovery(hass: HomeAssistant, discovery: YaleXSBLEDiscovery) -> None:
+    """Update keys for the yalexs-ble integration if available."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            "yalexs_ble",
+            context={"source": SOURCE_INTEGRATION_DISCOVERY},
+            data=discovery,
+        )
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/tests/components/august/fixtures/get_lock.doorsense_init.json
+++ b/tests/components/august/fixtures/get_lock.doorsense_init.json
@@ -40,15 +40,7 @@
   },
   "OfflineKeys": {
     "created": [],
-    "loaded": [
-      {
-        "UserID": "cccca94e-373e-aaaa-bbbb-333396827777",
-        "slot": 1,
-        "key": "kkk01d4300c1dcxxx1c330f794941111",
-        "created": "2017-12-10T03:12:09.215Z",
-        "loaded": "2017-12-10T03:12:54.391Z"
-      }
-    ],
+    "loaded": [],
     "deleted": [],
     "loadedhk": [
       {

--- a/tests/components/august/fixtures/get_lock.offline.json
+++ b/tests/components/august/fixtures/get_lock.offline.json
@@ -19,15 +19,7 @@
       }
     ],
     "deleted": [],
-    "loaded": [
-      {
-        "UserID": "userid",
-        "created": "2000-00-00T00:00:00.447Z",
-        "key": "key",
-        "loaded": "2000-00-00T00:00:00.447Z",
-        "slot": 1
-      }
-    ]
+    "loaded": []
   },
   "SerialNumber": "ABC",
   "Type": 3,

--- a/tests/components/august/fixtures/get_lock.online.json
+++ b/tests/components/august/fixtures/get_lock.online.json
@@ -40,15 +40,7 @@
   },
   "OfflineKeys": {
     "created": [],
-    "loaded": [
-      {
-        "UserID": "cccca94e-373e-aaaa-bbbb-333396827777",
-        "slot": 1,
-        "key": "kkk01d4300c1dcxxx1c330f794941111",
-        "created": "2017-12-10T03:12:09.215Z",
-        "loaded": "2017-12-10T03:12:54.391Z"
-      }
-    ],
+    "loaded": [],
     "deleted": [],
     "loadedhk": [
       {

--- a/tests/components/august/fixtures/get_lock.online_with_keys.json
+++ b/tests/components/august/fixtures/get_lock.online_with_keys.json
@@ -35,12 +35,20 @@
     "lockID": "92412D1B44004595B5DEB134E151A8D3",
     "currentFirmwareVersion": "2.27.0",
     "battery": {},
-    "batteryLevel": "Low",
+    "batteryLevel": "Medium",
     "batteryRaw": 170
   },
   "OfflineKeys": {
     "created": [],
-    "loaded": [],
+    "loaded": [
+      {
+        "UserID": "cccca94e-373e-aaaa-bbbb-333396827777",
+        "slot": 1,
+        "key": "kkk01d4300c1dcxxx1c330f794941111",
+        "created": "2017-12-10T03:12:09.215Z",
+        "loaded": "2017-12-10T03:12:54.391Z"
+      }
+    ],
     "deleted": [],
     "loadedhk": [
       {

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -302,6 +302,10 @@ async def _mock_operative_august_lock_detail(hass):
     return await _mock_lock_from_fixture(hass, "get_lock.online.json")
 
 
+async def _mock_lock_with_offline_key(hass):
+    return await _mock_lock_from_fixture(hass, "get_lock.online_with_keys.json")
+
+
 async def _mock_inoperative_august_lock_detail(hass):
     return await _mock_lock_from_fixture(hass, "get_lock.offline.json")
 

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -340,7 +340,7 @@ async def test_load_triggers_ble_discovery(hass):
     assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(mock_discovery.mock_calls) == 1
-    assert mock_discovery.mock_calls[0][1][0] == {
+    assert mock_discovery.mock_calls[0][1][1] == {
         "name": "Front Door Lock",
         "address": None,
         "serial": "X2FSW05DGA",

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -330,16 +330,17 @@ async def test_load_triggers_ble_discovery(hass):
     august_lock_with_key = await _mock_lock_with_offline_key(hass)
     august_lock_without_key = await _mock_operative_august_lock_detail(hass)
 
-    with patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
+    with patch(
+        "homeassistant.components.august.yalexs_ble.async_discovery"
+    ) as mock_discovery:
         config_entry = await _create_august_with_devices(
             hass, [august_lock_with_key, august_lock_without_key]
         )
         await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    assert len(mock_config_flow.mock_calls) == 1
-    assert mock_config_flow.mock_calls[0][1][0] == "yalexs_ble"
-    assert mock_config_flow.mock_calls[0].kwargs["data"] == {
+    assert len(mock_discovery.mock_calls) == 1
+    assert mock_discovery.mock_calls[0][1][0] == {
         "name": "Front Door Lock",
         "address": None,
         "serial": "X2FSW05DGA",

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -29,6 +29,7 @@ from tests.components.august.mocks import (
     _mock_doorsense_missing_august_lock_detail,
     _mock_get_config,
     _mock_inoperative_august_lock_detail,
+    _mock_lock_with_offline_key,
     _mock_operative_august_lock_detail,
 )
 
@@ -321,6 +322,30 @@ async def test_load_unload(hass):
 
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_load_triggers_ble_discovery(hass):
+    """Test that loading a lock that supports offline ble operation passes the keys to yalexe_ble."""
+
+    august_lock_with_key = await _mock_lock_with_offline_key(hass)
+    august_lock_without_key = await _mock_operative_august_lock_detail(hass)
+
+    with patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
+        config_entry = await _create_august_with_devices(
+            hass, [august_lock_with_key, august_lock_without_key]
+        )
+        await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert len(mock_config_flow.mock_calls) == 1
+    assert mock_config_flow.mock_calls[0][1][0] == "yalexs_ble"
+    assert mock_config_flow.mock_calls[0].kwargs["data"] == {
+        "name": "Front Door Lock",
+        "address": None,
+        "serial": "X2FSW05DGA",
+        "key": "kkk01d4300c1dcxxx1c330f794941111",
+        "slot": 1,
+    }
 
 
 async def remove_device(ws_client, device_id, config_entry_id):


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update offline keys from august cloud for august branded yale locks

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23725

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
