### PR TITLE
Adjust version comparison in HA Cloud account linking

### DIFF
--- a/homeassistant/components/cloud/account_link.py
+++ b/homeassistant/components/cloud/account_link.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CURRENT_VERSION = AwesomeVersion(HA_VERSION)
 CURRENT_PLAIN_VERSION = AwesomeVersion(
-    CURRENT_VERSION.string.removesuffix(f".{CURRENT_VERSION.modifier}")
+    CURRENT_VERSION.string.removesuffix(f"{CURRENT_VERSION.modifier}")
 )
 
 

--- a/homeassistant/components/cloud/account_link.py
+++ b/homeassistant/components/cloud/account_link.py
@@ -18,6 +18,9 @@ CACHE_TIMEOUT = 3600
 _LOGGER = logging.getLogger(__name__)
 
 CURRENT_VERSION = AwesomeVersion(HA_VERSION)
+CURRENT_PLAIN_VERSION = AwesomeVersion(
+    CURRENT_VERSION.string.removesuffix(f".{CURRENT_VERSION.modifier}")
+)
 
 
 @callback
@@ -35,7 +38,7 @@ async def async_provide_implementation(hass: HomeAssistant, domain: str):
     for service in services:
         if (
             service["service"] == domain
-            and CURRENT_VERSION >= service["min_version"]
+            and CURRENT_PLAIN_VERSION >= service["min_version"]
             and (
                 service.get("accepts_new_authorizations", True)
                 or (

--- a/tests/components/cloud/test_account_link.py
+++ b/tests/components/cloud/test_account_link.py
@@ -57,6 +57,7 @@ async def test_setup_provide_implementation(hass):
         return_value=[
             {"service": "test", "min_version": "0.1.0"},
             {"service": "too_new", "min_version": "1000000.0.0"},
+            {"service": "dev", "min_version": "2022.9.0"},
             {
                 "service": "deprecated",
                 "min_version": "0.1.0",
@@ -73,6 +74,8 @@ async def test_setup_provide_implementation(hass):
                 "accepts_new_authorizations": False,
             },
         ],
+    ), patch(
+        "homeassistant.components.cloud.account_link.HA_VERSION", "2022.9.0.dev20220817"
     ):
         assert (
             await config_entry_oauth2_flow.async_get_implementations(
@@ -101,6 +104,10 @@ async def test_setup_provide_implementation(hass):
             await config_entry_oauth2_flow.async_get_implementations(hass, "legacy")
         )
 
+        dev_implementations = await config_entry_oauth2_flow.async_get_implementations(
+            hass, "dev"
+        )
+
     assert "cloud" in implementations
     assert implementations["cloud"].domain == "cloud"
     assert implementations["cloud"].service == "test"
@@ -110,6 +117,11 @@ async def test_setup_provide_implementation(hass):
     assert legacy_implementations["cloud"].domain == "cloud"
     assert legacy_implementations["cloud"].service == "legacy"
     assert legacy_implementations["cloud"].hass is hass
+
+    assert "cloud" in dev_implementations
+    assert dev_implementations["cloud"].domain == "cloud"
+    assert dev_implementations["cloud"].service == "dev"
+    assert dev_implementations["cloud"].hass is hass
 
 
 async def test_get_services_cached(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adjusts the version check in the Home Assistant Cloud account linking to ignore the version modifier from the current version.

This allows a service set for, e.g., `2022.9.0` already to work in 2022.9.0 dev & beta.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
