### PR TITLE
Add screen on/off switch to Fully Kiosk Browser integration

### DIFF
--- a/homeassistant/components/fully_kiosk/switch.py
+++ b/homeassistant/components/fully_kiosk/switch.py
@@ -66,6 +66,13 @@ SWITCHES: tuple[FullySwitchEntityDescription, ...] = (
         off_action=lambda fully: fully.disableMotionDetection(),
         is_on_fn=lambda data: data["settings"].get("motionDetection"),
     ),
+    FullySwitchEntityDescription(
+        key="screenOn",
+        name="Screen",
+        on_action=lambda fully: fully.screenOn(),
+        off_action=lambda fully: fully.screenOff(),
+        is_on_fn=lambda data: data.get("screenOn"),
+    ),
 )
 
 

--- a/tests/components/fully_kiosk/test_switch.py
+++ b/tests/components/fully_kiosk/test_switch.py
@@ -61,6 +61,17 @@ async def test_switches(
     await call_service(hass, "turn_off", "switch.amazon_fire_motion_detection")
     assert len(mock_fully_kiosk.disableMotionDetection.mock_calls) == 1
 
+    entity = hass.states.get("switch.amazon_fire_screen")
+    assert entity
+    assert entity.state == "on"
+    entry = entity_registry.async_get("switch.amazon_fire_screen")
+    assert entry
+    assert entry.unique_id == "abcdef-123456-screenOn"
+    await call_service(hass, "turn_off", "switch.amazon_fire_screen")
+    assert len(mock_fully_kiosk.screenOff.mock_calls) == 1
+    await call_service(hass, "turn_on", "switch.amazon_fire_screen")
+    assert len(mock_fully_kiosk.screenOn.mock_calls) == 1
+
     assert entry.device_id
     device_entry = device_registry.async_get(entry.device_id)
     assert device_entry


### PR DESCRIPTION
## Proposed change
Add a `switch` entity to toggle the device screen on/off.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23806

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
