### PR TITLE
Restore fixed step fan speeds for google assistant

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -186,3 +186,21 @@ SOURCE_CLOUD = "cloud"
 SOURCE_LOCAL = "local"
 
 NOT_EXPOSE_LOCAL = {TYPE_ALARM, TYPE_LOCK}
+
+FAN_SPEEDS = {
+    "5/5": ["High", "Max", "Fast", "5"],
+    "4/5": ["Medium High", "4"],
+    "3/5": ["Medium", "3"],
+    "2/5": ["Medium Low", "2"],
+    "1/5": ["Low", "Min", "Slow", "1"],
+    "4/4": ["High", "Max", "Fast", "4"],
+    "3/4": ["Medium High", "3"],
+    "2/4": ["Medium Low", "2"],
+    "1/4": ["Low", "Min", "Slow", "1"],
+    "3/3": ["High", "Max", "Fast", "3"],
+    "2/3": ["Medium", "2"],
+    "1/3": ["Low", "Min", "Slow", "1"],
+    "2/2": ["High", "Max", "Fast", "2"],
+    "1/2": ["Low", "Min", "Slow", "1"],
+    "1/1": ["Normal", "1"],
+}

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1621,10 +1621,55 @@ async def test_fan_speed(hass):
 @pytest.mark.parametrize(
     "percentage,percentage_step, speed, speeds, percentage_result",
     [
-        (33, 1.0, "2", ["1", "2", "3", "4", "5"], 40),
-        (40, 1.0, "2", ["1", "2", "3", "4", "5"], 40),
-        (33, 100 / 3, "1", ["1", "2", "3"], 33),
-        (20, 100 / 4, "1", ["1", "2", "3", "4"], 25),
+        (
+            33,
+            1.0,
+            "2/5",
+            [
+                ["Low", "Min", "Slow", "1"],
+                ["Medium Low", "2"],
+                ["Medium", "3"],
+                ["Medium High", "4"],
+                ["High", "Max", "Fast", "5"],
+            ],
+            40,
+        ),
+        (
+            40,
+            1.0,
+            "2/5",
+            [
+                ["Low", "Min", "Slow", "1"],
+                ["Medium Low", "2"],
+                ["Medium", "3"],
+                ["Medium High", "4"],
+                ["High", "Max", "Fast", "5"],
+            ],
+            40,
+        ),
+        (
+            33,
+            100 / 3,
+            "1/3",
+            [
+                ["Low", "Min", "Slow", "1"],
+                ["Medium", "2"],
+                ["High", "Max", "Fast", "3"],
+            ],
+            33,
+        ),
+        (
+            20,
+            100 / 4,
+            "1/4",
+            [
+                ["Low", "Min", "Slow", "1"],
+                ["Medium Low", "2"],
+                ["Medium High", "3"],
+                ["High", "Max", "Fast", "4"],
+            ],
+            25,
+        ),
     ],
 )
 async def test_fan_speed_ordered(
@@ -1632,7 +1677,7 @@ async def test_fan_speed_ordered(
     percentage: int,
     percentage_step: float,
     speed: str,
-    speeds: list[str],
+    speeds: list[list[str]],
     percentage_result: int,
 ):
     """Test FanSpeed trait speed control support for fan domain."""
@@ -1659,12 +1704,10 @@ async def test_fan_speed_ordered(
             "ordered": True,
             "speeds": [
                 {
-                    "speed_name": f"{x}",
-                    "speed_values": [
-                        {"lang": "en", "speed_synonym": [f"Speed {x}", f"{x}"]}
-                    ],
+                    "speed_name": f"{idx+1}/{len(speeds)}",
+                    "speed_values": [{"lang": "en", "speed_synonym": x}],
                 }
-                for x in speeds
+                for idx, x in enumerate(speeds)
             ],
         },
     }

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1,6 +1,6 @@
 """Tests for the Google Assistant traits."""
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -1601,10 +1601,12 @@ async def test_fan_speed(hass):
     assert trt.sync_attributes() == {
         "reversible": False,
         "supportsFanSpeedPercent": True,
+        "availableFanSpeeds": ANY,
     }
 
     assert trt.query_attributes() == {
         "currentFanSpeedPercent": 33,
+        "currentFanSpeedSetting": ANY,
     }
 
     assert trt.can_execute(trait.COMMAND_FANSPEED, params={"fanSpeedPercent": 10})
@@ -1614,6 +1616,74 @@ async def test_fan_speed(hass):
 
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage": 10}
+
+
+@pytest.mark.parametrize(
+    "percentage,percentage_step, speed, speeds, percentage_result",
+    [
+        (33, 1.0, "2", ["1", "2", "3", "4", "5"], 40),
+        (40, 1.0, "2", ["1", "2", "3", "4", "5"], 40),
+        (33, 100 / 3, "1", ["1", "2", "3"], 33),
+        (20, 100 / 4, "1", ["1", "2", "3", "4"], 25),
+    ],
+)
+async def test_fan_speed_ordered(
+    hass,
+    percentage: int,
+    percentage_step: float,
+    speed: str,
+    speeds: list[str],
+    percentage_result: int,
+):
+    """Test FanSpeed trait speed control support for fan domain."""
+    assert helpers.get_google_type(fan.DOMAIN, None) is not None
+    assert trait.FanSpeedTrait.supported(fan.DOMAIN, fan.SUPPORT_SET_SPEED, None, None)
+
+    trt = trait.FanSpeedTrait(
+        hass,
+        State(
+            "fan.living_room_fan",
+            STATE_ON,
+            attributes={
+                "percentage": percentage,
+                "percentage_step": percentage_step,
+            },
+        ),
+        BASIC_CONFIG,
+    )
+
+    assert trt.sync_attributes() == {
+        "reversible": False,
+        "supportsFanSpeedPercent": True,
+        "availableFanSpeeds": {
+            "ordered": True,
+            "speeds": [
+                {
+                    "speed_name": f"{x}",
+                    "speed_values": [
+                        {"lang": "en", "speed_synonym": [f"Speed {x}", f"{x}"]}
+                    ],
+                }
+                for x in speeds
+            ],
+        },
+    }
+
+    assert trt.query_attributes() == {
+        "currentFanSpeedPercent": percentage,
+        "currentFanSpeedSetting": speed,
+    }
+
+    assert trt.can_execute(trait.COMMAND_FANSPEED, params={"fanSpeed": speed})
+
+    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_SET_PERCENTAGE)
+    await trt.execute(trait.COMMAND_FANSPEED, BASIC_DATA, {"fanSpeed": speed}, {})
+
+    assert len(calls) == 1
+    assert calls[0].data == {
+        "entity_id": "fan.living_room_fan",
+        "percentage": percentage_result,
+    }
 
 
 @pytest.mark.parametrize(
@@ -1647,10 +1717,12 @@ async def test_fan_reverse(hass, direction_state, direction_call):
     assert trt.sync_attributes() == {
         "reversible": True,
         "supportsFanSpeedPercent": True,
+        "availableFanSpeeds": ANY,
     }
 
     assert trt.query_attributes() == {
         "currentFanSpeedPercent": 33,
+        "currentFanSpeedSetting": ANY,
     }
 
     assert trt.can_execute(trait.COMMAND_REVERSE, params={})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Restore fixed speeds for google assistant since google home devices UI currently don't support percentage based controls, nor does increase/decrease fan speed work with percentage only.

This adds up to 5 speed steps for a fan based on it's percentage_step / speed_count attributes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
