### PR TITLE
Add newly-released Amazon Polly voices

### DIFF
--- a/homeassistant/components/amazon_polly/const.py
+++ b/homeassistant/components/amazon_polly/const.py
@@ -36,6 +36,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Aditi",  # Hindi
     "Amy",
     "Aria",
+    "Arthur", # English, Neural
     "Astrid",  # Swedish
     "Ayanda",
     "Bianca",  # Italian
@@ -47,6 +48,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Chantal",  # French Canadian
     "Conchita",
     "Cristiano",
+    "Daniel", # German, Neural
     "Dora",  # Icelandic
     "Emma",  # English
     "Enrique",
@@ -69,6 +71,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Kevin",
     "Kimberly",
     "Lea",  # French
+    "Liam", # Canadian French, Neural
     "Liv",  # Norwegian
     "Lotte",  # Dutch
     "Lucia",  # Spanish European
@@ -86,6 +89,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Nicole",  # English Australian
     "Olivia",  # Female, Australian, Neural
     "Penelope",  # Spanish US
+    "Pedro", # Spanish US, Neural
     "Raveena",  # English, Indian
     "Ricardo",
     "Ruben",

--- a/homeassistant/components/amazon_polly/const.py
+++ b/homeassistant/components/amazon_polly/const.py
@@ -36,7 +36,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Aditi",  # Hindi
     "Amy",
     "Aria",
-    "Arthur", # English, Neural
+    "Arthur",  # English, Neural
     "Astrid",  # Swedish
     "Ayanda",
     "Bianca",  # Italian
@@ -48,7 +48,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Chantal",  # French Canadian
     "Conchita",
     "Cristiano",
-    "Daniel", # German, Neural
+    "Daniel",  # German, Neural
     "Dora",  # Icelandic
     "Emma",  # English
     "Enrique",
@@ -71,7 +71,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Kevin",
     "Kimberly",
     "Lea",  # French
-    "Liam", # Canadian French, Neural
+    "Liam",  # Canadian French, Neural
     "Liv",  # Norwegian
     "Lotte",  # Dutch
     "Lucia",  # Spanish European
@@ -89,7 +89,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Nicole",  # English Australian
     "Olivia",  # Female, Australian, Neural
     "Penelope",  # Spanish US
-    "Pedro", # Spanish US, Neural
+    "Pedro",  # Spanish US, Neural
     "Raveena",  # English, Indian
     "Ricardo",
     "Ruben",


### PR DESCRIPTION
## Proposed change
Adds 4 new neural voices to the amazon_polly component. These were released by AWS for Amazon Polly on 28 June 2022. They are supported by AWS but erroneously blocked by amazon_polly's validation because they are missing from `const.py`.

References:
- AWS announcement of new voices: https://aws.amazon.com/about-aws/whats-new/2022/06/amazon-polly-adds-male-neural-tts-voices-languages/
- Updated voice list: https://docs.aws.amazon.com/polly/latest/dg/voicelist.html

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to issue: #64223

The above is an example of voices that were previously missing and then added.

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
