### PR TITLE
Add strict typing to mikrotik

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -169,6 +169,7 @@ homeassistant.components.mailbox.*
 homeassistant.components.media_player.*
 homeassistant.components.media_source.*
 homeassistant.components.metoffice.*
+homeassistant.components.mikrotik.*
 homeassistant.components.mjpeg.*
 homeassistant.components.modbus.*
 homeassistant.components.modem_callerid.*

--- a/homeassistant/components/mikrotik/__init__.py
+++ b/homeassistant/components/mikrotik/__init__.py
@@ -1,14 +1,17 @@
 """The Mikrotik component."""
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
-from .const import ATTR_MANUFACTURER, DOMAIN, PLATFORMS
+from .const import ATTR_MANUFACTURER, DOMAIN
 from .errors import CannotConnect, LoginError
 from .hub import MikrotikDataUpdateCoordinator, get_api
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
+
+PLATFORMS = [Platform.DEVICE_TRACKER]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -26,7 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
 
-    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(

--- a/homeassistant/components/mikrotik/const.py
+++ b/homeassistant/components/mikrotik/const.py
@@ -1,8 +1,6 @@
 """Constants used in the Mikrotik components."""
 from typing import Final
 
-from homeassistant.const import Platform
-
 DOMAIN: Final = "mikrotik"
 DEFAULT_NAME: Final = "Mikrotik"
 DEFAULT_API_PORT: Final = 8728
@@ -40,7 +38,6 @@ MIKROTIK_SERVICES: Final = {
     IS_CAPSMAN: "/caps-man/interface/print",
 }
 
-PLATFORMS: Final = [Platform.DEVICE_TRACKER]
 
 ATTR_DEVICE_TRACKER: Final = [
     "comment",

--- a/homeassistant/components/mikrotik/device.py
+++ b/homeassistant/components/mikrotik/device.py
@@ -1,0 +1,66 @@
+"""Network client device class."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from homeassistant.util import slugify
+import homeassistant.util.dt as dt_util
+
+from .const import ATTR_DEVICE_TRACKER
+
+
+class Device:
+    """Represents a network device."""
+
+    def __init__(self, mac: str, params: dict[str, Any]) -> None:
+        """Initialize the network device."""
+        self._mac = mac
+        self._params = params
+        self._last_seen: datetime | None = None
+        self._attrs: dict[str, Any] = {}
+        self._wireless_params: dict[str, Any] = {}
+
+    @property
+    def name(self) -> str:
+        """Return device name."""
+        return self._params.get("host-name", self.mac)
+
+    @property
+    def ip_address(self) -> str | None:
+        """Return device primary ip address."""
+        return self._params.get("address")
+
+    @property
+    def mac(self) -> str:
+        """Return device mac."""
+        return self._mac
+
+    @property
+    def last_seen(self) -> datetime | None:
+        """Return device last seen."""
+        return self._last_seen
+
+    @property
+    def attrs(self) -> dict[str, Any]:
+        """Return device attributes."""
+        attr_data = self._wireless_params | self._params
+        for attr in ATTR_DEVICE_TRACKER:
+            if attr in attr_data:
+                self._attrs[slugify(attr)] = attr_data[attr]
+        return self._attrs
+
+    def update(
+        self,
+        wireless_params: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        active: bool = False,
+    ) -> None:
+        """Update Device params."""
+        if wireless_params:
+            self._wireless_params = wireless_params
+        if params:
+            self._params = params
+        if active:
+            self._last_seen = dt_util.utcnow()

--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -63,7 +63,7 @@ def update_items(
     coordinator: MikrotikDataUpdateCoordinator,
     async_add_entities: AddEntitiesCallback,
     tracked: dict[str, MikrotikDataUpdateCoordinatorTracker],
-):
+) -> None:
     """Update tracked device state from the hub."""
     new_tracked: list[MikrotikDataUpdateCoordinatorTracker] = []
     for mac, device in coordinator.api.devices.items():

--- a/mypy.ini
+++ b/mypy.ini
@@ -1449,6 +1449,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.mikrotik.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.mjpeg.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add strict typing to mikrotik
- Move `Device` class into its own file.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
