### PR TITLE
Add goToAlias button (my position) to Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -18,7 +18,7 @@ from .entity import OverkizDescriptiveEntity
 
 @dataclass
 class OverkizButtonDescription(ButtonEntityDescription):
-    """Class to describe an Overkiz switch."""
+    """Class to describe an Overkiz button."""
 
     press_args: OverkizStateType | None = None
 

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -61,7 +61,7 @@ BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
     # DynamicScreen (ogp:blind) uses goToAlias (id 1: favorite1) instead of 'my'
     OverkizButtonDescription(
         key="goToAlias",
-        press_args=1,
+        press_args="1",
         name="My position",
         icon="mdi:star",
     ),

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -112,5 +112,6 @@ class OverkizButton(OverkizDescriptiveEntity, ButtonEntity):
             await self.executor.async_execute_command(
                 self.entity_description.key, self.entity_description.press_args
             )
-        else:
-            await self.executor.async_execute_command(self.entity_description.key)
+            return
+
+        await self.executor.async_execute_command(self.entity_description.key)

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -1,6 +1,10 @@
 """Support for Overkiz (virtual) buttons."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from pyoverkiz.types import StateType as OverkizStateType
+
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -11,41 +15,56 @@ from . import HomeAssistantOverkizData
 from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES
 from .entity import OverkizDescriptiveEntity
 
-BUTTON_DESCRIPTIONS: list[ButtonEntityDescription] = [
+
+@dataclass
+class OverkizButtonDescription(ButtonEntityDescription):
+    """Class to describe an Overkiz switch."""
+
+    press_args: OverkizStateType | None = None
+
+
+BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
     # My Position (cover, light)
-    ButtonEntityDescription(
+    OverkizButtonDescription(
         key="my",
         name="My Position",
         icon="mdi:star",
     ),
     # Identify
-    ButtonEntityDescription(
+    OverkizButtonDescription(
         key="identify",  # startIdentify and identify are reversed... Swap this when fixed in API.
         name="Start Identify",
         icon="mdi:human-greeting-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
-    ButtonEntityDescription(
+    OverkizButtonDescription(
         key="stopIdentify",
         name="Stop Identify",
         icon="mdi:human-greeting-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
-    ButtonEntityDescription(
+    OverkizButtonDescription(
         key="startIdentify",  # startIdentify and identify are reversed... Swap this when fixed in API.
         name="Identify",
         icon="mdi:human-greeting-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # RTDIndoorSiren / RTDOutdoorSiren
-    ButtonEntityDescription(key="dingDong", name="Ding Dong", icon="mdi:bell-ring"),
-    ButtonEntityDescription(key="bip", name="Bip", icon="mdi:bell-ring"),
-    ButtonEntityDescription(
+    OverkizButtonDescription(key="dingDong", name="Ding Dong", icon="mdi:bell-ring"),
+    OverkizButtonDescription(key="bip", name="Bip", icon="mdi:bell-ring"),
+    OverkizButtonDescription(
         key="fastBipSequence", name="Fast Bip Sequence", icon="mdi:bell-ring"
     ),
-    ButtonEntityDescription(key="ring", name="Ring", icon="mdi:bell-ring"),
+    OverkizButtonDescription(key="ring", name="Ring", icon="mdi:bell-ring"),
+    # DynamicScreen (ogp:blind) uses goToAlias (id 1: favorite1) instead of 'my'
+    OverkizButtonDescription(
+        key="goToAlias",
+        press_args=1,
+        name="My position",
+        icon="mdi:star",
+    ),
 ]
 
 SUPPORTED_COMMANDS = {
@@ -85,6 +104,13 @@ async def async_setup_entry(
 class OverkizButton(OverkizDescriptiveEntity, ButtonEntity):
     """Representation of an Overkiz Button."""
 
+    entity_description: OverkizButtonDescription
+
     async def async_press(self) -> None:
         """Handle the button press."""
-        await self.executor.async_execute_command(self.entity_description.key)
+        if self.entity_description.press_args:
+            await self.executor.async_execute_command(
+                self.entity_description.key, self.entity_description.press_args
+            )
+        else:
+            await self.executor.async_execute_command(self.entity_description.key)


### PR DESCRIPTION
## Proposed change
Fixes #75067. DynamicScreen (ogp:blind) uses goToAlias (id 1: favorite1) instead of 'my' as a command. This has been reported previously in https://github.com/iMicknl/ha-tahoma/issues/738 as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75067
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
