### PR TITLE
Dont rely on config flow to monitor homekit_controller c# changes

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.typing import ConfigType
 from .config_flow import normalize_hkid
 from .connection import HKDevice
 from .const import ENTITY_MAP, KNOWN_DEVICES, TRIGGERS
-from .storage import EntityMapStorage, async_get_entity_storage
+from .storage import EntityMapStorage
 from .utils import async_get_controller
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,8 +50,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up for Homekit devices."""
-    await async_get_entity_storage(hass)
-
     await async_get_controller(hass)
 
     hass.data[KNOWN_DEVICES] = {}

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -24,7 +24,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import device_registry as dr
 
-from .connection import HKDevice
 from .const import DOMAIN, KNOWN_DEVICES
 from .storage import async_get_entity_storage
 from .utils import async_get_controller
@@ -253,17 +252,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         category = Categories(int(properties.get("ci", 0)))
         paired = not status_flags & 0x01
 
-        # The configuration number increases every time the characteristic map
-        # needs updating. Some devices use a slightly off-spec name so handle
-        # both cases.
-        try:
-            config_num = int(properties["c#"])
-        except KeyError:
-            _LOGGER.warning(
-                "HomeKit device %s: c# not exposed, in violation of spec", hkid
-            )
-            config_num = None
-
         # Set unique-id and error out if it's already configured
         existing_entry = await self.async_set_unique_id(
             normalized_hkid, raise_on_progress=False
@@ -280,12 +268,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self.hass.config_entries.async_update_entry(
                     existing_entry, data={**existing_entry.data, **updated_ip_port}
                 )
-            conn: HKDevice = self.hass.data[KNOWN_DEVICES][hkid]
-            if config_num and conn.config_num != config_num:
-                _LOGGER.debug(
-                    "HomeKit info %s: c# incremented, refreshing entities", hkid
-                )
-                conn.async_notify_config_changed(config_num)
             return self.async_abort(reason="already_configured")
 
         _LOGGER.debug("Discovered device %s (%s - %s)", name, model, hkid)

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -182,13 +182,9 @@ class HKDevice:
 
     async def async_setup(self) -> None:
         """Prepare to use a paired HomeKit device in Home Assistant."""
-        entity_storage: EntityMapStorage = self.hass.data[ENTITY_MAP]
         pairing = self.pairing
         transport = pairing.transport
         entry = self.config_entry
-
-        if cache := entity_storage.get_map(self.unique_id):
-            pairing.restore_accessories_state(cache["accessories"], cache["config_num"])
 
         # We need to force an update here to make sure we have
         # the latest values since the async_update we do in
@@ -203,7 +199,7 @@ class HKDevice:
         try:
             await self.pairing.async_populate_accessories_state(force_update=True)
         except AccessoryNotFoundError:
-            if transport != Transport.BLE or not cache:
+            if transport != Transport.BLE or not pairing.accessories:
                 # BLE devices may sleep and we can't force a connection
                 raise
 

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -438,10 +438,6 @@ class HKDevice:
             self.config_entry, self.platforms
         )
 
-    def async_notify_config_changed(self, config_num: int) -> None:
-        """Notify the pairing of a config change."""
-        self.pairing.notify_config_changed(config_num)
-
     def process_config_changed(self, config_num: int) -> None:
         """Handle a config change notification from the pairing."""
         self.hass.async_create_task(self.async_update_new_accessories_state())

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==1.3.0"],
+  "requirements": ["aiohomekit==1.4.0"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
   "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_start": [6] }],
   "dependencies": ["bluetooth", "zeroconf"],

--- a/homeassistant/components/homekit_controller/utils.py
+++ b/homeassistant/components/homekit_controller/utils.py
@@ -8,6 +8,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
 
 from .const import CONTROLLER
+from .storage import async_get_entity_storage
 
 
 def folded_name(name: str) -> str:
@@ -22,6 +23,8 @@ async def async_get_controller(hass: HomeAssistant) -> Controller:
 
     async_zeroconf_instance = await zeroconf.async_get_async_instance(hass)
 
+    char_cache = await async_get_entity_storage(hass)
+
     # In theory another call to async_get_controller could have run while we were
     # trying to get the zeroconf instance. So we check again to make sure we
     # don't leak a Controller instance here.
@@ -33,6 +36,7 @@ async def async_get_controller(hass: HomeAssistant) -> Controller:
     controller = Controller(
         async_zeroconf_instance=async_zeroconf_instance,
         bleak_scanner_instance=bleak_scanner_instance,  # type: ignore[arg-type]
+        char_cache=char_cache,
     )
 
     hass.data[CONTROLLER] = controller

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -168,7 +168,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.3.0
+aiohomekit==1.4.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==1.3.0
+aiohomekit==1.4.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -11,10 +11,9 @@ from unittest import mock
 
 from aiohomekit.model import Accessories, AccessoriesState, Accessory
 from aiohomekit.testing import FakeController, FakePairing
+from aiohomekit.zeroconf import HomeKitService
 
-from homeassistant.components import zeroconf
 from homeassistant.components.device_automation import DeviceAutomationType
-from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import (
     CONTROLLER,
     DOMAIN,
@@ -228,30 +227,40 @@ async def device_config_changed(hass, accessories):
     pairing._accessories_state = AccessoriesState(
         accessories_obj, pairing.config_num + 1
     )
-
-    discovery_info = zeroconf.ZeroconfServiceInfo(
-        host="127.0.0.1",
-        addresses=["127.0.0.1"],
-        hostname="mock_hostname",
-        name="TestDevice._hap._tcp.local.",
-        port=8080,
-        properties={
-            "md": "TestDevice",
-            "id": "00:00:00:00:00:00",
-            "c#": "2",
-            "sf": "0",
-        },
-        type="mock_type",
+    pairing._async_description_update(
+        HomeKitService(
+            name="TestDevice.local",
+            id="00:00:00:00:00:00",
+            model="",
+            config_num=2,
+            state_num=3,
+            feature_flags=0,
+            status_flags=0,
+            category=1,
+            protocol_version="1.0",
+            type="_hap._tcp.local.",
+            address="127.0.0.1",
+            addresses=["127.0.0.1"],
+            port=8080,
+        )
     )
-
-    # Config Flow will abort and notify us if the discovery event is of
-    # interest - in this case c# has incremented
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
-    flow.context = {}
-    result = await flow.async_step_zeroconf(discovery_info)
-    assert result["type"] == "abort"
-    assert result["reason"] == "already_configured"
+    pairing._async_description_update(
+        HomeKitService(
+            name="TestDevice.local",
+            id="00:00:00:00:00:00",
+            model="",
+            config_num=3,
+            state_num=3,
+            feature_flags=0,
+            status_flags=0,
+            category=1,
+            protocol_version="1.0",
+            type="_hap._tcp.local.",
+            address="127.0.0.1",
+            addresses=["127.0.0.1"],
+            port=8080,
+        )
+    )
 
     # Wait for services to reconfigure
     await hass.async_block_till_done()

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -21,6 +21,7 @@ from homeassistant.components.homekit_controller.const import (
     IDENTIFIER_ACCESSORY_ID,
     IDENTIFIER_SERIAL_NUMBER,
 )
+from homeassistant.components.homekit_controller.utils import async_get_controller
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -174,12 +175,11 @@ async def setup_platform(hass):
     config = {"discovery": {}}
 
     with mock.patch(
-        "homeassistant.components.homekit_controller.utils.Controller"
-    ) as controller:
-        fake_controller = controller.return_value = FakeController()
+        "homeassistant.components.homekit_controller.utils.Controller", FakeController
+    ):
         await async_setup_component(hass, DOMAIN, config)
 
-    return fake_controller
+    return await async_get_controller(hass)
 
 
 async def setup_test_accessories(hass, accessories):

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -244,23 +244,6 @@ async def device_config_changed(hass, accessories):
             port=8080,
         )
     )
-    pairing._async_description_update(
-        HomeKitService(
-            name="TestDevice.local",
-            id="00:00:00:00:00:00",
-            model="",
-            config_num=3,
-            state_num=3,
-            feature_flags=0,
-            status_flags=0,
-            category=1,
-            protocol_version="1.0",
-            type="_hap._tcp.local.",
-            address="127.0.0.1",
-            addresses=["127.0.0.1"],
-            port=8080,
-        )
-    )
 
     # Wait for services to reconfigure
     await hass.async_block_till_done()

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -6,7 +6,7 @@ https://github.com/home-assistant/core/issues/15336
 
 from unittest import mock
 
-from aiohomekit import AccessoryDisconnectedError
+from aiohomekit import AccessoryNotFoundError
 from aiohomekit.testing import FakePairing
 
 from homeassistant.components.climate.const import (
@@ -184,9 +184,8 @@ async def test_ecobee3_setup_connection_failure(hass):
 
     # Test that the connection fails during initial setup.
     # No entities should be created.
-    list_accessories = "list_accessories_and_characteristics"
-    with mock.patch.object(FakePairing, list_accessories) as laac:
-        laac.side_effect = AccessoryDisconnectedError("Connection failed")
+    with mock.patch.object(FakePairing, "async_populate_accessories_state") as laac:
+        laac.side_effect = AccessoryNotFoundError("Connection failed")
 
         # If there is no cached entity map and the accessory connection is
         # failing then we have to fail the config entry setup.

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for homekit_controller config flow."""
 import asyncio
 import unittest.mock
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import aiohomekit
 from aiohomekit.exceptions import AuthenticationError
@@ -524,7 +524,6 @@ async def test_discovery_already_configured_update_csharp(hass, controller):
     entry.add_to_hass(hass)
 
     connection_mock = AsyncMock()
-    connection_mock.async_notify_config_changed = MagicMock()
     hass.data[KNOWN_DEVICES] = {"AA:BB:CC:DD:EE:FF": connection_mock}
 
     device = setup_mock_accessory(controller)
@@ -547,7 +546,6 @@ async def test_discovery_already_configured_update_csharp(hass, controller):
 
     assert entry.data["AccessoryIP"] == discovery_info.host
     assert entry.data["AccessoryPort"] == discovery_info.port
-    assert connection_mock.async_notify_config_changed.call_count == 1
 
 
 @pytest.mark.parametrize("exception,expected", PAIRING_START_ABORT_ERRORS)

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -119,6 +119,7 @@ async def test_offline_device_raises(hass, controller):
             nonlocal is_connected
             if not is_connected:
                 raise AccessoryNotFoundError("any")
+            await super().async_populate_accessories_state(*args, **kwargs)
 
         async def get_characteristics(self, chars, *args, **kwargs):
             nonlocal is_connected
@@ -173,6 +174,7 @@ async def test_ble_device_only_checks_is_available(hass, controller):
             nonlocal is_available
             if not is_available:
                 raise AccessoryNotFoundError("any")
+            await super().async_populate_accessories_state(*args, **kwargs)
 
         async def get_characteristics(self, chars, *args, **kwargs):
             nonlocal is_available


### PR DESCRIPTION
## Proposed change

An attribute called c# increments when the char map changes - this might mean there are new entities that need creating. For the 2 IP based  backends, this is part of the zeroconf data. Right now we learn this through the zeroconf config flow. For BLE, aiohomekit calls us via pairing.dispatcher_connect_config_changed. 

With this PR, we remove the special handling from the config flow and use the same mechanism as BLE for all backends. This further reduces any abstraction leaks / unifies the BLE vs IP behaviours.

https://github.com/Jc2k/aiohomekit/compare/1.3.0...1.4.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
