### PR TITLE
Fix implicit Optional [t-z]

### DIFF
--- a/homeassistant/components/tomorrowio/config_flow.py
+++ b/homeassistant/components/tomorrowio/config_flow.py
@@ -45,7 +45,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _get_config_schema(
-    hass: core.HomeAssistant, source: str | None, input_dict: dict[str, Any] = None
+    hass: core.HomeAssistant,
+    source: str | None,
+    input_dict: dict[str, Any] | None = None,
 ) -> vol.Schema:
     """
     Return schema defaults for init step based on user input/config dict.
@@ -99,7 +101,9 @@ class TomorrowioOptionsConfigFlow(config_entries.OptionsFlow):
         """Initialize Tomorrow.io options flow."""
         self._config_entry = config_entry
 
-    async def async_step_init(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Manage the Tomorrow.io options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
@@ -134,7 +138,9 @@ class TomorrowioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return TomorrowioOptionsConfigFlow(config_entry)
 
-    async def async_step_user(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle the initial step."""
         errors = {}
         if user_input is not None:

--- a/homeassistant/components/toon/config_flow.py
+++ b/homeassistant/components/toon/config_flow.py
@@ -64,7 +64,7 @@ class ToonFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         return await self.async_step_user()
 
     async def async_step_agreement(
-        self, user_input: dict[str, Any] = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Select Toon agreement to add."""
         if len(self.agreements) == 1:

--- a/homeassistant/components/tuya/base.py
+++ b/homeassistant/components/tuya/base.py
@@ -189,7 +189,7 @@ class TuyaEntity(Entity):
         dpcodes: str | DPCode | tuple[DPCode, ...] | None,
         *,
         prefer_function: bool = False,
-        dptype: DPType = None,
+        dptype: DPType | None = None,
     ) -> DPCode | EnumTypeData | IntegerTypeData | None:
         """Find a matching DP code available on for this device."""
         if dpcodes is None:

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -49,7 +49,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def _get_config_schema(input_dict: dict[str, Any] = None) -> vol.Schema:
+def _get_config_schema(input_dict: dict[str, Any] | None = None) -> vol.Schema:
     """
     Return schema defaults for init step based on user input/config dict.
 
@@ -81,7 +81,7 @@ def _get_config_schema(input_dict: dict[str, Any] = None) -> vol.Schema:
     )
 
 
-def _get_pairing_schema(input_dict: dict[str, Any] = None) -> vol.Schema:
+def _get_pairing_schema(input_dict: dict[str, Any] | None = None) -> vol.Schema:
     """
     Return schema defaults for pairing data based on user input.
 
@@ -112,7 +112,9 @@ class VizioOptionsConfigFlow(config_entries.OptionsFlow):
         """Initialize vizio options flow."""
         self.config_entry = config_entry
 
-    async def async_step_init(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Manage the vizio options."""
         if user_input is not None:
             if user_input.get(CONF_APPS_TO_INCLUDE_OR_EXCLUDE):
@@ -204,7 +206,9 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=input_dict[CONF_NAME], data=input_dict)
 
-    async def async_step_user(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors = {}
 
@@ -381,7 +385,9 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-    async def async_step_pair_tv(self, user_input: dict[str, Any] = None) -> FlowResult:
+    async def async_step_pair_tv(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """
         Start pairing process for TV.
 
@@ -460,7 +466,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_pairing_complete(
-        self, user_input: dict[str, Any] = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """
         Complete non-import sourced config flow.
@@ -470,7 +476,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._pairing_complete("pairing_complete")
 
     async def async_step_pairing_complete_import(
-        self, user_input: dict[str, Any] = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """
         Complete import sourced config flow.

--- a/homeassistant/components/yamaha_musiccast/__init__.py
+++ b/homeassistant/components/yamaha_musiccast/__init__.py
@@ -216,7 +216,7 @@ class MusicCastCapabilityEntity(MusicCastDeviceEntity):
         self,
         coordinator: MusicCastDataUpdateCoordinator,
         capability: Capability,
-        zone_id: str = None,
+        zone_id: str | None = None,
     ) -> None:
         """Initialize a capability based entity."""
         if zone_id is not None:

--- a/homeassistant/components/yamaha_musiccast/number.py
+++ b/homeassistant/components/yamaha_musiccast/number.py
@@ -42,7 +42,7 @@ class NumberCapability(MusicCastCapabilityEntity, NumberEntity):
         self,
         coordinator: MusicCastDataUpdateCoordinator,
         capability: NumberSetter,
-        zone_id: str = None,
+        zone_id: str | None = None,
     ) -> None:
         """Initialize the number entity."""
         super().__init__(coordinator, capability, zone_id)


### PR DESCRIPTION
## Proposed change
Mypy will soon make `no_implicit_optional` the default behavior. Currently, it's only applied together with `strict` typing.
This PR updates existing integrations to mention `None` explicitly. Once done, I'll open a follow up PR to set `no_implicit_optional` for all files.

```diff
def f(
-    var: int = None
+    var: int | None = None
) -> None:
    ...
```

See:
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
