### PR TITLE
Update aioqsw to v0.2.2

### DIFF
--- a/homeassistant/components/qnap_qsw/manifest.json
+++ b/homeassistant/components/qnap_qsw/manifest.json
@@ -3,7 +3,7 @@
   "name": "QNAP QSW",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/qnap_qsw",
-  "requirements": ["aioqsw==0.2.1"],
+  "requirements": ["aioqsw==0.2.2"],
   "codeowners": ["@Noltari"],
   "iot_class": "local_polling",
   "loggers": ["aioqsw"],

--- a/homeassistant/components/qnap_qsw/manifest.json
+++ b/homeassistant/components/qnap_qsw/manifest.json
@@ -3,7 +3,7 @@
   "name": "QNAP QSW",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/qnap_qsw",
-  "requirements": ["aioqsw==0.2.0"],
+  "requirements": ["aioqsw==0.2.1"],
   "codeowners": ["@Noltari"],
   "iot_class": "local_polling",
   "loggers": ["aioqsw"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -232,7 +232,7 @@ aiopvpc==3.0.0
 aiopyarr==22.7.0
 
 # homeassistant.components.qnap_qsw
-aioqsw==0.2.0
+aioqsw==0.2.1
 
 # homeassistant.components.recollect_waste
 aiorecollect==1.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -232,7 +232,7 @@ aiopvpc==3.0.0
 aiopyarr==22.7.0
 
 # homeassistant.components.qnap_qsw
-aioqsw==0.2.1
+aioqsw==0.2.2
 
 # homeassistant.components.recollect_waste
 aiorecollect==1.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -207,7 +207,7 @@ aiopvpc==3.0.0
 aiopyarr==22.7.0
 
 # homeassistant.components.qnap_qsw
-aioqsw==0.2.0
+aioqsw==0.2.1
 
 # homeassistant.components.recollect_waste
 aiorecollect==1.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -207,7 +207,7 @@ aiopvpc==3.0.0
 aiopyarr==22.7.0
 
 # homeassistant.components.qnap_qsw
-aioqsw==0.2.1
+aioqsw==0.2.2
 
 # homeassistant.components.recollect_waste
 aiorecollect==1.0.8

--- a/tests/components/qnap_qsw/test_coordinator.py
+++ b/tests/components/qnap_qsw/test_coordinator.py
@@ -18,6 +18,7 @@ from .util import (
     FIRMWARE_CONDITION_MOCK,
     FIRMWARE_INFO_MOCK,
     FIRMWARE_UPDATE_CHECK_MOCK,
+    LACP_INFO_MOCK,
     PORTS_STATISTICS_MOCK,
     PORTS_STATUS_MOCK,
     SYSTEM_BOARD_MOCK,
@@ -46,6 +47,9 @@ async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
         "homeassistant.components.qnap_qsw.QnapQswApi.get_firmware_update_check",
         return_value=FIRMWARE_UPDATE_CHECK_MOCK,
     ) as mock_firmware_update_check, patch(
+        "homeassistant.components.qnap_qsw.QnapQswApi.get_lacp_info",
+        return_value=LACP_INFO_MOCK,
+    ) as mock_lacp_info, patch(
         "homeassistant.components.qnap_qsw.QnapQswApi.get_ports_statistics",
         return_value=PORTS_STATISTICS_MOCK,
     ) as mock_ports_statistics, patch(
@@ -73,6 +77,7 @@ async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
         mock_firmware_condition.assert_called_once()
         mock_firmware_info.assert_called_once()
         mock_firmware_update_check.assert_called_once()
+        mock_lacp_info.assert_called_once()
         mock_ports_statistics.assert_called_once()
         mock_ports_status.assert_called_once()
         mock_system_board.assert_called_once()
@@ -84,6 +89,7 @@ async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
         mock_firmware_condition.reset_mock()
         mock_firmware_info.reset_mock()
         mock_firmware_update_check.reset_mock()
+        mock_lacp_info.reset_mock()
         mock_ports_statistics.reset_mock()
         mock_ports_status.reset_mock()
         mock_system_board.reset_mock()

--- a/tests/components/qnap_qsw/util.py
+++ b/tests/components/qnap_qsw/util.py
@@ -23,6 +23,8 @@ from aioqsw.const import (
     API_KEY,
     API_LINK,
     API_MAC_ADDR,
+    API_MAX_PORT_CHANNELS,
+    API_MAX_PORTS_PER_PORT_CHANNEL,
     API_MAX_SWITCH_TEMP,
     API_MESSAGE,
     API_MODEL,
@@ -36,6 +38,7 @@ from aioqsw.const import (
     API_RX_OCTETS,
     API_SERIAL,
     API_SPEED,
+    API_START_INDEX,
     API_SWITCH_TEMP,
     API_TRUNK_NUM,
     API_TX_OCTETS,
@@ -117,6 +120,16 @@ FIRMWARE_UPDATE_CHECK_MOCK = {
             "https://us1.qnap.com/Storage/Networking/QSW408FW/QSW-M408AC3-FW.v1.2.0_S20220128_29649.img",
         ],
         API_NEWER: False,
+    },
+}
+
+LACP_INFO_MOCK = {
+    API_ERROR_CODE: 200,
+    API_ERROR_MESSAGE: "OK",
+    API_RESULT: {
+        API_START_INDEX: 28,
+        API_MAX_PORT_CHANNELS: 8,
+        API_MAX_PORTS_PER_PORT_CHANNEL: 8,
     },
 }
 
@@ -499,6 +512,9 @@ async def async_init_integration(
     ), patch(
         "homeassistant.components.qnap_qsw.QnapQswApi.get_firmware_update_check",
         return_value=FIRMWARE_UPDATE_CHECK_MOCK,
+    ), patch(
+        "homeassistant.components.qnap_qsw.QnapQswApi.get_lacp_info",
+        return_value=LACP_INFO_MOCK,
     ), patch(
         "homeassistant.components.qnap_qsw.QnapQswApi.get_ports_statistics",
         return_value=PORTS_STATISTICS_MOCK,


### PR DESCRIPTION
## Proposed change
Update aioqsw to [v0.2.2](https://github.com/Noltari/aioqsw/compare/0.2.0...0.2.2)

Releases:
 - https://github.com/Noltari/aioqsw/releases/tag/0.2.2
 - https://github.com/Noltari/aioqsw/releases/tag/0.2.1

Git compare: https://github.com/Noltari/aioqsw/compare/0.2.0...0.2.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
