### PR TITLE
Improve Awair config flow

### DIFF
--- a/homeassistant/components/awair/manifest.json
+++ b/homeassistant/components/awair/manifest.json
@@ -12,5 +12,10 @@
       "type": "_http._tcp.local.",
       "name": "awair*"
     }
+  ],
+  "dhcp": [
+    {
+      "macaddress": "70886B1*"
+    }
   ]
 }

--- a/homeassistant/components/awair/strings.json
+++ b/homeassistant/components/awair/strings.json
@@ -9,10 +9,13 @@
         }
       },
       "local": {
+        "description": "Follow [these instructions]({url}) on how to enable the Awair Local API.\n\nClick submit when done."
+      },
+      "local_pick": {
         "data": {
+          "device": "[%key:common::config_flow::data::device%]",
           "host": "[%key:common::config_flow::data::ip%]"
-        },
-        "description": "Awair Local API must be enabled following these steps: {url}"
+        }
       },
       "reauth_confirm": {
         "description": "Please re-enter your Awair developer access token.",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -11,6 +11,7 @@ DHCP: list[dict[str, str | bool]] = [
     {'domain': 'august', 'hostname': 'connect', 'macaddress': 'B8B7F1*'},
     {'domain': 'august', 'hostname': 'connect', 'macaddress': '2C9FFB*'},
     {'domain': 'august', 'hostname': 'august*', 'macaddress': 'E076D0*'},
+    {'domain': 'awair', 'macaddress': '70886B1*'},
     {'domain': 'axis', 'registered_devices': True},
     {'domain': 'axis', 'hostname': 'axis-00408c*', 'macaddress': '00408C*'},
     {'domain': 'axis', 'hostname': 'axis-accc8e*', 'macaddress': 'ACCC8E*'},

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -26,6 +26,7 @@
         "confirm_setup": "Do you want to start set up?"
       },
       "data": {
+        "device": "Device",
         "name": "Name",
         "email": "Email",
         "username": "Username",

--- a/tests/components/awair/test_config_flow.py
+++ b/tests/components/awair/test_config_flow.py
@@ -240,6 +240,12 @@ async def test_create_local_entry(hass: HomeAssistant, local_devices):
             {"next_step_id": "local"},
         )
 
+        # We're being shown the local instructions
+        form_step = await hass.config_entries.flow.async_configure(
+            form_step["flow_id"],
+            {},
+        )
+
         result = await hass.config_entries.flow.async_configure(
             form_step["flow_id"],
             LOCAL_CONFIG,
@@ -249,6 +255,48 @@ async def test_create_local_entry(hass: HomeAssistant, local_devices):
         assert result["title"] == "Awair Element (24947)"
         assert result["data"][CONF_HOST] == LOCAL_CONFIG[CONF_HOST]
         assert result["result"].unique_id == LOCAL_UNIQUE_ID
+
+
+async def test_create_local_entry_from_discovery(hass: HomeAssistant, local_devices):
+    """Test local API when device discovered after instructions shown."""
+
+    menu_step = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=LOCAL_CONFIG
+    )
+
+    form_step = await hass.config_entries.flow.async_configure(
+        menu_step["flow_id"],
+        {"next_step_id": "local"},
+    )
+
+    # Create discovered entry in progress
+    with patch("python_awair.AwairClient.query", side_effect=[local_devices]):
+        await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=Mock(host=LOCAL_CONFIG[CONF_HOST]),
+            context={"source": SOURCE_ZEROCONF},
+        )
+
+    # We're being shown the local instructions
+    form_step = await hass.config_entries.flow.async_configure(
+        form_step["flow_id"],
+        {},
+    )
+
+    with patch("python_awair.AwairClient.query", side_effect=[local_devices]), patch(
+        "homeassistant.components.awair.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            form_step["flow_id"],
+            {"device": LOCAL_CONFIG[CONF_HOST]},
+        )
+
+    print(result)
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Awair Element (24947)"
+    assert result["data"][CONF_HOST] == LOCAL_CONFIG[CONF_HOST]
+    assert result["result"].unique_id == LOCAL_UNIQUE_ID
 
 
 async def test_create_local_entry_awair_error(hass: HomeAssistant):
@@ -267,6 +315,12 @@ async def test_create_local_entry_awair_error(hass: HomeAssistant):
             {"next_step_id": "local"},
         )
 
+        # We're being shown the local instructions
+        form_step = await hass.config_entries.flow.async_configure(
+            form_step["flow_id"],
+            {},
+        )
+
         result = await hass.config_entries.flow.async_configure(
             form_step["flow_id"],
             LOCAL_CONFIG,
@@ -274,7 +328,7 @@ async def test_create_local_entry_awair_error(hass: HomeAssistant):
 
         # User is returned to form to try again
         assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == "local"
+        assert result["step_id"] == "local_pick"
 
 
 async def test_create_zeroconf_entry(hass: HomeAssistant, local_devices):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Awair is only locally discoverable when the local API is enabled. They don't turn it always on because [it was causing issues for some users](https://twitter.com/deanlyoung/status/1558558884624625664).

The config flow guides the user to turn on the local API but then asks in same screen for an IP, that is a poor experience. When the local API is turned on, the device is immediately discovered, but the user doesn't know because it is looking at the current flow.

This PR changes the flow to first just show the instructions. Once the user goes to the next step it will be shown the discovered devices and the option to enter a manual IP. If no devices are discovered, it will fallback to showing just the IP input.

![image](https://user-images.githubusercontent.com/1444314/184793639-2830bb27-f612-48eb-b88b-90c6857ec1e5.png)

![image](https://user-images.githubusercontent.com/1444314/184793672-772cebe1-7895-4716-9a44-d3fd2f000a8a.png)

![image](https://user-images.githubusercontent.com/1444314/184793682-21252733-64c8-4d00-98c5-00896c750f8e.png)

Also added DHCP discovery for Awair devices and catch the correct error when a connection error happens.

CC @zachberger


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
