### PR TITLE
Indieauth updates

### DIFF
--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -90,6 +90,7 @@ from homeassistant.components.http.ban import (
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import network
 
 from . import indieauth
 
@@ -101,9 +102,38 @@ async def async_setup(
     hass: HomeAssistant, store_result: Callable[[str, Credentials], str]
 ) -> None:
     """Component to allow users to login."""
+    hass.http.register_view(WellKnownOAuthInfoView)
     hass.http.register_view(AuthProvidersView)
     hass.http.register_view(LoginFlowIndexView(hass.auth.login_flow, store_result))
     hass.http.register_view(LoginFlowResourceView(hass.auth.login_flow, store_result))
+
+
+class WellKnownOAuthInfoView(HomeAssistantView):
+    """View to host the OAuth2 information."""
+
+    requires_auth = False
+    url = "/.well-known/oauth-authorization-server"
+    name = "well-known/oauth-authorization-server"
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Return the well known OAuth2 authorization info."""
+        hass: HomeAssistant = request.app["hass"]
+
+        try:
+            base_url = network.get_url(hass, require_current_request=True)
+        except network.NoURLAvailableError:
+            base_url = network.get_url(hass, prefer_external=True)
+
+        return self.json(
+            {
+                "issuer": base_url,
+                "authorization_endpoint": f"{base_url}/auth/authorize",
+                "token_endpoint": f"{base_url}/token",
+                "revocation_endpoint": f"{base_url}/revoke",
+                "response_types_supported": ["code"],
+                "service_documentation": "https://developers.home-assistant.io/docs/auth_api",
+            }
+        )
 
 
 class AuthProvidersView(HomeAssistantView):
@@ -172,6 +202,7 @@ class LoginFlowBaseView(HomeAssistantView):
         self,
         request: web.Request,
         client_id: str,
+        redirect_uri: str,
         result: data_entry_flow.FlowResult,
     ) -> web.Response:
         """Convert the flow result to a response."""
@@ -190,9 +221,13 @@ class LoginFlowBaseView(HomeAssistantView):
                 await process_wrong_login(request)
             return self.json(_prepare_result_json(result))
 
+        hass: HomeAssistant = request.app["hass"]
+
+        if not await indieauth.verify_redirect_uri(hass, client_id, redirect_uri):
+            return self.json_message("Invalid redirect URI", HTTPStatus.FORBIDDEN)
+
         result.pop("data")
 
-        hass: HomeAssistant = request.app["hass"]
         result_obj: Credentials = result.pop("result")
 
         # Result can be None if credential was never linked to a user before.
@@ -234,14 +269,11 @@ class LoginFlowIndexView(LoginFlowBaseView):
     @log_invalid_auth
     async def post(self, request: web.Request, data: dict[str, Any]) -> web.Response:
         """Create a new login flow."""
-        hass: HomeAssistant = request.app["hass"]
         client_id: str = data["client_id"]
         redirect_uri: str = data["redirect_uri"]
 
-        if not await indieauth.verify_redirect_uri(hass, client_id, redirect_uri):
-            return self.json_message(
-                "invalid client id or redirect uri", HTTPStatus.BAD_REQUEST
-            )
+        if not indieauth.verify_client_id(client_id):
+            return self.json_message("Invalid client id", HTTPStatus.BAD_REQUEST)
 
         handler: tuple[str, ...] | str
         if isinstance(data["handler"], list):
@@ -264,7 +296,9 @@ class LoginFlowIndexView(LoginFlowBaseView):
                 "Handler does not support init", HTTPStatus.BAD_REQUEST
             )
 
-        return await self._async_flow_result_to_response(request, client_id, result)
+        return await self._async_flow_result_to_response(
+            request, client_id, redirect_uri, result
+        )
 
 
 class LoginFlowResourceView(LoginFlowBaseView):
@@ -277,13 +311,19 @@ class LoginFlowResourceView(LoginFlowBaseView):
         """Do not allow getting status of a flow in progress."""
         return self.json_message("Invalid flow specified", HTTPStatus.NOT_FOUND)
 
-    @RequestDataValidator(vol.Schema({"client_id": str}, extra=vol.ALLOW_EXTRA))
+    @RequestDataValidator(
+        vol.Schema(
+            {vol.Required("client_id"): str, vol.Required("redirect_uri"): str},
+            extra=vol.ALLOW_EXTRA,
+        )
+    )
     @log_invalid_auth
     async def post(
         self, request: web.Request, data: dict[str, Any], flow_id: str
     ) -> web.Response:
         """Handle progressing a login flow request."""
-        client_id = data.pop("client_id")
+        client_id: str = data.pop("client_id")
+        redirect_uri: str = data.pop("redirect_uri")
 
         if not indieauth.verify_client_id(client_id):
             return self.json_message("Invalid client id", HTTPStatus.BAD_REQUEST)
@@ -299,7 +339,9 @@ class LoginFlowResourceView(LoginFlowBaseView):
         except vol.Invalid:
             return self.json_message("User input malformed", HTTPStatus.BAD_REQUEST)
 
-        return await self._async_flow_result_to_response(request, client_id, result)
+        return await self._async_flow_result_to_response(
+            request, client_id, redirect_uri, result
+        )
 
     async def delete(self, request: web.Request, flow_id: str) -> web.Response:
         """Cancel a flow in progress."""

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -90,7 +90,6 @@ from homeassistant.components.http.ban import (
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import network
 
 from . import indieauth
 
@@ -117,19 +116,11 @@ class WellKnownOAuthInfoView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Return the well known OAuth2 authorization info."""
-        hass: HomeAssistant = request.app["hass"]
-
-        try:
-            base_url = network.get_url(hass, require_current_request=True)
-        except network.NoURLAvailableError:
-            base_url = network.get_url(hass, prefer_external=True)
-
         return self.json(
             {
-                "issuer": base_url,
-                "authorization_endpoint": f"{base_url}/auth/authorize",
-                "token_endpoint": f"{base_url}/token",
-                "revocation_endpoint": f"{base_url}/revoke",
+                "authorization_endpoint": "/auth/authorize",
+                "token_endpoint": "/auth/token",
+                "revocation_endpoint": "/auth/revoke",
                 "response_types_supported": ["code"],
                 "service_documentation": "https://developers.home-assistant.io/docs/auth_api",
             }

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -62,7 +62,12 @@ async def test_login_new_user_and_trying_refresh_token(hass, aiohttp_client):
 
     resp = await client.post(
         f"/auth/login_flow/{step['flow_id']}",
-        json={"client_id": CLIENT_ID, "username": "test-user", "password": "test-pass"},
+        json={
+            "client_id": CLIENT_ID,
+            "redirect_uri": CLIENT_REDIRECT_URI,
+            "username": "test-user",
+            "password": "test-pass",
+        },
     )
 
     assert resp.status == HTTPStatus.OK
@@ -126,7 +131,12 @@ async def test_auth_code_checks_local_only_user(hass, aiohttp_client):
 
     resp = await client.post(
         f"/auth/login_flow/{step['flow_id']}",
-        json={"client_id": CLIENT_ID, "username": "test-user", "password": "test-pass"},
+        json={
+            "client_id": CLIENT_ID,
+            "redirect_uri": CLIENT_REDIRECT_URI,
+            "username": "test-user",
+            "password": "test-pass",
+        },
     )
 
     assert resp.status == HTTPStatus.OK
@@ -358,7 +368,10 @@ async def test_refresh_token_provider_rejected(
     assert result["error_description"] == "Invalid access"
 
 
-async def test_revoking_refresh_token(hass, aiohttp_client):
+@pytest.mark.parametrize(
+    "url,base_data", [("/auth/token", {"action": "revoke"}), ("/auth/revoke", {})]
+)
+async def test_revoking_refresh_token(url, base_data, hass, aiohttp_client):
     """Test that we can revoke refresh tokens."""
     client = await async_setup_auth(hass, aiohttp_client)
     refresh_token = await async_setup_user_refresh_token(hass)
@@ -380,9 +393,7 @@ async def test_revoking_refresh_token(hass, aiohttp_client):
     )
 
     # Revoke refresh token
-    resp = await client.post(
-        "/auth/token", data={"token": refresh_token.token, "action": "revoke"}
-    )
+    resp = await client.post(url, data={**base_data, "token": refresh_token.token})
     assert resp.status == HTTPStatus.OK
 
     # Old access token should be no longer valid

--- a/tests/components/auth/test_init_link_user.py
+++ b/tests/components/auth/test_init_link_user.py
@@ -46,7 +46,12 @@ async def async_get_code(hass, aiohttp_client):
 
     resp = await client.post(
         f"/auth/login_flow/{step['flow_id']}",
-        json={"client_id": CLIENT_ID, "username": "2nd-user", "password": "2nd-pass"},
+        json={
+            "client_id": CLIENT_ID,
+            "redirect_uri": CLIENT_REDIRECT_URI,
+            "username": "2nd-user",
+            "password": "2nd-pass",
+        },
     )
 
     assert resp.status == HTTPStatus.OK

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -61,6 +61,7 @@ async def test_invalid_username_password(hass, aiohttp_client):
             f"/auth/login_flow/{step['flow_id']}",
             json={
                 "client_id": CLIENT_ID,
+                "redirect_uri": CLIENT_REDIRECT_URI,
                 "username": "wrong-user",
                 "password": "test-pass",
             },
@@ -83,6 +84,49 @@ async def test_invalid_username_password(hass, aiohttp_client):
                 "client_id": CLIENT_ID,
                 "username": "test-user",
                 "password": "wrong-pass",
+            },
+        )
+
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+    assert len(mock_process_wrong_login.mock_calls) == 1
+
+    assert step["step_id"] == "init"
+    assert step["errors"]["base"] == "invalid_auth"
+
+    # Incorrect redirect URI
+    with patch(
+        "homeassistant.components.auth.indieauth.fetch_redirect_uris", return_value=[]
+    ), patch(
+        "homeassistant.components.auth.login_flow.process_wrong_login"
+    ) as mock_process_wrong_login:
+        resp = await client.post(
+            f"/auth/login_flow/{step['flow_id']}",
+            json={
+                "client_id": CLIENT_ID,
+                "redirect_uri": "http://some-other-domain.com",
+                "username": "test-user",
+                "password": "test-pass",
+            },
+        )
+
+    assert resp.status == HTTPStatus.FORBIDDEN
+    data = await resp.json()
+    assert len(mock_process_wrong_login.mock_calls) == 1
+
+    assert data["message"] == "Invalid redirect URI"
+
+    # Incorrect username and invalid redirect URI fails on wrong login
+    with patch(
+        "homeassistant.components.auth.login_flow.process_wrong_login"
+    ) as mock_process_wrong_login:
+        resp = await client.post(
+            f"/auth/login_flow/{step['flow_id']}",
+            json={
+                "client_id": CLIENT_ID,
+                "redirect_uri": "http://some-other-domain.com",
+                "username": "wrong-user",
+                "password": "test-pass",
             },
         )
 
@@ -120,6 +164,7 @@ async def test_login_exist_user(hass, aiohttp_client):
             f"/auth/login_flow/{step['flow_id']}",
             json={
                 "client_id": CLIENT_ID,
+                "redirect_uri": CLIENT_REDIRECT_URI,
                 "username": "test-user",
                 "password": "test-pass",
             },
@@ -160,6 +205,7 @@ async def test_login_local_only_user(hass, aiohttp_client):
             f"/auth/login_flow/{step['flow_id']}",
             json={
                 "client_id": CLIENT_ID,
+                "redirect_uri": CLIENT_REDIRECT_URI,
                 "username": "test-user",
                 "password": "test-pass",
             },
@@ -202,9 +248,31 @@ async def test_login_exist_user_ip_changes(hass, aiohttp_client):
 
     resp = await client.post(
         f"/auth/login_flow/{step['flow_id']}",
-        json={"client_id": CLIENT_ID, "username": "test-user", "password": "test-pass"},
+        json={
+            "client_id": CLIENT_ID,
+            "redirect_uri": CLIENT_REDIRECT_URI,
+            "username": "test-user",
+            "password": "test-pass",
+        },
     )
 
     assert resp.status == 400
     response = await resp.json()
     assert response == {"message": "IP address changed"}
+
+
+async def test_well_known_auth_info(hass, aiohttp_client):
+    """Test logging in and the ip address changes results in an rejection."""
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.get(
+        "/.well-known/oauth-authorization-server",
+    )
+    assert resp.status == 200
+    assert await resp.json() == {
+        "issuer": "http://127.0.0.1:8123",
+        "authorization_endpoint": "http://127.0.0.1:8123/auth/authorize",
+        "token_endpoint": "http://127.0.0.1:8123/token",
+        "revocation_endpoint": "http://127.0.0.1:8123/revoke",
+        "response_types_supported": ["code"],
+        "service_documentation": "https://developers.home-assistant.io/docs/auth_api",
+    }

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -269,10 +269,9 @@ async def test_well_known_auth_info(hass, aiohttp_client):
     )
     assert resp.status == 200
     assert await resp.json() == {
-        "issuer": "http://127.0.0.1:8123",
-        "authorization_endpoint": "http://127.0.0.1:8123/auth/authorize",
-        "token_endpoint": "http://127.0.0.1:8123/token",
-        "revocation_endpoint": "http://127.0.0.1:8123/revoke",
+        "authorization_endpoint": "/auth/authorize",
+        "token_endpoint": "/auth/token",
+        "revocation_endpoint": "/auth/revoke",
         "response_types_supported": ["code"],
         "service_documentation": "https://developers.home-assistant.io/docs/auth_api",
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We implement [IndieAuth](https://indieauth.spec.indieweb.org) on top of OAuth 2.0 to allow any website to login to Home Assistant without requiring pre-registering client ID and Secret.

I noticed today that the IndieAuth spec has [received updates](https://indieauth.spec.indieweb.org/#change-log) since we implemented it. Most changes are to better align with the OAuth2 spec.

This addresses a few of those updates:

- Add `/.well-known/oauth-authorization-server` endpoint with information about OAuth2 endpoints.
- Revoke endpoint used to be an action handled by the `/auth/token` endpoint. It now has it's own URL as per [RFC7009](https://www.rfc-editor.org/rfc/rfc7009). Old endpoint has been kept for backwards compatibility.
- Redirect URI is now validated as the last step of the login flow instead of the first.

The changes are not breaking. For revoke the old URL is maintained and the login flow is only interacted with via our frontend as part of the OAuth2 flow. 

Requires https://github.com/home-assistant/frontend/pull/13389

Related (but not required) https://github.com/home-assistant/home-assistant-js-websocket/pull/304

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
