### PR TITLE
Add Fully Kiosk Browser light platform

### DIFF
--- a/homeassistant/components/fully_kiosk/__init__.py
+++ b/homeassistant/components/fully_kiosk/__init__.py
@@ -6,7 +6,13 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import FullyKioskDataUpdateCoordinator
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.LIGHT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/fully_kiosk/light.py
+++ b/homeassistant/components/fully_kiosk/light.py
@@ -43,7 +43,7 @@ class FullyLightEntity(FullyKioskEntity, LightEntity):
     @property
     def is_on(self) -> bool | None:
         """Return if the screen is on."""
-        if self.coordinator.data:
+        if self.coordinator.data.get("screenOn") is not None:
             return bool(self.coordinator.data["screenOn"])
         return None
 

--- a/homeassistant/components/fully_kiosk/light.py
+++ b/homeassistant/components/fully_kiosk/light.py
@@ -1,0 +1,69 @@
+"""Fully Kiosk Browser light entity for controlling screen brightness & on/off."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    SUPPORT_BRIGHTNESS,
+    LightEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import FullyKioskDataUpdateCoordinator
+from .entity import FullyKioskEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Fully Kiosk Browser light."""
+    coordinator: FullyKioskDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+    async_add_entities([FullyLightEntity(coordinator)], False)
+
+
+class FullyLightEntity(FullyKioskEntity, LightEntity):
+    """Representation of a Fully Kiosk Browser light."""
+
+    def __init__(self, coordinator: FullyKioskDataUpdateCoordinator) -> None:
+        """Initialize the light (screen) entity."""
+        super().__init__(coordinator)
+
+        self._attr_name = "Screen"
+        self._attr_unique_id = f"{coordinator.data['deviceID']}-screen"
+        self._attr_supported_features = SUPPORT_BRIGHTNESS
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return if the screen is on."""
+        if self.coordinator.data:
+            return bool(self.coordinator.data["screenOn"])
+        return None
+
+    @property
+    def brightness(self) -> int:
+        """Return the screen brightness."""
+        return int(self.coordinator.data["screenBrightness"])
+
+    async def async_turn_on(self, **kwargs: dict[str, Any]) -> None:
+        """Turn on the screen."""
+        await self.coordinator.fully.screenOn()
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+        if brightness is None:
+            await self.coordinator.async_refresh()
+            return
+        if brightness != self.coordinator.data["screenBrightness"]:
+            await self.coordinator.fully.setScreenBrightness(brightness)
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs: dict[str, Any]) -> None:
+        """Turn off the screen."""
+        await self.coordinator.fully.screenOff()
+        await self.coordinator.async_refresh()

--- a/tests/components/fully_kiosk/test_light.py
+++ b/tests/components/fully_kiosk/test_light.py
@@ -1,0 +1,60 @@
+"""Test the Fully Kiosk Browser light."""
+from unittest.mock import MagicMock
+
+from homeassistant.components.fully_kiosk.const import DOMAIN
+import homeassistant.components.light as light
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_switches(
+    hass: HomeAssistant, mock_fully_kiosk: MagicMock, init_integration: MockConfigEntry
+) -> None:
+    """Test Fully Kiosk switches."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    entity = hass.states.get("light.amazon_fire_screen")
+    assert entity
+    assert entity.state == "on"
+    assert entity.attributes.get(light.ATTR_BRIGHTNESS) == 9
+
+    entry = entity_registry.async_get("light.amazon_fire_screen")
+    assert entry
+    assert entry.unique_id == "abcdef-123456-screen"
+
+    await call_service(hass, "turn_off", "light.amazon_fire_screen")
+    assert len(mock_fully_kiosk.screenOff.mock_calls) == 1
+
+    await call_service(hass, "turn_on", "light.amazon_fire_screen")
+    assert len(mock_fully_kiosk.screenOn.mock_calls) == 1
+
+    await hass.services.async_call(
+        light.DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: "light.amazon_fire_screen", light.ATTR_BRIGHTNESS: 100},
+        blocking=True,
+    )
+    assert len(mock_fully_kiosk.setScreenBrightness.mock_calls) == 1
+
+    assert entry.device_id
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry
+    assert device_entry.configuration_url == "http://192.168.1.234:2323"
+    assert device_entry.entry_type is None
+    assert device_entry.hw_version is None
+    assert device_entry.identifiers == {(DOMAIN, "abcdef-123456")}
+    assert device_entry.manufacturer == "amzn"
+    assert device_entry.model == "KFDOWI"
+    assert device_entry.name == "Amazon Fire"
+    assert device_entry.sw_version == "1.42.5"
+
+
+def call_service(hass, service, entity_id):
+    """Call any service on entity."""
+    return hass.services.async_call(
+        light.DOMAIN, service, {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )


### PR DESCRIPTION
## Proposed change
Adds a light platform to the Fully Kiosk Browser integration for controlling the device screen on/off and screen brightness.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23797

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
