### PR TITLE
Revert rename of confirm step in zha config flow

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -138,9 +138,9 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
         self._set_confirm_only()
         self.context["title_placeholders"] = {CONF_NAME: self._title}
-        return await self.async_step_confirm_usb()
+        return await self.async_step_confirm()
 
-    async def async_step_confirm_usb(self, user_input=None):
+    async def async_step_confirm(self, user_input=None):
         """Confirm a USB discovery."""
         if user_input is not None or not onboarding.async_is_onboarded(self.hass):
             auto_detected_data = await detect_radios(self._device_path)
@@ -155,7 +155,7 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_show_form(
-            step_id="confirm_usb",
+            step_id="confirm",
             description_placeholders={CONF_NAME: self._title},
         )
 

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -10,6 +10,9 @@
       "confirm": {
         "description": "Do you want to setup {name}?"
       },
+      "confirm_hardware": {
+        "description": "Do you want to setup {name}?"
+      },
       "pick_radio": {
         "data": { "radio_type": "Radio Type" },
         "title": "Radio Type",

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -21,8 +21,6 @@ USB_DATA = usb.UsbServiceInfo(
 
 async def test_config_flow(hass: HomeAssistant) -> None:
     """Test the config flow."""
-    # mock_integration(hass, MockModule("hassio"))
-
     with patch(
         "homeassistant.components.homeassistant_sky_connect.async_setup_entry",
         return_value=True,

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -228,7 +228,7 @@ async def test_discovery_via_usb(detect_mock, hass):
     )
     await hass.async_block_till_done()
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm_usb"
+    assert result["step_id"] == "confirm"
 
     with patch("homeassistant.components.zha.async_setup_entry"):
         result2 = await hass.config_entries.flow.async_configure(
@@ -264,7 +264,7 @@ async def test_zigate_discovery_via_usb(detect_mock, hass):
     )
     await hass.async_block_till_done()
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm_usb"
+    assert result["step_id"] == "confirm"
 
     with patch("homeassistant.components.zha.async_setup_entry"):
         result2 = await hass.config_entries.flow.async_configure(
@@ -298,7 +298,7 @@ async def test_discovery_via_usb_no_radio(detect_mock, hass):
     )
     await hass.async_block_till_done()
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm_usb"
+    assert result["step_id"] == "confirm"
 
     with patch("homeassistant.components.zha.async_setup_entry"):
         result2 = await hass.config_entries.flow.async_configure(
@@ -451,7 +451,7 @@ async def test_discovery_via_usb_deconz_ignored(detect_mock, hass):
     await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm_usb"
+    assert result["step_id"] == "confirm"
 
 
 @patch("zigpy_znp.zigbee.application.ControllerApplication.probe", return_value=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Address a couple of open review comments from #76795:
- Revert rename of `confirm` step in zha config flow because it broke translations
- Remove commented out code from a test

In addition:
- Add missing translation string for the `confirm_hardware` step in zha config flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
