### PR TITLE
Migrate BMW Connected Drive to new entity naming

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -163,6 +163,7 @@ class BMWBaseEntity(CoordinatorEntity[BMWDataUpdateCoordinator]):
 
     coordinator: BMWDataUpdateCoordinator
     _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -182,7 +183,7 @@ class BMWBaseEntity(CoordinatorEntity[BMWDataUpdateCoordinator]):
             identifiers={(DOMAIN, self.vehicle.vin)},
             manufacturer=vehicle.brand.name,
             model=vehicle.name,
-            name=f"{vehicle.brand.name} {vehicle.name}",
+            name=vehicle.name,
         )
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -224,8 +224,6 @@ class BMWBinarySensor(BMWBaseEntity, BinarySensorEntity):
         super().__init__(coordinator, vehicle)
         self.entity_description = description
         self._unit_system = unit_system
-
-        self._attr_name = description.name
         self._attr_unique_id = f"{vehicle.vin}-{description.key}"
 
     @callback

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -121,7 +121,7 @@ class BMWBinarySensorEntityDescription(
 SENSOR_TYPES: tuple[BMWBinarySensorEntityDescription, ...] = (
     BMWBinarySensorEntityDescription(
         key="lids",
-        name="Doors",
+        name="Lids",
         device_class=BinarySensorDeviceClass.OPENING,
         icon="mdi:car-door-lock",
         # device class opening: On means open, Off means closed
@@ -165,7 +165,7 @@ SENSOR_TYPES: tuple[BMWBinarySensorEntityDescription, ...] = (
     ),
     BMWBinarySensorEntityDescription(
         key="check_control_messages",
-        name="Control messages",
+        name="Check control messages",
         device_class=BinarySensorDeviceClass.PROBLEM,
         icon="mdi:car-tire-alert",
         # device class problem: On means problem detected, Off means no problem
@@ -225,7 +225,7 @@ class BMWBinarySensor(BMWBaseEntity, BinarySensorEntity):
         self.entity_description = description
         self._unit_system = unit_system
 
-        self._attr_name = f"{vehicle.name} {description.key}"
+        self._attr_name = description.name
         self._attr_unique_id = f"{vehicle.vin}-{description.key}"
 
     @callback

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -112,8 +112,6 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
         """Initialize BMW vehicle sensor."""
         super().__init__(coordinator, vehicle)
         self.entity_description = description
-
-        self._attr_name = description.name
         self._attr_unique_id = f"{vehicle.vin}-{description.key}"
 
     async def async_press(self) -> None:

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -38,31 +38,31 @@ BUTTON_TYPES: tuple[BMWButtonEntityDescription, ...] = (
     BMWButtonEntityDescription(
         key="light_flash",
         icon="mdi:car-light-alert",
-        name="Flash Lights",
+        name="Flash lights",
         remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_light_flash(),
     ),
     BMWButtonEntityDescription(
         key="sound_horn",
         icon="mdi:bullhorn",
-        name="Sound Horn",
+        name="Sound horn",
         remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_horn(),
     ),
     BMWButtonEntityDescription(
         key="activate_air_conditioning",
         icon="mdi:hvac",
-        name="Activate Air Conditioning",
+        name="Activate air conditioning",
         remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_air_conditioning(),
     ),
     BMWButtonEntityDescription(
         key="deactivate_air_conditioning",
         icon="mdi:hvac-off",
-        name="Deactivate Air Conditioning",
+        name="Deactivate air conditioning",
         remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_air_conditioning_stop(),
     ),
     BMWButtonEntityDescription(
         key="find_vehicle",
         icon="mdi:crosshairs-question",
-        name="Find Vehicle",
+        name="Find vehicle",
         remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_vehicle_finder(),
     ),
     BMWButtonEntityDescription(
@@ -113,7 +113,7 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
         super().__init__(coordinator, vehicle)
         self.entity_description = description
 
-        self._attr_name = f"{vehicle.name} {description.name}"
+        self._attr_name = description.name
         self._attr_unique_id = f"{vehicle.vin}-{description.key}"
 
     async def async_press(self) -> None:

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -54,6 +54,7 @@ class BMWDeviceTracker(BMWBaseEntity, TrackerEntity):
         super().__init__(coordinator, vehicle)
 
         self._attr_unique_id = vehicle.vin
+        self._attr_name = None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from bimmer_connected.vehicle import MyBMWVehicle
 
@@ -53,10 +54,9 @@ class BMWDeviceTracker(BMWBaseEntity, TrackerEntity):
         super().__init__(coordinator, vehicle)
 
         self._attr_unique_id = vehicle.vin
-        self._attr_name = vehicle.name
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity specific state attributes."""
         return {**self._attrs, ATTR_DIRECTION: self.vehicle.vehicle_location.heading}
 

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
 
     for vehicle in coordinator.account.vehicles:
         if not coordinator.read_only:
-            entities.append(BMWLock(coordinator, vehicle, "lock", "BMW lock"))
+            entities.append(BMWLock(coordinator, vehicle, "lock", "Lock"))
     async_add_entities(entities)
 
 
@@ -50,9 +50,8 @@ class BMWLock(BMWBaseEntity, LockEntity):
         super().__init__(coordinator, vehicle)
 
         self._attribute = attribute
-        self._attr_name = f"{vehicle.name} {attribute}"
+        self._attr_name = sensor_name
         self._attr_unique_id = f"{vehicle.vin}-{attribute}"
-        self._sensor_name = sensor_name
         self.door_lock_state_available = DOOR_LOCK_STATE in vehicle.available_attributes
 
     async def async_lock(self, **kwargs: Any) -> None:

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -7,7 +7,7 @@ from typing import Any
 from bimmer_connected.vehicle import MyBMWVehicle
 from bimmer_connected.vehicle.doors_windows import LockState
 
-from homeassistant.components.lock import LockEntity
+from homeassistant.components.lock import LockEntity, LockEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -32,7 +32,13 @@ async def async_setup_entry(
 
     for vehicle in coordinator.account.vehicles:
         if not coordinator.read_only:
-            entities.append(BMWLock(coordinator, vehicle, "lock", "Lock"))
+            entities.append(
+                BMWLock(
+                    coordinator,
+                    vehicle,
+                    LockEntityDescription(key="lock", device_class="lock", name="Lock"),
+                )
+            )
     async_add_entities(entities)
 
 
@@ -43,15 +49,13 @@ class BMWLock(BMWBaseEntity, LockEntity):
         self,
         coordinator: BMWDataUpdateCoordinator,
         vehicle: MyBMWVehicle,
-        attribute: str,
-        sensor_name: str,
+        description: LockEntityDescription,
     ) -> None:
         """Initialize the lock."""
         super().__init__(coordinator, vehicle)
 
-        self._attribute = attribute
-        self._attr_name = sensor_name
-        self._attr_unique_id = f"{vehicle.vin}-{attribute}"
+        self.entity_description = description
+        self._attr_unique_id = f"{vehicle.vin}-{description.key}"
         self.door_lock_state_available = DOOR_LOCK_STATE in vehicle.available_attributes
 
     async def async_lock(self, **kwargs: Any) -> None:

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -56,23 +56,27 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
     # --- Generic ---
     "charging_start_time": BMWSensorEntityDescription(
         key="charging_start_time",
+        name="Charging start time",
         key_class="fuel_and_battery",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
     ),
     "charging_end_time": BMWSensorEntityDescription(
         key="charging_end_time",
+        name="Charging end time",
         key_class="fuel_and_battery",
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
     "charging_status": BMWSensorEntityDescription(
         key="charging_status",
+        name="Charging status",
         key_class="fuel_and_battery",
         icon="mdi:ev-station",
         value=lambda x, y: x.value,
     ),
     "remaining_battery_percent": BMWSensorEntityDescription(
         key="remaining_battery_percent",
+        name="Remaining battery percent",
         key_class="fuel_and_battery",
         unit_type=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
@@ -80,12 +84,14 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
     # --- Specific ---
     "mileage": BMWSensorEntityDescription(
         key="mileage",
+        name="Mileage",
         icon="mdi:speedometer",
         unit_type=LENGTH,
         value=lambda x, hass: convert_and_round(x, hass.config.units.length, 2),
     ),
     "remaining_range_total": BMWSensorEntityDescription(
         key="remaining_range_total",
+        name="Remaining range total",
         key_class="fuel_and_battery",
         icon="mdi:map-marker-distance",
         unit_type=LENGTH,
@@ -93,6 +99,7 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
     ),
     "remaining_range_electric": BMWSensorEntityDescription(
         key="remaining_range_electric",
+        name="Remaining range electric",
         key_class="fuel_and_battery",
         icon="mdi:map-marker-distance",
         unit_type=LENGTH,
@@ -100,6 +107,7 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
     ),
     "remaining_range_fuel": BMWSensorEntityDescription(
         key="remaining_range_fuel",
+        name="Remaining range fuel",
         key_class="fuel_and_battery",
         icon="mdi:map-marker-distance",
         unit_type=LENGTH,
@@ -107,6 +115,7 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
     ),
     "remaining_fuel": BMWSensorEntityDescription(
         key="remaining_fuel",
+        name="Remaining fuel",
         key_class="fuel_and_battery",
         icon="mdi:gas-station",
         unit_type=VOLUME,
@@ -114,6 +123,7 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
     ),
     "remaining_fuel_percent": BMWSensorEntityDescription(
         key="remaining_fuel_percent",
+        name="Remaining fuel percent",
         key_class="fuel_and_battery",
         icon="mdi:gas-station",
         unit_type=PERCENTAGE,
@@ -160,7 +170,7 @@ class BMWSensor(BMWBaseEntity, SensorEntity):
         super().__init__(coordinator, vehicle)
         self.entity_description = description
 
-        self._attr_name = f"{vehicle.name} {description.key}"
+        self._attr_name = description.name
         self._attr_unique_id = f"{vehicle.vin}-{description.key}"
 
         # Set the correct unit of measurement based on the unit_type

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -169,8 +169,6 @@ class BMWSensor(BMWBaseEntity, SensorEntity):
         """Initialize BMW vehicle sensor."""
         super().__init__(coordinator, vehicle)
         self.entity_description = description
-
-        self._attr_name = description.name
         self._attr_unique_id = f"{vehicle.vin}-{description.key}"
 
         # Set the correct unit of measurement based on the unit_type


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enables `has_entity_name` on all BMW entities. Luckily, almost all of our naming scheme already fits the new convention, so no breaking changes like entity name or unique id changes are required.

Cosmetic changes:
- the device name in device info doesn't include the manufacturer anymore
- `binary_sensors.<vehicle>_lids`'s friendly name has changed from `Doors` to `Lids`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
