### PR TITLE
Fix, improve input validation and add tests to ClickSend tts

### DIFF
--- a/homeassistant/components/clicksend_tts/notify.py
+++ b/homeassistant/components/clicksend_tts/notify.py
@@ -38,7 +38,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_API_KEY): cv.string,
-        vol.Required(CONF_RECIPIENT): cv.string,
+        vol.Required(CONF_RECIPIENT): vol.All(
+            cv.string, vol.Match(r"^\+?[1-9]\d{1,14}$")
+        ),
         vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): cv.string,
         vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(
             [MALE_VOICE, FEMALE_VOICE]

--- a/homeassistant/components/clicksend_tts/notify.py
+++ b/homeassistant/components/clicksend_tts/notify.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 from homeassistant.const import (
     CONF_API_KEY,
+    CONF_NAME,
     CONF_RECIPIENT,
     CONF_USERNAME,
     CONTENT_TYPE_JSON,
@@ -24,12 +25,14 @@ HEADERS = {"Content-Type": CONTENT_TYPE_JSON}
 CONF_LANGUAGE = "language"
 CONF_VOICE = "voice"
 
+DEFAULT_NAME = "clicksend_tts"
 DEFAULT_LANGUAGE = "en-us"
 DEFAULT_VOICE = "female"
 TIMEOUT = 5
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_API_KEY): cv.string,
         vol.Required(CONF_RECIPIENT): cv.string,

--- a/homeassistant/components/clicksend_tts/notify.py
+++ b/homeassistant/components/clicksend_tts/notify.py
@@ -23,7 +23,6 @@ HEADERS = {"Content-Type": CONTENT_TYPE_JSON}
 
 CONF_LANGUAGE = "language"
 CONF_VOICE = "voice"
-CONF_CALLER = "caller"
 
 DEFAULT_LANGUAGE = "en-us"
 DEFAULT_VOICE = "female"
@@ -36,7 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_RECIPIENT): cv.string,
         vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): cv.string,
         vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): cv.string,
-        vol.Optional(CONF_CALLER): cv.string,
     }
 )
 
@@ -60,9 +58,6 @@ class ClicksendNotificationService(BaseNotificationService):
         self.recipient = config[CONF_RECIPIENT]
         self.language = config[CONF_LANGUAGE]
         self.voice = config[CONF_VOICE]
-        self.caller = config.get(CONF_CALLER)
-        if self.caller is None:
-            self.caller = self.recipient
 
     def send_message(self, message="", **kwargs):
         """Send a voice call to a user."""
@@ -70,7 +65,6 @@ class ClicksendNotificationService(BaseNotificationService):
             "messages": [
                 {
                     "source": "hass.notify",
-                    "from": self.caller,
                     "to": self.recipient,
                     "body": message,
                     "lang": self.language,

--- a/homeassistant/components/clicksend_tts/notify.py
+++ b/homeassistant/components/clicksend_tts/notify.py
@@ -25,9 +25,12 @@ HEADERS = {"Content-Type": CONTENT_TYPE_JSON}
 CONF_LANGUAGE = "language"
 CONF_VOICE = "voice"
 
+MALE_VOICE = "male"
+FEMALE_VOICE = "female"
+
 DEFAULT_NAME = "clicksend_tts"
 DEFAULT_LANGUAGE = "en-us"
-DEFAULT_VOICE = "female"
+DEFAULT_VOICE = FEMALE_VOICE
 TIMEOUT = 5
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -37,7 +40,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_API_KEY): cv.string,
         vol.Required(CONF_RECIPIENT): cv.string,
         vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): cv.string,
-        vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): cv.string,
+        vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(
+            [MALE_VOICE, FEMALE_VOICE]
+        ),
     }
 )
 

--- a/tests/components/clicksend_tts/__init__.py
+++ b/tests/components/clicksend_tts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ClickSend TTS component."""

--- a/tests/components/clicksend_tts/test_notify.py
+++ b/tests/components/clicksend_tts/test_notify.py
@@ -1,0 +1,78 @@
+"""The test for the Facebook notify module."""
+import base64
+from http import HTTPStatus
+
+import pytest
+import requests_mock
+
+import homeassistant.components.clicksend_tts.notify as cs_tts
+
+# Infos from https://developers.clicksend.com/docs/rest/v3/#testing
+TEST_USERNAME = "nocredit"
+TEST_API_KEY = "D83DED51-9E35-4D42-9BB9-0E34B7CA85AE"
+TEST_VOICE_NUMBER = "+61411111111"
+
+TEST_VOICE = "male"
+TEST_LANGUAGE = "fr-fr"
+TEST_MESSAGE = "Just a test message!"
+
+
+@pytest.fixture
+def cs_tts_test_config():
+    """Fixture for a test config of ClickSend TTS."""
+    return {
+        cs_tts.CONF_USERNAME: TEST_USERNAME,
+        cs_tts.CONF_API_KEY: TEST_API_KEY,
+        cs_tts.CONF_RECIPIENT: TEST_VOICE_NUMBER,
+        cs_tts.CONF_LANGUAGE: TEST_LANGUAGE,
+        cs_tts.CONF_VOICE: TEST_VOICE,
+    }
+
+
+@pytest.fixture
+def clicksend_tts(cs_tts_test_config):
+    """Fixture for ClickSend TTS."""
+    return cs_tts.ClicksendNotificationService(cs_tts_test_config)
+
+
+async def test_send_simple_message(hass, clicksend_tts):
+    """Test sending a simple message with success."""
+    with requests_mock.Mocker() as mock:
+        url = f"{cs_tts.BASE_API_URL}/voice/send"
+        mock.register_uri(
+            requests_mock.POST,
+            url,
+            status_code=HTTPStatus.OK,
+        )
+
+        clicksend_tts.send_message(message=TEST_MESSAGE)
+        assert mock.called
+        assert mock.call_count == 1
+
+        expected_body = {
+            "messages": [
+                {
+                    "source": "hass.notify",
+                    "to": TEST_VOICE_NUMBER,
+                    "body": TEST_MESSAGE,
+                    "lang": TEST_LANGUAGE,
+                    "voice": TEST_VOICE,
+                }
+            ]
+        }
+        assert mock.last_request.json() == expected_body
+
+        expected_content_type = "application/json"
+        assert (
+            "Content-Type" in mock.last_request.headers.keys()
+            and mock.last_request.headers["Content-Type"] == expected_content_type
+        )
+
+        encoded_auth = base64.b64encode(
+            f"{TEST_USERNAME}:{TEST_API_KEY}".encode()
+        ).decode()
+        expected_auth = f"Basic {encoded_auth}"
+        assert (
+            "Authorization" in mock.last_request.headers.keys()
+            and mock.last_request.headers["Authorization"] == expected_auth
+        )

--- a/tests/components/clicksend_tts/test_notify.py
+++ b/tests/components/clicksend_tts/test_notify.py
@@ -1,11 +1,17 @@
 """The test for the Facebook notify module."""
 import base64
 from http import HTTPStatus
+import logging
+from unittest.mock import patch
 
 import pytest
 import requests_mock
 
+from homeassistant.components import notify
 import homeassistant.components.clicksend_tts.notify as cs_tts
+from homeassistant.setup import async_setup_component
+
+from tests.common import assert_setup_component
 
 # Infos from https://developers.clicksend.com/docs/rest/v3/#testing
 TEST_USERNAME = "nocredit"
@@ -17,37 +23,75 @@ TEST_LANGUAGE = "fr-fr"
 TEST_MESSAGE = "Just a test message!"
 
 
-@pytest.fixture
-def cs_tts_test_config():
-    """Fixture for a test config of ClickSend TTS."""
-    return {
+CONFIG = {
+    notify.DOMAIN: {
+        "platform": "clicksend_tts",
         cs_tts.CONF_USERNAME: TEST_USERNAME,
         cs_tts.CONF_API_KEY: TEST_API_KEY,
         cs_tts.CONF_RECIPIENT: TEST_VOICE_NUMBER,
         cs_tts.CONF_LANGUAGE: TEST_LANGUAGE,
         cs_tts.CONF_VOICE: TEST_VOICE,
     }
+}
 
 
 @pytest.fixture
-def clicksend_tts(cs_tts_test_config):
-    """Fixture for ClickSend TTS."""
-    return cs_tts.ClicksendNotificationService(cs_tts_test_config)
+def mock_clicksend_tts_notify():
+    """Mock Clicksend TTS notify service."""
+    with patch(
+        "homeassistant.components.clicksend_tts.notify.get_service", autospec=True
+    ) as ns:
+        yield ns
 
 
-async def test_send_simple_message(hass, clicksend_tts):
+async def setup_notify(hass):
+    """Test setup."""
+    with assert_setup_component(1, notify.DOMAIN) as config:
+        assert await async_setup_component(hass, notify.DOMAIN, CONFIG)
+        assert config[notify.DOMAIN]
+        await hass.async_block_till_done()
+
+
+async def test_no_notify_service(hass, mock_clicksend_tts_notify, caplog):
+    """Test missing platform notify service instance."""
+    caplog.set_level(logging.ERROR)
+    mock_clicksend_tts_notify.return_value = None
+    await setup_notify(hass)
+    await hass.async_block_till_done()
+    assert mock_clicksend_tts_notify.called
+    assert "Failed to initialize notification service clicksend_tts" in caplog.text
+
+
+async def test_send_simple_message(hass):
     """Test sending a simple message with success."""
+
     with requests_mock.Mocker() as mock:
-        url = f"{cs_tts.BASE_API_URL}/voice/send"
-        mock.register_uri(
-            requests_mock.POST,
-            url,
+        # Mocking authentication endpoint
+        mock.get(
+            f"{cs_tts.BASE_API_URL}/account",
             status_code=HTTPStatus.OK,
         )
 
-        clicksend_tts.send_message(message=TEST_MESSAGE)
+        # Mocking TTS endpoint
+        mock.post(
+            f"{cs_tts.BASE_API_URL}/voice/send",
+            status_code=HTTPStatus.OK,
+        )
+
+        # Setting up integration
+        await setup_notify(hass)
+
+        # Sending message
+        data = {
+            notify.ATTR_MESSAGE: TEST_MESSAGE,
+        }
+        await hass.services.async_call(
+            notify.DOMAIN, cs_tts.DEFAULT_NAME, data, blocking=True
+        )
+
+        # Checking if everything went well
         assert mock.called
-        assert mock.call_count == 1
+        assert mock.call_count == 2
 
         expected_body = {
             "messages": [

--- a/tests/components/clicksend_tts/test_notify.py
+++ b/tests/components/clicksend_tts/test_notify.py
@@ -117,6 +117,6 @@ async def test_send_simple_message(hass):
         ).decode()
         expected_auth = f"Basic {encoded_auth}"
         assert (
-            "Authorization" in mock.last_request.headers.keys()
+            "Authorization" in mock.last_request.headers
             and mock.last_request.headers["Authorization"] == expected_auth
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

- Remove `caller` attribute from `ClickSend TTS` configuration, as it prevents calls from being made and it is not referenced in their REST API [doc](https://developers.clicksend.com/docs/rest/v3/#Send-Voice-Message).  
- Set default name to `clicksend_tts` instead of an empty string, otherwise service appears as `notify.notify`. Now it will by default appears as `notify.clicksend_tts`.  
- Recipient phone number now must match E.164 format as said in their documentation. It seems to be working even without respecting the format but it seems better to respect it.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR changes the request body sent to the API in order to respect their REST API [doc](https://developers.clicksend.com/docs/rest/v3/#Send-Voice-Message). It also improves input config validation of the integration and it adds tests.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23740

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
