### PR TITLE
Use TriggerActionType [a-k]

### DIFF
--- a/homeassistant/components/arcam_fmj/device_trigger.py
+++ b/homeassistant/components/arcam_fmj/device_trigger.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.automation import (
-    AutomationActionType,
-    AutomationTriggerInfo,
-)
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -18,6 +14,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, EVENT_TURN_ON
@@ -57,11 +54,11 @@ async def async_get_triggers(
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
-    action: AutomationActionType,
-    automation_info: AutomationTriggerInfo,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
-    trigger_data = automation_info["trigger_data"]
+    trigger_data = trigger_info["trigger_data"]
     job = HassJob(action)
 
     if config[CONF_TYPE] == "turn_on":

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.automation import (
-    AutomationActionType,
-    AutomationTriggerInfo,
-)
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
@@ -22,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from . import DOMAIN
@@ -668,8 +665,8 @@ async def async_validate_trigger_config(
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
-    action: AutomationActionType,
-    automation_info: AutomationTriggerInfo,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     event_data: dict[str, int | str] = {}
@@ -693,7 +690,7 @@ async def async_attach_trigger(
 
     event_config = event_trigger.TRIGGER_SCHEMA(raw_event_config)
     return await event_trigger.async_attach_trigger(
-        hass, event_config, action, automation_info, platform_type="device"
+        hass, event_config, action, trigger_info, platform_type="device"
     )
 
 

--- a/homeassistant/components/homekit_controller/device_trigger.py
+++ b/homeassistant/components/homekit_controller/device_trigger.py
@@ -10,14 +10,11 @@ from aiohomekit.model.services import ServicesTypes
 from aiohomekit.utils import clamp_enum_to_char
 import voluptuous as vol
 
-from homeassistant.components.automation import (
-    AutomationActionType,
-    AutomationTriggerInfo,
-)
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, KNOWN_DEVICES, TRIGGERS
@@ -84,11 +81,11 @@ class TriggerSource:
     async def async_attach_trigger(
         self,
         config: ConfigType,
-        action: AutomationActionType,
-        automation_info: AutomationTriggerInfo,
+        action: TriggerActionType,
+        trigger_info: TriggerInfo,
     ) -> CALLBACK_TYPE:
         """Attach a trigger."""
-        trigger_data = automation_info["trigger_data"]
+        trigger_data = trigger_info["trigger_data"]
         job = HassJob(action)
 
         @callback
@@ -269,10 +266,10 @@ async def async_get_triggers(
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
-    action: AutomationActionType,
-    automation_info: AutomationTriggerInfo,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
     device_id = config[CONF_DEVICE_ID]
     device = hass.data[TRIGGERS][device_id]
-    return await device.async_attach_trigger(config, action, automation_info)
+    return await device.async_attach_trigger(config, action, trigger_info)

--- a/homeassistant/components/hue/device_trigger.py
+++ b/homeassistant/components/hue/device_trigger.py
@@ -24,11 +24,8 @@ from .v2.device_trigger import (
 )
 
 if TYPE_CHECKING:
-    from homeassistant.components.automation import (
-        AutomationActionType,
-        AutomationTriggerInfo,
-    )
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 
     from .bridge import HueBridge
 
@@ -59,8 +56,8 @@ async def async_validate_trigger_config(
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
-    action: AutomationActionType,
-    automation_info: AutomationTriggerInfo,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     device_id = config[CONF_DEVICE_ID]
@@ -75,10 +72,10 @@ async def async_attach_trigger(
         bridge: HueBridge = hass.data[DOMAIN][conf_entry_id]
         if bridge.api_version == 1:
             return await async_attach_trigger_v1(
-                bridge, device_entry, config, action, automation_info
+                bridge, device_entry, config, action, trigger_info
             )
         return await async_attach_trigger_v2(
-            bridge, device_entry, config, action, automation_info
+            bridge, device_entry, config, action, trigger_info
         )
     raise InvalidDeviceAutomationConfig(
         f"Device ID {device_id} is not found on any Hue bridge"

--- a/homeassistant/components/hue/v1/device_trigger.py
+++ b/homeassistant/components/hue/v1/device_trigger.py
@@ -3,10 +3,6 @@ from typing import TYPE_CHECKING
 
 import voluptuous as vol
 
-from homeassistant.components.automation import (
-    AutomationActionType,
-    AutomationTriggerInfo,
-)
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
@@ -22,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from ..const import ATTR_HUE_EVENT, CONF_SUBTYPE, DOMAIN
@@ -148,8 +145,8 @@ async def async_attach_trigger(
     bridge: "HueBridge",
     device_entry: DeviceEntry,
     config: ConfigType,
-    action: AutomationActionType,
-    automation_info: AutomationTriggerInfo,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     hass = bridge.hass
@@ -171,7 +168,7 @@ async def async_attach_trigger(
 
     event_config = event_trigger.TRIGGER_SCHEMA(event_config)
     return await event_trigger.async_attach_trigger(
-        hass, event_config, action, automation_info, platform_type="device"
+        hass, event_config, action, trigger_info, platform_type="device"
     )
 
 

--- a/homeassistant/components/hue/v2/device_trigger.py
+++ b/homeassistant/components/hue/v2/device_trigger.py
@@ -26,10 +26,7 @@ from ..const import ATTR_HUE_EVENT, CONF_SUBTYPE, DOMAIN
 if TYPE_CHECKING:
     from aiohue.v2 import HueBridgeV2
 
-    from homeassistant.components.automation import (
-        AutomationActionType,
-        AutomationTriggerInfo,
-    )
+    from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 
     from ..bridge import HueBridge
 
@@ -59,7 +56,7 @@ def check_invalid_device_trigger(
     bridge: HueBridge,
     config: ConfigType,
     device_entry: DeviceEntry,
-    automation_info: AutomationTriggerInfo | None = None,
+    trigger_info: TriggerInfo | None = None,
 ):
     """Check automation config for deprecated format."""
     # NOTE: Remove this check after 2022.6
@@ -71,8 +68,8 @@ def check_invalid_device_trigger(
         f"[{device_entry.name}](/config/devices/device/{device_entry.id}) "
         "Please manually fix the outdated automation(s) once to fix this issue."
     )
-    if automation_info:
-        automation_id = automation_info["variables"]["this"]["attributes"]["id"]  # type: ignore[index]
+    if trigger_info:
+        automation_id = trigger_info["variables"]["this"]["attributes"]["id"]  # type: ignore[index]
         msg += f"\n\n[Check it out](/config/automation/edit/{automation_id})."
     persistent_notification.async_create(
         bridge.hass,
@@ -97,8 +94,8 @@ async def async_attach_trigger(
     bridge: "HueBridge",
     device_entry: DeviceEntry,
     config: ConfigType,
-    action: AutomationActionType,
-    automation_info: AutomationTriggerInfo,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     hass = bridge.hass
@@ -113,9 +110,9 @@ async def async_attach_trigger(
             },
         }
     )
-    check_invalid_device_trigger(bridge, config, device_entry, automation_info)
+    check_invalid_device_trigger(bridge, config, device_entry, trigger_info)
     return await event_trigger.async_attach_trigger(
-        hass, event_config, action, automation_info, platform_type="device"
+        hass, event_config, action, trigger_info, platform_type="device"
     )
 
 

--- a/homeassistant/components/kodi/device_trigger.py
+++ b/homeassistant/components/kodi/device_trigger.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.automation import (
-    AutomationActionType,
-    AutomationTriggerInfo,
-)
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -18,6 +14,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, EVENT_TURN_OFF, EVENT_TURN_ON
@@ -68,11 +65,11 @@ async def async_get_triggers(
 def _attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
-    action: AutomationActionType,
+    action: TriggerActionType,
     event_type,
-    automation_info: AutomationTriggerInfo,
+    trigger_info: TriggerInfo,
 ):
-    trigger_data = automation_info["trigger_data"]
+    trigger_data = trigger_info["trigger_data"]
     job = HassJob(action)
 
     @callback
@@ -90,14 +87,14 @@ def _attach_trigger(
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
-    action: AutomationActionType,
-    automation_info: AutomationTriggerInfo,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
     if config[CONF_TYPE] == "turn_on":
-        return _attach_trigger(hass, config, action, EVENT_TURN_ON, automation_info)
+        return _attach_trigger(hass, config, action, EVENT_TURN_ON, trigger_info)
 
     if config[CONF_TYPE] == "turn_off":
-        return _attach_trigger(hass, config, action, EVENT_TURN_OFF, automation_info)
+        return _attach_trigger(hass, config, action, EVENT_TURN_OFF, trigger_info)
 
     return lambda: None


### PR DESCRIPTION
## Proposed change
Remove deprecated `AutomationActionType` in favor of `TriggerActionType`.
Ref #76790


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
