### PR TITLE
Remove deprecated white_value support from MQTT light

### DIFF
--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -17,13 +17,8 @@ from homeassistant.components.light import (
     ATTR_RGBWW_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
     ATTR_WHITE,
-    ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
     ENTITY_ID_FORMAT,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_COLOR_TEMP,
-    SUPPORT_WHITE_VALUE,
     ColorMode,
     LightEntity,
     LightEntityFeature,
@@ -119,7 +114,6 @@ MQTT_LIGHT_ATTRIBUTES_BLOCKED = frozenset(
         ATTR_RGBW_COLOR,
         ATTR_RGBWW_COLOR,
         ATTR_SUPPORTED_COLOR_MODES,
-        ATTR_WHITE_VALUE,
         ATTR_XY_COLOR,
     }
 )
@@ -129,7 +123,6 @@ DEFAULT_NAME = "MQTT LightEntity"
 DEFAULT_OPTIMISTIC = False
 DEFAULT_PAYLOAD_OFF = "OFF"
 DEFAULT_PAYLOAD_ON = "ON"
-DEFAULT_WHITE_VALUE_SCALE = 255
 DEFAULT_WHITE_SCALE = 255
 DEFAULT_ON_COMMAND_TYPE = "last"
 
@@ -153,7 +146,6 @@ VALUE_TEMPLATE_KEYS = [
     CONF_RGBW_VALUE_TEMPLATE,
     CONF_RGBWW_VALUE_TEMPLATE,
     CONF_STATE_VALUE_TEMPLATE,
-    CONF_WHITE_VALUE_TEMPLATE,
     CONF_XY_VALUE_TEMPLATE,
 ]
 
@@ -207,12 +199,6 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_WHITE_SCALE, default=DEFAULT_WHITE_SCALE): vol.All(
                 vol.Coerce(int), vol.Range(min=1)
             ),
-            vol.Optional(CONF_WHITE_VALUE_COMMAND_TOPIC): valid_publish_topic,
-            vol.Optional(
-                CONF_WHITE_VALUE_SCALE, default=DEFAULT_WHITE_VALUE_SCALE
-            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
-            vol.Optional(CONF_WHITE_VALUE_STATE_TOPIC): valid_subscribe_topic,
-            vol.Optional(CONF_WHITE_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_XY_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_XY_STATE_TOPIC): valid_subscribe_topic,
             vol.Optional(CONF_XY_VALUE_TEMPLATE): cv.template,
@@ -224,22 +210,17 @@ _PLATFORM_SCHEMA_BASE = (
 
 # The use of PLATFORM_SCHEMA is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA_BASIC = vol.All(
-    # CONF_WHITE_VALUE_* is deprecated, support will be removed in release 2022.9
-    cv.deprecated(CONF_WHITE_VALUE_COMMAND_TOPIC),
-    cv.deprecated(CONF_WHITE_VALUE_SCALE),
-    cv.deprecated(CONF_WHITE_VALUE_STATE_TOPIC),
-    cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
     cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
 )
 
 DISCOVERY_SCHEMA_BASIC = vol.All(
     # CONF_VALUE_TEMPLATE is no longer supported, support was removed in 2022.2
     cv.removed(CONF_VALUE_TEMPLATE),
-    # CONF_WHITE_VALUE_* is deprecated, support will be removed in release 2022.9
-    cv.deprecated(CONF_WHITE_VALUE_COMMAND_TOPIC),
-    cv.deprecated(CONF_WHITE_VALUE_SCALE),
-    cv.deprecated(CONF_WHITE_VALUE_STATE_TOPIC),
-    cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
+    # CONF_WHITE_VALUE_* is no longer supported, support was removed in 2022.9
+    cv.removed(CONF_WHITE_VALUE_COMMAND_TOPIC),
+    cv.removed(CONF_WHITE_VALUE_SCALE),
+    cv.removed(CONF_WHITE_VALUE_STATE_TOPIC),
+    cv.removed(CONF_WHITE_VALUE_TEMPLATE),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
 )
 
@@ -266,13 +247,11 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         self._color_temp = None
         self._effect = None
         self._hs_color = None
-        self._legacy_mode = False
         self._rgb_color = None
         self._rgbw_color = None
         self._rgbww_color = None
         self._state = None
         self._supported_color_modes = None
-        self._white_value = None
         self._xy_color = None
 
         self._topic = None
@@ -288,7 +267,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         self._optimistic_rgb_color = False
         self._optimistic_rgbw_color = False
         self._optimistic_rgbww_color = False
-        self._optimistic_white_value = False
         self._optimistic_xy_color = False
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
@@ -324,8 +302,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
                 CONF_RGBWW_STATE_TOPIC,
                 CONF_STATE_TOPIC,
                 CONF_WHITE_COMMAND_TOPIC,
-                CONF_WHITE_VALUE_COMMAND_TOPIC,
-                CONF_WHITE_VALUE_STATE_TOPIC,
                 CONF_XY_COMMAND_TOPIC,
                 CONF_XY_STATE_TOPIC,
             )
@@ -384,9 +360,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         )
         self._optimistic_effect = optimistic or topic[CONF_EFFECT_STATE_TOPIC] is None
         self._optimistic_hs_color = optimistic or topic[CONF_HS_STATE_TOPIC] is None
-        self._optimistic_white_value = (
-            optimistic or topic[CONF_WHITE_VALUE_STATE_TOPIC] is None
-        )
         self._optimistic_xy_color = optimistic or topic[CONF_XY_STATE_TOPIC] is None
         supported_color_modes = set()
         if topic[CONF_COLOR_TEMP_COMMAND_TOPIC] is not None:
@@ -422,9 +395,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
 
         # Validate the color_modes configuration
         self._supported_color_modes = valid_supported_color_modes(supported_color_modes)
-
-        if topic[CONF_WHITE_VALUE_COMMAND_TOPIC] is not None:
-            self._legacy_mode = True
 
     def _is_optimistic(self, attribute):
         """Return True if the attribute is optimistically updated."""
@@ -513,10 +483,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             )
             if not rgb:
                 return
-            if self._legacy_mode:
-                self._hs_color = color_util.color_RGB_to_hs(*rgb)
-            else:
-                self._rgb_color = rgb
+            self._rgb_color = rgb
             self.async_write_ha_state()
 
         add_topic(CONF_RGB_STATE_TOPIC, rgb_received)
@@ -626,24 +593,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
 
         @callback
         @log_messages(self.hass, self.entity_id)
-        def white_value_received(msg):
-            """Handle new MQTT messages for white value."""
-            payload = self._value_templates[CONF_WHITE_VALUE_TEMPLATE](
-                msg.payload, None
-            )
-            if not payload:
-                _LOGGER.debug("Ignoring empty white value message from '%s'", msg.topic)
-                return
-
-            device_value = float(payload)
-            percent_white = device_value / self._config[CONF_WHITE_VALUE_SCALE]
-            self._white_value = percent_white * 255
-            self.async_write_ha_state()
-
-        add_topic(CONF_WHITE_VALUE_STATE_TOPIC, white_value_received)
-
-        @callback
-        @log_messages(self.hass, self.entity_id)
         def xy_received(msg):
             """Handle new MQTT messages for xy color."""
             payload = self._value_templates[CONF_XY_VALUE_TEMPLATE](msg.payload, None)
@@ -654,10 +603,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             xy_color = tuple(float(val) for val in payload.split(","))
             if self._optimistic_color_mode:
                 self._color_mode = ColorMode.XY
-            if self._legacy_mode:
-                self._hs_color = color_util.color_xy_to_hs(*xy_color)
-            else:
-                self._xy_color = xy_color
+            self._xy_color = xy_color
             self.async_write_ha_state()
 
         add_topic(CONF_XY_STATE_TOPIC, xy_received)
@@ -690,7 +636,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         restore_state(ATTR_COLOR_TEMP)
         restore_state(ATTR_EFFECT)
         restore_state(ATTR_HS_COLOR)
-        restore_state(ATTR_WHITE_VALUE)
         restore_state(ATTR_XY_COLOR)
         restore_state(ATTR_HS_COLOR, ATTR_XY_COLOR)
 
@@ -704,19 +649,11 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
     @property
     def color_mode(self):
         """Return current color mode."""
-        if self._legacy_mode:
-            return None
         return self._color_mode
 
     @property
     def hs_color(self):
         """Return the hs color value."""
-        if not self._legacy_mode:
-            return self._hs_color
-
-        # Legacy mode, gate color_temp with white_value == 0
-        if self._white_value:
-            return None
         return self._hs_color
 
     @property
@@ -742,18 +679,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
     @property
     def color_temp(self):
         """Return the color temperature in mired."""
-        if not self._legacy_mode:
-            return self._color_temp
-
-        # Legacy mode, gate color_temp with white_value > 0
-        supports_color = (
-            self._topic[CONF_RGB_COMMAND_TOPIC]
-            or self._topic[CONF_HS_COMMAND_TOPIC]
-            or self._topic[CONF_XY_COMMAND_TOPIC]
-        )
-        if self._white_value or not supports_color:
-            return self._color_temp
-        return None
+        return self._color_temp
 
     @property
     def min_mireds(self):
@@ -764,13 +690,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
     def max_mireds(self):
         """Return the warmest color_temp that this light supports."""
         return self._config.get(CONF_MAX_MIREDS, super().max_mireds)
-
-    @property
-    def white_value(self):
-        """Return the white property."""
-        if white_value := self._white_value:
-            return min(round(white_value), 255)
-        return None
 
     @property
     def is_on(self):
@@ -795,8 +714,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
     @property
     def supported_color_modes(self):
         """Flag supported color modes."""
-        if self._legacy_mode:
-            return None
         return self._supported_color_modes
 
     @property
@@ -807,32 +724,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             self._topic[CONF_EFFECT_COMMAND_TOPIC] is not None
             and LightEntityFeature.EFFECT
         )
-        if not self._legacy_mode:
-            return supported_features
-
-        # Legacy mode
-        supported_features |= self._topic[CONF_RGB_COMMAND_TOPIC] is not None and (
-            SUPPORT_COLOR | SUPPORT_BRIGHTNESS
-        )
-        supported_features |= (
-            self._topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None
-            and SUPPORT_BRIGHTNESS
-        )
-        supported_features |= (
-            self._topic[CONF_COLOR_TEMP_COMMAND_TOPIC] is not None
-            and SUPPORT_COLOR_TEMP
-        )
-        supported_features |= (
-            self._topic[CONF_HS_COMMAND_TOPIC] is not None and SUPPORT_COLOR
-        )
-        supported_features |= (
-            self._topic[CONF_WHITE_VALUE_COMMAND_TOPIC] is not None
-            and SUPPORT_WHITE_VALUE
-        )
-        supported_features |= (
-            self._topic[CONF_XY_COMMAND_TOPIC] is not None and SUPPORT_COLOR
-        )
-
         return supported_features
 
     async def async_turn_on(self, **kwargs):  # noqa: C901
@@ -905,70 +796,38 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             kwargs[ATTR_BRIGHTNESS] = self._brightness if self._brightness else 255
 
         hs_color = kwargs.get(ATTR_HS_COLOR)
-        if (
-            hs_color
-            and self._topic[CONF_RGB_COMMAND_TOPIC] is not None
-            and self._legacy_mode
-        ):
-            # Legacy mode: Convert HS to RGB
-            rgb = scale_rgbx(color_util.color_hsv_to_RGB(*hs_color, 100))
-            rgb_s = render_rgbx(rgb, CONF_RGB_COMMAND_TEMPLATE, ColorMode.RGB)
-            await publish(CONF_RGB_COMMAND_TOPIC, rgb_s)
-            should_update |= set_optimistic(
-                ATTR_HS_COLOR, hs_color, condition_attribute=ATTR_RGB_COLOR
-            )
 
         if hs_color and self._topic[CONF_HS_COMMAND_TOPIC] is not None:
             await publish(CONF_HS_COMMAND_TOPIC, f"{hs_color[0]},{hs_color[1]}")
             should_update |= set_optimistic(ATTR_HS_COLOR, hs_color, ColorMode.HS)
 
-        if (
-            hs_color
-            and self._topic[CONF_XY_COMMAND_TOPIC] is not None
-            and self._legacy_mode
-        ):
-            # Legacy mode: Convert HS to XY
-            xy_color = color_util.color_hs_to_xy(*hs_color)
-            await publish(CONF_XY_COMMAND_TOPIC, f"{xy_color[0]},{xy_color[1]}")
-            should_update |= set_optimistic(
-                ATTR_HS_COLOR, hs_color, condition_attribute=ATTR_XY_COLOR
-            )
-
-        if (
-            (rgb := kwargs.get(ATTR_RGB_COLOR))
-            and self._topic[CONF_RGB_COMMAND_TOPIC] is not None
-            and not self._legacy_mode
-        ):
+        if (rgb := kwargs.get(ATTR_RGB_COLOR)) and self._topic[
+            CONF_RGB_COMMAND_TOPIC
+        ] is not None:
             scaled = scale_rgbx(rgb)
             rgb_s = render_rgbx(scaled, CONF_RGB_COMMAND_TEMPLATE, ColorMode.RGB)
             await publish(CONF_RGB_COMMAND_TOPIC, rgb_s)
             should_update |= set_optimistic(ATTR_RGB_COLOR, rgb, ColorMode.RGB)
 
-        if (
-            (rgbw := kwargs.get(ATTR_RGBW_COLOR))
-            and self._topic[CONF_RGBW_COMMAND_TOPIC] is not None
-            and not self._legacy_mode
-        ):
+        if (rgbw := kwargs.get(ATTR_RGBW_COLOR)) and self._topic[
+            CONF_RGBW_COMMAND_TOPIC
+        ] is not None:
             scaled = scale_rgbx(rgbw)
             rgbw_s = render_rgbx(scaled, CONF_RGBW_COMMAND_TEMPLATE, ColorMode.RGBW)
             await publish(CONF_RGBW_COMMAND_TOPIC, rgbw_s)
             should_update |= set_optimistic(ATTR_RGBW_COLOR, rgbw, ColorMode.RGBW)
 
-        if (
-            (rgbww := kwargs.get(ATTR_RGBWW_COLOR))
-            and self._topic[CONF_RGBWW_COMMAND_TOPIC] is not None
-            and not self._legacy_mode
-        ):
+        if (rgbww := kwargs.get(ATTR_RGBWW_COLOR)) and self._topic[
+            CONF_RGBWW_COMMAND_TOPIC
+        ] is not None:
             scaled = scale_rgbx(rgbww)
             rgbww_s = render_rgbx(scaled, CONF_RGBWW_COMMAND_TEMPLATE, ColorMode.RGBWW)
             await publish(CONF_RGBWW_COMMAND_TOPIC, rgbww_s)
             should_update |= set_optimistic(ATTR_RGBWW_COLOR, rgbww, ColorMode.RGBWW)
 
-        if (
-            (xy_color := kwargs.get(ATTR_XY_COLOR))
-            and self._topic[CONF_XY_COMMAND_TOPIC] is not None
-            and not self._legacy_mode
-        ):
+        if (xy_color := kwargs.get(ATTR_XY_COLOR)) and self._topic[
+            CONF_XY_COMMAND_TOPIC
+        ] is not None:
             await publish(CONF_XY_COMMAND_TOPIC, f"{xy_color[0]},{xy_color[1]}")
             should_update |= set_optimistic(ATTR_XY_COLOR, xy_color, ColorMode.XY)
 
@@ -989,22 +848,8 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             should_update |= set_optimistic(ATTR_BRIGHTNESS, kwargs[ATTR_BRIGHTNESS])
         elif (
             ATTR_BRIGHTNESS in kwargs
-            and ATTR_HS_COLOR not in kwargs
-            and self._topic[CONF_RGB_COMMAND_TOPIC] is not None
-            and self._legacy_mode
-        ):
-            # Legacy mode
-            hs_color = self._hs_color if self._hs_color is not None else (0, 0)
-            brightness = kwargs[ATTR_BRIGHTNESS]
-            rgb = scale_rgbx(color_util.color_hsv_to_RGB(*hs_color, 100), brightness)
-            rgb_s = render_rgbx(rgb, CONF_RGB_COMMAND_TEMPLATE, ColorMode.RGB)
-            await publish(CONF_RGB_COMMAND_TOPIC, rgb_s)
-            should_update |= set_optimistic(ATTR_BRIGHTNESS, kwargs[ATTR_BRIGHTNESS])
-        elif (
-            ATTR_BRIGHTNESS in kwargs
             and ATTR_RGB_COLOR not in kwargs
             and self._topic[CONF_RGB_COMMAND_TOPIC] is not None
-            and not self._legacy_mode
         ):
             rgb_color = self._rgb_color if self._rgb_color is not None else (255,) * 3
             rgb = scale_rgbx(rgb_color, kwargs[ATTR_BRIGHTNESS])
@@ -1015,7 +860,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             ATTR_BRIGHTNESS in kwargs
             and ATTR_RGBW_COLOR not in kwargs
             and self._topic[CONF_RGBW_COMMAND_TOPIC] is not None
-            and not self._legacy_mode
         ):
             rgbw_color = (
                 self._rgbw_color if self._rgbw_color is not None else (255,) * 4
@@ -1028,7 +872,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             ATTR_BRIGHTNESS in kwargs
             and ATTR_RGBWW_COLOR not in kwargs
             and self._topic[CONF_RGBWW_COMMAND_TOPIC] is not None
-            and not self._legacy_mode
         ):
             rgbww_color = (
                 self._rgbww_color if self._rgbww_color is not None else (255,) * 5
@@ -1068,16 +911,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
                 kwargs[ATTR_WHITE],
                 ColorMode.WHITE,
             )
-
-        if (
-            ATTR_WHITE_VALUE in kwargs
-            and self._topic[CONF_WHITE_VALUE_COMMAND_TOPIC] is not None
-        ):
-            percent_white = float(kwargs[ATTR_WHITE_VALUE]) / 255
-            white_scale = self._config[CONF_WHITE_VALUE_SCALE]
-            device_white_value = min(round(percent_white * white_scale), white_scale)
-            await publish(CONF_WHITE_VALUE_COMMAND_TOPIC, device_white_value)
-            should_update |= set_optimistic(ATTR_WHITE_VALUE, kwargs[ATTR_WHITE_VALUE])
 
         if on_command_type == "last":
             await publish(CONF_COMMAND_TOPIC, self._payload["on"])

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -10,12 +10,10 @@ from homeassistant.components.light import (
     ATTR_FLASH,
     ATTR_HS_COLOR,
     ATTR_TRANSITION,
-    ATTR_WHITE_VALUE,
     ENTITY_ID_FORMAT,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
-    SUPPORT_WHITE_VALUE,
     LightEntity,
     LightEntityFeature,
 )
@@ -84,7 +82,6 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
             vol.Optional(CONF_RED_TEMPLATE): cv.template,
             vol.Optional(CONF_STATE_TEMPLATE): cv.template,
-            vol.Optional(CONF_WHITE_VALUE_TEMPLATE): cv.template,
         }
     )
     .extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
@@ -93,14 +90,12 @@ _PLATFORM_SCHEMA_BASE = (
 
 # Configuring MQTT Lights under the light platform key is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA_TEMPLATE = vol.All(
-    # CONF_WHITE_VALUE_TEMPLATE is deprecated, support will be removed in release 2022.9
-    cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
     cv.PLATFORM_SCHEMA.extend(_PLATFORM_SCHEMA_BASE.schema),
 )
 
 DISCOVERY_SCHEMA_TEMPLATE = vol.All(
-    # CONF_WHITE_VALUE_TEMPLATE is deprecated, support will be removed in release 2022.9
-    cv.deprecated(CONF_WHITE_VALUE_TEMPLATE),
+    # CONF_WHITE_VALUE_TEMPLATE is no longer supported, support was removed in 2022.9
+    cv.removed(CONF_WHITE_VALUE_TEMPLATE),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
 )
 
@@ -131,7 +126,6 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
         # features
         self._brightness = None
         self._color_temp = None
-        self._white_value = None
         self._hs = None
         self._effect = None
 
@@ -159,7 +153,6 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
                 CONF_GREEN_TEMPLATE,
                 CONF_RED_TEMPLATE,
                 CONF_STATE_TEMPLATE,
-                CONF_WHITE_VALUE_TEMPLATE,
             )
         }
         optimistic = config[CONF_OPTIMISTIC]
@@ -236,16 +229,6 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
                 except ValueError:
                     _LOGGER.warning("Invalid color value received")
 
-            if self._templates[CONF_WHITE_VALUE_TEMPLATE] is not None:
-                try:
-                    self._white_value = int(
-                        self._templates[
-                            CONF_WHITE_VALUE_TEMPLATE
-                        ].async_render_with_possible_json_value(msg.payload)
-                    )
-                except ValueError:
-                    _LOGGER.warning("Invalid white value received")
-
             if self._templates[CONF_EFFECT_TEMPLATE] is not None:
                 effect = self._templates[
                     CONF_EFFECT_TEMPLATE
@@ -287,8 +270,6 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
                 self._color_temp = last_state.attributes.get(ATTR_COLOR_TEMP)
             if last_state.attributes.get(ATTR_EFFECT):
                 self._effect = last_state.attributes.get(ATTR_EFFECT)
-            if last_state.attributes.get(ATTR_WHITE_VALUE):
-                self._white_value = last_state.attributes.get(ATTR_WHITE_VALUE)
 
     @property
     def brightness(self):
@@ -314,11 +295,6 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
     def hs_color(self):
         """Return the hs color value [int, int]."""
         return self._hs
-
-    @property
-    def white_value(self):
-        """Return the white property."""
-        return self._white_value
 
     @property
     def is_on(self):
@@ -384,12 +360,6 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
 
             if self._optimistic:
                 self._hs = kwargs[ATTR_HS_COLOR]
-
-        if ATTR_WHITE_VALUE in kwargs:
-            values["white_value"] = int(kwargs[ATTR_WHITE_VALUE])
-
-            if self._optimistic:
-                self._white_value = kwargs[ATTR_WHITE_VALUE]
 
         if ATTR_EFFECT in kwargs:
             values["effect"] = kwargs.get(ATTR_EFFECT)
@@ -457,7 +427,5 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             features = features | LightEntityFeature.EFFECT
         if self._templates[CONF_COLOR_TEMP_TEMPLATE] is not None:
             features = features | SUPPORT_COLOR_TEMP
-        if self._templates[CONF_WHITE_VALUE_TEMPLATE] is not None:
-            features = features | SUPPORT_WHITE_VALUE
 
         return features

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -106,23 +106,6 @@ light:
   payload_on: "on"
   payload_off: "off"
 
-config for RGB Version with white value and scale:
-
-light:
-  platform: mqtt
-  name: "Office Light RGB"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  white_value_state_topic: "office/rgb1/white_value/status"
-  white_value_command_topic: "office/rgb1/white_value/set"
-  white_value_scale: 99
-  rgb_state_topic: "office/rgb1/rgb/status"
-  rgb_command_topic: "office/rgb1/rgb/set"
-  rgb_scale: 99
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
-
 config for RGB Version with RGB command template:
 
 light:
@@ -199,13 +182,11 @@ from homeassistant.components.mqtt.light.schema_basic import (
     CONF_RGB_COMMAND_TOPIC,
     CONF_RGBW_COMMAND_TOPIC,
     CONF_RGBWW_COMMAND_TOPIC,
-    CONF_WHITE_VALUE_COMMAND_TOPIC,
     CONF_XY_COMMAND_TOPIC,
     MQTT_LIGHT_ATTRIBUTES_BLOCKED,
 )
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
-    ATTR_SUPPORTED_FEATURES,
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
@@ -270,33 +251,6 @@ async def test_fail_setup_if_no_command_topic(hass, mqtt_mock_entry_no_yaml_conf
     assert hass.states.get("light.test") is None
 
 
-async def test_legacy_rgb_white_light(hass, mqtt_mock_entry_with_yaml_config):
-    """Test legacy RGB + white light flags brightness support."""
-    assert await async_setup_component(
-        hass,
-        light.DOMAIN,
-        {
-            light.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "test_light_rgb/set",
-                "rgb_command_topic": "test_light_rgb/rgb/set",
-                "white_value_command_topic": "test_light_rgb/white/set",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get("light.test")
-    expected_features = (
-        light.SUPPORT_COLOR | light.SUPPORT_BRIGHTNESS | light.SUPPORT_WHITE_VALUE
-    )
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
-    assert state.attributes.get(light.ATTR_COLOR_MODE) is None
-    assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == ["hs", "rgbw"]
-
-
 async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(
     hass, mqtt_mock_entry_with_yaml_config
 ):
@@ -325,7 +279,6 @@ async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) is None
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == ["onoff"]
@@ -341,7 +294,6 @@ async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) == "onoff"
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == ["onoff"]
@@ -355,138 +307,6 @@ async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
-
-
-async def test_legacy_controlling_state_via_topic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test the controlling of the state via topic for legacy light (white_value)."""
-    config = {
-        light.DOMAIN: {
-            "platform": "mqtt",
-            "name": "test",
-            "state_topic": "test_light_rgb/status",
-            "command_topic": "test_light_rgb/set",
-            "brightness_state_topic": "test_light_rgb/brightness/status",
-            "brightness_command_topic": "test_light_rgb/brightness/set",
-            "rgb_state_topic": "test_light_rgb/rgb/status",
-            "rgb_command_topic": "test_light_rgb/rgb/set",
-            "color_temp_state_topic": "test_light_rgb/color_temp/status",
-            "color_temp_command_topic": "test_light_rgb/color_temp/set",
-            "effect_state_topic": "test_light_rgb/effect/status",
-            "effect_command_topic": "test_light_rgb/effect/set",
-            "hs_state_topic": "test_light_rgb/hs/status",
-            "hs_command_topic": "test_light_rgb/hs/set",
-            "white_value_state_topic": "test_light_rgb/white_value/status",
-            "white_value_command_topic": "test_light_rgb/white_value/set",
-            "xy_state_topic": "test_light_rgb/xy/status",
-            "xy_command_topic": "test_light_rgb/xy/set",
-            "qos": "0",
-            "payload_on": 1,
-            "payload_off": 0,
-        }
-    }
-    color_modes = ["color_temp", "hs", "rgbw"]
-
-    assert await async_setup_component(hass, light.DOMAIN, config)
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("rgb_color") is None
-    assert state.attributes.get("brightness") is None
-    assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("effect") is None
-    assert state.attributes.get("hs_color") is None
-    assert state.attributes.get("rgb_color") is None
-    assert state.attributes.get("rgbw_color") is None
-    assert state.attributes.get("rgbww_color") is None
-    assert state.attributes.get("white_value") is None
-    assert state.attributes.get("xy_color") is None
-    assert state.attributes.get(light.ATTR_COLOR_MODE) is None
-    assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-    assert not state.attributes.get(ATTR_ASSUMED_STATE)
-
-    async_fire_mqtt_message(hass, "test_light_rgb/status", "1")
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("rgb_color") is None
-    assert state.attributes.get("brightness") is None
-    assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("effect") is None
-    assert state.attributes.get("hs_color") is None
-    assert state.attributes.get("rgb_color") is None
-    assert state.attributes.get("rgbw_color") is None
-    assert state.attributes.get("rgbww_color") is None
-    assert state.attributes.get("white_value") is None
-    assert state.attributes.get("xy_color") is None
-    assert state.attributes.get(light.ATTR_COLOR_MODE) == "unknown"
-    assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    async_fire_mqtt_message(hass, "test_light_rgb/status", "0")
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
-
-    async_fire_mqtt_message(hass, "test_light_rgb/status", "1")
-
-    async_fire_mqtt_message(hass, "test_light_rgb/brightness/status", "100")
-
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes["brightness"] == 100
-    assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "unknown"
-    assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    async_fire_mqtt_message(hass, "test_light_rgb/color_temp/status", "300")
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("color_temp") is None
-    assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "unknown"
-    assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    async_fire_mqtt_message(hass, "test_light_rgb/white_value/status", "100")
-
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes["white_value"] == 100
-    assert light_state.attributes["color_temp"] == 300
-    assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "color_temp"
-    assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    async_fire_mqtt_message(hass, "test_light_rgb/effect/status", "rainbow")
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes["effect"] == "rainbow"
-    assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "color_temp"
-    assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    async_fire_mqtt_message(hass, "test_light_rgb/status", "1")
-
-    async_fire_mqtt_message(hass, "test_light_rgb/rgb/status", "125,125,125")
-
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("rgb_color") == (255, 187, 131)
-    assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "color_temp"
-    assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    async_fire_mqtt_message(hass, "test_light_rgb/white_value/status", "0")
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("rgb_color") == (255, 255, 255)
-    assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "hs"
-    assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    async_fire_mqtt_message(hass, "test_light_rgb/hs/status", "200,50")
-
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("hs_color") == (200, 50)
-    assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "hs"
-    assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    async_fire_mqtt_message(hass, "test_light_rgb/xy/status", "0.675,0.322")
-
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("xy_color") == (0.672, 0.324)
-    assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "hs"
-    assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
 
 
 async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_config):
@@ -534,7 +354,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) is None
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
@@ -551,7 +370,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) == "unknown"
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
@@ -609,125 +427,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     assert light_state.attributes.get("xy_color") == (0.675, 0.322)
     assert light_state.attributes.get(light.ATTR_COLOR_MODE) == "xy"
     assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-
-async def test_legacy_invalid_state_via_topic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
-    """Test handling of empty data via topic."""
-    config = {
-        light.DOMAIN: {
-            "platform": "mqtt",
-            "name": "test",
-            "state_topic": "test_light_rgb/status",
-            "command_topic": "test_light_rgb/set",
-            "brightness_state_topic": "test_light_rgb/brightness/status",
-            "brightness_command_topic": "test_light_rgb/brightness/set",
-            "rgb_state_topic": "test_light_rgb/rgb/status",
-            "rgb_command_topic": "test_light_rgb/rgb/set",
-            "color_temp_state_topic": "test_light_rgb/color_temp/status",
-            "color_temp_command_topic": "test_light_rgb/color_temp/set",
-            "effect_state_topic": "test_light_rgb/effect/status",
-            "effect_command_topic": "test_light_rgb/effect/set",
-            "hs_state_topic": "test_light_rgb/hs/status",
-            "hs_command_topic": "test_light_rgb/hs/set",
-            "white_value_state_topic": "test_light_rgb/white_value/status",
-            "white_value_command_topic": "test_light_rgb/white_value/set",
-            "xy_state_topic": "test_light_rgb/xy/status",
-            "xy_command_topic": "test_light_rgb/xy/set",
-            "qos": "0",
-            "payload_on": 1,
-            "payload_off": 0,
-        }
-    }
-
-    assert await async_setup_component(hass, light.DOMAIN, config)
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("rgb_color") is None
-    assert state.attributes.get("brightness") is None
-    assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("effect") is None
-    assert state.attributes.get("hs_color") is None
-    assert state.attributes.get("white_value") is None
-    assert state.attributes.get("xy_color") is None
-    assert not state.attributes.get(ATTR_ASSUMED_STATE)
-
-    async_fire_mqtt_message(hass, "test_light_rgb/status", "1")
-    async_fire_mqtt_message(hass, "test_light_rgb/rgb/status", "255,255,255")
-    async_fire_mqtt_message(hass, "test_light_rgb/brightness/status", "255")
-    async_fire_mqtt_message(hass, "test_light_rgb/effect/status", "none")
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("rgb_color") == (255, 255, 255)
-    assert state.attributes.get("brightness") == 255
-    assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("effect") == "none"
-    assert state.attributes.get("hs_color") == (0, 0)
-    assert state.attributes.get("white_value") is None
-    assert state.attributes.get("xy_color") == (0.323, 0.329)
-
-    async_fire_mqtt_message(hass, "test_light_rgb/status", "")
-    assert "Ignoring empty state message" in caplog.text
-    light_state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-
-    async_fire_mqtt_message(hass, "test_light_rgb/brightness/status", "")
-    assert "Ignoring empty brightness message" in caplog.text
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes["brightness"] == 255
-
-    async_fire_mqtt_message(hass, "test_light_rgb/effect/status", "")
-    assert "Ignoring empty effect message" in caplog.text
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes["effect"] == "none"
-
-    async_fire_mqtt_message(hass, "test_light_rgb/rgb/status", "")
-    assert "Ignoring empty rgb message" in caplog.text
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("rgb_color") == (255, 255, 255)
-
-    async_fire_mqtt_message(hass, "test_light_rgb/hs/status", "")
-    assert "Ignoring empty hs message" in caplog.text
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("hs_color") == (0, 0)
-
-    async_fire_mqtt_message(hass, "test_light_rgb/hs/status", "bad,bad")
-    assert "Failed to parse hs state update" in caplog.text
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("hs_color") == (0, 0)
-
-    async_fire_mqtt_message(hass, "test_light_rgb/xy/status", "")
-    assert "Ignoring empty xy-color message" in caplog.text
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("xy_color") == (0.323, 0.329)
-
-    async_fire_mqtt_message(hass, "test_light_rgb/color_temp/status", "153")
-    async_fire_mqtt_message(hass, "test_light_rgb/white_value/status", "255")
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("rgb_color") == (255, 254, 250)
-    assert state.attributes.get("brightness") == 255
-    assert state.attributes.get("color_temp") == 153
-    assert state.attributes.get("effect") == "none"
-    assert state.attributes.get("hs_color") == (54.768, 1.6)
-    assert state.attributes.get("white_value") == 255
-    assert state.attributes.get("xy_color") == (0.326, 0.333)
-
-    async_fire_mqtt_message(hass, "test_light_rgb/color_temp/status", "")
-    assert "Ignoring empty color temp message" in caplog.text
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes["color_temp"] == 153
-
-    async_fire_mqtt_message(hass, "test_light_rgb/white_value/status", "")
-    assert "Ignoring empty white value message" in caplog.text
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes["white_value"] == 255
 
 
 async def test_invalid_state_via_topic(hass, mqtt_mock_entry_with_yaml_config, caplog):
@@ -955,148 +654,6 @@ async def test_brightness_from_rgb_controlling_scale(
     assert state.attributes.get("brightness") == 127
 
 
-async def test_legacy_white_value_controlling_scale(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test the white_value controlling scale."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
-                light.DOMAIN: {
-                    "platform": "mqtt",
-                    "name": "test",
-                    "state_topic": "test_scale/status",
-                    "command_topic": "test_scale/set",
-                    "white_value_state_topic": "test_scale/white_value/status",
-                    "white_value_command_topic": "test_scale/white_value/set",
-                    "white_value_scale": "99",
-                    "qos": 0,
-                    "payload_on": "on",
-                    "payload_off": "off",
-                }
-            },
-        )
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("white_value") is None
-    assert not state.attributes.get(ATTR_ASSUMED_STATE)
-
-    async_fire_mqtt_message(hass, "test_scale/status", "on")
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("white_value") is None
-
-    async_fire_mqtt_message(hass, "test_scale/status", "off")
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
-
-    async_fire_mqtt_message(hass, "test_scale/status", "on")
-
-    async_fire_mqtt_message(hass, "test_scale/white_value/status", "99")
-
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes["white_value"] == 255
-
-
-async def test_legacy_controlling_state_via_topic_with_templates(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test the setting of the state with a template."""
-    config = {
-        light.DOMAIN: {
-            "platform": "mqtt",
-            "name": "test",
-            "state_topic": "test_light_rgb/status",
-            "command_topic": "test_light_rgb/set",
-            "brightness_command_topic": "test_light_rgb/brightness/set",
-            "rgb_command_topic": "test_light_rgb/rgb/set",
-            "color_temp_command_topic": "test_light_rgb/color_temp/set",
-            "effect_command_topic": "test_light_rgb/effect/set",
-            "hs_command_topic": "test_light_rgb/hs/set",
-            "white_value_command_topic": "test_light_rgb/white_value/set",
-            "xy_command_topic": "test_light_rgb/xy/set",
-            "brightness_state_topic": "test_light_rgb/brightness/status",
-            "color_temp_state_topic": "test_light_rgb/color_temp/status",
-            "effect_state_topic": "test_light_rgb/effect/status",
-            "hs_state_topic": "test_light_rgb/hs/status",
-            "rgb_state_topic": "test_light_rgb/rgb/status",
-            "white_value_state_topic": "test_light_rgb/white_value/status",
-            "xy_state_topic": "test_light_rgb/xy/status",
-            "state_value_template": "{{ value_json.hello }}",
-            "brightness_value_template": "{{ value_json.hello }}",
-            "color_temp_value_template": "{{ value_json.hello }}",
-            "effect_value_template": "{{ value_json.hello }}",
-            "hs_value_template": '{{ value_json.hello | join(",") }}',
-            "rgb_value_template": '{{ value_json.hello | join(",") }}',
-            "white_value_template": "{{ value_json.hello }}",
-            "xy_value_template": '{{ value_json.hello | join(",") }}',
-        }
-    }
-
-    assert await async_setup_component(hass, light.DOMAIN, config)
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("brightness") is None
-    assert state.attributes.get("rgb_color") is None
-
-    async_fire_mqtt_message(hass, "test_light_rgb/rgb/status", '{"hello": [1, 2, 3]}')
-    async_fire_mqtt_message(hass, "test_light_rgb/status", '{"hello": "ON"}')
-    async_fire_mqtt_message(hass, "test_light_rgb/brightness/status", '{"hello": "50"}')
-    async_fire_mqtt_message(
-        hass, "test_light_rgb/color_temp/status", '{"hello": "300"}'
-    )
-    async_fire_mqtt_message(
-        hass, "test_light_rgb/effect/status", '{"hello": "rainbow"}'
-    )
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("brightness") == 50
-    assert state.attributes.get("rgb_color") == (84, 169, 255)
-    assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("effect") == "rainbow"
-    assert state.attributes.get("white_value") is None
-
-    async_fire_mqtt_message(
-        hass, "test_light_rgb/white_value/status", '{"hello": "75"}'
-    )
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("brightness") == 50
-    assert state.attributes.get("rgb_color") == (255, 187, 131)
-    assert state.attributes.get("color_temp") == 300
-    assert state.attributes.get("effect") == "rainbow"
-    assert state.attributes.get("white_value") == 75
-
-    async_fire_mqtt_message(hass, "test_light_rgb/hs/status", '{"hello": [100,50]}')
-    async_fire_mqtt_message(hass, "test_light_rgb/white_value/status", '{"hello": "0"}')
-
-    state = hass.states.get("light.test")
-    assert state.attributes.get("hs_color") == (100, 50)
-
-    async_fire_mqtt_message(
-        hass, "test_light_rgb/xy/status", '{"hello": [0.123,0.123]}'
-    )
-
-    state = hass.states.get("light.test")
-    assert state.attributes.get("xy_color") == (0.14, 0.131)
-
-    async_fire_mqtt_message(hass, "test_light_rgb/status", '{"hello": null}')
-    state = hass.states.get("light.test")
-    assert state.state == STATE_UNKNOWN
-
-
 async def test_controlling_state_via_topic_with_templates(
     hass, mqtt_mock_entry_with_yaml_config
 ):
@@ -1198,139 +755,6 @@ async def test_controlling_state_via_topic_with_templates(
     assert state.attributes.get("xy_color") == (0.123, 0.123)
     assert state.attributes.get(light.ATTR_COLOR_MODE) == "xy"
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-
-async def test_legacy_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test the sending of command in optimistic mode."""
-    config = {
-        light.DOMAIN: {
-            "platform": "mqtt",
-            "name": "test",
-            "command_topic": "test_light_rgb/set",
-            "brightness_command_topic": "test_light_rgb/brightness/set",
-            "rgb_command_topic": "test_light_rgb/rgb/set",
-            "color_temp_command_topic": "test_light_rgb/color_temp/set",
-            "effect_command_topic": "test_light_rgb/effect/set",
-            "hs_command_topic": "test_light_rgb/hs/set",
-            "white_value_command_topic": "test_light_rgb/white_value/set",
-            "xy_command_topic": "test_light_rgb/xy/set",
-            "effect_list": ["colorloop", "random"],
-            "qos": 2,
-            "payload_on": "on",
-            "payload_off": "off",
-        }
-    }
-    color_modes = ["color_temp", "hs", "rgbw"]
-    fake_state = ha.State(
-        "light.test",
-        "on",
-        {
-            "brightness": 95,
-            "hs_color": [100, 100],
-            "effect": "random",
-            "color_temp": 100,
-            # TODO: Test restoring state with white_value
-            "white_value": 0,
-        },
-    )
-    with patch(
-        "homeassistant.helpers.restore_state.RestoreEntity.async_get_last_state",
-        return_value=fake_state,
-    ), assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(hass, light.DOMAIN, config)
-        await hass.async_block_till_done()
-        mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("brightness") == 95
-    assert state.attributes.get("hs_color") == (100, 100)
-    assert state.attributes.get("effect") == "random"
-    assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("white_value") is None
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-    assert state.attributes.get(light.ATTR_COLOR_MODE) == "hs"
-    assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    await common.async_turn_on(hass, "light.test")
-    mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on", 2, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get(light.ATTR_COLOR_MODE) == "hs"
-    assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    await common.async_turn_off(hass, "light.test")
-    mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "off", 2, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
-
-    mqtt_mock.reset_mock()
-    await common.async_turn_on(
-        hass, "light.test", brightness=50, xy_color=[0.123, 0.123]
-    )
-    state = hass.states.get("light.test")
-    assert state.attributes.get(light.ATTR_COLOR_MODE) == "hs"
-    assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    await common.async_turn_on(hass, "light.test", brightness=50, hs_color=[359, 78])
-    state = hass.states.get("light.test")
-    assert state.attributes.get(light.ATTR_COLOR_MODE) == "hs"
-    assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
-    state = hass.states.get("light.test")
-    assert state.attributes.get(light.ATTR_COLOR_MODE) == "hs"
-    assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    mqtt_mock.async_publish.assert_has_calls(
-        [
-            call("test_light_rgb/set", "on", 2, False),
-            call("test_light_rgb/rgb/set", "255,128,0", 2, False),
-            call("test_light_rgb/brightness/set", "50", 2, False),
-            call("test_light_rgb/hs/set", "359.0,78.0", 2, False),
-            call("test_light_rgb/xy/set", "0.14,0.131", 2, False),
-        ],
-        any_order=True,
-    )
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes["rgb_color"] == (255, 128, 0)
-    assert state.attributes["brightness"] == 50
-    assert state.attributes["hs_color"] == (30.118, 100)
-    assert state.attributes.get("white_value") is None
-    assert state.attributes["xy_color"] == (0.611, 0.375)
-    assert state.attributes.get("color_temp") is None
-
-    await common.async_turn_on(hass, "light.test", white_value=80, color_temp=125)
-    state = hass.states.get("light.test")
-    assert state.attributes.get(light.ATTR_COLOR_MODE) == "color_temp"
-    assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-
-    mqtt_mock.async_publish.assert_has_calls(
-        [
-            call("test_light_rgb/white_value/set", "80", 2, False),
-            call("test_light_rgb/color_temp/set", "125", 2, False),
-        ],
-        any_order=True,
-    )
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("rgb_color") == (221, 229, 255)
-    assert state.attributes["brightness"] == 50
-    assert state.attributes.get("hs_color") == (224.772, 13.249)
-    assert state.attributes["white_value"] == 80
-    assert state.attributes.get("xy_color") == (0.296, 0.301)
-    assert state.attributes["color_temp"] == 125
 
 
 async def test_sending_mqtt_commands_and_optimistic(
@@ -1884,98 +1308,6 @@ async def test_on_command_brightness_scaled(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_legacy_on_command_rgb(hass, mqtt_mock_entry_with_yaml_config):
-    """Test on command in RGB brightness mode."""
-    config = {
-        light.DOMAIN: {
-            "platform": "mqtt",
-            "name": "test",
-            "command_topic": "test_light/set",
-            "rgb_command_topic": "test_light/rgb",
-            "white_value_command_topic": "test_light/white_value",
-        }
-    }
-
-    assert await async_setup_component(hass, light.DOMAIN, config)
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
-
-    state = hass.states.get("light.test")
-    assert state.state == STATE_UNKNOWN
-
-    await common.async_turn_on(hass, "light.test", brightness=127)
-
-    # Should get the following MQTT messages.
-    #    test_light/rgb: '127,127,127'
-    #    test_light/set: 'ON'
-    mqtt_mock.async_publish.assert_has_calls(
-        [
-            call("test_light/rgb", "127,127,127", 0, False),
-            call("test_light/set", "ON", 0, False),
-        ],
-        any_order=True,
-    )
-    mqtt_mock.async_publish.reset_mock()
-
-    await common.async_turn_on(hass, "light.test", brightness=255)
-
-    # Should get the following MQTT messages.
-    #    test_light/rgb: '255,255,255'
-    #    test_light/set: 'ON'
-    mqtt_mock.async_publish.assert_has_calls(
-        [
-            call("test_light/rgb", "255,255,255", 0, False),
-            call("test_light/set", "ON", 0, False),
-        ],
-        any_order=True,
-    )
-    mqtt_mock.async_publish.reset_mock()
-
-    await common.async_turn_on(hass, "light.test", brightness=1)
-
-    # Should get the following MQTT messages.
-    #    test_light/rgb: '1,1,1'
-    #    test_light/set: 'ON'
-    mqtt_mock.async_publish.assert_has_calls(
-        [
-            call("test_light/rgb", "1,1,1", 0, False),
-            call("test_light/set", "ON", 0, False),
-        ],
-        any_order=True,
-    )
-    mqtt_mock.async_publish.reset_mock()
-
-    await common.async_turn_off(hass, "light.test")
-
-    mqtt_mock.async_publish.assert_called_once_with("test_light/set", "OFF", 0, False)
-
-    # Ensure color gets scaled with brightness.
-    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
-
-    mqtt_mock.async_publish.assert_has_calls(
-        [
-            call("test_light/rgb", "1,0,0", 0, False),
-            call("test_light/set", "ON", 0, False),
-        ],
-        any_order=True,
-    )
-    mqtt_mock.async_publish.reset_mock()
-
-    await common.async_turn_on(hass, "light.test", brightness=255)
-
-    # Should get the following MQTT messages.
-    #    test_light/rgb: '255,128,0'
-    #    test_light/set: 'ON'
-    mqtt_mock.async_publish.assert_has_calls(
-        [
-            call("test_light/rgb", "255,128,0", 0, False),
-            call("test_light/set", "ON", 0, False),
-        ],
-        any_order=True,
-    )
-    mqtt_mock.async_publish.reset_mock()
-
-
 async def test_on_command_rgb(hass, mqtt_mock_entry_with_yaml_config):
     """Test on command in RGB brightness mode."""
     config = {
@@ -2486,7 +1818,6 @@ async def test_explicit_color_mode(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) is None
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
@@ -2503,7 +1834,6 @@ async def test_explicit_color_mode(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) == "unknown"
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
@@ -2923,14 +2253,12 @@ async def test_discovery_update_light_topic_and_template(
         "color_temp_command_topic": "test_light_rgb/state1",
         "effect_command_topic": "test_light_rgb/effect/set",
         "hs_command_topic": "test_light_rgb/hs/set",
-        "white_value_command_topic": "test_light_rgb/white_value/set",
         "xy_command_topic": "test_light_rgb/xy/set",
         "brightness_state_topic": "test_light_rgb/state1",
         "color_temp_state_topic": "test_light_rgb/state1",
         "effect_state_topic": "test_light_rgb/state1",
         "hs_state_topic": "test_light_rgb/state1",
         "rgb_state_topic": "test_light_rgb/state1",
-        "white_value_state_topic": "test_light_rgb/state1",
         "xy_state_topic": "test_light_rgb/state1",
         "state_value_template": "{{ value_json.state1.state }}",
         "brightness_value_template": "{{ value_json.state1.brightness }}",
@@ -2938,7 +2266,6 @@ async def test_discovery_update_light_topic_and_template(
         "effect_value_template": "{{ value_json.state1.fx }}",
         "hs_value_template": "{{ value_json.state1.hs }}",
         "rgb_value_template": "{{ value_json.state1.rgb }}",
-        "white_value_template": "{{ value_json.state1.white }}",
         "xy_value_template": "{{ value_json.state1.xy }}",
     }
 
@@ -2951,14 +2278,12 @@ async def test_discovery_update_light_topic_and_template(
         "color_temp_command_topic": "test_light_rgb/state2",
         "effect_command_topic": "test_light_rgb/effect/set",
         "hs_command_topic": "test_light_rgb/hs/set",
-        "white_value_command_topic": "test_light_rgb/white_value/set",
         "xy_command_topic": "test_light_rgb/xy/set",
         "brightness_state_topic": "test_light_rgb/state2",
         "color_temp_state_topic": "test_light_rgb/state2",
         "effect_state_topic": "test_light_rgb/state2",
         "hs_state_topic": "test_light_rgb/state2",
         "rgb_state_topic": "test_light_rgb/state2",
-        "white_value_state_topic": "test_light_rgb/state2",
         "xy_state_topic": "test_light_rgb/state2",
         "state_value_template": "{{ value_json.state2.state }}",
         "brightness_value_template": "{{ value_json.state2.brightness }}",
@@ -2966,7 +2291,6 @@ async def test_discovery_update_light_topic_and_template(
         "effect_value_template": "{{ value_json.state2.fx }}",
         "hs_value_template": "{{ value_json.state2.hs }}",
         "rgb_value_template": "{{ value_json.state2.rgb }}",
-        "white_value_template": "{{ value_json.state2.white }}",
         "xy_value_template": "{{ value_json.state2.xy }}",
     }
     state_data1 = [
@@ -2981,7 +2305,6 @@ async def test_discovery_update_light_topic_and_template(
             [
                 ("brightness", 100),
                 ("color_temp", 123),
-                ("white_value", 100),
                 ("effect", "cycle"),
             ],
         ),
@@ -2998,7 +2321,7 @@ async def test_discovery_update_light_topic_and_template(
                 )
             ],
             "on",
-            [("hs_color", (1, 2)), ("white_value", None)],
+            [("hs_color", (1, 2))],
         ),
         (
             [
@@ -3018,7 +2341,7 @@ async def test_discovery_update_light_topic_and_template(
                 )
             ],
             "on",
-            [("xy_color", (0.3, 0.401))],
+            [("xy_color", (0.3, 0.4))],
         ),
     ]
     state_data2 = [
@@ -3033,7 +2356,6 @@ async def test_discovery_update_light_topic_and_template(
             [
                 ("brightness", 50),
                 ("color_temp", 200),
-                ("white_value", 50),
                 ("effect", "loop"),
             ],
         ),
@@ -3083,7 +2405,7 @@ async def test_discovery_update_light_topic_and_template(
                 )
             ],
             "on",
-            [("hs_color", (1.2, 2.2)), ("white_value", None)],
+            [("hs_color", (1.2, 2.2))],
         ),
         (
             [
@@ -3186,14 +2508,12 @@ async def test_discovery_update_light_template(
         "color_temp_command_topic": "test_light_rgb/state1",
         "effect_command_topic": "test_light_rgb/effect/set",
         "hs_command_topic": "test_light_rgb/hs/set",
-        "white_value_command_topic": "test_light_rgb/white_value/set",
         "xy_command_topic": "test_light_rgb/xy/set",
         "brightness_state_topic": "test_light_rgb/state1",
         "color_temp_state_topic": "test_light_rgb/state1",
         "effect_state_topic": "test_light_rgb/state1",
         "hs_state_topic": "test_light_rgb/state1",
         "rgb_state_topic": "test_light_rgb/state1",
-        "white_value_state_topic": "test_light_rgb/state1",
         "xy_state_topic": "test_light_rgb/state1",
         "state_value_template": "{{ value_json.state1.state }}",
         "brightness_value_template": "{{ value_json.state1.brightness }}",
@@ -3201,7 +2521,6 @@ async def test_discovery_update_light_template(
         "effect_value_template": "{{ value_json.state1.fx }}",
         "hs_value_template": "{{ value_json.state1.hs }}",
         "rgb_value_template": "{{ value_json.state1.rgb }}",
-        "white_value_template": "{{ value_json.state1.white }}",
         "xy_value_template": "{{ value_json.state1.xy }}",
     }
 
@@ -3214,14 +2533,12 @@ async def test_discovery_update_light_template(
         "color_temp_command_topic": "test_light_rgb/state1",
         "effect_command_topic": "test_light_rgb/effect/set",
         "hs_command_topic": "test_light_rgb/hs/set",
-        "white_value_command_topic": "test_light_rgb/white_value/set",
         "xy_command_topic": "test_light_rgb/xy/set",
         "brightness_state_topic": "test_light_rgb/state1",
         "color_temp_state_topic": "test_light_rgb/state1",
         "effect_state_topic": "test_light_rgb/state1",
         "hs_state_topic": "test_light_rgb/state1",
         "rgb_state_topic": "test_light_rgb/state1",
-        "white_value_state_topic": "test_light_rgb/state1",
         "xy_state_topic": "test_light_rgb/state1",
         "state_value_template": "{{ value_json.state2.state }}",
         "brightness_value_template": "{{ value_json.state2.brightness }}",
@@ -3229,7 +2546,6 @@ async def test_discovery_update_light_template(
         "effect_value_template": "{{ value_json.state2.fx }}",
         "hs_value_template": "{{ value_json.state2.hs }}",
         "rgb_value_template": "{{ value_json.state2.rgb }}",
-        "white_value_template": "{{ value_json.state2.white }}",
         "xy_value_template": "{{ value_json.state2.xy }}",
     }
     state_data1 = [
@@ -3244,7 +2560,6 @@ async def test_discovery_update_light_template(
             [
                 ("brightness", 100),
                 ("color_temp", 123),
-                ("white_value", 100),
                 ("effect", "cycle"),
             ],
         ),
@@ -3281,7 +2596,7 @@ async def test_discovery_update_light_template(
                 )
             ],
             "on",
-            [("white_value", None), ("xy_color", (0.3, 0.401))],
+            [("xy_color", (0.3, 0.4))],
         ),
     ]
     state_data2 = [
@@ -3296,7 +2611,6 @@ async def test_discovery_update_light_template(
             [
                 ("brightness", 50),
                 ("color_temp", 200),
-                ("white_value", 50),
                 ("effect", "loop"),
             ],
         ),
@@ -3368,7 +2682,7 @@ async def test_discovery_update_light_template(
                 )
             ],
             "on",
-            [("white_value", None), ("xy_color", (0.4, 0.3))],
+            [("xy_color", (0.4, 0.3))],
         ),
         (
             [
@@ -3378,7 +2692,7 @@ async def test_discovery_update_light_template(
                 )
             ],
             "on",
-            [("white_value", None), ("xy_color", (0.4, 0.3))],
+            [("xy_color", (0.4, 0.3))],
         ),
     ]
 
@@ -3646,7 +2960,6 @@ async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     "topic,value,attribute,attribute_value,init_payload",
     [
         ("state_topic", "ON", None, "on", None),
-        ("brightness_state_topic", "60", "brightness", 60, ("state_topic", "ON")),
         (
             "color_mode_state_topic",
             "200",
@@ -3695,8 +3008,40 @@ async def test_encoding_subscribable_topics(
     config[CONF_RGBWW_COMMAND_TOPIC] = "light/CONF_RGBWW_COMMAND_TOPIC"
     config[CONF_XY_COMMAND_TOPIC] = "light/CONF_XY_COMMAND_TOPIC"
     config[CONF_EFFECT_LIST] = ["colorloop", "random"]
-    if attribute and attribute == "brightness":
-        config[CONF_WHITE_VALUE_COMMAND_TOPIC] = "light/CONF_WHITE_VALUE_COMMAND_TOPIC"
+
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        light.DOMAIN,
+        config,
+        topic,
+        value,
+        attribute,
+        attribute_value,
+        init_payload,
+    )
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value,init_payload",
+    [
+        ("brightness_state_topic", "60", "brightness", 60, ("state_topic", "ON")),
+    ],
+)
+async def test_encoding_subscribable_topics_brightness(
+    hass,
+    mqtt_mock_entry_with_yaml_config,
+    caplog,
+    topic,
+    value,
+    attribute,
+    attribute_value,
+    init_payload,
+):
+    """Test handling of incoming encoded payload for a brightness only light."""
+    config = copy.deepcopy(DEFAULT_CONFIG[light.DOMAIN])
+    config[CONF_BRIGHTNESS_COMMAND_TOPIC] = "light/CONF_BRIGHTNESS_COMMAND_TOPIC"
 
     await help_test_encoding_subscribable_topics(
         hass,

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -1,6 +1,6 @@
 """The tests for the MQTT JSON light platform.
 
-Configuration with RGB, brightness, color temp, effect, white value and XY:
+Configuration with RGB, brightness, color temp, effect, and XY:
 
 light:
   platform: mqtt_json
@@ -11,21 +11,7 @@ light:
   color_temp: true
   effect: true
   rgb: true
-  white_value: true
   xy: true
-
-Configuration with RGB, brightness, color temp, effect, white value:
-
-light:
-  platform: mqtt_json
-  name: mqtt_json_light_1
-  state_topic: "home/rgb1"
-  command_topic: "home/rgb1/set"
-  brightness: true
-  color_temp: true
-  effect: true
-  rgb: true
-  white_value: true
 
 Configuration with RGB, brightness, color temp and effect:
 
@@ -182,7 +168,7 @@ async def test_fail_setup_if_no_command_topic(hass, mqtt_mock_entry_no_yaml_conf
     assert hass.states.get("light.test") is None
 
 
-@pytest.mark.parametrize("deprecated", ("color_temp", "hs", "rgb", "white_value", "xy"))
+@pytest.mark.parametrize("deprecated", ("color_temp", "hs", "rgb", "xy"))
 async def test_fail_setup_if_color_mode_deprecated(
     hass, mqtt_mock_entry_no_yaml_config, deprecated
 ):
@@ -267,10 +253,10 @@ async def test_rgb_light(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
 
 
-async def test_no_color_brightness_color_temp_white_val_if_no_topics(
+async def test_no_color_brightness_color_temp_if_no_topics(
     hass, mqtt_mock_entry_with_yaml_config
 ):
-    """Test for no RGB, brightness, color temp, effect, white val or XY."""
+    """Test for no RGB, brightness, color temp, effector XY."""
     assert await async_setup_component(
         hass,
         light.DOMAIN,
@@ -295,7 +281,6 @@ async def test_no_color_brightness_color_temp_white_val_if_no_topics(
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
     assert state.attributes.get("effect") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get("hs_color") is None
 
@@ -307,7 +292,6 @@ async def test_no_color_brightness_color_temp_white_val_if_no_topics(
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
     assert state.attributes.get("effect") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get("hs_color") is None
 
@@ -338,7 +322,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
                 "color_temp": True,
                 "effect": True,
                 "rgb": True,
-                "white_value": True,
                 "xy": True,
                 "hs": True,
                 "qos": "0",
@@ -357,19 +340,17 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
         | light.SUPPORT_EFFECT
         | light.SUPPORT_FLASH
         | light.SUPPORT_TRANSITION
-        | light.SUPPORT_WHITE_VALUE
     )
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
     assert state.attributes.get("effect") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get("hs_color") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
-    # Turn on the light, full white
+    # Turn on the light
     async_fire_mqtt_message(
         hass,
         "test_light_rgb",
@@ -377,8 +358,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
         '"color":{"r":255,"g":255,"b":255},'
         '"brightness":255,'
         '"color_temp":155,'
-        '"effect":"colorloop",'
-        '"white_value":150}',
+        '"effect":"colorloop"}',
     )
 
     state = hass.states.get("light.test")
@@ -387,7 +367,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     assert state.attributes.get("brightness") == 255
     assert state.attributes.get("color_temp") == 155
     assert state.attributes.get("effect") == "colorloop"
-    assert state.attributes.get("white_value") == 150
     assert state.attributes.get("xy_color") == (0.323, 0.329)
     assert state.attributes.get("hs_color") == (0.0, 0.0)
 
@@ -446,11 +425,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("effect") == "colorloop"
 
-    async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON", "white_value":155}')
-
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("white_value") == 155
-
 
 async def test_controlling_state_via_topic2(
     hass, mqtt_mock_entry_with_yaml_config, caplog
@@ -499,7 +473,6 @@ async def test_controlling_state_via_topic2(
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") is None
     assert state.attributes.get("supported_color_modes") == supported_color_modes
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -512,8 +485,7 @@ async def test_controlling_state_via_topic2(
         '"color":{"r":255,"g":128,"b":64, "c": 32, "w": 16, "x": 1, "y": 1},'
         '"brightness":255,'
         '"color_temp":155,'
-        '"effect":"colorloop",'
-        '"white_value":150}',
+        '"effect":"colorloop"}',
     )
 
     state = hass.states.get("light.test")
@@ -526,7 +498,6 @@ async def test_controlling_state_via_topic2(
     assert state.attributes.get("rgb_color") == (255, 136, 74)
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") == (255, 128, 64, 32, 16)
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") == (0.571, 0.361)
 
     # Light turned off
@@ -595,11 +566,6 @@ async def test_controlling_state_via_topic2(
     state = hass.states.get("light.test")
     assert state.attributes.get("effect") == "other_effect"
 
-    # White value should be ignored
-    async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON", "white_value":155}')
-    state = hass.states.get("light.test")
-    assert state.attributes.get("white_value") is None
-
     # Invalid color mode
     async_fire_mqtt_message(
         hass, "test_light_rgb", '{"state":"ON", "color_mode":"col_temp"}'
@@ -635,7 +601,6 @@ async def test_sending_mqtt_commands_and_optimistic(
             "hs_color": [100, 100],
             "effect": "random",
             "color_temp": 100,
-            "white_value": 50,
         },
     )
 
@@ -658,7 +623,6 @@ async def test_sending_mqtt_commands_and_optimistic(
                     "hs": True,
                     "rgb": True,
                     "xy": True,
-                    "white_value": True,
                     "qos": 2,
                 }
             },
@@ -672,7 +636,6 @@ async def test_sending_mqtt_commands_and_optimistic(
     assert state.attributes.get("hs_color") == (100, 100)
     assert state.attributes.get("effect") == "random"
     assert state.attributes.get("color_temp") == 100
-    assert state.attributes.get("white_value") == 50
     expected_features = (
         light.SUPPORT_BRIGHTNESS
         | light.SUPPORT_COLOR
@@ -680,7 +643,6 @@ async def test_sending_mqtt_commands_and_optimistic(
         | light.SUPPORT_EFFECT
         | light.SUPPORT_FLASH
         | light.SUPPORT_TRANSITION
-        | light.SUPPORT_WHITE_VALUE
     )
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
     assert state.attributes.get(ATTR_ASSUMED_STATE)
@@ -720,9 +682,7 @@ async def test_sending_mqtt_commands_and_optimistic(
         hass, "light.test", brightness=50, xy_color=[0.123, 0.123]
     )
     await common.async_turn_on(hass, "light.test", brightness=50, hs_color=[359, 78])
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[255, 128, 0], white_value=80
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
 
     mqtt_mock.async_publish.assert_has_calls(
         [
@@ -750,8 +710,7 @@ async def test_sending_mqtt_commands_and_optimistic(
                 "test_light_rgb/set",
                 JsonValidator(
                     '{"state": "ON", "color": {"r": 255, "g": 128, "b": 0,'
-                    ' "x": 0.611, "y": 0.375, "h": 30.118, "s": 100.0},'
-                    ' "white_value": 80}'
+                    ' "x": 0.611, "y": 0.375, "h": 30.118, "s": 100.0}}'
                 ),
                 2,
                 False,
@@ -765,7 +724,6 @@ async def test_sending_mqtt_commands_and_optimistic(
     assert state.attributes["rgb_color"] == (255, 128, 0)
     assert state.attributes["brightness"] == 50
     assert state.attributes["hs_color"] == (30.118, 100)
-    assert state.attributes["white_value"] == 80
     assert state.attributes["xy_color"] == (0.611, 0.375)
 
 
@@ -783,7 +741,6 @@ async def test_sending_mqtt_commands_and_optimistic2(
             "color_mode": "rgb",
             "effect": "random",
             "hs_color": [100, 100],
-            "white_value": 50,
         },
     )
 
@@ -831,7 +788,6 @@ async def test_sending_mqtt_commands_and_optimistic2(
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") is None
     assert state.attributes.get("supported_color_modes") == supported_color_modes
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -876,7 +832,6 @@ async def test_sending_mqtt_commands_and_optimistic2(
     assert state.attributes["xy_color"] == (0.654, 0.301)
     assert "rgbw_color" not in state.attributes
     assert "rgbww_color" not in state.attributes
-    assert "white_value" not in state.attributes
     mqtt_mock.async_publish.assert_called_once_with(
         "test_light_rgb/set",
         JsonValidator(
@@ -887,10 +842,8 @@ async def test_sending_mqtt_commands_and_optimistic2(
     )
     mqtt_mock.async_publish.reset_mock()
 
-    # Set rgb color, white value should be discarded
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[255, 128, 0], white_value=80
-    )
+    # Set rgb color
+    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
     assert state.attributes["brightness"] == 75
@@ -900,7 +853,6 @@ async def test_sending_mqtt_commands_and_optimistic2(
     assert state.attributes["xy_color"] == (0.611, 0.375)
     assert "rgbw_color" not in state.attributes
     assert "rgbww_color" not in state.attributes
-    assert "white_value" not in state.attributes
     mqtt_mock.async_publish.assert_called_once_with(
         "test_light_rgb/set",
         JsonValidator('{"state": "ON", "color": {"r": 255, "g": 128, "b": 0} }'),
@@ -910,9 +862,7 @@ async def test_sending_mqtt_commands_and_optimistic2(
     mqtt_mock.async_publish.reset_mock()
 
     # Set rgbw color
-    await common.async_turn_on(
-        hass, "light.test", rgbw_color=[255, 128, 0, 123], white_value=80
-    )
+    await common.async_turn_on(hass, "light.test", rgbw_color=[255, 128, 0, 123])
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
     assert state.attributes["brightness"] == 75
@@ -921,7 +871,6 @@ async def test_sending_mqtt_commands_and_optimistic2(
     assert state.attributes["hs_color"] == (30.0, 67.451)
     assert state.attributes["rgb_color"] == (255, 169, 83)
     assert "rgbww_color" not in state.attributes
-    assert "white_value" not in state.attributes
     assert state.attributes["xy_color"] == (0.526, 0.393)
     mqtt_mock.async_publish.assert_called_once_with(
         "test_light_rgb/set",
@@ -943,7 +892,6 @@ async def test_sending_mqtt_commands_and_optimistic2(
     assert state.attributes["hs_color"] == (29.872, 92.157)
     assert state.attributes["rgb_color"] == (255, 137, 20)
     assert "rgbw_color" not in state.attributes
-    assert "white_value" not in state.attributes
     assert state.attributes["xy_color"] == (0.596, 0.382)
     mqtt_mock.async_publish.assert_called_once_with(
         "test_light_rgb/set",
@@ -968,7 +916,6 @@ async def test_sending_mqtt_commands_and_optimistic2(
     assert state.attributes["xy_color"] == (0.123, 0.223)
     assert "rgbw_color" not in state.attributes
     assert "rgbww_color" not in state.attributes
-    assert "white_value" not in state.attributes
     mqtt_mock.async_publish.assert_called_once_with(
         "test_light_rgb/set",
         JsonValidator(
@@ -993,7 +940,6 @@ async def test_sending_hs_color(hass, mqtt_mock_entry_with_yaml_config):
                 "command_topic": "test_light_rgb/set",
                 "brightness": True,
                 "hs": True,
-                "white_value": True,
             }
         },
     )
@@ -1008,9 +954,7 @@ async def test_sending_hs_color(hass, mqtt_mock_entry_with_yaml_config):
         hass, "light.test", brightness=50, xy_color=[0.123, 0.123]
     )
     await common.async_turn_on(hass, "light.test", brightness=50, hs_color=[359, 78])
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[255, 128, 0], white_value=80
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
 
     mqtt_mock.async_publish.assert_has_calls(
         [
@@ -1034,10 +978,7 @@ async def test_sending_hs_color(hass, mqtt_mock_entry_with_yaml_config):
             ),
             call(
                 "test_light_rgb/set",
-                JsonValidator(
-                    '{"state": "ON", "color": {"h": 30.118, "s": 100.0},'
-                    ' "white_value": 80}'
-                ),
+                JsonValidator('{"state": "ON", "color": {"h": 30.118, "s": 100.0}}'),
                 0,
                 False,
             ),
@@ -1193,7 +1134,6 @@ async def test_sending_rgb_color_with_brightness(
                 "command_topic": "test_light_rgb/set",
                 "brightness": True,
                 "rgb": True,
-                "white_value": True,
             }
         },
     )
@@ -1208,9 +1148,7 @@ async def test_sending_rgb_color_with_brightness(
     )
     await common.async_turn_on(hass, "light.test", brightness=255, hs_color=[359, 78])
     await common.async_turn_on(hass, "light.test", brightness=1)
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[255, 128, 0], white_value=80
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
 
     mqtt_mock.async_publish.assert_has_calls(
         [
@@ -1240,10 +1178,7 @@ async def test_sending_rgb_color_with_brightness(
             ),
             call(
                 "test_light_rgb/set",
-                JsonValidator(
-                    '{"state": "ON", "color": {"r": 255, "g": 128, "b": 0},'
-                    ' "white_value": 80}'
-                ),
+                JsonValidator('{"state": "ON", "color": {"r": 255, "g": 128, "b": 0}}'),
                 0,
                 False,
             ),
@@ -1267,7 +1202,6 @@ async def test_sending_rgb_color_with_scaled_brightness(
                 "brightness": True,
                 "brightness_scale": 100,
                 "rgb": True,
-                "white_value": True,
             }
         },
     )
@@ -1282,9 +1216,7 @@ async def test_sending_rgb_color_with_scaled_brightness(
     )
     await common.async_turn_on(hass, "light.test", brightness=255, hs_color=[359, 78])
     await common.async_turn_on(hass, "light.test", brightness=1)
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[255, 128, 0], white_value=80
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
 
     mqtt_mock.async_publish.assert_has_calls(
         [
@@ -1314,10 +1246,7 @@ async def test_sending_rgb_color_with_scaled_brightness(
             ),
             call(
                 "test_light_rgb/set",
-                JsonValidator(
-                    '{"state": "ON", "color": {"r": 255, "g": 128, "b": 0},'
-                    ' "white_value": 80}'
-                ),
+                JsonValidator('{"state": "ON", "color": {"r": 255, "g": 128, "b": 0}}'),
                 0,
                 False,
             ),
@@ -1338,7 +1267,6 @@ async def test_sending_xy_color(hass, mqtt_mock_entry_with_yaml_config):
                 "command_topic": "test_light_rgb/set",
                 "brightness": True,
                 "xy": True,
-                "white_value": True,
             }
         },
     )
@@ -1352,9 +1280,7 @@ async def test_sending_xy_color(hass, mqtt_mock_entry_with_yaml_config):
         hass, "light.test", brightness=50, xy_color=[0.123, 0.123]
     )
     await common.async_turn_on(hass, "light.test", brightness=50, hs_color=[359, 78])
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[255, 128, 0], white_value=80
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
 
     mqtt_mock.async_publish.assert_has_calls(
         [
@@ -1378,10 +1304,7 @@ async def test_sending_xy_color(hass, mqtt_mock_entry_with_yaml_config):
             ),
             call(
                 "test_light_rgb/set",
-                JsonValidator(
-                    '{"state": "ON", "color": {"x": 0.611, "y": 0.375},'
-                    ' "white_value": 80}'
-                ),
+                JsonValidator('{"state": "ON", "color": {"x": 0.611, "y": 0.375}}'),
                 0,
                 False,
             ),
@@ -1605,7 +1528,7 @@ async def test_brightness_scale(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
-    """Test that invalid color/brightness/white/etc. values are ignored."""
+    """Test that invalid color/brightness/etc. values are ignored."""
     assert await async_setup_component(
         hass,
         light.DOMAIN,
@@ -1619,7 +1542,6 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
                 "brightness": True,
                 "color_temp": True,
                 "rgb": True,
-                "white_value": True,
                 "qos": "0",
             }
         },
@@ -1635,12 +1557,10 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
         | light.SUPPORT_COLOR_TEMP
         | light.SUPPORT_FLASH
         | light.SUPPORT_TRANSITION
-        | light.SUPPORT_WHITE_VALUE
     )
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
-    assert state.attributes.get("white_value") is None
     assert state.attributes.get("color_temp") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -1651,7 +1571,6 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
         '{"state":"ON",'
         '"color":{"r":255,"g":255,"b":255},'
         '"brightness": 255,'
-        '"white_value": 255,'
         '"color_temp": 100,'
         '"effect": "rainbow"}',
     )
@@ -1660,7 +1579,6 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_ON
     assert state.attributes.get("rgb_color") == (255, 255, 255)
     assert state.attributes.get("brightness") == 255
-    assert state.attributes.get("white_value") == 255
     assert state.attributes.get("color_temp") == 100
 
     # Empty color value
@@ -1720,16 +1638,6 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
     assert state.attributes.get("brightness") == 255
-
-    # Bad white value
-    async_fire_mqtt_message(
-        hass, "test_light_rgb", '{"state":"ON",' '"white_value": "badValue"}'
-    )
-
-    # White value should not have changed
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("white_value") == 255
 
     # Bad color temperature
     async_fire_mqtt_message(
@@ -2071,8 +1979,6 @@ async def test_publishing_with_custom_encoding(
     config = copy.deepcopy(DEFAULT_CONFIG[domain])
     if topic == "effect_command_topic":
         config["effect_list"] = ["random", "color_loop"]
-    elif topic == "white_command_topic":
-        config["rgb_command_topic"] = "some-cmd-topic"
 
     await help_test_publishing_with_custom_encoding(
         hass,

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -13,7 +13,6 @@ light:
   state_template: '{{ value.split(",")[0] }}'
   brightness_template: '{{ value.split(",")[1] }}'
   color_temp_template: '{{ value.split(",")[2] }}'
-  white_value_template: '{{ value.split(",")[3] }}'
   red_template: '{{ value.split(",")[4].split("-")[0] }}'
   green_template: '{{ value.split(",")[4].split("-")[1] }}'
   blue_template: '{{ value.split(",")[4].split("-")[2] }}'
@@ -21,8 +20,6 @@ light:
 If your light doesn't support brightness feature, omit `brightness_template`.
 
 If your light doesn't support color temp feature, omit `color_temp_template`.
-
-If your light doesn't support white value feature, omit `white_value_template`.
 
 If your light doesn't support RGB feature, omit `(red|green|blue)_template`.
 """
@@ -194,7 +191,6 @@ async def test_state_change_via_topic(hass, mqtt_mock_entry_with_yaml_config):
                     "command_on_template": "on,"
                     "{{ brightness|d }},"
                     "{{ color_temp|d }},"
-                    "{{ white_value|d }},"
                     "{{ red|d }}-"
                     "{{ green|d }}-"
                     "{{ blue|d }}",
@@ -211,7 +207,6 @@ async def test_state_change_via_topic(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("white_value") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "test_light_rgb", "on")
@@ -221,7 +216,6 @@ async def test_state_change_via_topic(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("white_value") is None
 
     async_fire_mqtt_message(hass, "test_light_rgb", "off")
 
@@ -234,10 +228,10 @@ async def test_state_change_via_topic(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_state_brightness_color_effect_temp_white_change_via_topic(
+async def test_state_brightness_color_effect_temp_change_via_topic(
     hass, mqtt_mock_entry_with_yaml_config
 ):
-    """Test state, bri, color, effect, color temp, white val change."""
+    """Test state, bri, color, effect, color temp change."""
     with assert_setup_component(1, light.DOMAIN):
         assert await async_setup_component(
             hass,
@@ -253,7 +247,6 @@ async def test_state_brightness_color_effect_temp_white_change_via_topic(
                     "command_on_template": "on,"
                     "{{ brightness|d }},"
                     "{{ color_temp|d }},"
-                    "{{ white_value|d }},"
                     "{{ red|d }}-"
                     "{{ green|d }}-"
                     "{{ blue|d }},"
@@ -262,11 +255,10 @@ async def test_state_brightness_color_effect_temp_white_change_via_topic(
                     "state_template": '{{ value.split(",")[0] }}',
                     "brightness_template": '{{ value.split(",")[1] }}',
                     "color_temp_template": '{{ value.split(",")[2] }}',
-                    "white_value_template": '{{ value.split(",")[3] }}',
-                    "red_template": '{{ value.split(",")[4].' 'split("-")[0] }}',
-                    "green_template": '{{ value.split(",")[4].' 'split("-")[1] }}',
-                    "blue_template": '{{ value.split(",")[4].' 'split("-")[2] }}',
-                    "effect_template": '{{ value.split(",")[5] }}',
+                    "red_template": '{{ value.split(",")[3].' 'split("-")[0] }}',
+                    "green_template": '{{ value.split(",")[3].' 'split("-")[1] }}',
+                    "blue_template": '{{ value.split(",")[3].' 'split("-")[2] }}',
+                    "effect_template": '{{ value.split(",")[4] }}',
                 }
             },
         )
@@ -279,18 +271,16 @@ async def test_state_brightness_color_effect_temp_white_change_via_topic(
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("effect") is None
     assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("white_value") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
-    # turn on the light, full white
-    async_fire_mqtt_message(hass, "test_light_rgb", "on,255,145,123,255-128-64,")
+    # turn on the light
+    async_fire_mqtt_message(hass, "test_light_rgb", "on,255,145,255-128-64,")
 
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
     assert state.attributes.get("rgb_color") == (255, 128, 63)
     assert state.attributes.get("brightness") == 255
     assert state.attributes.get("color_temp") == 145
-    assert state.attributes.get("white_value") == 123
     assert state.attributes.get("effect") is None
 
     # make the light state unknown
@@ -318,19 +308,13 @@ async def test_state_brightness_color_effect_temp_white_change_via_topic(
     assert light_state.attributes["color_temp"] == 195
 
     # change the color
-    async_fire_mqtt_message(hass, "test_light_rgb", "on,,,,41-42-43")
+    async_fire_mqtt_message(hass, "test_light_rgb", "on,,,41-42-43")
 
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("rgb_color") == (243, 249, 255)
 
-    # change the white value
-    async_fire_mqtt_message(hass, "test_light_rgb", "on,,,134")
-
-    light_state = hass.states.get("light.test")
-    assert light_state.attributes["white_value"] == 134
-
     # change the effect
-    async_fire_mqtt_message(hass, "test_light_rgb", "on,,,,41-42-43,rainbow")
+    async_fire_mqtt_message(hass, "test_light_rgb", "on,,,41-42-43,rainbow")
 
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("effect") == "rainbow"
@@ -348,7 +332,6 @@ async def test_sending_mqtt_commands_and_optimistic(
             "hs_color": [100, 100],
             "effect": "random",
             "color_temp": 100,
-            "white_value": 50,
         },
     )
 
@@ -368,7 +351,6 @@ async def test_sending_mqtt_commands_and_optimistic(
                     "command_on_template": "on,"
                     "{{ brightness|d }},"
                     "{{ color_temp|d }},"
-                    "{{ white_value|d }},"
                     "{{ red|d }}-"
                     "{{ green|d }}-"
                     "{{ blue|d }},"
@@ -379,11 +361,10 @@ async def test_sending_mqtt_commands_and_optimistic(
                     "optimistic": True,
                     "state_template": '{{ value.split(",")[0] }}',
                     "color_temp_template": '{{ value.split(",")[2] }}',
-                    "white_value_template": '{{ value.split(",")[3] }}',
-                    "red_template": '{{ value.split(",")[4].' 'split("-")[0] }}',
-                    "green_template": '{{ value.split(",")[4].' 'split("-")[1] }}',
-                    "blue_template": '{{ value.split(",")[4].' 'split("-")[2] }}',
-                    "effect_template": '{{ value.split(",")[5] }}',
+                    "red_template": '{{ value.split(",")[3].' 'split("-")[0] }}',
+                    "green_template": '{{ value.split(",")[3].' 'split("-")[1] }}',
+                    "blue_template": '{{ value.split(",")[3].' 'split("-")[2] }}',
+                    "effect_template": '{{ value.split(",")[4] }}',
                     "qos": 2,
                 }
             },
@@ -396,7 +377,6 @@ async def test_sending_mqtt_commands_and_optimistic(
     assert state.attributes.get("hs_color") == (100, 100)
     assert state.attributes.get("effect") == "random"
     assert state.attributes.get("color_temp") == 100
-    assert state.attributes.get("white_value") == 50
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_turn_off(hass, "light.test")
@@ -409,7 +389,7 @@ async def test_sending_mqtt_commands_and_optimistic(
 
     await common.async_turn_on(hass, "light.test")
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,,--,-", 2, False
+        "test_light_rgb/set", "on,,,--,-", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -418,7 +398,7 @@ async def test_sending_mqtt_commands_and_optimistic(
     # Set color_temp
     await common.async_turn_on(hass, "light.test", color_temp=70)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,70,,--,-", 2, False
+        "test_light_rgb/set", "on,,70,--,-", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -428,29 +408,26 @@ async def test_sending_mqtt_commands_and_optimistic(
     # Set full brightness
     await common.async_turn_on(hass, "light.test", brightness=255)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,255,,,--,-", 2, False
+        "test_light_rgb/set", "on,255,,--,-", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
 
     # Full brightness - no scaling of RGB values sent over MQTT
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[255, 128, 0], white_value=80
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,80,255-128-0,30.118-100.0", 2, False
+        "test_light_rgb/set", "on,,,255-128-0,30.118-100.0", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
-    assert state.attributes.get("white_value") == 80
     assert state.attributes.get("rgb_color") == (255, 128, 0)
 
     # Full brightness - normalization of RGB values sent over MQTT
     await common.async_turn_on(hass, "light.test", rgb_color=[128, 64, 0])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,,255-127-0,30.0-100.0", 2, False
+        "test_light_rgb/set", "on,,,255-127-0,30.0-100.0", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -460,36 +437,30 @@ async def test_sending_mqtt_commands_and_optimistic(
     # Set half brightness
     await common.async_turn_on(hass, "light.test", brightness=128)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,128,,,--,-", 2, False
+        "test_light_rgb/set", "on,128,,--,-", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
 
     # Half brightness - scaling of RGB values sent over MQTT
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[0, 255, 128], white_value=40
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[0, 255, 128])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,40,0-128-64,150.118-100.0", 2, False
+        "test_light_rgb/set", "on,,,0-128-64,150.118-100.0", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
-    assert state.attributes.get("white_value") == 40
     assert state.attributes.get("rgb_color") == (0, 255, 128)
 
     # Half brightness - normalization+scaling of RGB values sent over MQTT
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[0, 32, 16], white_value=40
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[0, 32, 16])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,40,0-128-64,150.0-100.0", 2, False
+        "test_light_rgb/set", "on,,,0-128-64,150.0-100.0", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
-    assert state.attributes.get("white_value") == 40
     assert state.attributes.get("rgb_color") == (0, 255, 127)
 
 
@@ -512,7 +483,6 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
                     "command_on_template": "on,"
                     "{{ brightness|d }},"
                     "{{ color_temp|d }},"
-                    "{{ white_value|d }},"
                     "{{ red|d }}-"
                     "{{ green|d }}-"
                     "{{ blue|d }},"
@@ -522,11 +492,10 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
                     "state_template": '{{ value.split(",")[0] }}',
                     "brightness_template": '{{ value.split(",")[1] }}',
                     "color_temp_template": '{{ value.split(",")[2] }}',
-                    "white_value_template": '{{ value.split(",")[3] }}',
-                    "red_template": '{{ value.split(",")[4].' 'split("-")[0] }}',
-                    "green_template": '{{ value.split(",")[4].' 'split("-")[1] }}',
-                    "blue_template": '{{ value.split(",")[4].' 'split("-")[2] }}',
-                    "effect_template": '{{ value.split(",")[5] }}',
+                    "red_template": '{{ value.split(",")[3].' 'split("-")[0] }}',
+                    "green_template": '{{ value.split(",")[3].' 'split("-")[1] }}',
+                    "blue_template": '{{ value.split(",")[3].' 'split("-")[2] }}',
+                    "effect_template": '{{ value.split(",")[4] }}',
                 }
             },
         )
@@ -539,7 +508,6 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     assert not state.attributes.get("hs_color")
     assert not state.attributes.get("effect")
     assert not state.attributes.get("color_temp")
-    assert not state.attributes.get("white_value")
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_turn_off(hass, "light.test")
@@ -552,7 +520,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
 
     await common.async_turn_on(hass, "light.test")
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,,--,-", 0, False
+        "test_light_rgb/set", "on,,,--,-", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -561,7 +529,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     # Set color_temp
     await common.async_turn_on(hass, "light.test", color_temp=70)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,70,,--,-", 0, False
+        "test_light_rgb/set", "on,,70,--,-", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -571,7 +539,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     # Set full brightness
     await common.async_turn_on(hass, "light.test", brightness=255)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,255,,,--,-", 0, False
+        "test_light_rgb/set", "on,255,,--,-", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -579,48 +547,41 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     assert not state.attributes.get("brightness")
 
     # Full brightness - no scaling of RGB values sent over MQTT
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[255, 128, 0], white_value=80
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 0])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,80,255-128-0,30.118-100.0", 0, False
+        "test_light_rgb/set", "on,,,255-128-0,30.118-100.0", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
-    assert not state.attributes.get("white_value")
     assert not state.attributes.get("rgb_color")
 
     # Full brightness - normalization of RGB values sent over MQTT
     await common.async_turn_on(hass, "light.test", rgb_color=[128, 64, 0])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,,255-127-0,30.0-100.0", 0, False
+        "test_light_rgb/set", "on,,,255-127-0,30.0-100.0", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
 
     # Set half brightness
     await common.async_turn_on(hass, "light.test", brightness=128)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,128,,,--,-", 0, False
+        "test_light_rgb/set", "on,128,,--,-", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
 
     # Half brightness - no scaling of RGB values sent over MQTT
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[0, 255, 128], white_value=40
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[0, 255, 128])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,40,0-255-128,150.118-100.0", 0, False
+        "test_light_rgb/set", "on,,,0-255-128,150.118-100.0", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
 
     # Half brightness - normalization but no scaling of RGB values sent over MQTT
-    await common.async_turn_on(
-        hass, "light.test", rgb_color=[0, 32, 16], white_value=40
-    )
+    await common.async_turn_on(hass, "light.test", rgb_color=[0, 32, 16])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,40,0-255-127,150.0-100.0", 0, False
+        "test_light_rgb/set", "on,,,0-255-127,150.0-100.0", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -795,11 +756,10 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
                     "state_template": '{{ value.split(",")[0] }}',
                     "brightness_template": '{{ value.split(",")[1] }}',
                     "color_temp_template": '{{ value.split(",")[2] }}',
-                    "white_value_template": '{{ value.split(",")[3] }}',
-                    "red_template": '{{ value.split(",")[4].' 'split("-")[0] }}',
-                    "green_template": '{{ value.split(",")[4].' 'split("-")[1] }}',
-                    "blue_template": '{{ value.split(",")[4].' 'split("-")[2] }}',
-                    "effect_template": '{{ value.split(",")[5] }}',
+                    "red_template": '{{ value.split(",")[3].' 'split("-")[0] }}',
+                    "green_template": '{{ value.split(",")[3].' 'split("-")[1] }}',
+                    "blue_template": '{{ value.split(",")[3].' 'split("-")[2] }}',
+                    "effect_template": '{{ value.split(",")[4] }}',
                 }
             },
         )
@@ -812,20 +772,16 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
     assert state.attributes.get("effect") is None
-    assert state.attributes.get("white_value") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
-    # turn on the light, full white
-    async_fire_mqtt_message(
-        hass, "test_light_rgb", "on,255,215,222,255-255-255,rainbow"
-    )
+    # turn on the light
+    async_fire_mqtt_message(hass, "test_light_rgb", "on,255,215,255-255-255,rainbow")
 
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
     assert state.attributes.get("brightness") == 255
     assert state.attributes.get("color_temp") == 215
     assert state.attributes.get("rgb_color") == (255, 255, 255)
-    assert state.attributes.get("white_value") == 222
     assert state.attributes.get("effect") == "rainbow"
 
     # bad state value
@@ -855,13 +811,6 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
     # color should not have changed
     state = hass.states.get("light.test")
     assert state.attributes.get("rgb_color") == (255, 255, 255)
-
-    # bad white value values
-    async_fire_mqtt_message(hass, "test_light_rgb", "on,,,off,255-255-255")
-
-    # white value should not have changed
-    state = hass.states.get("light.test")
-    assert state.attributes.get("white_value") == 222
 
     # bad effect value
     async_fire_mqtt_message(hass, "test_light_rgb", "on,255,a-b-c,white")
@@ -1191,8 +1140,6 @@ async def test_publishing_with_custom_encoding(
     config = copy.deepcopy(DEFAULT_CONFIG[domain])
     if topic == "effect_command_topic":
         config["effect_list"] = ["random", "color_loop"]
-    elif topic == "white_command_topic":
-        config["rgb_command_topic"] = "some-cmd-topic"
 
     await help_test_publishing_with_custom_encoding(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Support for `white_value` has been removed from MQTT light.
For MQTT light basic schema, `white_value` support is replaced by configuring support for `white` + either of `hs`, `rgb`, `xy`, or `rgbw` or `rgbww`.
For MQTT light JSON schema, `white_value` support is replaced by configuring support for color mode `white` + either of color modes `hs`, rgb`, `xy`, or color mode `rgbw` or `rgbww`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated white_value support from MQTT light (deprecated by https://github.com/home-assistant/core/pull/71002)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
