### PR TITLE
Add support for August locks to Yale Access Bluetooth

### DIFF
--- a/homeassistant/components/yalexs_ble/manifest.json
+++ b/homeassistant/components/yalexs_ble/manifest.json
@@ -7,5 +7,8 @@
   "dependencies": ["bluetooth"],
   "codeowners": ["@bdraco"],
   "bluetooth": [{ "manufacturer_id": 465 }],
-  "iot_class": "local_push"
+  "iot_class": "local_push",
+  "supported_brands": {
+    "august_ble": "August Bluetooth"
+  }
 }

--- a/homeassistant/components/yalexs_ble/util.py
+++ b/homeassistant/components/yalexs_ble/util.py
@@ -1,6 +1,8 @@
 """The yalexs_ble integration models."""
 from __future__ import annotations
 
+import platform
+
 from yalexs_ble import local_name_is_unique
 
 from homeassistant.components.bluetooth import (
@@ -23,8 +25,14 @@ def bluetooth_callback_matcher(
     local_name: str, address: str
 ) -> BluetoothCallbackMatcher:
     """Return a BluetoothCallbackMatcher for the given local_name and address."""
-    if local_name_is_unique(local_name):
+    # On MacOS, coreblueooth uses UUIDs for addresses so we must
+    # have a unique local_name to match since the system
+    # hides the address from us.
+    if local_name_is_unique(local_name) and platform.system() == "Darwin":
         return BluetoothCallbackMatcher({LOCAL_NAME: local_name})
+    # On every other platform we actually get the mac address
+    # which is needed for the older August locks that use the
+    # older version of the underlying protocol.
     return BluetoothCallbackMatcher({ADDRESS: address})
 
 

--- a/homeassistant/generated/supported_brands.py
+++ b/homeassistant/generated/supported_brands.py
@@ -12,5 +12,6 @@ HAS_SUPPORTED_BRANDS = (
     "overkiz",
     "renault",
     "wemo",
+    "yalexs_ble",
     "zwave_js"
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for August locks to Yale Access Bluetooth.

Assa Abloy, Yale's parent company, purchased August in 2017, and most newer devices use the Yale Access branding.

Although Assa Abloy has not released anything new under the August brand since 2020, they still sell under the August brand in at least North America. I expect people will likely have trouble finding August Bluetooth support under Yale Access Bluetooth since they seem to have actively tried not to mix the branding.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23732

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
