### PR TITLE
Change growatt server URL

### DIFF
--- a/homeassistant/components/growatt_server/const.py
+++ b/homeassistant/components/growatt_server/const.py
@@ -13,6 +13,10 @@ SERVER_URLS = [
     "http://server.smten.com/",
 ]
 
+DEPRECATED_URLS = [
+    "https://server.growatt.com/",
+]
+
 DEFAULT_URL = SERVER_URLS[0]
 
 DOMAIN = "growatt_server"

--- a/homeassistant/components/growatt_server/const.py
+++ b/homeassistant/components/growatt_server/const.py
@@ -8,7 +8,7 @@ DEFAULT_PLANT_ID = "0"
 DEFAULT_NAME = "Growatt"
 
 SERVER_URLS = [
-    "https://server.growatt.com/",
+    "https://server-api.growatt.com/",
     "https://server-us.growatt.com/",
     "http://server.smten.com/",
 ]

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_PLANT_ID,
     DEFAULT_PLANT_ID,
     DEFAULT_URL,
+    DEPRECATED_URLS,
     DOMAIN,
     LOGIN_INVALID_AUTH_CODE,
 )
@@ -62,11 +63,22 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Growatt sensor."""
-    config = config_entry.data
+    config = {**config_entry.data}
     username = config[CONF_USERNAME]
     password = config[CONF_PASSWORD]
     url = config.get(CONF_URL, DEFAULT_URL)
     name = config[CONF_NAME]
+
+    # If the URL has been deprecated then change to the default instead
+    if url in DEPRECATED_URLS:
+        _LOGGER.info(
+            "URL: %s has been deprecated, migrating to the latest default: %s",
+            url,
+            DEFAULT_URL,
+        )
+        url = DEFAULT_URL
+        config[CONF_URL] = url
+        hass.config_entries.async_update_entry(config_entry, data=config)
 
     api = growattServer.GrowattApi()
     api.server_url = url


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The default URL used to retrieve data for this integration ( https://server.growatt.com ) is unreliable and appears to be being replaced by the new url https://server-api.growatt.com. Other open source libraries for accesing growatt solar api have already made this update, but it has not yet been done for home assistant. New users of this api will get errors when thy first log in and will be unable to retrieve data reliably.

This update is needed to change the default URL Selection to one that works on the growatt servers. More info on the issue can be found in https://github.com/home-assistant/core/issues/76453

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #76453
- This PR is related to issue: 76453
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
