### PR TITLE
Move `AutomationActionType` to helpers.trigger

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import logging
-from typing import Any, Protocol, TypedDict, cast
+from typing import Any, cast
 
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
@@ -72,8 +72,13 @@ from homeassistant.helpers.trace import (
     trace_get,
     trace_path,
 )
-from homeassistant.helpers.trigger import async_initialize_triggers
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+from homeassistant.helpers.trigger import (
+    TriggerActionType,
+    TriggerData,
+    TriggerInfo,
+    async_initialize_triggers,
+)
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 from homeassistant.util.dt import parse_datetime
 
@@ -112,32 +117,11 @@ SERVICE_TRIGGER = "trigger"
 _LOGGER = logging.getLogger(__name__)
 
 
-class AutomationActionType(Protocol):
-    """Protocol type for automation action callback."""
-
-    async def __call__(
-        self,
-        run_variables: dict[str, Any],
-        context: Context | None = None,
-    ) -> None:
-        """Define action callback type."""
-
-
-class AutomationTriggerData(TypedDict):
-    """Automation trigger data."""
-
-    id: str
-    idx: str
-
-
-class AutomationTriggerInfo(TypedDict):
-    """Information about automation trigger."""
-
-    domain: str
-    name: str
-    home_assistant_start: bool
-    variables: TemplateVarsType
-    trigger_data: AutomationTriggerData
+# AutomationActionType, AutomationTriggerData,
+# and AutomationTriggerInfo are deprecated as of 2022.9.
+AutomationActionType = TriggerActionType
+AutomationTriggerData = TriggerData
+AutomationTriggerInfo = TriggerInfo
 
 
 @bind_hass

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -1,10 +1,6 @@
 """Provides device triggers for binary sensors."""
 import voluptuous as vol
 
-from homeassistant.components.automation import (
-    AutomationActionType,
-    AutomationTriggerInfo,
-)
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.const import (
     CONF_TURNED_OFF,
@@ -15,6 +11,7 @@ from homeassistant.const import CONF_ENTITY_ID, CONF_FOR, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity import get_device_class
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from . import DOMAIN, BinarySensorDeviceClass
@@ -263,8 +260,8 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
-    action: AutomationActionType,
-    automation_info: AutomationTriggerInfo,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     trigger_type = config[CONF_TYPE]
@@ -283,7 +280,7 @@ async def async_attach_trigger(
 
     state_config = await state_trigger.async_validate_trigger_config(hass, state_config)
     return await state_trigger.async_attach_trigger(
-        hass, state_config, action, automation_info, platform_type="device"
+        hass, state_config, action, trigger_info, platform_type="device"
     )
 
 

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -5,7 +5,7 @@ import asyncio
 from collections.abc import Callable
 import functools
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict
 
 import voluptuous as vol
 
@@ -25,6 +25,34 @@ _PLATFORM_ALIASES = {
     "device_automation": ("device",),
     "homeassistant": ("event", "numeric_state", "state", "time_pattern", "time"),
 }
+
+
+class TriggerActionType(Protocol):
+    """Protocol type for trigger action callback."""
+
+    async def __call__(
+        self,
+        run_variables: dict[str, Any],
+        context: Context | None = None,
+    ) -> None:
+        """Define action callback type."""
+
+
+class TriggerData(TypedDict):
+    """Trigger data."""
+
+    id: str
+    idx: str
+
+
+class TriggerInfo(TypedDict):
+    """Information about trigger."""
+
+    domain: str
+    name: str
+    home_assistant_start: bool
+    variables: TemplateVarsType
+    trigger_data: TriggerData
 
 
 async def _async_get_trigger_platform(
@@ -93,11 +121,6 @@ async def async_initialize_triggers(
     variables: TemplateVarsType = None,
 ) -> CALLBACK_TYPE | None:
     """Initialize triggers."""
-    from homeassistant.components.automation import (  # pylint:disable=[import-outside-toplevel]
-        AutomationTriggerData,
-        AutomationTriggerInfo,
-    )
-
     triggers = []
     for idx, conf in enumerate(trigger_config):
         # Skip triggers that are not enabled
@@ -107,8 +130,8 @@ async def async_initialize_triggers(
         platform = await _async_get_trigger_platform(hass, conf)
         trigger_id = conf.get(CONF_ID, f"{idx}")
         trigger_idx = f"{idx}"
-        trigger_data = AutomationTriggerData(id=trigger_id, idx=trigger_idx)
-        info = AutomationTriggerInfo(
+        trigger_data = TriggerData(id=trigger_id, idx=trigger_idx)
+        info = TriggerInfo(
             domain=domain,
             name=name,
             home_assistant_start=home_assistant_start,

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -337,8 +337,8 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
             arg_types={
                 0: "HomeAssistant",
                 1: "ConfigType",
-                2: "AutomationActionType",
-                3: "AutomationTriggerInfo",
+                # 2: "AutomationActionType",  # AutomationActionType is deprecated -> TriggerActionType
+                # 3: "AutomationTriggerInfo",  # AutomationTriggerInfo is deprecated -> TriggerInfo
             },
             return_type="CALLBACK_TYPE",
         ),


### PR DESCRIPTION
## Deprecation
**Custom integrations only**: Deprecate `AutomationActionType`, `AutomationTriggerInfo`, and `AutomationTriggerData`. Use `TriggerActionType`, `TriggerInfo`, and `TriggerData` from `homeassistant/helpers/trigger.py` instead.

## Proposed change
Follow up to https://github.com/home-assistant/core/pull/76054#discussion_r941364713

Move `AutomationActionType`, `AutomationTriggerInfo`, and `AutomationTriggerData` to `helpers/trigger.py` and rename them to better reflect that triggers work with any info, not just automations.

This PR only updates `binary_sensor/device_trigger.py` as an example. Once accepted, I will open new PR(s) to update the remaining instances.

/CC @balloob


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1435

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
