### PR TITLE
Fix bluetooth callback registration not surviving a reload

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -364,13 +364,13 @@ class BluetoothManager:
             async with async_timeout.timeout(START_TIMEOUT):
                 await self.scanner.start()  # type: ignore[no-untyped-call]
         except InvalidMessageError as ex:
-            self._cancel_device_detected()
+            self._async_cancel_scanner_callback()
             _LOGGER.debug("Invalid DBus message received: %s", ex, exc_info=True)
             raise ConfigEntryNotReady(
                 f"Invalid DBus message received: {ex}; try restarting `dbus`"
             ) from ex
         except BrokenPipeError as ex:
-            self._cancel_device_detected()
+            self._async_cancel_scanner_callback()
             _LOGGER.debug("DBus connection broken: %s", ex, exc_info=True)
             if is_docker_env():
                 raise ConfigEntryNotReady(
@@ -380,7 +380,7 @@ class BluetoothManager:
                 f"DBus connection broken: {ex}; try restarting `bluetooth` and `dbus`"
             ) from ex
         except FileNotFoundError as ex:
-            self._cancel_device_detected()
+            self._async_cancel_scanner_callback()
             _LOGGER.debug(
                 "FileNotFoundError while starting bluetooth: %s", ex, exc_info=True
             )
@@ -392,12 +392,12 @@ class BluetoothManager:
                 f"DBus service not found; make sure the DBus socket is available to Home Assistant: {ex}"
             ) from ex
         except asyncio.TimeoutError as ex:
-            self._cancel_device_detected()
+            self._async_cancel_scanner_callback()
             raise ConfigEntryNotReady(
                 f"Timed out starting Bluetooth after {START_TIMEOUT} seconds"
             ) from ex
         except BleakError as ex:
-            self._cancel_device_detected()
+            self._async_cancel_scanner_callback()
             _LOGGER.debug("BleakError while starting bluetooth: %s", ex, exc_info=True)
             raise ConfigEntryNotReady(f"Failed to start Bluetooth: {ex}") from ex
         self.async_setup_unavailable_tracking()
@@ -579,15 +579,20 @@ class BluetoothManager:
         self._cancel_stop = None
         await self.async_stop()
 
+    @hass_callback
+    def _async_cancel_scanner_callback(self) -> None:
+        """Cancel the scanner callback."""
+        if self._cancel_device_detected:
+            self._cancel_device_detected()
+            self._cancel_device_detected = None
+
     async def async_stop(self) -> None:
         """Stop bluetooth discovery."""
         _LOGGER.debug("Stopping bluetooth discovery")
         if self._cancel_watchdog:
             self._cancel_watchdog()
             self._cancel_watchdog = None
-        if self._cancel_device_detected:
-            self._cancel_device_detected()
-            self._cancel_device_detected = None
+        self._async_cancel_scanner_callback()
         if self._cancel_unavailable_tracking:
             self._cancel_unavailable_tracking()
             self._cancel_unavailable_tracking = None

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -165,6 +165,43 @@ async def test_setup_and_retry_adapter_not_yet_available(hass, caplog):
         await hass.async_block_till_done()
 
 
+async def test_no_race_during_manual_reload_in_retry_state(hass, caplog):
+    """Test we can successfully reload when the entry is in a retry state."""
+    mock_bt = []
+    with patch("homeassistant.components.bluetooth.HaBleakScanner.async_setup"), patch(
+        "homeassistant.components.bluetooth.HaBleakScanner.start",
+        side_effect=BleakError,
+    ), patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        assert await async_setup_component(
+            hass, bluetooth.DOMAIN, {bluetooth.DOMAIN: {}}
+        )
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    entry = hass.config_entries.async_entries(bluetooth.DOMAIN)[0]
+
+    assert "Failed to start Bluetooth" in caplog.text
+    assert len(bluetooth.async_discovered_service_info(hass)) == 0
+    assert entry.state == ConfigEntryState.SETUP_RETRY
+
+    with patch(
+        "homeassistant.components.bluetooth.HaBleakScanner.start",
+    ):
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state == ConfigEntryState.LOADED
+
+    with patch(
+        "homeassistant.components.bluetooth.HaBleakScanner.stop",
+    ):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+
 async def test_calling_async_discovered_devices_no_bluetooth(hass, caplog):
     """Test we fail gracefully when asking for discovered devices and there is no blueooth."""
     mock_bt = []
@@ -866,6 +903,66 @@ async def test_register_callback_by_address(
         assert service_info.name == "wohand"
         assert service_info.manufacturer == "Nordic Semiconductor ASA"
         assert service_info.manufacturer_id == 89
+
+
+async def test_register_callback_survives_reload(
+    hass, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Test registering a callback by address survives bluetooth being reloaded."""
+    mock_bt = []
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo, change: BluetoothChange
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        assert await async_setup_component(
+            hass, bluetooth.DOMAIN, {bluetooth.DOMAIN: {}}
+        )
+        await hass.async_block_till_done()
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    bluetooth.async_register_callback(
+        hass,
+        _fake_subscriber,
+        {"address": "44:44:33:11:23:45"},
+        BluetoothScanningMode.ACTIVE,
+    )
+
+    assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_adv = AdvertisementData(
+        local_name="wohand",
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        manufacturer_data={89: b"\xd8.\xad\xcd\r\x85"},
+        service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x10c"},
+    )
+
+    _get_underlying_scanner()._callback(switchbot_device, switchbot_adv)
+    assert len(callbacks) == 1
+    service_info: BluetoothServiceInfo = callbacks[0][0]
+    assert service_info.name == "wohand"
+    assert service_info.manufacturer == "Nordic Semiconductor ASA"
+    assert service_info.manufacturer_id == 89
+
+    entry = hass.config_entries.async_entries(bluetooth.DOMAIN)[0]
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    _get_underlying_scanner()._callback(switchbot_device, switchbot_adv)
+    assert len(callbacks) == 2
+    service_info: BluetoothServiceInfo = callbacks[1][0]
+    assert service_info.name == "wohand"
+    assert service_info.manufacturer == "Nordic Semiconductor ASA"
+    assert service_info.manufacturer_id == 89
 
 
 async def test_process_advertisements_bail_on_good_advertisement(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes
```
2022-08-15 06:45:45.277 ERROR (MainThread) [homeassistant.config_entries] Error unloading entry Bluetooth for bluetooth
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 496, in async_unload
    result = await component.async_unload_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 288, in async_unload_entry
    await manager.async_stop()
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 589, in async_stop
    self._cancel_device_detected()
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/models.py", line 89, in _remove_callback
    self._callbacks.remove(callback_entry)
ValueError: list.remove(x): x not in list
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
