### PR TITLE
Add remote learn command to BraviaTV

### DIFF
--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -262,7 +262,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
     async def async_learn_command(self, entity_id: str) -> None:
         """Display a list of available commands in a persistent notification."""
         commands = await self.client.get_command_list()
-        codes = ", ".join(list(commands.keys()))
+        codes = ", ".join(commands.keys())
         title = "Bravia TV"
         message = f"**List of available commands for `{entity_id}`**:\n\n{codes}"
         persistent_notification.async_create(

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -10,6 +10,7 @@ from typing import Any, Final, TypeVar
 from pybravia import BraviaTV, BraviaTVError
 from typing_extensions import Concatenate, ParamSpec
 
+from homeassistant.components import persistent_notification
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_APP,
     MEDIA_TYPE_CHANNEL,
@@ -256,3 +257,16 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         for _ in range(repeats):
             for cmd in command:
                 await self.client.send_command(cmd)
+
+    @catch_braviatv_errors
+    async def async_learn_command(self, entity_id: str) -> None:
+        """Display a list of available commands in a persistent notification."""
+        commands = await self.client.get_command_list()
+        codes = ", ".join(list(commands.keys()))
+        title = "Bravia TV"
+        message = f"**List of available commands for `{entity_id}`**:\n\n{codes}"
+        persistent_notification.async_create(
+            self.hass,
+            title=title,
+            message=message,
+        )

--- a/homeassistant/components/braviatv/remote.py
+++ b/homeassistant/components/braviatv/remote.py
@@ -47,3 +47,7 @@ class BraviaTVRemote(BraviaTVEntity, RemoteEntity):
         """Send a command to device."""
         repeats = kwargs[ATTR_NUM_REPEATS]
         await self.coordinator.async_send_command(command, repeats)
+
+    async def async_learn_command(self, **kwargs: Any) -> None:
+        """Learn commands from the device."""
+        await self.coordinator.async_learn_command(self.entity_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added support `remote.learn_command` service to get a list of all supported commands by the TV (depends on model) and display it in notifications. [It was discussed a long time ago](https://github.com/home-assistant/core/pull/50845#issuecomment-844310205) and [now it has become possible](https://github.com/home-assistant/core/pull/75727).

**Demo:**

<img width="350" src="https://user-images.githubusercontent.com/11841379/184330355-d89a7c13-ab95-4a2e-84cd-0c75e231d293.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23738

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
