### PR TITLE
Log not allowed attributes only once in BMW binary sensors

### DIFF
--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -37,10 +37,10 @@ ALLOWED_CONDITION_BASED_SERVICE_KEYS = {
     "VEHICLE_CHECK",
     "VEHICLE_TUV",
 }
-LOGGED_CONDITION_BASED_SERVICE_WARINGS = set()
+LOGGED_CONDITION_BASED_SERVICE_WARNINGS = set()
 
 ALLOWED_CHECK_CONTROL_MESSAGE_KEYS = {"ENGINE_OIL", "TIRE_PRESSURE"}
-LOGGED_CHECK_CONTROL_MESSAGE_WARINGS = set()
+LOGGED_CHECK_CONTROL_MESSAGE_WARNINGS = set()
 
 
 def _condition_based_services(
@@ -50,14 +50,14 @@ def _condition_based_services(
     for report in vehicle.condition_based_services.messages:
         if (
             report.service_type not in ALLOWED_CONDITION_BASED_SERVICE_KEYS
-            and report.service_type not in LOGGED_CONDITION_BASED_SERVICE_WARINGS
+            and report.service_type not in LOGGED_CONDITION_BASED_SERVICE_WARNINGS
         ):
             _LOGGER.warning(
                 "'%s' not an allowed condition based service (%s)",
                 report.service_type,
                 report,
             )
-            LOGGED_CONDITION_BASED_SERVICE_WARINGS.add(report.service_type)
+            LOGGED_CONDITION_BASED_SERVICE_WARNINGS.add(report.service_type)
             continue
 
         extra_attributes.update(_format_cbs_report(report, unit_system))
@@ -69,14 +69,14 @@ def _check_control_messages(vehicle: MyBMWVehicle) -> dict[str, Any]:
     for message in vehicle.check_control_messages.messages:
         if (
             message.description_short not in ALLOWED_CHECK_CONTROL_MESSAGE_KEYS
-            and message.description_short not in LOGGED_CHECK_CONTROL_MESSAGE_WARINGS
+            and message.description_short not in LOGGED_CHECK_CONTROL_MESSAGE_WARNINGS
         ):
             _LOGGER.warning(
                 "'%s' not an allowed check control message (%s)",
                 message.description_short,
                 message,
             )
-            LOGGED_CHECK_CONTROL_MESSAGE_WARINGS.add(message.description_short)
+            LOGGED_CHECK_CONTROL_MESSAGE_WARNINGS.add(message.description_short)
             continue
 
         extra_attributes[message.description_short.lower()] = message.state.value

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -37,8 +37,10 @@ ALLOWED_CONDITION_BASED_SERVICE_KEYS = {
     "VEHICLE_CHECK",
     "VEHICLE_TUV",
 }
+LOGGED_CONDITION_BASED_SERVICE_WARINGS = set()
 
 ALLOWED_CHECK_CONTROL_MESSAGE_KEYS = {"ENGINE_OIL", "TIRE_PRESSURE"}
+LOGGED_CHECK_CONTROL_MESSAGE_WARINGS = set()
 
 
 def _condition_based_services(
@@ -46,12 +48,16 @@ def _condition_based_services(
 ) -> dict[str, Any]:
     extra_attributes = {}
     for report in vehicle.condition_based_services.messages:
-        if report.service_type not in ALLOWED_CONDITION_BASED_SERVICE_KEYS:
+        if (
+            report.service_type not in ALLOWED_CONDITION_BASED_SERVICE_KEYS
+            and report.service_type not in LOGGED_CONDITION_BASED_SERVICE_WARINGS
+        ):
             _LOGGER.warning(
                 "'%s' not an allowed condition based service (%s)",
                 report.service_type,
                 report,
             )
+            LOGGED_CONDITION_BASED_SERVICE_WARINGS.add(report.service_type)
             continue
 
         extra_attributes.update(_format_cbs_report(report, unit_system))
@@ -61,17 +67,19 @@ def _condition_based_services(
 def _check_control_messages(vehicle: MyBMWVehicle) -> dict[str, Any]:
     extra_attributes: dict[str, Any] = {}
     for message in vehicle.check_control_messages.messages:
-        if message.description_short not in ALLOWED_CHECK_CONTROL_MESSAGE_KEYS:
+        if (
+            message.description_short not in ALLOWED_CHECK_CONTROL_MESSAGE_KEYS
+            and message.description_short not in LOGGED_CHECK_CONTROL_MESSAGE_WARINGS
+        ):
             _LOGGER.warning(
                 "'%s' not an allowed check control message (%s)",
                 message.description_short,
                 message,
             )
+            LOGGED_CHECK_CONTROL_MESSAGE_WARINGS.add(message.description_short)
             continue
 
-        extra_attributes.update(
-            {message.description_short.lower(): message.state.value}
-        )
+        extra_attributes[message.description_short.lower()] = message.state.value
     return extra_attributes
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on #76663, logged warnings on previously unseen attribute keys will now occur only once.
It cannot be done on initialization, because new states can always appear during normal updates, so we have to keep track on which errors we have logged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
