### PR TITLE
Hive Add ability to trigger the alarm

### DIFF
--- a/homeassistant/components/hive/alarm_control_panel.py
+++ b/homeassistant/components/hive/alarm_control_panel.py
@@ -64,11 +64,10 @@ class HiveAlarmControlPanelEntity(HiveEntity, AlarmControlPanelEntity):
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self.hive.alarm.setMode(self.device, "away")
-    
+
     async def async_alarm_trigger(self, code=None) -> None:
         """Send alarm trigger command."""
         await self.hive.alarm.setMode(self.device, "sos")
-
 
     async def async_update(self) -> None:
         """Update all Node data from Hive."""

--- a/homeassistant/components/hive/alarm_control_panel.py
+++ b/homeassistant/components/hive/alarm_control_panel.py
@@ -27,6 +27,7 @@ HIVETOHA = {
     "home": STATE_ALARM_DISARMED,
     "asleep": STATE_ALARM_ARMED_NIGHT,
     "away": STATE_ALARM_ARMED_AWAY,
+    "sos": STATE_ALARM_TRIGGERED,
 }
 
 

--- a/homeassistant/components/hive/alarm_control_panel.py
+++ b/homeassistant/components/hive/alarm_control_panel.py
@@ -49,6 +49,7 @@ class HiveAlarmControlPanelEntity(HiveEntity, AlarmControlPanelEntity):
     _attr_supported_features = (
         AlarmControlPanelEntityFeature.ARM_NIGHT
         | AlarmControlPanelEntityFeature.ARM_AWAY
+        | AlarmControlPanelEntityFeature.TRIGGER
     )
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
@@ -62,6 +63,11 @@ class HiveAlarmControlPanelEntity(HiveEntity, AlarmControlPanelEntity):
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self.hive.alarm.setMode(self.device, "away")
+    
+    async def async_alarm_trigger(self, code=None) -> None:
+        """Send alarm trigger command."""
+        await self.hive.alarm.setMode(self.device, "sos")
+
 
     async def async_update(self) -> None:
         """Update all Node data from Hive."""

--- a/homeassistant/components/hive/alarm_control_panel.py
+++ b/homeassistant/components/hive/alarm_control_panel.py
@@ -64,7 +64,6 @@ class HiveAlarmControlPanelEntity(HiveEntity, AlarmControlPanelEntity):
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self.hive.alarm.setMode(self.device, "away")
-    
     async def async_alarm_trigger(self, code=None) -> None:
         """Send alarm trigger command."""
         await self.hive.alarm.setMode(self.device, "sos")

--- a/homeassistant/components/hive/alarm_control_panel.py
+++ b/homeassistant/components/hive/alarm_control_panel.py
@@ -69,7 +69,6 @@ class HiveAlarmControlPanelEntity(HiveEntity, AlarmControlPanelEntity):
         """Send alarm trigger command."""
         await self.hive.alarm.setMode(self.device, "sos")
 
-
     async def async_update(self) -> None:
         """Update all Node data from Hive."""
         await self.hive.session.updateData(self.device)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the ability to trigger the alarm.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
