### PR TITLE
Fix titles for discoveries and device names in xiaomi_ble

### DIFF
--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -8,7 +8,7 @@
       "service_data_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.8.1"],
+  "requirements": ["xiaomi-ble==0.8.2"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2480,7 +2480,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.8.1
+xiaomi-ble==0.8.2
 
 # homeassistant.components.knx
 xknx==0.22.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1678,7 +1678,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.8.1
+xiaomi-ble==0.8.2
 
 # homeassistant.components.knx
 xknx==0.22.1

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -39,7 +39,7 @@ async def test_async_step_bluetooth_valid_device(hass):
             result["flow_id"], user_input={}
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "MMC_T201_1"
+    assert result2["title"] == "Baby Thermometer DD6FC1 (MMC-T201-1)"
     assert result2["data"] == {}
     assert result2["result"].unique_id == "00:81:F9:DD:6F:C1"
 
@@ -65,7 +65,7 @@ async def test_async_step_bluetooth_valid_device_but_missing_payload(hass):
             result["flow_id"], user_input={}
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "LYWSD02MMC"
+    assert result2["title"] == "Temperature/Humidity Sensor 565384 (LYWSD03MMC)"
     assert result2["data"] == {}
     assert result2["result"].unique_id == "A4:C1:38:56:53:84"
 
@@ -123,7 +123,7 @@ async def test_async_step_bluetooth_during_onboarding(hass):
         )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "MMC_T201_1"
+    assert result["title"] == "Baby Thermometer DD6FC1 (MMC-T201-1)"
     assert result["data"] == {}
     assert result["result"].unique_id == "00:81:F9:DD:6F:C1"
     assert len(mock_setup_entry.mock_calls) == 1
@@ -148,7 +148,7 @@ async def test_async_step_bluetooth_valid_device_legacy_encryption(hass):
             user_input={"bindkey": "b853075158487ca39a5b5ea9"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "YLKG07YL"
+    assert result2["title"] == "Dimmer Switch C5988B (YLKG07YL/YLKG08YL)"
     assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
@@ -180,7 +180,7 @@ async def test_async_step_bluetooth_valid_device_legacy_encryption_wrong_key(has
             user_input={"bindkey": "b853075158487ca39a5b5ea9"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "YLKG07YL"
+    assert result2["title"] == "Dimmer Switch C5988B (YLKG07YL/YLKG08YL)"
     assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
@@ -214,7 +214,7 @@ async def test_async_step_bluetooth_valid_device_legacy_encryption_wrong_key_len
             user_input={"bindkey": "b853075158487ca39a5b5ea9"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "YLKG07YL"
+    assert result2["title"] == "Dimmer Switch C5988B (YLKG07YL/YLKG08YL)"
     assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
@@ -238,7 +238,7 @@ async def test_async_step_bluetooth_valid_device_v4_encryption(hass):
         )
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "JTYJGD03MI"
+    assert result2["title"] == "Thermometer E39CBC (JTYJGD03MI)"
     assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
@@ -272,7 +272,7 @@ async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key(hass):
         )
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "JTYJGD03MI"
+    assert result2["title"] == "Thermometer E39CBC (JTYJGD03MI)"
     assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
@@ -306,7 +306,7 @@ async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key_length(
         )
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "JTYJGD03MI"
+    assert result2["title"] == "Thermometer E39CBC (JTYJGD03MI)"
     assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
@@ -370,7 +370,7 @@ async def test_async_step_user_with_found_devices(hass):
             user_input={"address": "58:2D:34:35:93:21"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "LYWSDCGQ"
+    assert result2["title"] == "Temperature/Humidity Sensor 359321 (LYWSDCGQ)"
     assert result2["data"] == {}
     assert result2["result"].unique_id == "58:2D:34:35:93:21"
 
@@ -405,7 +405,7 @@ async def test_async_step_user_short_payload(hass):
             result["flow_id"], user_input={}
         )
     assert result3["type"] == FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "LYWSD02MMC"
+    assert result3["title"] == "Temperature/Humidity Sensor 565384 (LYWSD03MMC)"
     assert result3["data"] == {}
     assert result3["result"].unique_id == "A4:C1:38:56:53:84"
 
@@ -453,7 +453,7 @@ async def test_async_step_user_short_payload_then_full(hass):
         )
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "LYWSD02MMC"
+    assert result2["title"] == "Temperature/Humidity Sensor 565384 (LYWSD03MMC)"
     assert result2["data"] == {"bindkey": "a115210eed7a88e50ad52662e732a9fb"}
 
 
@@ -486,7 +486,7 @@ async def test_async_step_user_with_found_devices_v4_encryption(hass):
         )
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "JTYJGD03MI"
+    assert result2["title"] == "Thermometer E39CBC (JTYJGD03MI)"
     assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
@@ -532,7 +532,7 @@ async def test_async_step_user_with_found_devices_v4_encryption_wrong_key(hass):
         )
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "JTYJGD03MI"
+    assert result2["title"] == "Thermometer E39CBC (JTYJGD03MI)"
     assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
@@ -580,7 +580,7 @@ async def test_async_step_user_with_found_devices_v4_encryption_wrong_key_length
         )
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "JTYJGD03MI"
+    assert result2["title"] == "Thermometer E39CBC (JTYJGD03MI)"
     assert result2["data"] == {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
@@ -613,7 +613,7 @@ async def test_async_step_user_with_found_devices_legacy_encryption(hass):
             user_input={"bindkey": "b853075158487ca39a5b5ea9"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "YLKG07YL"
+    assert result2["title"] == "Dimmer Switch C5988B (YLKG07YL/YLKG08YL)"
     assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
@@ -658,7 +658,7 @@ async def test_async_step_user_with_found_devices_legacy_encryption_wrong_key(
             user_input={"bindkey": "b853075158487ca39a5b5ea9"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "YLKG07YL"
+    assert result2["title"] == "Dimmer Switch C5988B (YLKG07YL/YLKG08YL)"
     assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
@@ -703,7 +703,7 @@ async def test_async_step_user_with_found_devices_legacy_encryption_wrong_key_le
             user_input={"bindkey": "b853075158487ca39a5b5ea9"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "YLKG07YL"
+    assert result2["title"] == "Dimmer Switch C5988B (YLKG07YL/YLKG08YL)"
     assert result2["data"] == {"bindkey": "b853075158487ca39a5b5ea9"}
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
@@ -792,7 +792,7 @@ async def test_async_step_user_takes_precedence_over_discovery(hass):
             user_input={"address": "00:81:F9:DD:6F:C1"},
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "MMC_T201_1"
+    assert result2["title"] == "Baby Thermometer DD6FC1 (MMC-T201-1)"
     assert result2["data"] == {}
     assert result2["result"].unique_id == "00:81:F9:DD:6F:C1"
 

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -39,10 +39,13 @@ async def test_sensors(hass):
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 2
 
-    temp_sensor = hass.states.get("sensor.mmc_t201_1_temperature")
+    temp_sensor = hass.states.get("sensor.baby_thermometer_dd6fc1_temperature")
     temp_sensor_attribtes = temp_sensor.attributes
     assert temp_sensor.state == "36.8719980616822"
-    assert temp_sensor_attribtes[ATTR_FRIENDLY_NAME] == "MMC_T201_1 Temperature"
+    assert (
+        temp_sensor_attribtes[ATTR_FRIENDLY_NAME]
+        == "Baby Thermometer DD6FC1 Temperature"
+    )
     assert temp_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "°C"
     assert temp_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
 
@@ -86,10 +89,10 @@ async def test_xiaomi_formaldeyhde(hass):
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 1
 
-    sensor = hass.states.get("sensor.test_device_formaldehyde")
+    sensor = hass.states.get("sensor.smart_flower_pot_6a3e7a_formaldehyde")
     sensor_attr = sensor.attributes
     assert sensor.state == "2.44"
-    assert sensor_attr[ATTR_FRIENDLY_NAME] == "Test Device Formaldehyde"
+    assert sensor_attr[ATTR_FRIENDLY_NAME] == "Smart Flower Pot 6A3E7A Formaldehyde"
     assert sensor_attr[ATTR_UNIT_OF_MEASUREMENT] == "mg/m³"
     assert sensor_attr[ATTR_STATE_CLASS] == "measurement"
 
@@ -133,10 +136,10 @@ async def test_xiaomi_consumable(hass):
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 1
 
-    sensor = hass.states.get("sensor.test_device_consumable")
+    sensor = hass.states.get("sensor.smart_flower_pot_6a3e7a_consumable")
     sensor_attr = sensor.attributes
     assert sensor.state == "96"
-    assert sensor_attr[ATTR_FRIENDLY_NAME] == "Test Device Consumable"
+    assert sensor_attr[ATTR_FRIENDLY_NAME] == "Smart Flower Pot 6A3E7A Consumable"
     assert sensor_attr[ATTR_UNIT_OF_MEASUREMENT] == "%"
     assert sensor_attr[ATTR_STATE_CLASS] == "measurement"
 
@@ -180,17 +183,17 @@ async def test_xiaomi_battery_voltage(hass):
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 2
 
-    volt_sensor = hass.states.get("sensor.test_device_voltage")
+    volt_sensor = hass.states.get("sensor.smart_flower_pot_6a3e7a_voltage")
     volt_sensor_attr = volt_sensor.attributes
     assert volt_sensor.state == "3.1"
-    assert volt_sensor_attr[ATTR_FRIENDLY_NAME] == "Test Device Voltage"
+    assert volt_sensor_attr[ATTR_FRIENDLY_NAME] == "Smart Flower Pot 6A3E7A Voltage"
     assert volt_sensor_attr[ATTR_UNIT_OF_MEASUREMENT] == "V"
     assert volt_sensor_attr[ATTR_STATE_CLASS] == "measurement"
 
-    bat_sensor = hass.states.get("sensor.test_device_battery")
+    bat_sensor = hass.states.get("sensor.smart_flower_pot_6a3e7a_battery")
     bat_sensor_attr = bat_sensor.attributes
     assert bat_sensor.state == "100"
-    assert bat_sensor_attr[ATTR_FRIENDLY_NAME] == "Test Device Battery"
+    assert bat_sensor_attr[ATTR_FRIENDLY_NAME] == "Smart Flower Pot 6A3E7A Battery"
     assert bat_sensor_attr[ATTR_UNIT_OF_MEASUREMENT] == "%"
     assert bat_sensor_attr[ATTR_STATE_CLASS] == "measurement"
 
@@ -248,38 +251,42 @@ async def test_xiaomi_HHCCJCY01(hass):
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 5
 
-    illum_sensor = hass.states.get("sensor.test_device_illuminance")
+    illum_sensor = hass.states.get("sensor.plant_sensor_6a3e7a_illuminance")
     illum_sensor_attr = illum_sensor.attributes
     assert illum_sensor.state == "0"
-    assert illum_sensor_attr[ATTR_FRIENDLY_NAME] == "Test Device Illuminance"
+    assert illum_sensor_attr[ATTR_FRIENDLY_NAME] == "Plant Sensor 6A3E7A Illuminance"
     assert illum_sensor_attr[ATTR_UNIT_OF_MEASUREMENT] == "lx"
     assert illum_sensor_attr[ATTR_STATE_CLASS] == "measurement"
 
-    cond_sensor = hass.states.get("sensor.test_device_conductivity")
+    cond_sensor = hass.states.get("sensor.plant_sensor_6a3e7a_conductivity")
     cond_sensor_attribtes = cond_sensor.attributes
     assert cond_sensor.state == "599"
-    assert cond_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Test Device Conductivity"
+    assert (
+        cond_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Plant Sensor 6A3E7A Conductivity"
+    )
     assert cond_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "µS/cm"
     assert cond_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
 
-    moist_sensor = hass.states.get("sensor.test_device_moisture")
+    moist_sensor = hass.states.get("sensor.plant_sensor_6a3e7a_moisture")
     moist_sensor_attribtes = moist_sensor.attributes
     assert moist_sensor.state == "64"
-    assert moist_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Test Device Moisture"
+    assert moist_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Plant Sensor 6A3E7A Moisture"
     assert moist_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "%"
     assert moist_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
 
-    temp_sensor = hass.states.get("sensor.test_device_temperature")
+    temp_sensor = hass.states.get("sensor.plant_sensor_6a3e7a_temperature")
     temp_sensor_attribtes = temp_sensor.attributes
     assert temp_sensor.state == "24.4"
-    assert temp_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Test Device Temperature"
+    assert (
+        temp_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Plant Sensor 6A3E7A Temperature"
+    )
     assert temp_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "°C"
     assert temp_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
 
-    batt_sensor = hass.states.get("sensor.test_device_battery")
+    batt_sensor = hass.states.get("sensor.plant_sensor_6a3e7a_battery")
     batt_sensor_attribtes = batt_sensor.attributes
     assert batt_sensor.state == "5"
-    assert batt_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Test Device Battery"
+    assert batt_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Plant Sensor 6A3E7A Battery"
     assert batt_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "%"
     assert batt_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
 
@@ -321,10 +328,15 @@ async def test_xiaomi_CGDK2(hass):
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 1
 
-    temp_sensor = hass.states.get("sensor.test_device_temperature")
+    temp_sensor = hass.states.get(
+        "sensor.temperature_humidity_sensor_122089_temperature"
+    )
     temp_sensor_attribtes = temp_sensor.attributes
     assert temp_sensor.state == "22.6"
-    assert temp_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Test Device Temperature"
+    assert (
+        temp_sensor_attribtes[ATTR_FRIENDLY_NAME]
+        == "Temperature/Humidity Sensor 122089 Temperature"
+    )
     assert temp_sensor_attribtes[ATTR_UNIT_OF_MEASUREMENT] == "°C"
     assert temp_sensor_attribtes[ATTR_STATE_CLASS] == "measurement"
 


### PR DESCRIPTION
## Proposed change

There is a bug where the title of a device is not stable (depending on whether local name has propagated through the bluetooth stack). It means sometimes users see the MAC address and sometimes they see "Flower Care". Additionally, one of the biggest feature requests for xiaomi_ble has been better names so that users can tell which device is which. A list with "Flower Care" 10 times is not that great!

![Screenshot 2022-08-11 at 15 38 43](https://user-images.githubusercontent.com/11544/184159462-009c0e9c-79ab-4da7-969f-085ace33f8e8.png)

Most of this is just updating the tests to use the friendlier names.

https://github.com/Bluetooth-Devices/xiaomi-ble/compare/v0.8.1...v0.8.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #76163
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
