### PR TITLE
Enable no_implicit_optional globally [mypy]

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ show_error_codes = true
 follow_imports = silent
 ignore_missing_imports = true
 strict_equality = true
+no_implicit_optional = true
 warn_incomplete_stub = true
 warn_redundant_casts = true
 warn_unused_configs = true
@@ -20,7 +21,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -124,7 +124,6 @@ disallow_subclassing_any = false
 disallow_untyped_calls = false
 disallow_untyped_decorators = false
 disallow_untyped_defs = false
-no_implicit_optional = false
 warn_return_any = false
 warn_unreachable = false
 no_implicit_reexport = false
@@ -136,7 +135,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 no_implicit_reexport = true
@@ -148,7 +146,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -159,7 +156,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -170,7 +166,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -181,7 +176,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -192,7 +186,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -203,7 +196,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -214,7 +206,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -225,7 +216,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -236,7 +226,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -247,7 +236,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -258,7 +246,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -269,7 +256,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -280,7 +266,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -291,7 +276,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -302,7 +286,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -313,7 +296,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -324,7 +306,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -335,7 +316,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -346,7 +326,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -357,7 +336,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -368,7 +346,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -379,7 +356,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -390,7 +366,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -401,7 +376,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -412,7 +386,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -423,7 +396,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -434,7 +406,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -445,7 +416,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -456,7 +426,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -467,7 +436,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -478,7 +446,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -489,7 +456,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -500,7 +466,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -511,7 +476,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -522,7 +486,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -533,7 +496,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -544,7 +506,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -555,7 +516,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -566,7 +526,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -577,7 +536,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -588,7 +546,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -599,7 +556,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -610,7 +566,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -621,7 +576,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -632,7 +586,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -643,7 +596,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -654,7 +606,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -665,7 +616,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -676,7 +626,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -687,7 +636,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -698,7 +646,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -709,7 +656,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -720,7 +666,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -731,7 +676,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -742,7 +686,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -753,7 +696,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -764,7 +706,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -775,7 +716,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -786,7 +726,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -797,7 +736,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -808,7 +746,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -819,7 +756,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -830,7 +766,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -841,7 +776,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -852,7 +786,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -863,7 +796,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -874,7 +806,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -885,7 +816,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -896,7 +826,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -907,7 +836,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -918,7 +846,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -929,7 +856,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -940,7 +866,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -951,7 +876,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -962,7 +886,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -973,7 +896,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -984,7 +906,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -995,7 +916,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1006,7 +926,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1017,7 +936,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1028,7 +946,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1039,7 +956,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1050,7 +966,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1061,7 +976,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1072,7 +986,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1083,7 +996,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1094,7 +1006,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1105,7 +1016,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1116,7 +1026,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1127,7 +1036,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1138,7 +1046,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1149,7 +1056,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1160,7 +1066,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1171,7 +1076,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1182,7 +1086,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1193,7 +1096,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1204,7 +1106,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1215,7 +1116,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1226,7 +1126,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1237,7 +1136,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1248,7 +1146,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1259,7 +1156,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1270,7 +1166,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1281,7 +1176,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1292,7 +1186,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1303,7 +1196,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1314,7 +1206,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1325,7 +1216,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1336,7 +1226,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1347,7 +1236,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1358,7 +1246,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1369,7 +1256,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1380,7 +1266,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1391,7 +1276,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1402,7 +1286,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1413,7 +1296,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1424,7 +1306,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1435,7 +1316,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1446,7 +1326,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1457,7 +1336,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1468,7 +1346,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1479,7 +1356,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1490,7 +1366,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1501,7 +1376,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1512,7 +1386,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1523,7 +1396,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1534,7 +1406,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1545,7 +1416,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1556,7 +1426,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1567,7 +1436,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1578,7 +1446,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1589,7 +1456,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1600,7 +1466,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1611,7 +1476,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1622,7 +1486,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1633,7 +1496,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1644,7 +1506,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1655,7 +1516,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1666,7 +1526,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1677,7 +1536,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1688,7 +1546,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1699,7 +1556,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1710,7 +1566,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1721,7 +1576,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1732,7 +1586,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1743,7 +1596,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1754,7 +1606,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1765,7 +1616,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1776,7 +1626,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1787,7 +1636,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1798,7 +1646,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1809,7 +1656,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1820,7 +1666,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1831,7 +1676,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1842,7 +1686,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1853,7 +1696,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1864,7 +1706,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1875,7 +1716,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1886,7 +1726,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1897,7 +1736,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1908,7 +1746,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1919,7 +1756,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1930,7 +1766,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1941,7 +1776,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1952,7 +1786,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1963,7 +1796,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1974,7 +1806,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1985,7 +1816,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -1996,7 +1826,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2007,7 +1836,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2018,7 +1846,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2029,7 +1856,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2040,7 +1866,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2051,7 +1876,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2062,7 +1886,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2073,7 +1896,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2084,7 +1906,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2095,7 +1916,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2106,7 +1926,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2117,7 +1936,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2128,7 +1946,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2139,7 +1956,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2150,7 +1966,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2161,7 +1976,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2172,7 +1986,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2183,7 +1996,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2194,7 +2006,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2205,7 +2016,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2216,7 +2026,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2227,7 +2036,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2238,7 +2046,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 no_implicit_reexport = true
@@ -2250,7 +2057,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2261,7 +2067,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2272,7 +2077,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2283,7 +2087,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2294,7 +2097,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2305,7 +2107,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2316,7 +2117,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2327,7 +2127,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2338,7 +2137,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2349,7 +2147,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2360,7 +2157,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2371,7 +2167,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2382,7 +2177,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2393,7 +2187,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2404,7 +2197,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2415,7 +2207,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2426,7 +2217,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2437,7 +2227,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2448,7 +2237,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2459,7 +2247,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2470,7 +2257,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2481,7 +2267,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2492,7 +2277,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 no_implicit_reexport = true
@@ -2504,7 +2288,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2515,7 +2298,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2526,7 +2308,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2537,7 +2318,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2548,7 +2328,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2559,7 +2338,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2570,7 +2348,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2581,7 +2358,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2592,7 +2368,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2603,7 +2378,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2614,7 +2388,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2625,7 +2398,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2636,7 +2408,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2647,7 +2418,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2658,7 +2428,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2669,7 +2438,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2680,7 +2448,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2691,7 +2458,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2702,7 +2468,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2713,7 +2478,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2724,7 +2488,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2735,7 +2498,6 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
@@ -2755,7 +2517,6 @@ disallow_subclassing_any = false
 disallow_untyped_calls = false
 disallow_untyped_decorators = false
 disallow_untyped_defs = false
-no_implicit_optional = false
 warn_return_any = false
 warn_unreachable = false
 

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -54,6 +54,7 @@ GENERAL_SETTINGS: Final[dict[str, str]] = {
     # Enable some checks globally.
     "ignore_missing_imports": "true",
     "strict_equality": "true",
+    "no_implicit_optional": "true",
     "warn_incomplete_stub": "true",
     "warn_redundant_casts": "true",
     "warn_unused_configs": "true",
@@ -74,7 +75,6 @@ STRICT_SETTINGS: Final[list[str]] = [
     "disallow_untyped_calls",
     "disallow_untyped_decorators",
     "disallow_untyped_defs",
-    "no_implicit_optional",
     "warn_return_any",
     "warn_unreachable",
     # TODO: turn these on, address issues


### PR DESCRIPTION
## Proposed change
Mypy will soon make `no_implicit_optional` the default behavior. Currently, it's only applied together with `strict` typing. This PR enables it globally.

```diff
def f(
-    var: int = None
+    var: int | None = None
) -> None:
    ...
```

See:
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401

Depends on:
* #76719
* #76720
* #76721
* #76722

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
