### PR TITLE
Remove white_value support from group light

### DIFF
--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -25,10 +25,8 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ATTR_TRANSITION,
     ATTR_WHITE,
-    ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
     PLATFORM_SCHEMA,
-    SUPPORT_WHITE_VALUE,
     ColorMode,
     LightEntity,
     LightEntityFeature,
@@ -71,10 +69,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 SUPPORT_GROUP_LIGHT = (
-    LightEntityFeature.EFFECT
-    | LightEntityFeature.FLASH
-    | LightEntityFeature.TRANSITION
-    | SUPPORT_WHITE_VALUE
+    LightEntityFeature.EFFECT | LightEntityFeature.FLASH | LightEntityFeature.TRANSITION
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -128,7 +123,6 @@ FORWARDED_ATTRIBUTES = frozenset(
         ATTR_RGBWW_COLOR,
         ATTR_TRANSITION,
         ATTR_WHITE,
-        ATTR_WHITE_VALUE,
         ATTR_XY_COLOR,
     }
 )
@@ -148,7 +142,6 @@ class LightGroup(GroupEntity, LightEntity):
     ) -> None:
         """Initialize a light group."""
         self._entity_ids = entity_ids
-        self._white_value: int | None = None
 
         self._attr_name = name
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
@@ -173,11 +166,6 @@ class LightGroup(GroupEntity, LightEntity):
         )
 
         await super().async_added_to_hass()
-
-    @property
-    def white_value(self) -> int | None:
-        """Return the white value of this light group between 0..255."""
-        return self._white_value
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Forward the turn_on command to all lights in the light group."""
@@ -250,8 +238,6 @@ class LightGroup(GroupEntity, LightEntity):
         self._attr_xy_color = reduce_attribute(
             on_states, ATTR_XY_COLOR, reduce=mean_tuple
         )
-
-        self._white_value = reduce_attribute(on_states, ATTR_WHITE_VALUE)
 
         self._attr_color_temp = reduce_attribute(on_states, ATTR_COLOR_TEMP)
         self._attr_min_mireds = reduce_attribute(

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -618,48 +618,6 @@ async def test_color_rgbww(hass, enable_custom_integrations):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_white_value(hass):
-    """Test white value reporting."""
-    await async_setup_component(
-        hass,
-        LIGHT_DOMAIN,
-        {
-            LIGHT_DOMAIN: {
-                "platform": DOMAIN,
-                "entities": ["light.test1", "light.test2"],
-                "all": "false",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    hass.states.async_set(
-        "light.test1", STATE_ON, {ATTR_WHITE_VALUE: 255, ATTR_SUPPORTED_FEATURES: 128}
-    )
-    await hass.async_block_till_done()
-    state = hass.states.get("light.light_group")
-    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 128
-    assert state.attributes[ATTR_WHITE_VALUE] == 255
-
-    hass.states.async_set(
-        "light.test2", STATE_ON, {ATTR_WHITE_VALUE: 100, ATTR_SUPPORTED_FEATURES: 128}
-    )
-    await hass.async_block_till_done()
-    state = hass.states.get("light.light_group")
-    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 128
-    assert state.attributes[ATTR_WHITE_VALUE] == 177
-
-    hass.states.async_set(
-        "light.test1", STATE_OFF, {ATTR_WHITE_VALUE: 255, ATTR_SUPPORTED_FEATURES: 128}
-    )
-    await hass.async_block_till_done()
-    state = hass.states.get("light.light_group")
-    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 128
-    assert state.attributes[ATTR_WHITE_VALUE] == 100
-
-
 async def test_white(hass, enable_custom_integrations):
     """Test white reporting."""
     platform = getattr(hass.components, "test.light")
@@ -1493,7 +1451,6 @@ async def test_invalid_service_calls(hass):
             ATTR_XY_COLOR: (0.5, 0.42),
             ATTR_RGB_COLOR: (80, 120, 50),
             ATTR_COLOR_TEMP: 1234,
-            ATTR_WHITE_VALUE: 1,
             ATTR_EFFECT: "Sunshine",
             ATTR_TRANSITION: 4,
             ATTR_FLASH: "long",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Light groups no longer support `white_value`, which was deprecated in May 2021 and is no longer used by any core integrations.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `white_value` support from group light, it's no longer used by any core integrations

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
