### PR TITLE
Fix Hue events for relative_rotary devices (such as Hue Tap Dial)

### DIFF
--- a/homeassistant/components/hue/logbook.py
+++ b/homeassistant/components/hue/logbook.py
@@ -28,6 +28,8 @@ TRIGGER_SUBTYPE = {
     "2": "second button",
     "3": "third button",
     "4": "fourth button",
+    "clock_wise": "Rotation clockwise",
+    "counter_clock_wise": "Rotation counter-clockwise",
 }
 TRIGGER_TYPE = {
     "remote_button_long_release": "{subtype} released after long press",
@@ -40,6 +42,7 @@ TRIGGER_TYPE = {
     "short_release": "{subtype} released after short press",
     "long_release": "{subtype} released after long press",
     "double_short_release": "both {subtype} released",
+    "start": '"{subtype}" pressed initially',
 }
 
 UNKNOWN_TYPE = "unknown type"

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -49,20 +49,23 @@
       "1": "First button",
       "2": "Second button",
       "3": "Third button",
-      "4": "Fourth button"
+      "4": "Fourth button",
+      "clock_wise": "Rotation clockwise",
+      "counter_clock_wise": "Rotation counter-clockwise"
     },
     "trigger_type": {
-      "remote_button_long_release": "\"{subtype}\" button released after long press",
-      "remote_button_short_press": "\"{subtype}\" button pressed",
-      "remote_button_short_release": "\"{subtype}\" button released",
+      "remote_button_long_release": "\"{subtype}\" released after long press",
+      "remote_button_short_press": "\"{subtype}\" pressed",
+      "remote_button_short_release": "\"{subtype}\" released",
       "remote_double_button_long_press": "Both \"{subtype}\" released after long press",
       "remote_double_button_short_press": "Both \"{subtype}\" released",
 
-      "initial_press": "Button \"{subtype}\" pressed initially",
-      "repeat": "Button \"{subtype}\" held down",
-      "short_release": "Button \"{subtype}\" released after short press",
-      "long_release": "Button \"{subtype}\" released after long press",
-      "double_short_release": "Both \"{subtype}\" released"
+      "initial_press": "\"{subtype}\" pressed initially",
+      "repeat": "\"{subtype}\" held down",
+      "short_release": "\"{subtype}\" released after short press",
+      "long_release": "\"{subtype}\" released after long press",
+      "double_short_release": "Both \"{subtype}\" released",
+      "start": "\"{subtype}\" pressed initially"
     }
   },
   "options": {

--- a/homeassistant/components/hue/translations/en.json
+++ b/homeassistant/components/hue/translations/en.json
@@ -49,19 +49,22 @@
             "double_buttons_1_3": "First and Third buttons",
             "double_buttons_2_4": "Second and Fourth buttons",
             "turn_off": "Turn off",
-            "turn_on": "Turn on"
+            "turn_on": "Turn on",
+            "clock_wise": "Rotation clockwise",
+            "counter_clock_wise": "Rotation counter-clockwise"
         },
         "trigger_type": {
             "double_short_release": "Both \"{subtype}\" released",
-            "initial_press": "Button \"{subtype}\" pressed initially",
-            "long_release": "Button \"{subtype}\" released after long press",
-            "remote_button_long_release": "\"{subtype}\" button released after long press",
-            "remote_button_short_press": "\"{subtype}\" button pressed",
-            "remote_button_short_release": "\"{subtype}\" button released",
+            "initial_press": "\"{subtype}\" pressed initially",
+            "long_release": "\"{subtype}\" released after long press",
+            "remote_button_long_release": "\"{subtype}\" released after long press",
+            "remote_button_short_press": "\"{subtype}\" pressed",
+            "remote_button_short_release": "\"{subtype}\" released",
             "remote_double_button_long_press": "Both \"{subtype}\" released after long press",
             "remote_double_button_short_press": "Both \"{subtype}\" released",
-            "repeat": "Button \"{subtype}\" held down",
-            "short_release": "Button \"{subtype}\" released after short press"
+            "repeat": "\"{subtype}\" held down",
+            "short_release": "\"{subtype}\" released after short press",
+            "start": "\"{subtype}\" pressed initially"
         }
     },
     "options": {

--- a/homeassistant/components/hue/v2/device_trigger.py
+++ b/homeassistant/components/hue/v2/device_trigger.py
@@ -128,7 +128,7 @@ def async_get_triggers(
                     }
                 )
         # relative_rotary triggers
-        if resource.type == ResourceTypes.RELATIVE_ROTARY:
+        elif resource.type == ResourceTypes.RELATIVE_ROTARY:
             for event_type in DEFAULT_ROTARY_EVENT_TYPES:
                 for sub_type in DEFAULT_ROTARY_EVENT_SUBTYPES:
                     triggers.append(

--- a/homeassistant/components/hue/v2/device_trigger.py
+++ b/homeassistant/components/hue/v2/device_trigger.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from aiohue.v2.models.button import ButtonEvent
+from aiohue.v2.models.relative_rotary import (
+    RelativeRotaryAction,
+    RelativeRotaryDirection,
+)
 from aiohue.v2.models.resource import ResourceTypes
 import voluptuous as vol
 
-from homeassistant.components import persistent_notification
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import (
@@ -49,37 +52,16 @@ DEFAULT_BUTTON_EVENT_TYPES = (
     ButtonEvent.LONG_RELEASE,
 )
 
+DEFAULT_ROTARY_EVENT_TYPES = (RelativeRotaryAction.START, RelativeRotaryAction.REPEAT)
+DEFAULT_ROTARY_EVENT_SUBTYPES = (
+    RelativeRotaryDirection.CLOCK_WISE,
+    RelativeRotaryDirection.COUNTER_CLOCK_WISE,
+)
+
 DEVICE_SPECIFIC_EVENT_TYPES = {
     # device specific overrides of specific supported button events
     "Hue tap switch": (ButtonEvent.INITIAL_PRESS,),
 }
-
-
-def check_invalid_device_trigger(
-    bridge: HueBridge,
-    config: ConfigType,
-    device_entry: DeviceEntry,
-    automation_info: AutomationTriggerInfo | None = None,
-):
-    """Check automation config for deprecated format."""
-    # NOTE: Remove this check after 2022.6
-    if isinstance(config["subtype"], int):
-        return
-    # found deprecated V1 style trigger, notify the user that it should be adjusted
-    msg = (
-        f"Incompatible device trigger detected for "
-        f"[{device_entry.name}](/config/devices/device/{device_entry.id}) "
-        "Please manually fix the outdated automation(s) once to fix this issue."
-    )
-    if automation_info:
-        automation_id = automation_info["variables"]["this"]["attributes"]["id"]  # type: ignore[index]
-        msg += f"\n\n[Check it out](/config/automation/edit/{automation_id})."
-    persistent_notification.async_create(
-        bridge.hass,
-        msg,
-        title="Outdated device trigger found",
-        notification_id=f"hue_trigger_{device_entry.id}",
-    )
 
 
 async def async_validate_trigger_config(
@@ -88,9 +70,7 @@ async def async_validate_trigger_config(
     config: ConfigType,
 ) -> ConfigType:
     """Validate config."""
-    config = TRIGGER_SCHEMA(config)
-    check_invalid_device_trigger(bridge, config, device_entry)
-    return config
+    return TRIGGER_SCHEMA(config)
 
 
 async def async_attach_trigger(
@@ -113,7 +93,6 @@ async def async_attach_trigger(
             },
         }
     )
-    check_invalid_device_trigger(bridge, config, device_entry, automation_info)
     return await event_trigger.async_attach_trigger(
         hass, event_config, action, automation_info, platform_type="device"
     )
@@ -131,22 +110,37 @@ def async_get_triggers(
     # extract triggers from all button resources of this Hue device
     triggers = []
     model_id = api.devices[hue_dev_id].product_data.product_name
+
     for resource in api.devices.get_sensors(hue_dev_id):
-        if resource.type != ResourceTypes.BUTTON:
-            continue
-        for event_type in DEVICE_SPECIFIC_EVENT_TYPES.get(
-            model_id, DEFAULT_BUTTON_EVENT_TYPES
-        ):
-            triggers.append(
-                {
-                    CONF_DEVICE_ID: device_entry.id,
-                    CONF_DOMAIN: DOMAIN,
-                    CONF_PLATFORM: "device",
-                    CONF_TYPE: event_type.value,
-                    CONF_SUBTYPE: resource.metadata.control_id,
-                    CONF_UNIQUE_ID: resource.id,
-                }
-            )
+        # button triggers
+        if resource.type == ResourceTypes.BUTTON:
+            for event_type in DEVICE_SPECIFIC_EVENT_TYPES.get(
+                model_id, DEFAULT_BUTTON_EVENT_TYPES
+            ):
+                triggers.append(
+                    {
+                        CONF_DEVICE_ID: device_entry.id,
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_PLATFORM: "device",
+                        CONF_TYPE: event_type.value,
+                        CONF_SUBTYPE: resource.metadata.control_id,
+                        CONF_UNIQUE_ID: resource.id,
+                    }
+                )
+        # relative_rotary triggers
+        if resource.type == ResourceTypes.RELATIVE_ROTARY:
+            for event_type in DEFAULT_ROTARY_EVENT_TYPES:
+                for sub_type in DEFAULT_ROTARY_EVENT_SUBTYPES:
+                    triggers.append(
+                        {
+                            CONF_DEVICE_ID: device_entry.id,
+                            CONF_DOMAIN: DOMAIN,
+                            CONF_PLATFORM: "device",
+                            CONF_TYPE: event_type.value,
+                            CONF_SUBTYPE: sub_type.value,
+                            CONF_UNIQUE_ID: resource.id,
+                        }
+                    )
     return triggers
 
 

--- a/homeassistant/components/hue/v2/hue_event.py
+++ b/homeassistant/components/hue/v2/hue_event.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
 from aiohue.v2.models.button import Button
+from aiohue.v2.models.relative_rotary import RelativeRotary
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_ID, CONF_TYPE, CONF_UNIQUE_ID
 from homeassistant.core import callback
@@ -14,6 +15,8 @@ from homeassistant.util import slugify
 from ..const import ATTR_HUE_EVENT, CONF_SUBTYPE, DOMAIN as DOMAIN
 
 CONF_CONTROL_ID = "control_id"
+CONF_DURATION = "duration"
+CONF_STEPS = "steps"
 
 if TYPE_CHECKING:
     from ..bridge import HueBridge
@@ -28,12 +31,12 @@ async def async_setup_hue_events(bridge: "HueBridge"):
     conf_entry = bridge.config_entry
     dev_reg = device_registry.async_get(hass)
 
-    # at this time the `button` resource is the only source of hue events
     btn_controller = api.sensors.button
+    rotary_controller = api.sensors.relative_rotary
 
     @callback
     def handle_button_event(evt_type: EventType, hue_resource: Button) -> None:
-        """Handle event from Hue devices controller."""
+        """Handle event from Hue button resource controller."""
         LOGGER.debug("Received button event: %s", hue_resource)
 
         # guard for missing button object on the resource
@@ -58,5 +61,31 @@ async def async_setup_hue_events(bridge: "HueBridge"):
     conf_entry.async_on_unload(
         btn_controller.subscribe(
             handle_button_event, event_filter=EventType.RESOURCE_UPDATED
+        )
+    )
+
+    @callback
+    def handle_rotary_event(evt_type: EventType, hue_resource: RelativeRotary) -> None:
+        """Handle event from Hue relative_rotary resource controller."""
+        LOGGER.debug("Received relative_rotary event: %s", hue_resource)
+
+        hue_device = btn_controller.get_device(hue_resource.id)
+        device = dev_reg.async_get_device({(DOMAIN, hue_device.id)})
+
+        # Fire event
+        data = {
+            CONF_DEVICE_ID: device.id,  # type: ignore[union-attr]
+            CONF_UNIQUE_ID: hue_resource.id,
+            CONF_TYPE: hue_resource.relative_rotary.last_event.action.value,
+            CONF_SUBTYPE: hue_resource.relative_rotary.last_event.rotation.direction.value,
+            CONF_DURATION: hue_resource.relative_rotary.last_event.rotation.duration,
+            CONF_STEPS: hue_resource.relative_rotary.last_event.rotation.steps,
+        }
+        hass.bus.async_fire(ATTR_HUE_EVENT, data)
+
+    # add listener for updates from `relative_rotary` resource
+    conf_entry.async_on_unload(
+        rotary_controller.subscribe(
+            handle_rotary_event, event_filter=EventType.RESOURCE_UPDATED
         )
     )


### PR DESCRIPTION
## Proposed change
The support for the "relative_rotary" resource type was missing from the Hue V2 API but has now been added.
This fixes support for rotary encoder switches/remotes such as the Hue Tap Dial and maybe (untested) also the Lutron Aurora.

Depends on aiohue lib version 4.5.0 bumped in https://github.com/home-assistant/core/pull/76757

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #75082
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
