### PR TITLE
Raise repairs issue if automation calls unknown service

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -527,7 +527,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
                     await self.action_script.async_run(
                         variables, trigger_context, started_action
                     )
-            except (ServiceNotFound) as err:
+            except ServiceNotFound as err:
                 async_create_issue(
                     self.hass,
                     DOMAIN,

--- a/homeassistant/components/automation/manifest.json
+++ b/homeassistant/components/automation/manifest.json
@@ -2,7 +2,7 @@
   "domain": "automation",
   "name": "Automation",
   "documentation": "https://www.home-assistant.io/integrations/automation",
-  "dependencies": ["blueprint", "trace"],
+  "dependencies": ["blueprint", "repairs", "trace"],
   "after_dependencies": ["device_automation", "webhook"],
   "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"

--- a/homeassistant/components/automation/strings.json
+++ b/homeassistant/components/automation/strings.json
@@ -13,7 +13,7 @@
         "step": {
           "confirm": {
             "title": "{name} uses an unknown service",
-            "description": "The automation \"{name}\" (`{entity_id}`) has an action that calls an unknown service: `{service}`.\n\nThis error prevents the automation from running correctly. Maybe this service is no longer available, or a typo caused it.\n\nTo fix this error, [edit the automation]({edit}) and remove the action that calls this service.\n\nClick on SUBMIT below to confirm you have fixed this automation."
+            "description": "The automation \"{name}\" (`{entity_id}`) has an action that calls an unknown service: `{service}`.\n\nThis error prevents the automation from running correctly. Maybe this service is no longer available, or perhaps a typo caused it.\n\nTo fix this error, [edit the automation]({edit}) and remove the action that calls this service.\n\nClick on SUBMIT below to confirm you have fixed this automation."
           }
         }
       }

--- a/homeassistant/components/automation/strings.json
+++ b/homeassistant/components/automation/strings.json
@@ -5,5 +5,18 @@
       "off": "[%key:common::state::off%]",
       "on": "[%key:common::state::on%]"
     }
+  },
+  "issues": {
+    "service_not_found": {
+      "title": "{name} uses unknown service",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "{name} uses an unknown service",
+            "description": "The automation \"{name}\" (`{entity_id}`) has an action that calls an unknown service: `{service}`.\n\nThis error prevents the automation from running correctly. Maybe this service is no longer available, or a typo caused it.\n\nTo fix this error, [edit the automation]({edit}) and remove the action that calls this service.\n\nClick on SUBMIT below to confirm you have fixed this automation."
+          }
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/automation/strings.json
+++ b/homeassistant/components/automation/strings.json
@@ -8,7 +8,7 @@
   },
   "issues": {
     "service_not_found": {
-      "title": "{name} uses unknown service",
+      "title": "{name} uses an unknown service",
       "fix_flow": {
         "step": {
           "confirm": {

--- a/homeassistant/components/automation/translations/en.json
+++ b/homeassistant/components/automation/translations/en.json
@@ -4,7 +4,7 @@
             "fix_flow": {
                 "step": {
                     "confirm": {
-                        "description": "The automation \"{name}\" (`{entity_id}`) has an action that calls an unknown service: `{service}`.\n\nThis error prevents the automation from running correctly. Maybe this service is no longer available, or a typo caused it.\n\nTo fix this error, [edit the automation]({edit}) and remove the action that calls this service.\n\nClick on SUBMIT below to confirm you have fixed this automation.",
+                        "description": "The automation \"{name}\" (`{entity_id}`) has an action that calls an unknown service: `{service}`.\n\nThis error prevents the automation from running correctly. Maybe this service is no longer available, or perhaps a typo caused it.\n\nTo fix this error, [edit the automation]({edit}) and remove the action that calls this service.\n\nClick on SUBMIT below to confirm you have fixed this automation.",
                         "title": "{name} uses an unknown service"
                     }
                 }

--- a/homeassistant/components/automation/translations/en.json
+++ b/homeassistant/components/automation/translations/en.json
@@ -9,7 +9,7 @@
                     }
                 }
             },
-            "title": "{name} uses unknown service"
+            "title": "{name} uses an unknown service"
         }
     },
     "state": {

--- a/homeassistant/components/automation/translations/en.json
+++ b/homeassistant/components/automation/translations/en.json
@@ -1,4 +1,17 @@
 {
+    "issues": {
+        "service_not_found": {
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "description": "The automation \"{name}\" (`{entity_id}`) has an action that calls an unknown service: `{service}`.\n\nThis error prevents the automation from running correctly. Maybe this service is no longer available, or a typo caused it.\n\nTo fix this error, [edit the automation]({edit}) and remove the action that calls this service.\n\nClick on SUBMIT below to confirm you have fixed this automation.",
+                        "title": "{name} uses an unknown service"
+                    }
+                }
+            },
+            "title": "{name} uses unknown service"
+        }
+    },
     "state": {
         "_": {
             "off": "Off",

--- a/tests/components/mobile_app/conftest.py
+++ b/tests/components/mobile_app/conftest.py
@@ -75,5 +75,6 @@ async def authed_api_client(hass, hass_client):
 @pytest.fixture(autouse=True)
 async def setup_ws(hass):
     """Configure the websocket_api component."""
+    assert await async_setup_component(hass, "repairs", {})
     assert await async_setup_component(hass, "websocket_api", {})
     await hass.async_block_till_done()

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -696,6 +696,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 ):
     """Test triggers not firing after removal."""
     assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, "repairs", {})
     await hass.async_block_till_done()
     await mqtt_mock_entry_no_yaml_config()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR raises an issue for repairs in case an automation calls an unknown service.

![CleanShot 2022-08-17 at 20 53 22](https://user-images.githubusercontent.com/195327/185219907-9edd820c-cef6-44b5-97ec-be32fa8bfb1f.png)

![CleanShot 2022-08-17 at 20 53 26](https://user-images.githubusercontent.com/195327/185219928-5820afbc-29fe-4eb1-b112-aefddeaa4531.png)

Notes: We can only catch this issue when the automation actually runs and triggers this. Hence it is persistent and uses the default confirm flow to mark as fixed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
