### PR TITLE
Add button platform to LaMetric

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -641,6 +641,7 @@ omit =
     homeassistant/components/kwb/sensor.py
     homeassistant/components/lacrosse/sensor.py
     homeassistant/components/lametric/__init__.py
+    homeassistant/components/lametric/button.py
     homeassistant/components/lametric/coordinator.py
     homeassistant/components/lametric/entity.py
     homeassistant/components/lametric/notify.py

--- a/homeassistant/components/lametric/button.py
+++ b/homeassistant/components/lametric/button.py
@@ -1,0 +1,86 @@
+"""Support for LaMetric buttons."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from demetriek import LaMetricDevice
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import LaMetricDataUpdateCoordinator
+from .entity import LaMetricEntity
+
+
+@dataclass
+class LaMetricButtonEntityDescriptionMixin:
+    """Mixin values for LaMetric entities."""
+
+    press_fn: Callable[[LaMetricDevice], Awaitable[Any]]
+
+
+@dataclass
+class LaMetricButtonEntityDescription(
+    ButtonEntityDescription, LaMetricButtonEntityDescriptionMixin
+):
+    """Class describing LaMetric button entities."""
+
+
+BUTTONS = [
+    LaMetricButtonEntityDescription(
+        key="app_next",
+        name="Next app",
+        icon="mdi:arrow-right-bold",
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda api: api.app_next(),
+    ),
+    LaMetricButtonEntityDescription(
+        key="app_previous",
+        name="Previous app",
+        icon="mdi:arrow-left-bold",
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda api: api.app_previous(),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up WLED button based on a config entry."""
+    coordinator: LaMetricDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        LaMetricButtonEntity(
+            coordinator=coordinator,
+            description=description,
+        )
+        for description in BUTTONS
+    )
+
+
+class LaMetricButtonEntity(LaMetricEntity, ButtonEntity):
+    """Representation of a LaMetric number."""
+
+    entity_description: LaMetricButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: LaMetricDataUpdateCoordinator,
+        description: LaMetricButtonEntityDescription,
+    ) -> None:
+        """Initialize the button entity."""
+        super().__init__(coordinator=coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.data.serial_number}-{description.key}"
+
+    async def async_press(self) -> None:
+        """Send out a command to LaMetric."""
+        await self.entity_description.press_fn(self.coordinator.lametric)

--- a/homeassistant/components/lametric/button.py
+++ b/homeassistant/components/lametric/button.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up WLED button based on a config entry."""
+    """Set up LaMetric button based on a config entry."""
     coordinator: LaMetricDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         LaMetricButtonEntity(

--- a/homeassistant/components/lametric/const.py
+++ b/homeassistant/components/lametric/const.py
@@ -7,7 +7,7 @@ from typing import Final
 from homeassistant.const import Platform
 
 DOMAIN: Final = "lametric"
-PLATFORMS = [Platform.NUMBER]
+PLATFORMS = [Platform.BUTTON, Platform.NUMBER]
 
 LOGGER = logging.getLogger(__package__)
 SCAN_INTERVAL = timedelta(seconds=30)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Implements the button platform for the LaMetric integrations. Initially adds buttons to switch between apps shown in the LaMetric TIME.

Needs #76759 & #76766, this PR needs to be rebased after those.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23824

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
