### PR TITLE
Expose extra PJLink data as state attributes

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -201,6 +201,7 @@ homeassistant.components.overkiz.*
 homeassistant.components.peco.*
 homeassistant.components.persistent_notification.*
 homeassistant.components.pi_hole.*
+homeassistant.components.pjlink.*
 homeassistant.components.powerwall.*
 homeassistant.components.proximity.*
 homeassistant.components.prusalink.*

--- a/homeassistant/components/pjlink/__init__.py
+++ b/homeassistant/components/pjlink/__init__.py
@@ -1,18 +1,18 @@
 """The pjlink component."""
 
+import asyncio
 import socket
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_ENCODING, CONFIG_ENTRY_SCHEMA, DEFAULT_TIMEOUT, DOMAIN
+from .const import DOMAIN
 from .coordinator import PJLinkUpdateCoordinator
 from .device import PJLinkDevice
-
-PLATFORM_SCHEMA = CONFIG_ENTRY_SCHEMA
+from .util import PJLinkConfig
 
 PLATFORMS = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR, Platform.SENSOR]
 
@@ -32,12 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if entry.entry_id in domain_data:
         return True
 
-    host = entry.data[CONF_HOST]
-    port = entry.data[CONF_PORT]
-    name = entry.data[CONF_NAME]
-    encoding = entry.data[CONF_ENCODING]
-    password = entry.data[CONF_PASSWORD]
-    timeout = DEFAULT_TIMEOUT
+    conf = PJLinkConfig.from_dict(dict(entry.data))
 
     unique_id = entry.unique_id
 
@@ -49,13 +44,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry, data={**entry.data, "unique_id": unique_id}
         )
 
-    device = PJLinkDevice(host, port, name, encoding, password, timeout)
+    device = PJLinkDevice(conf)
 
     coordinator = PJLinkUpdateCoordinator(hass, device, unique_id)
 
     try:
         await coordinator.async_config_entry_first_refresh()
     except socket.timeout as exc:
+        device.async_stop()
+        raise ConfigEntryNotReady() from exc
+    except AssertionError as exc:
         device.async_stop()
         raise ConfigEntryNotReady() from exc
     except ConfigEntryNotReady:
@@ -66,6 +64,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    remove_update_listener = entry.add_update_listener(update_listener)
+
+    entry.async_on_unload(remove_update_listener)
+
     return True
 
 
@@ -73,6 +75,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Destroy a PJLink device."""
     domain_data = hass.data[DOMAIN]
 
-    domain_data.pop(entry.entry_id)
+    if entry.entry_id in domain_data:
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in PLATFORMS
+            ]
+        )
+
+        domain_data[entry.entry_id].device.async_stop()
+
+        domain_data.pop(entry.entry_id)
 
     return True
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/pjlink/__init__.py
+++ b/homeassistant/components/pjlink/__init__.py
@@ -1,1 +1,72 @@
 """The pjlink component."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (
+    CONF_ENCODING,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONFIG_ENTRY_SCHEMA,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+)
+from .coordinator import PJLinkUpdateCoordinator
+from .device import PJLinkDevice
+
+PLATFORM_SCHEMA = CONFIG_ENTRY_SCHEMA
+
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR, Platform.SENSOR]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up a PJLink device from a yaml entry (deprecated)."""
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a PJLink device from a UI config entry."""
+    domain_data = hass.data[DOMAIN]
+
+    if entry.entry_id in domain_data:
+        return True
+
+    host = entry.data[CONF_HOST]
+    port = entry.data[CONF_PORT]
+    name = entry.data[CONF_NAME]
+    encoding = entry.data[CONF_ENCODING]
+    password = entry.data[CONF_PASSWORD]
+    timeout = DEFAULT_TIMEOUT
+
+    device = PJLinkDevice(host, port, name, encoding, password, timeout)
+
+    coordinator = PJLinkUpdateCoordinator(hass, device)
+
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady:
+        device.async_stop()
+        raise
+
+    domain_data[entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Destroy a PJLink device."""
+    domain_data = hass.data[DOMAIN]
+
+    domain_data.pop(entry.entry_id)
+
+    return True

--- a/homeassistant/components/pjlink/__init__.py
+++ b/homeassistant/components/pjlink/__init__.py
@@ -1,21 +1,12 @@
 """The pjlink component."""
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_ENCODING,
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONFIG_ENTRY_SCHEMA,
-    DEFAULT_TIMEOUT,
-    DOMAIN,
-)
+from .const import CONF_ENCODING, CONFIG_ENTRY_SCHEMA, DEFAULT_TIMEOUT, DOMAIN
 from .coordinator import PJLinkUpdateCoordinator
 from .device import PJLinkDevice
 

--- a/homeassistant/components/pjlink/binary_sensor.py
+++ b/homeassistant/components/pjlink/binary_sensor.py
@@ -1,0 +1,135 @@
+"""Binary sensor entities for PJLink integration."""
+
+from typing import Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import ATTR_IS_WARNING, DOMAIN, ERROR_KEYS
+from .coordinator import PJLinkUpdateCoordinator
+from .entity import PJLinkEntity
+
+LAMP_STATE_SENSOR = BinarySensorEntityDescription(
+    key="lamp_state",
+    name="Lamp State",
+    entity_category=EntityCategory.DIAGNOSTIC,
+    device_class=BinarySensorDeviceClass.RUNNING,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up PJLink from a config entry."""
+    domain_data = hass.data[DOMAIN]
+    coordinator: PJLinkUpdateCoordinator = domain_data[entry.entry_id]
+
+    entities: list[PJLinkEntity] = []
+
+    # Create lamp entities
+    for lamp_idx in range(coordinator.device.lamp_count):
+        entities.append(
+            PJLinkLampBinarySensorEntity(coordinator=coordinator, lamp_idx=lamp_idx)
+        )
+
+    # Create error entities
+    for error_key, friendly_name in ERROR_KEYS:
+        entities.append(
+            PJLinkErrorBinarySensorEntity(
+                coordinator=coordinator,
+                error_key=error_key,
+                friendly_name=friendly_name,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class PJLinkErrorBinarySensorEntity(PJLinkEntity, BinarySensorEntity):
+    """PJLink device error state binary sensor."""
+
+    _attr_has_entity_name = True
+
+    _attr_is_warning = False
+
+    def __init__(
+        self, coordinator: PJLinkUpdateCoordinator, error_key: str, friendly_name: str
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+
+        description = BinarySensorEntityDescription(
+            key=f"{error_key}_error_state",
+            name=friendly_name,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+        )
+
+        self.error_name = error_key
+
+        self.entity_description = description
+        self._attr_name = description.name
+        self._attr_unique_id = f"{coordinator.name}_{description.key}"
+
+        self._async_update_attrs()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Handle coordinator updates."""
+        error_state = self.device.async_get_error_state(self.error_name)
+
+        self._attr_is_on = error_state != "ok"
+        self._attr_is_warning = error_state == "warning"
+
+    @property
+    def is_warning(self) -> bool:
+        """Get whether the error is a warning."""
+        return self._attr_is_warning
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Add the extra projector specific attributes."""
+        return {ATTR_IS_WARNING: self.is_warning}
+
+
+class PJLinkLampBinarySensorEntity(PJLinkEntity, BinarySensorEntity):
+    """PJLink lamp state binary sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: PJLinkUpdateCoordinator, lamp_idx: int) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+
+        description = LAMP_STATE_SENSOR
+
+        self.lamp_index = lamp_idx
+
+        self.entity_description = description
+        self._attr_name = description.name
+        self._attr_unique_id = f"{coordinator.name}_lamp_{lamp_idx}_state"
+        self._async_update_attrs()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Handle coordinator updates."""
+        self._attr_is_on = self.device.async_get_lamp_state(self.lamp_index)["state"]

--- a/homeassistant/components/pjlink/binary_sensor.py
+++ b/homeassistant/components/pjlink/binary_sensor.py
@@ -76,7 +76,7 @@ class PJLinkErrorBinarySensorEntity(PJLinkEntity, BinarySensorEntity):
 
         self.entity_description = description
         self._attr_name = description.name
-        self._attr_unique_id = f"{coordinator.name}_{description.key}"
+        self._attr_unique_id = f"{coordinator.projector_unique_id}_{description.key}"
 
         self._async_update_attrs()
 

--- a/homeassistant/components/pjlink/config_flow.py
+++ b/homeassistant/components/pjlink/config_flow.py
@@ -1,0 +1,21 @@
+"""PJLink config flow."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant import config_entries, data_entry_flow
+
+from .const import CONFIG_ENTRY_SCHEMA, DOMAIN, INTEGRATION_NAME
+
+
+class PJLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """PJLink config flow."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Create a user-configured PJLink device."""
+        if user_input is not None:
+            return self.async_create_entry(title=INTEGRATION_NAME, data=user_input)
+
+        return self.async_show_form(step_id="user", data_schema=CONFIG_ENTRY_SCHEMA)

--- a/homeassistant/components/pjlink/config_flow.py
+++ b/homeassistant/components/pjlink/config_flow.py
@@ -3,9 +3,21 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant import config_entries, data_entry_flow
+import voluptuous as vol
 
-from .const import CONFIG_ENTRY_SCHEMA, DOMAIN, INTEGRATION_NAME
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
+
+from .const import (
+    CONF_ENCODING,
+    DEFAULT_ENCODING,
+    DEFAULT_PORT,
+    DOMAIN,
+    INTEGRATION_NAME,
+)
 
 
 class PJLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -18,4 +30,57 @@ class PJLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return self.async_create_entry(title=INTEGRATION_NAME, data=user_input)
 
-        return self.async_show_form(step_id="user", data_schema=CONFIG_ENTRY_SCHEMA)
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST): cv.string,
+                    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+                    vol.Optional(CONF_NAME): cv.string,
+                    vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
+                    vol.Optional(CONF_PASSWORD): cv.string,
+                }
+            ),
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Create an options flow."""
+        return PJLinkOptionsFlowHandler(config_entry)
+
+
+class PJLinkOptionsFlowHandler(config_entries.OptionsFlow):
+    """PJLink options flow."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title=INTEGRATION_NAME, data=user_input)
+
+        options = self.config_entry.options
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=options.get(CONF_HOST)): cv.string,
+                    vol.Optional(CONF_PORT, default=options.get(CONF_PORT)): cv.port,
+                    vol.Optional(CONF_NAME, default=options.get(CONF_NAME)): cv.string,
+                    vol.Optional(
+                        CONF_ENCODING, default=options.get(CONF_ENCODING)
+                    ): cv.string,
+                    vol.Optional(
+                        CONF_PASSWORD, default=options.get(CONF_PASSWORD)
+                    ): cv.string,
+                }
+            ),
+        )

--- a/homeassistant/components/pjlink/const.py
+++ b/homeassistant/components/pjlink/const.py
@@ -4,16 +4,13 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
 import homeassistant.helpers.config_validation as cv
 
 INTEGRATION_NAME = "PJLink"
 DOMAIN = "pjlink"
 
-CONF_HOST = "host"
-CONF_PORT = "port"
-CONF_NAME = "name"
 CONF_ENCODING = "encoding"
-CONF_PASSWORD = "password"
 
 DEFAULT_PORT = 4352
 DEFAULT_ENCODING = "utf-8"

--- a/homeassistant/components/pjlink/const.py
+++ b/homeassistant/components/pjlink/const.py
@@ -1,0 +1,52 @@
+"""Const for PJLink."""
+
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+
+INTEGRATION_NAME = "PJLink"
+DOMAIN = "pjlink"
+
+CONF_HOST = "host"
+CONF_PORT = "port"
+CONF_NAME = "name"
+CONF_ENCODING = "encoding"
+CONF_PASSWORD = "password"
+
+DEFAULT_PORT = 4352
+DEFAULT_ENCODING = "utf-8"
+DEFAULT_TIMEOUT = 10
+
+UPDATE_INTERVAL = 10
+
+ERROR_KEYS = [
+    ("fan", "Fan Error"),
+    ("lamp", "Lamp Error"),
+    ("temp", "Temperature Error"),
+    ("cover", "Cover Error"),
+    ("filter", "Filter Error"),
+    ("other", "Other Error"),
+]
+
+ATTR_IS_WARNING = "is_warning"
+ATTR_PROJECTOR_STATUS = "projector_status"
+ATTR_OTHER_INFO = "other_info"
+
+ATTR_TO_PROPERTY = [
+    ATTR_PROJECTOR_STATUS,
+    ATTR_OTHER_INFO,
+]
+
+CONFIG_ENTRY_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_NAME, default=""): cv.string,
+        vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
+        vol.Optional(CONF_PASSWORD, default=""): cv.string,
+    }
+)
+
+_LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/pjlink/const.py
+++ b/homeassistant/components/pjlink/const.py
@@ -2,11 +2,6 @@
 
 import logging
 
-import voluptuous as vol
-
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
-import homeassistant.helpers.config_validation as cv
-
 INTEGRATION_NAME = "PJLink"
 DOMAIN = "pjlink"
 
@@ -35,15 +30,5 @@ ATTR_TO_PROPERTY = [
     ATTR_PROJECTOR_STATUS,
     ATTR_OTHER_INFO,
 ]
-
-CONFIG_ENTRY_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_NAME, default=""): cv.string,
-        vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
-        vol.Optional(CONF_PASSWORD, default=""): cv.string,
-    }
-)
 
 _LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/pjlink/coordinator.py
+++ b/homeassistant/components/pjlink/coordinator.py
@@ -1,0 +1,58 @@
+"""Coordinator for PJLink."""
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import _LOGGER, UPDATE_INTERVAL
+from .device import PJLinkDevice
+
+
+class PJLinkUpdateCoordinator(DataUpdateCoordinator):
+    """DataUpdateCoordinator to gather data for a specific PJLink device."""
+
+    _device_label: str
+
+    _first_metadata_run: bool = False
+
+    def __init__(self, hass: HomeAssistant, device: PJLinkDevice) -> None:
+        """Initialize the DataUpdateCoordinator."""
+        self.lock = asyncio.Lock()
+        self.device = device
+
+        self._device_label = f"{device.host}_{device.port}"
+
+        update_interval = timedelta(seconds=UPDATE_INTERVAL)
+
+        super().__init__(
+            hass, _LOGGER, name=self.device_label, update_interval=update_interval
+        )
+
+    async def _async_update_data(self) -> None:
+        """Fetch all data from the PJLink device."""
+
+        async with self.lock:
+            await self.device.async_update()
+
+    @property
+    def device_name(self) -> str:
+        """Get the projector name."""
+        return self.device.name
+
+    @property
+    def manufacturer(self) -> str | None:
+        """Get the projector manufacturer."""
+        return self.device.manufacturer
+
+    @property
+    def model(self) -> str | None:
+        """Get the projector model."""
+        return self.device.model
+
+    @property
+    def device_label(self) -> str:
+        """Get the device label."""
+        return self._device_label

--- a/homeassistant/components/pjlink/coordinator.py
+++ b/homeassistant/components/pjlink/coordinator.py
@@ -14,21 +14,26 @@ from .device import PJLinkDevice
 class PJLinkUpdateCoordinator(DataUpdateCoordinator):
     """DataUpdateCoordinator to gather data for a specific PJLink device."""
 
-    _device_label: str
+    _unique_id: str
 
     _first_metadata_run: bool = False
 
-    def __init__(self, hass: HomeAssistant, device: PJLinkDevice) -> None:
+    def __init__(
+        self, hass: HomeAssistant, device: PJLinkDevice, unique_id: str
+    ) -> None:
         """Initialize the DataUpdateCoordinator."""
         self.lock = asyncio.Lock()
         self.device = device
 
-        self._device_label = f"{device.host}_{device.port}"
+        self._unique_id = unique_id
 
         update_interval = timedelta(seconds=UPDATE_INTERVAL)
 
         super().__init__(
-            hass, _LOGGER, name=self.device_label, update_interval=update_interval
+            hass,
+            _LOGGER,
+            name=f"{device.host}:{device.port} ({device.name})",
+            update_interval=update_interval,
         )
 
     async def _async_update_data(self) -> None:
@@ -53,6 +58,6 @@ class PJLinkUpdateCoordinator(DataUpdateCoordinator):
         return self.device.model
 
     @property
-    def device_label(self) -> str:
-        """Get the device label."""
-        return self._device_label
+    def projector_unique_id(self) -> str:
+        """Get the unique id of the projector media player entity."""
+        return self._unique_id

--- a/homeassistant/components/pjlink/device.py
+++ b/homeassistant/components/pjlink/device.py
@@ -1,0 +1,211 @@
+"""PJLink projector factory."""
+from __future__ import annotations
+
+import asyncio
+
+from pypjlink import Projector
+from pypjlink.projector import ProjectorError
+
+from .util import LampStateType, format_input_source
+
+
+class PJLinkDevice:
+    """PJLink projector factory."""
+
+    _name: str
+    _encoding: str
+    _timeout: int
+    _power_state: str | None = None
+    _muted: bool = False
+    _lamp_states: list[LampStateType]
+    _error_dict: dict[str, str]
+    _other_info: str
+    _current_source: str | None
+    _source_list: list[str] | None = None
+    _source_name_mapping: dict[str, tuple[str, int]]
+
+    _manufacturer: str | None = None
+    _model: str | None = None
+
+    _lock: asyncio.Lock
+
+    _first_metadata_run: bool = False
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        name: str,
+        encoding: str,
+        password: str,
+        timeout: int,
+    ) -> None:
+        """Initialize a PJLink projector factory."""
+        self.host = host
+        self.port = port
+
+        self._name = name
+        self._encoding = encoding
+        self._timeout = timeout
+
+        self._lock = asyncio.Lock()
+
+        self.__password = password
+
+        self._error_dict = {}
+        self._source_name_mapping = {}
+
+    def get_projector(self) -> Projector:
+        """Create PJLink Projector instance."""
+        projector = Projector.from_address(
+            self.host, self.port, self.encoding, self.timeout
+        )
+
+        projector.authenticate(self.__password)
+
+        return projector
+
+    def async_get_state(self) -> str | None:
+        """Get the current power state."""
+        return self._power_state
+
+    def async_get_muted(self) -> bool:
+        """Get the current volume mute state."""
+        return self._muted
+
+    def async_get_other_info(self) -> str:
+        """Get other info reported by the projector."""
+        return self._other_info
+
+    def async_get_error_state(self, error_key: str) -> str:
+        """Get the error state for a given error type."""
+        return self._error_dict[error_key]
+
+    def async_get_lamp_state(self, lamp_idx: int) -> LampStateType:
+        """Get the lamp state for a given lamp index."""
+        return self._lamp_states[lamp_idx]
+
+    def async_get_current_source(self) -> str | None:
+        """Get the current source."""
+        return self._current_source
+
+    def get_source_for_name(self, name: str) -> tuple[str, int]:
+        """Get the projector source name for a given friendly name."""
+        return self._source_name_mapping[name]
+
+    async def async_update(self) -> None:
+        """Update all polled parameters."""
+        async with self._lock:
+            with self.get_projector() as projector:
+                pwstate = projector.get_power()
+
+                self._power_state = pwstate
+
+                if pwstate in ("on", "warm-up"):
+                    self._muted = projector.get_mute()[1]
+                    self._current_source = format_input_source(*projector.get_input())
+                else:
+                    self._muted = False
+                    self._current_source = None
+
+                if not self._first_metadata_run or pwstate == "on":
+                    # Try and update metadata; some projectors won't report data if they're not on.
+                    self._update_metadata(projector)
+
+                # Lamp hours
+                try:
+                    lamp_states: list[LampStateType] = []
+
+                    for lamp_hours, lamp_state in projector.get_lamps():
+                        lamp_states.append({"state": lamp_state, "hours": lamp_hours})
+
+                    self._lamp_states = lamp_states
+                except ProjectorError:
+                    pass
+
+                # Errors
+                try:
+                    errors = projector.get_errors()
+
+                    for key, value in errors.items():
+                        if key == "temperature":
+                            key = "temp"
+
+                        self._error_dict[key] = value
+                except ProjectorError:
+                    pass
+
+                # Get other info
+                try:
+                    self._other_info = projector.get_other_info()
+                except ProjectorError:
+                    pass
+
+    def _update_metadata(self, projector: Projector) -> None:
+        """Update metadata for the projector, skipping cached values."""
+        self._first_metadata_run = True
+
+        if not self._name:
+            try:
+                self._name = projector.get_name()
+            except ProjectorError:
+                pass
+
+        if not self._manufacturer:
+            try:
+                self._manufacturer = projector.get_manufacturer()
+            except ProjectorError:
+                pass
+
+        if not self._model:
+            try:
+                self._model = projector.get_product_name()
+            except ProjectorError:
+                pass
+
+        if not self._source_list:
+            try:
+                inputs = projector.get_inputs()
+
+                self._source_name_mapping = {format_input_source(*x): x for x in inputs}
+                self._source_list = sorted(self._source_name_mapping.keys())
+            except ProjectorError:
+                pass
+
+    def async_stop(self) -> None:
+        """Destroy the device."""
+
+    @property
+    def manufacturer(self) -> str | None:
+        """Get the projector manufacturer."""
+        return self._manufacturer
+
+    @property
+    def model(self) -> str | None:
+        """Get the projector model."""
+        return self._model
+
+    @property
+    def name(self) -> str:
+        """Get the projector name."""
+        return self._name
+
+    @property
+    def encoding(self) -> str:
+        """Get the projector encoding."""
+        return self._encoding
+
+    @property
+    def timeout(self) -> int:
+        """Get the timeout for the projector."""
+        return self._timeout
+
+    @property
+    def source_list(self) -> list[str] | None:
+        """Get the projector sources."""
+        return self._source_list
+
+    @property
+    def lamp_count(self) -> int:
+        """Get the count of lamps in the projector."""
+        return len(self._lamp_states)

--- a/homeassistant/components/pjlink/device.py
+++ b/homeassistant/components/pjlink/device.py
@@ -6,7 +6,7 @@ import asyncio
 from pypjlink import Projector
 from pypjlink.projector import ProjectorError
 
-from .util import LampStateType, format_input_source
+from .util import LampStateType, PJLinkConfig, format_input_source
 
 
 class PJLinkDevice:
@@ -31,26 +31,18 @@ class PJLinkDevice:
 
     _first_metadata_run: bool = False
 
-    def __init__(
-        self,
-        host: str,
-        port: int,
-        name: str,
-        encoding: str,
-        password: str,
-        timeout: int,
-    ) -> None:
+    def __init__(self, conf: PJLinkConfig) -> None:
         """Initialize a PJLink projector factory."""
-        self.host = host
-        self.port = port
+        self.host = conf.host
+        self.port = conf.port
 
-        self._name = name
-        self._encoding = encoding
-        self._timeout = timeout
+        self._name = conf.name
+        self._encoding = conf.encoding
+        self._timeout = conf.timeout
 
         self._lock = asyncio.Lock()
 
-        self.__password = password
+        self.__password = conf.password
 
         self._error_dict = {}
         self._source_name_mapping = {}

--- a/homeassistant/components/pjlink/entity.py
+++ b/homeassistant/components/pjlink/entity.py
@@ -1,0 +1,32 @@
+"""Support for PJLink projectors."""
+
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PJLinkUpdateCoordinator
+from .device import PJLinkDevice
+
+
+class PJLinkEntity(CoordinatorEntity[PJLinkUpdateCoordinator]):
+    """Representation of a PJLink entity with a coordinator."""
+
+    _device: PJLinkDevice
+
+    def __init__(self, coordinator: PJLinkUpdateCoordinator) -> None:
+        """Initialize the projector."""
+        super().__init__(coordinator)
+
+        self._device = coordinator.device
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.device_label)},
+            manufacturer=coordinator.manufacturer,
+            model=coordinator.model,
+            name=self.device.name,
+            configuration_url=f"http://{coordinator.device.host}/",
+        )
+
+    @property
+    def device(self) -> PJLinkDevice:
+        """Get the device."""
+        return self._device

--- a/homeassistant/components/pjlink/entity.py
+++ b/homeassistant/components/pjlink/entity.py
@@ -19,11 +19,12 @@ class PJLinkEntity(CoordinatorEntity[PJLinkUpdateCoordinator]):
 
         self._device = coordinator.device
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.device_label)},
+            identifiers={(DOMAIN, coordinator.projector_unique_id)},
             manufacturer=coordinator.manufacturer,
             model=coordinator.model,
             name=self.device.name,
             configuration_url=f"http://{coordinator.device.host}/",
+            via_device=(DOMAIN, coordinator.projector_unique_id),
         )
 
     @property

--- a/homeassistant/components/pjlink/manifest.json
+++ b/homeassistant/components/pjlink/manifest.json
@@ -5,5 +5,6 @@
   "requirements": ["pypjlink2==1.2.1"],
   "codeowners": [],
   "iot_class": "local_polling",
-  "loggers": ["pypjlink"]
+  "loggers": ["pypjlink"],
+  "config_flow": true
 }

--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -1,102 +1,51 @@
 """Support for controlling projector via the PJLink protocol."""
+
 from __future__ import annotations
 
-from pypjlink import MUTE_AUDIO, Projector
-from pypjlink.projector import ProjectorError
-import voluptuous as vol
+from typing import Any
+
+from pypjlink import MUTE_AUDIO
 
 from homeassistant.components.media_player import (
-    PLATFORM_SCHEMA,
+    MediaPlayerDeviceClass,
     MediaPlayerEntity,
+    MediaPlayerEntityDescription,
     MediaPlayerEntityFeature,
     MediaPlayerState,
 )
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
-from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
+
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-CONF_ENCODING = "encoding"
+from .const import ATTR_TO_PROPERTY, DOMAIN
+from .coordinator import PJLinkUpdateCoordinator
+from .entity import PJLinkEntity
 
-DEFAULT_PORT = 4352
-DEFAULT_ENCODING = "utf-8"
-DEFAULT_TIMEOUT = 10
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
-        vol.Optional(CONF_PASSWORD): cv.string,
-    }
+PJLINK_MEDIA_PLAYER = MediaPlayerEntityDescription(
+    key="projector",
+    entity_category=entity.EntityCategory.CONFIG,
+    device_class=MediaPlayerDeviceClass.TV,
 )
 
-ATTR_PROJECTOR_STATUS = "projector_status"
-ATTR_LAMP_STATUS = "lamp_status"
-ATTR_FAN_ERROR = "fan_error"
-ATTR_LAMP_ERROR = "lamp_error"
-ATTR_TEMP_ERROR = "temp_error"
-ATTR_COVER_ERROR = "cover_error"
-ATTR_FILTER_ERROR = "filter_error"
-ATTR_OTHER_ERROR = "other_error"
-ATTR_MANUFACTURER = "manufacturer"
-ATTR_PRODUCT_NAME = "product_name"
-ATTR_OTHER_INFO = "other_info"
-ATTR_HAS_ERROR = "has_error"
 
-ATTR_TO_PROPERTY = [
-    ATTR_PROJECTOR_STATUS,
-    ATTR_LAMP_STATUS,
-    ATTR_FAN_ERROR,
-    ATTR_LAMP_ERROR,
-    ATTR_TEMP_ERROR,
-    ATTR_COVER_ERROR,
-    ATTR_FILTER_ERROR,
-    ATTR_OTHER_ERROR,
-    ATTR_MANUFACTURER,
-    ATTR_OTHER_INFO,
-    ATTR_HAS_ERROR,
-]
-
-
-def setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the PJLink platform."""
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    name = config.get(CONF_NAME)
-    encoding = config.get(CONF_ENCODING)
-    password = config.get(CONF_PASSWORD)
+    """Set up PJLink from a config entry."""
+    domain_data = hass.data[DOMAIN]
+    coordinator: PJLinkUpdateCoordinator = domain_data[entry.entry_id]
 
-    if "pjlink" not in hass.data:
-        hass.data["pjlink"] = {}
-
-    hass_data = hass.data["pjlink"]
-
-    device_label = f"{host}:{port}"
-
-    if device_label in hass_data:
-        return
-
-    device = PjLinkDevice(host, port, name, encoding, password)
-    hass_data[device_label] = device
-    add_entities([device], True)
+    async_add_entities([PJLinkMediaPlayerEntity(coordinator=coordinator)])
 
 
-def format_input_source(input_source_name, input_source_number):
-    """Format input source for display in UI."""
-    return f"{input_source_name} {input_source_number}"
-
-
-class PjLinkDevice(MediaPlayerEntity):
+class PJLinkMediaPlayerEntity(PJLinkEntity, MediaPlayerEntity):
     """Representation of a PJLink device."""
 
+    _attr_has_entity_name = True
     _attr_supported_features = (
         MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.TURN_ON
@@ -104,204 +53,60 @@ class PjLinkDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.SELECT_SOURCE
     )
 
-    def __init__(self, host, port, name, encoding, password):
+    _attr_projector_state: str | None = None
+    _attr_other_info: str | None = None
+
+    def __init__(self, coordinator: PJLinkUpdateCoordinator) -> None:
         """Initialize the PJLink device."""
-        self._host = host
-        self._port = port
-        self._name = name
-        self._password = password
-        self._encoding = encoding
-        self._muted = False
-        self._pwstate = MediaPlayerState.OFF
-        self._current_source = None
-        self._source_name_mapping = None
-        self._source_list = None
+        super().__init__(coordinator)
 
-        # Other projector data.
-        self._raw_pwstate = "off"
-        self._lamp_status = []
-        self._fan_error = None
-        self._lamp_error = None
-        self._temp_error = None
-        self._cover_error = None
-        self._filter_error = None
-        self._other_error = None
-        self._manufacturer = None
-        self._product_name = None
-        self._other_info = None
-        self._has_error = False
+        self.entity_description = PJLINK_MEDIA_PLAYER
+        self._attr_name = self.device.name
 
-        with self.projector() as projector:
-            self.update_metadata(projector)
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
 
-    def update_metadata(self, projector):
-        """Update projector metadata if metadata hasn't been set."""
-        if not self._name:
-            try:
-                self._name = projector.get_name()
-            except ProjectorError:
-                pass
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Handle coordinator updates."""
 
-        if not self._manufacturer:
-            try:
-                self._manufacturer = projector.get_manufacturer()
-            except ProjectorError:
-                pass
+        pwstate = self.device.async_get_state()
 
-        if not self._product_name:
-            try:
-                self._product_name = projector.get_product_name()
-            except ProjectorError:
-                pass
+        self._attr_state = STATE_ON if pwstate in ("on", "warm-up") else STATE_OFF
+        self._attr_is_volume_muted = self.device.async_get_muted()
+        self._attr_source = self.device.async_get_current_source()
+        self._attr_source_list = self.device.source_list
 
-        if not self._source_list:
-            try:
-                inputs = projector.get_inputs()
-
-                self._source_name_mapping = {format_input_source(*x): x for x in inputs}
-                self._source_list = sorted(self._source_name_mapping.keys())
-            except ProjectorError:
-                pass
-
-    def projector(self):
-        """Create PJLink Projector instance."""
-        projector = Projector.from_address(
-            self._host, self._port, self._encoding, DEFAULT_TIMEOUT
-        )
-
-        projector.authenticate(self._password)
-
-        return projector
-
-    def update(self) -> None:
-        """Get the latest state from the device."""
-        with self.projector() as projector:
-            try:
-                pwstate = projector.get_power()
-
-                self._raw_pwstate = pwstate
-
-                if pwstate in ("on", "warm-up"):
-                    self._pwstate = MediaPlayerState.ON
-                    self._muted = projector.get_mute()[1]
-                    self._current_source = format_input_source(*projector.get_input())
-                else:
-                    self._pwstate = MediaPlayerState.OFF
-                    self._muted = False
-                    self._current_source = None
-            except KeyError as err:
-                if str(err) == "'OK'":
-                    self._pwstate = MediaPlayerState.OFF
-                    self._muted = False
-                    self._current_source = None
-                else:
-                    raise
-            except ProjectorError as err:
-                if str(err) == "unavailable time":
-                    self._pwstate = MediaPlayerState.OFF
-                    self._muted = False
-                    self._current_source = None
-                else:
-                    raise
-
-            if self._raw_pwstate == "on":
-                # Try and update metadata; some projectors won't report data if they're not on.
-                self.update_metadata(projector)
-
-            try:
-                lamps_state = []
-
-                for lamp_hours, lamp_state in projector.get_lamps():
-                    lamps_state.append(
-                        {
-                            "hours": lamp_hours,
-                            "state": "on" if lamp_state else "off",
-                        }
-                    )
-
-                self._lamp_status = lamps_state
-            except ProjectorError:
-                pass
-
-            try:
-                # Get errors.
-                errors = projector.get_errors()
-
-                # Keep track of any errors.
-                self._has_error = False
-
-                for key, value in errors.items():
-                    if key == "temperature":
-                        key = "temp"
-
-                    # Clear error if error is "ok".
-                    if value == "ok":
-                        value = None
-                    else:
-                        self._has_error = True
-
-                    # Ignore unsupported errors - none at the time of writing.
-                    try:
-                        setattr(self, f"_{key}_error", value)
-                    except AttributeError:
-                        pass
-            except ProjectorError:
-                pass
-
-            # Get other info.
-            try:
-                self._other_info = projector.get_other_info()
-            except ProjectorError:
-                pass
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._pwstate
-
-    @property
-    def is_volume_muted(self):
-        """Return boolean indicating mute status."""
-        return self._muted
-
-    @property
-    def source(self):
-        """Return current input source."""
-        return self._current_source
-
-    @property
-    def source_list(self):
-        """Return all available input sources."""
-        return self._source_list
+        self._attr_projector_state = pwstate
+        self._attr_other_info = self.device.async_get_other_info()
 
     def turn_off(self) -> None:
         """Turn projector off."""
-        with self.projector() as projector:
+        with self.device.get_projector() as projector:
             projector.set_power("off")
 
     def turn_on(self) -> None:
         """Turn projector on."""
-        with self.projector() as projector:
+        with self.device.get_projector() as projector:
             projector.set_power("on")
 
     def mute_volume(self, mute: bool) -> None:
         """Mute (true) of unmute (false) media player."""
-        with self.projector() as projector:
+        with self.device.get_projector() as projector:
             projector.set_mute(MUTE_AUDIO, mute)
 
     def select_source(self, source: str) -> None:
         """Set the input source."""
-        source = self._source_name_mapping[source]
-        with self.projector() as projector:
-            projector.set_input(*source)
+        proj_source = self.device.get_source_for_name(source)
+
+        with self.device.get_projector() as projector:
+            projector.set_input(*proj_source)
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Add the extra projector specific attributes."""
         state_attr = {}
 
@@ -312,61 +117,11 @@ class PjLinkDevice(MediaPlayerEntity):
         return state_attr
 
     @property
-    def projector_status(self):
+    def projector_status(self) -> str | None:
         """Return the warming/on/cooling/off state of the device."""
-        return self._raw_pwstate
+        return self._attr_projector_state
 
     @property
-    def lamp_status(self):
-        """Return the lamp status of the device."""
-        return self._lamp_status
-
-    @property
-    def fan_error(self):
-        """Return the fan error, if any."""
-        return self._fan_error
-
-    @property
-    def lamp_error(self):
-        """Return the lamp error, if any."""
-        return self._lamp_error
-
-    @property
-    def temp_error(self):
-        """Return the temperature error, if any."""
-        return self._temp_error
-
-    @property
-    def cover_error(self):
-        """Return the cover error, if any."""
-        return self._cover_error
-
-    @property
-    def filter_error(self):
-        """Return the filter error, if any."""
-        return self._filter_error
-
-    @property
-    def other_error(self):
-        """Return the lamp error, if any."""
-        return self._other_error
-
-    @property
-    def manufacturer(self):
-        """Return the manufacturer."""
-        return self._manufacturer
-
-    @property
-    def product_name(self):
-        """Return the product name."""
-        return self._product_name
-
-    @property
-    def other_info(self):
+    def other_info(self) -> str | None:
         """Return other information."""
-        return self._other_info
-
-    @property
-    def has_error(self):
-        """Return whether any errors are set."""
-        return self._has_error
+        return self._attr_other_info

--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -59,6 +59,7 @@ class PJLinkMediaPlayerEntity(PJLinkEntity, MediaPlayerEntity):
 
         self.entity_description = PJLINK_MEDIA_PLAYER
         self._attr_name = self.device.name
+        self._attr_unique_id = coordinator.projector_unique_id
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -11,14 +11,11 @@ from homeassistant.components.media_player import (
     MediaPlayerEntity,
     MediaPlayerEntityDescription,
     MediaPlayerEntityFeature,
-    MediaPlayerState,
 )
-
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ATTR_TO_PROPERTY, DOMAIN
@@ -27,7 +24,7 @@ from .entity import PJLinkEntity
 
 PJLINK_MEDIA_PLAYER = MediaPlayerEntityDescription(
     key="projector",
-    entity_category=entity.EntityCategory.CONFIG,
+    entity_category=EntityCategory.CONFIG,
     device_class=MediaPlayerDeviceClass.TV,
 )
 

--- a/homeassistant/components/pjlink/sensor.py
+++ b/homeassistant/components/pjlink/sensor.py
@@ -1,0 +1,73 @@
+"""Sensor entities for PJLink integration."""
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import PJLinkUpdateCoordinator
+from .entity import PJLinkEntity
+
+LAMP_HOURS_SENSOR = SensorEntityDescription(
+    key="lamp_hours",
+    name="Lamp Hours",
+    entity_category=EntityCategory.DIAGNOSTIC,
+    device_class=SensorDeviceClass.DURATION,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up PJLink from a config entry."""
+    domain_data = hass.data[DOMAIN]
+    coordinator: PJLinkUpdateCoordinator = domain_data[entry.entry_id]
+
+    entities: list[PJLinkEntity] = []
+
+    # Create lamp entities
+    for lamp_idx in range(coordinator.device.lamp_count):
+        entities.append(
+            PJLinkLampHoursSensorEntity(coordinator=coordinator, lamp_idx=lamp_idx)
+        )
+
+    async_add_entities(entities)
+
+
+class PJLinkLampHoursSensorEntity(PJLinkEntity, SensorEntity):
+    """PJLink lamp hours state sensor."""
+
+    _attr_has_entity_name = True
+    _attr_native_unit_of_measurement = "hours"
+
+    def __init__(self, coordinator: PJLinkUpdateCoordinator, lamp_idx: int) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+
+        description = LAMP_HOURS_SENSOR
+
+        self.lamp_index = lamp_idx
+
+        self.entity_description = description
+        self._attr_name = description.name
+        self._attr_unique_id = f"{coordinator.name}_lamp_{lamp_idx}_hours"
+        self._async_update_attrs()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Handle coordinator updates."""
+        self._attr_native_value = self.device.async_get_lamp_state(self.lamp_index)[
+            "hours"
+        ]

--- a/homeassistant/components/pjlink/sensor.py
+++ b/homeassistant/components/pjlink/sensor.py
@@ -56,7 +56,9 @@ class PJLinkLampHoursSensorEntity(PJLinkEntity, SensorEntity):
 
         self.entity_description = description
         self._attr_name = description.name
-        self._attr_unique_id = f"{coordinator.name}_lamp_{lamp_idx}_hours"
+        self._attr_unique_id = (
+            f"{coordinator.projector_unique_id}_lamp_{lamp_idx}_hours"
+        )
         self._async_update_attrs()
 
     @callback

--- a/homeassistant/components/pjlink/translations/en.json
+++ b/homeassistant/components/pjlink/translations/en.json
@@ -16,5 +16,23 @@
                 "description": "Configure a PJLink projector for use with Home Assistant."
             }
         }
+    },
+    "options": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "flow_title": "PJLink: {name}",
+        "step": {
+            "init": {
+                "data": {
+                    "encoding": "Encoding",
+                    "host": "Host",
+                    "name": "Name",
+                    "password": "Password",
+                    "port": "Port"
+                },
+                "description": "Configure a PJLink projector for use with Home Assistant."
+            }
+        }
     }
 }

--- a/homeassistant/components/pjlink/translations/en.json
+++ b/homeassistant/components/pjlink/translations/en.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "flow_title": "PJLink: {name}",
+        "step": {
+            "user": {
+                "data": {
+                    "encoding": "Encoding",
+                    "host": "Host",
+                    "name": "Name",
+                    "password": "Password",
+                    "port": "Port"
+                },
+                "description": "Configure a PJLink projector for use with Home Assistant."
+            }
+        }
+    }
+}

--- a/homeassistant/components/pjlink/util.py
+++ b/homeassistant/components/pjlink/util.py
@@ -1,6 +1,10 @@
 """Common PJLink utilities and types."""
 
-from typing import TypedDict
+from typing import Any, NamedTuple, TypedDict
+
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
+
+from .const import CONF_ENCODING, DEFAULT_TIMEOUT
 
 
 def format_input_source(input_source_name: str, input_source_number: int) -> str:
@@ -13,3 +17,26 @@ class LampStateType(TypedDict):
 
     state: bool
     hours: int
+
+
+class PJLinkConfig(NamedTuple):
+    """Configuration options for a PJLink device."""
+
+    host: str
+    port: int
+    name: str
+    encoding: str
+    password: str
+    timeout: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PJLinkConfig":
+        """Create a PJLinkConfig from a dictionary."""
+        return cls(
+            data[CONF_HOST],
+            data[CONF_PORT],
+            data[CONF_NAME],
+            data[CONF_ENCODING],
+            data[CONF_PASSWORD],
+            DEFAULT_TIMEOUT,
+        )

--- a/homeassistant/components/pjlink/util.py
+++ b/homeassistant/components/pjlink/util.py
@@ -1,0 +1,15 @@
+"""Common PJLink utilities and types."""
+
+from typing import TypedDict
+
+
+def format_input_source(input_source_name: str, input_source_number: int) -> str:
+    """Format input source for display in UI."""
+    return f"{input_source_name} {input_source_number}"
+
+
+class LampStateType(TypedDict):
+    """Lamp state typed definition."""
+
+    state: bool
+    hours: int

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -289,6 +289,7 @@ FLOWS = {
         "philips_js",
         "pi_hole",
         "picnic",
+        "pjlink",
         "plaato",
         "plex",
         "plugwise",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3249,7 +3249,7 @@
       "name": "Pioneer"
     },
     "pjlink": {
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling",
       "name": "PJLink"
     },

--- a/mypy.ini
+++ b/mypy.ini
@@ -1769,7 +1769,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1762,6 +1762,17 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.pjlink.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.powerwall.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/tests/components/pjlink/__init__.py
+++ b/tests/components/pjlink/__init__.py
@@ -1,0 +1,1 @@
+"""PJLink unit testing."""

--- a/tests/components/pjlink/test_config_flow.py
+++ b/tests/components/pjlink/test_config_flow.py
@@ -95,6 +95,6 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     }
 
     registry = entity_registry.async_get(hass)
-    entry = registry.async_get("media_player.test_projector")
+    entry = registry.async_get("media_player.test_projector_test_projector")
 
     assert entry.unique_id == entry.config_entry_id

--- a/tests/components/pjlink/test_config_flow.py
+++ b/tests/components/pjlink/test_config_flow.py
@@ -1,0 +1,100 @@
+"""PJLink unit testing for config flow."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, Mock, patch
+
+from pypjlink import Projector
+
+from homeassistant.components.pjlink.const import (
+    CONF_ENCODING,
+    DEFAULT_ENCODING,
+    DOMAIN,
+    INTEGRATION_NAME,
+)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry
+
+
+def mock_projector() -> Projector:
+    """Create a mock projector."""
+
+    # Create projector class, f is a socket file-descriptor.
+    proj = Projector(f=MagicMock(), encoding="utf-8")
+
+    proj.authenticate = Mock()
+
+    # Metadata
+    proj.get_name = Mock(return_value="PJLink Test Name")
+    proj.get_product_name = Mock(return_value="PJLink Test Model")
+    proj.get_manufacturer = Mock(return_value="PJLink Test Manufacturer")
+
+    # Control methods
+    proj.get_inputs = Mock(return_value=[("DIGITAL", 1), ("RGB", 1), ("VIDEO", 1)])
+    proj.get_input = Mock(return_value=("DIGITAL", 1))
+    proj.set_input = Mock()
+
+    proj.get_power = Mock(return_value="off")
+    proj.set_power = Mock()
+
+    proj.get_mute = Mock(return_value=(True, False))
+    proj.set_mute = Mock()
+
+    # Status information
+    proj.get_lamps = Mock(return_value=[(1376, True), (1375, True)])
+    proj.get_other_info = Mock(return_value="Version 1.0")
+    proj.get_errors = Mock(
+        return_value={
+            "fan": "ok",
+            "lamp": "ok",
+            "temperature": "ok",
+            "cover": "ok",
+            "filter": "ok",
+            "other": "ok",
+        }
+    )
+
+    return proj
+
+
+async def test_full_user_flow(hass: HomeAssistant) -> None:
+    """Test the user configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
+
+    mock_user_input_data = {
+        CONF_HOST: "127.0.0.1",
+        CONF_PORT: 1234,
+        CONF_NAME: "test projector",
+        CONF_PASSWORD: "",
+    }
+
+    with patch.object(
+        Projector, "from_address", timeout=True, return_value=mock_projector()
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=mock_user_input_data
+        )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    assert result.get("title") == INTEGRATION_NAME
+
+    assert result.get("data") == {
+        CONF_ENCODING: DEFAULT_ENCODING,
+        CONF_HOST: mock_user_input_data[CONF_HOST],
+        CONF_PORT: mock_user_input_data[CONF_PORT],
+        CONF_NAME: mock_user_input_data[CONF_NAME],
+        CONF_PASSWORD: mock_user_input_data[CONF_PASSWORD],
+    }
+
+    registry = entity_registry.async_get(hass)
+    entry = registry.async_get("media_player.test_projector")
+
+    assert entry.unique_id == entry.config_entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exposes extra data from projectors such as lamp hours and warning/error states as new entities on a projector device, and moves the media_player entity under the device.

Also removes the ability for the integration to be configured via YAML and adds a config and options flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [#24468](https://github.com/home-assistant/home-assistant.io/pull/24468)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
