### PR TITLE
Remove name option from config_flow for P1 Monitor

### DIFF
--- a/homeassistant/components/p1_monitor/config_flow.py
+++ b/homeassistant/components/p1_monitor/config_flow.py
@@ -7,9 +7,10 @@ from p1monitor import P1Monitor, P1MonitorError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import TextSelector
 
 from .const import DOMAIN
 
@@ -37,7 +38,7 @@ class P1MonitorFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             else:
                 return self.async_create_entry(
-                    title=user_input[CONF_NAME],
+                    title="P1 Monitor",
                     data={
                         CONF_HOST: user_input[CONF_HOST],
                     },
@@ -47,10 +48,7 @@ class P1MonitorFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(
-                        CONF_NAME, default=self.hass.config.location_name
-                    ): str,
-                    vol.Required(CONF_HOST): str,
+                    vol.Required(CONF_HOST): TextSelector(),
                 }
             ),
             errors=errors,

--- a/homeassistant/components/p1_monitor/strings.json
+++ b/homeassistant/components/p1_monitor/strings.json
@@ -4,8 +4,10 @@
       "user": {
         "description": "Set up P1 Monitor to integrate with Home Assistant.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "name": "[%key:common::config_flow::data::name%]"
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "The IP address or hostname of your P1 Monitor installation."
         }
       }
     },

--- a/homeassistant/components/p1_monitor/translations/en.json
+++ b/homeassistant/components/p1_monitor/translations/en.json
@@ -6,8 +6,10 @@
         "step": {
             "user": {
                 "data": {
-                    "host": "Host",
-                    "name": "Name"
+                    "host": "Host"
+                },
+                "data_description": {
+                    "host": "The IP address or hostname of your P1 Monitor installation."
                 },
                 "description": "Set up P1 Monitor to integrate with Home Assistant."
             }

--- a/tests/components/p1_monitor/test_config_flow.py
+++ b/tests/components/p1_monitor/test_config_flow.py
@@ -5,7 +5,7 @@ from p1monitor import P1MonitorError
 
 from homeassistant.components.p1_monitor.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -27,11 +27,11 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_NAME: "Name", CONF_HOST: "example.com"},
+            user_input={CONF_HOST: "example.com"},
         )
 
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
-    assert result2.get("title") == "Name"
+    assert result2.get("title") == "P1 Monitor"
     assert result2.get("data") == {CONF_HOST: "example.com"}
 
     assert len(mock_setup_entry.mock_calls) == 1
@@ -47,7 +47,7 @@ async def test_api_error(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
-            data={CONF_NAME: "Name", CONF_HOST: "example.com"},
+            data={CONF_HOST: "example.com"},
         )
 
     assert result.get("type") == FlowResultType.FORM


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

At @frenck suggestion I removed the name value from the config flow, it never really added value except that you could give the device a name. An extra data description has now been added for the host, so that it is more clear what is expected from a host as input value.

<details>
  <summary>Screenshot of config_flow</summary>

![image](https://user-images.githubusercontent.com/20448157/185684360-4a6176fe-bb06-48e9-9d12-99890a841029.png)
</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/home-assistant.io/issues/23793
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
