### PR TITLE
Remove deprecated white_value support from template light

### DIFF
--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -9,12 +9,10 @@ from homeassistant.components.light import (
     ATTR_EFFECT,
     ATTR_HS_COLOR,
     ATTR_TRANSITION,
-    ATTR_WHITE_VALUE,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
     SUPPORT_TRANSITION,
-    SUPPORT_WHITE_VALUE,
     ColorMode,
     LightEntityFeature,
 )
@@ -612,97 +610,6 @@ async def test_off_action_optimistic(
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
-
-
-@pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes,expected_color_mode",
-    [(SUPPORT_WHITE_VALUE, [ColorMode.RGBW], ColorMode.UNKNOWN)],
-)
-@pytest.mark.parametrize(
-    "light_config",
-    [
-        {
-            "test_template_light": {
-                **OPTIMISTIC_WHITE_VALUE_LIGHT_CONFIG,
-                "value_template": "{{1 == 1}}",
-            }
-        },
-    ],
-)
-async def test_white_value_action_no_template(
-    hass,
-    setup_light,
-    calls,
-    supported_color_modes,
-    supported_features,
-    expected_color_mode,
-):
-    """Test setting white value with optimistic template."""
-    state = hass.states.get("light.test_template_light")
-    assert state.attributes.get("white_value") is None
-
-    await hass.services.async_call(
-        light.DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_template_light", ATTR_WHITE_VALUE: 124},
-        blocking=True,
-    )
-
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "set_white_value"
-    assert calls[-1].data["caller"] == "light.test_template_light"
-    assert calls[-1].data["white_value"] == 124
-
-    state = hass.states.get("light.test_template_light")
-    assert state.attributes.get("white_value") == 124
-    assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == expected_color_mode  # hs_color is None
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
-
-
-@pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes,expected_color_mode",
-    [(SUPPORT_WHITE_VALUE, [ColorMode.RGBW], ColorMode.UNKNOWN)],
-)
-@pytest.mark.parametrize(
-    "expected_white_value,white_value_template",
-    [
-        (255, "{{255}}"),
-        (None, "{{256}}"),
-        (None, "{{x-12}}"),
-        (None, "{{ none }}"),
-        (None, ""),
-    ],
-)
-async def test_white_value_template(
-    hass,
-    expected_white_value,
-    supported_features,
-    supported_color_modes,
-    expected_color_mode,
-    count,
-    white_value_template,
-):
-    """Test the template for the white value."""
-    light_config = {
-        "test_template_light": {
-            **OPTIMISTIC_WHITE_VALUE_LIGHT_CONFIG,
-            "value_template": "{{ 1 == 1 }}",
-            "white_value_template": white_value_template,
-        }
-    }
-    await async_setup_light(hass, count, light_config)
-
-    state = hass.states.get("light.test_template_light")
-    assert state is not None
-    assert state.attributes.get("white_value") == expected_white_value
-    assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == expected_color_mode  # hs_color is None
     assert state.attributes["supported_color_modes"] == supported_color_modes
     assert state.attributes["supported_features"] == supported_features
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Support for `white_value` has been removed from template light.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated `white_value` support from template light
Deprecated by: https://github.com/home-assistant/core/pull/71044

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
