### PR TITLE
Add Boost/Away mode duration to Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/number.py
+++ b/homeassistant/components/overkiz/number.py
@@ -207,14 +207,15 @@ class OverkizNumber(OverkizDescriptiveEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
+        if self.entity_description.inverted:
+            value = self.native_max_value - value
+
         if self.entity_description.set_native_value:
             await self.entity_description.set_native_value(
                 value, self.executor.async_execute_command
             )
-        else:
-            if self.entity_description.inverted:
-                value = self.native_max_value - value
+            return
 
-            await self.executor.async_execute_command(
-                self.entity_description.command, value
-            )
+        await self.executor.async_execute_command(
+            self.entity_description.command, value
+        )

--- a/homeassistant/components/overkiz/number.py
+++ b/homeassistant/components/overkiz/number.py
@@ -23,6 +23,9 @@ from . import HomeAssistantOverkizData
 from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES
 from .entity import OverkizDescriptiveEntity
 
+BOOST_MODE_DURATION_DELAY = 1
+OPERATING_MODE_DELAY = 3
+
 
 @dataclass
 class OverkizNumberDescriptionMixin:
@@ -48,7 +51,9 @@ async def _async_set_native_value_boost_mode_duration(
 
     if value > 0:
         await execute_command(OverkizCommand.SET_BOOST_MODE_DURATION, value)
-        await asyncio.sleep(1)  # wait one second to not overload the device
+        await asyncio.sleep(
+            BOOST_MODE_DURATION_DELAY
+        )  # wait one second to not overload the device
         await execute_command(
             OverkizCommand.SET_CURRENT_OPERATING_MODE,
             {
@@ -65,7 +70,9 @@ async def _async_set_native_value_boost_mode_duration(
             },
         )
 
-    await asyncio.sleep(3)  # wait 3 seconds to have the new duration in
+    await asyncio.sleep(
+        OPERATING_MODE_DELAY
+    )  # wait 3 seconds to have the new duration in
     await execute_command(OverkizCommand.REFRESH_BOOST_MODE_DURATION)
 
 

--- a/homeassistant/components/overkiz/number.py
+++ b/homeassistant/components/overkiz/number.py
@@ -134,7 +134,7 @@ NUMBER_DESCRIPTIONS: list[OverkizNumberDescription] = [
         native_max_value=100,
         inverted=True,
     ),
-    # DomesticHotWaterProduction - boost mode duration in hours (0 - 7)
+    # DomesticHotWaterProduction - boost mode duration in days (0 - 7)
     OverkizNumberDescription(
         key=OverkizState.CORE_BOOST_MODE_DURATION,
         name="Boost mode duration",

--- a/homeassistant/components/overkiz/number.py
+++ b/homeassistant/components/overkiz/number.py
@@ -1,6 +1,7 @@
 """Support for Overkiz (virtual) numbers."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import cast
@@ -47,7 +48,7 @@ async def _async_set_native_value_boost_mode_duration(
 
     if value > 0:
         await execute_command(OverkizCommand.SET_BOOST_MODE_DURATION, value)
-
+        await asyncio.sleep(1)  # wait one second to not overload the device
         await execute_command(
             OverkizCommand.SET_CURRENT_OPERATING_MODE,
             {
@@ -64,7 +65,8 @@ async def _async_set_native_value_boost_mode_duration(
             },
         )
 
-        # await execute_command(OverkizCommand.REFRESH_BOOST_MODE_DURATION)
+    await asyncio.sleep(3)  # wait 3 seconds to have the new duration in
+    await execute_command(OverkizCommand.REFRESH_BOOST_MODE_DURATION)
 
 
 NUMBER_DESCRIPTIONS: list[OverkizNumberDescription] = [

--- a/homeassistant/components/overkiz/number.py
+++ b/homeassistant/components/overkiz/number.py
@@ -137,7 +137,7 @@ NUMBER_DESCRIPTIONS: list[OverkizNumberDescription] = [
     # DomesticHotWaterProduction - boost mode duration in hours (0 - 7)
     OverkizNumberDescription(
         key=OverkizState.CORE_BOOST_MODE_DURATION,
-        name="Boost Mode Duration",
+        name="Boost mode duration",
         icon="mdi:water-boiler",
         command=OverkizCommand.SET_BOOST_MODE_DURATION,
         native_min_value=0,
@@ -148,7 +148,7 @@ NUMBER_DESCRIPTIONS: list[OverkizNumberDescription] = [
     # DomesticHotWaterProduction - away mode in days (0 - 6)
     OverkizNumberDescription(
         key=OverkizState.IO_AWAY_MODE_DURATION,
-        name="Away Mode Duration",
+        name="Away mode duration",
         icon="mdi:water-boiler-off",
         command=OverkizCommand.SET_AWAY_MODE_DURATION,
         native_min_value=0,

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -372,6 +372,12 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         name="Three Way Handle Direction",
         device_class=OverkizDeviceClass.THREE_WAY_HANDLE_DIRECTION,
     ),
+    # DomesticHotWaterProduction
+    OverkizSensorDescription(
+        key=OverkizState.MODBUSLINK_MIDDLE_WATER_TEMPERATURE,
+        name="Middle Water Temperature",
+        native_unit_of_measurement=TEMP_CELSIUS,
+    ),
 ]
 
 SUPPORTED_STATES = {description.key: description for description in SENSOR_DESCRIPTIONS}

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -372,12 +372,6 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         name="Three Way Handle Direction",
         device_class=OverkizDeviceClass.THREE_WAY_HANDLE_DIRECTION,
     ),
-    # DomesticHotWaterProduction
-    OverkizSensorDescription(
-        key=OverkizState.MODBUSLINK_MIDDLE_WATER_TEMPERATURE,
-        name="Middle Water Temperature",
-        native_unit_of_measurement=TEMP_CELSIUS,
-    ),
 ]
 
 SUPPORTED_STATES = {description.key: description for description in SENSOR_DESCRIPTIONS}


### PR DESCRIPTION
## Proposed change
As requested, added support for setting the Away and Boost mode duration for DomesticHotWaterProduction/WaterHeatingSystem.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
