### PR TITLE
Fix implicit Optional [p-s]

### DIFF
--- a/homeassistant/components/plaato/config_flow.py
+++ b/homeassistant/components/plaato/config_flow.py
@@ -127,7 +127,7 @@ class PlaatoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _show_api_method_form(
-        self, device_type: PlaatoDeviceType, errors: dict = None
+        self, device_type: PlaatoDeviceType, errors: dict | None = None
     ):
         data_schema = vol.Schema({vol.Optional(CONF_TOKEN, default=""): str})
 

--- a/homeassistant/components/sia/config_flow.py
+++ b/homeassistant/components/sia/config_flow.py
@@ -105,7 +105,9 @@ class SIAConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._data: dict[str, Any] = {}
         self._options: Mapping[str, Any] = {CONF_ACCOUNTS: {}}
 
-    async def async_step_user(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle the initial user step."""
         errors: dict[str, str] | None = None
         if user_input is not None:
@@ -117,7 +119,7 @@ class SIAConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_handle_data_and_route(user_input)
 
     async def async_step_add_account(
-        self, user_input: dict[str, Any] = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the additional accounts steps."""
         errors: dict[str, str] | None = None
@@ -179,7 +181,9 @@ class SIAOptionsFlowHandler(config_entries.OptionsFlow):
         self.hub: SIAHub | None = None
         self.accounts_todo: list = []
 
-    async def async_step_init(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Manage the SIA options."""
         self.hub = self.hass.data[DOMAIN][self.config_entry.entry_id]
         assert self.hub is not None
@@ -187,7 +191,9 @@ class SIAOptionsFlowHandler(config_entries.OptionsFlow):
         self.accounts_todo = [a.account_id for a in self.hub.sia_accounts]
         return await self.async_step_options()
 
-    async def async_step_options(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_options(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Create the options step for a account."""
         errors: dict[str, str] | None = None
         if user_input is not None:

--- a/homeassistant/components/sia/hub.py
+++ b/homeassistant/components/sia/hub.py
@@ -68,7 +68,7 @@ class SIAHub:
             self._hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, self.async_shutdown)
         )
 
-    async def async_shutdown(self, _: Event = None) -> None:
+    async def async_shutdown(self, _: Event | None = None) -> None:
         """Shutdown the SIA server."""
         await self.sia_client.stop()
 

--- a/homeassistant/components/solax/config_flow.py
+++ b/homeassistant/components/solax/config_flow.py
@@ -1,4 +1,6 @@
 """Config flow for solax integration."""
+from __future__ import annotations
+
 import logging
 from typing import Any
 
@@ -40,7 +42,9 @@ async def validate_api(data) -> str:
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Solax."""
 
-    async def async_step_user(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle the initial step."""
         errors: dict[str, Any] = {}
         if user_input is None:

--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -94,7 +94,9 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_confirm(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Confirm a single device."""
         assert self._discovered_adv is not None
         if user_input is not None:


### PR DESCRIPTION
## Proposed change
Mypy will soon make `no_implicit_optional` the default behavior. Currently, it's only applied together with `strict` typing.
This PR updates existing integrations to mention `None` explicitly. Once done, I'll open a follow up PR to set `no_implicit_optional` for all files.

```diff
def f(
-    var: int = None
+    var: int | None = None
) -> None:
    ...
```

See:
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
