### PR TITLE
Fix race in notify setup

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -42,7 +42,7 @@ PLATFORM_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the notify services."""
 
-    platform_setups = await async_setup_legacy(hass, config)
+    platform_setups = async_setup_legacy(hass, config)
 
     # We need to add the component here break the deadlock
     # when setting up integrations from config entries as

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -54,7 +54,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.config.components.add(DOMAIN)
 
     if platform_setups:
-        await asyncio.wait(platform_setups)
+        await asyncio.wait([asyncio.create_task(setup) for setup in platform_setups])
 
     async def persistent_notification(service: ServiceCall) -> None:
         """Send notification via the built-in persistsent_notify integration."""

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -54,7 +54,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.config.components.add(DOMAIN)
 
     if platform_setups:
-        await asyncio.gather(*platform_setups)
+        await asyncio.wait(platform_setups)
 
     async def persistent_notification(service: ServiceCall) -> None:
         """Send notification via the built-in persistsent_notify integration."""

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -40,13 +40,16 @@ PLATFORM_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the notify services."""
 
+    await async_setup_legacy(hass, config)
+
     # We need to add the component here break the deadlock
     # when setting up integrations from config entries as
     # they would otherwise wait for notify to be
     # setup and thus the config entries would not be able to
-    # setup their platforms.
+    # setup their platforms, but we need to do it after
+    # the dispatcher is connected so we don't miss integrations
+    # that are registered before the dispatcher is connected
     hass.config.components.add(DOMAIN)
-    await async_setup_legacy(hass, config)
 
     async def persistent_notification(service: ServiceCall) -> None:
         """Send notification via the built-in persistsent_notify integration."""

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -1,6 +1,8 @@
 """Provides functionality to notify people."""
 from __future__ import annotations
 
+import asyncio
+
 import voluptuous as vol
 
 import homeassistant.components.persistent_notification as pn
@@ -40,7 +42,7 @@ PLATFORM_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the notify services."""
 
-    await async_setup_legacy(hass, config)
+    platform_setups = await async_setup_legacy(hass, config)
 
     # We need to add the component here break the deadlock
     # when setting up integrations from config entries as
@@ -50,6 +52,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # the dispatcher is connected so we don't miss integrations
     # that are registered before the dispatcher is connected
     hass.config.components.add(DOMAIN)
+
+    if platform_setups:
+        await asyncio.gather(*platform_setups)
 
     async def persistent_notification(service: ServiceCall) -> None:
         """Send notification via the built-in persistsent_notify integration."""

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -33,7 +33,8 @@ NOTIFY_SERVICES = "notify_services"
 NOTIFY_DISCOVERY_DISPATCHER = "notify_discovery_dispatcher"
 
 
-async def async_setup_legacy(
+@callback
+def async_setup_legacy(
     hass: HomeAssistant, config: ConfigType
 ) -> list[Coroutine[Any, Any, None]]:
     """Set up legacy notify services."""

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
 from functools import partial
 from typing import Any, cast
 
@@ -32,7 +33,9 @@ NOTIFY_SERVICES = "notify_services"
 NOTIFY_DISCOVERY_DISPATCHER = "notify_discovery_dispatcher"
 
 
-async def async_setup_legacy(hass: HomeAssistant, config: ConfigType) -> None:
+async def async_setup_legacy(
+    hass: HomeAssistant, config: ConfigType
+) -> list[Coroutine[Any, Any, None]]:
     """Set up legacy notify services."""
     hass.data.setdefault(NOTIFY_SERVICES, {})
     hass.data.setdefault(NOTIFY_DISCOVERY_DISPATCHER, None)
@@ -101,15 +104,6 @@ async def async_setup_legacy(hass: HomeAssistant, config: ConfigType) -> None:
             )
             hass.config.components.add(f"{DOMAIN}.{integration_name}")
 
-    setup_tasks = [
-        asyncio.create_task(async_setup_platform(integration_name, p_config))
-        for integration_name, p_config in config_per_platform(config, DOMAIN)
-        if integration_name is not None
-    ]
-
-    if setup_tasks:
-        await asyncio.wait(setup_tasks)
-
     async def async_platform_discovered(
         platform: str, info: DiscoveryInfoType | None
     ) -> None:
@@ -119,6 +113,12 @@ async def async_setup_legacy(hass: HomeAssistant, config: ConfigType) -> None:
     hass.data[NOTIFY_DISCOVERY_DISPATCHER] = discovery.async_listen_platform(
         hass, DOMAIN, async_platform_discovered
     )
+
+    return [
+        async_setup_platform(integration_name, p_config)
+        for integration_name, p_config in config_per_platform(config, DOMAIN)
+        if integration_name is not None
+    ]
 
 
 @callback


### PR DESCRIPTION
Please see below.  I may be missing something but it doesn't look like `slack` and `discord` pass `hass_config` which may be the actual root cause here (although I think there is still a race).

It would be helpful if someone could validate that or tell me I'm reading it wrong 😄 

details: https://github.com/home-assistant/core/pull/76954#issuecomment-1218786046


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The discovery dispatcher must be connected before we can add
to `hass.config.components` to ensure signals are
not missed since the legacy setup await can return control
to the event loop before it gets connected.

Fixes #76564
Fixes #76402
Fixes #76343
Fixes #76919

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
