### PR TITLE
Add hide attribute support to attribute selector

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -224,7 +224,7 @@ class AttributeSelector(Selector):
             vol.Required("entity_id"): cv.entity_id,
             # hide_attributes is used to hide attributes in the frontend.
             # A hidden attribute can still be provided manually.
-            vol.Optional("exclude_attributes"): [str],
+            vol.Optional("hide_attributes"): [str],
         }
     )
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -206,10 +206,11 @@ class AreaSelector(Selector):
         return [vol.Schema(str)(val) for val in data]
 
 
-class AttributeSelectorConfig(TypedDict):
+class AttributeSelectorConfig(TypedDict, total=False):
     """Class to represent an attribute selector config."""
 
     entity_id: str
+    exclude_attributes: list[str]
 
 
 @SELECTORS.register("attribute")
@@ -218,7 +219,12 @@ class AttributeSelector(Selector):
 
     selector_type = "attribute"
 
-    CONFIG_SCHEMA = vol.Schema({vol.Required("entity_id"): cv.entity_id})
+    CONFIG_SCHEMA = vol.Schema(
+        {
+            vol.Required("entity_id"): cv.entity_id,
+            vol.Optional("exclude_attributes"): [str],
+        }
+    )
 
     def __init__(self, config: AttributeSelectorConfig) -> None:
         """Instantiate a selector."""

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -222,7 +222,9 @@ class AttributeSelector(Selector):
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Required("entity_id"): cv.entity_id,
-            vol.Optional("hide_attributes"): [str],
+            # hide_attributes is used to hide attributes in the frontend.
+            # A hidden attribute can still be provided manually.
+            vol.Optional("exclude_attributes"): [str],
         }
     )
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -210,7 +210,7 @@ class AttributeSelectorConfig(TypedDict, total=False):
     """Class to represent an attribute selector config."""
 
     entity_id: str
-    exclude_attributes: list[str]
+    hide_attributes: list[str]
 
 
 @SELECTORS.register("attribute")
@@ -222,7 +222,7 @@ class AttributeSelector(Selector):
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Required("entity_id"): cv.entity_id,
-            vol.Optional("exclude_attributes"): [str],
+            vol.Optional("hide_attributes"): [str],
         }
     )
 

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -454,7 +454,7 @@ def test_select_selector_schema_error(schema):
             (None,),
         ),
         (
-            {"entity_id": "sensor.abc", "exclude_attributes": ["friendly_name"]},
+            {"entity_id": "sensor.abc", "hide_attributes": ["friendly_name"]},
             ("device_class", "state_class"),
             (None,),
         ),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -453,6 +453,11 @@ def test_select_selector_schema_error(schema):
             ("friendly_name", "device_class"),
             (None,),
         ),
+        (
+            {"entity_id": "sensor.abc", "exclude_attributes": ["friendly_name"]},
+            ("device_class", "state_class"),
+            (None,),
+        ),
     ),
 )
 def test_attribute_selector_schema(schema, valid_selections, invalid_selections):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds `hide_attribute` support to the attribute selector. This allows for cleaning up the list of selectable attributes.

(In the screenshot below, lots of non-numeric attributes are hidden, for example, Friendly name and such).

![CleanShot 2022-08-20 at 11 13 36](https://user-images.githubusercontent.com/195327/185738349-46ca19f7-05fd-445a-b3d0-f100cbcc13ce.png)

Frontend PR: <https://github.com/home-assistant/frontend/pull/13421>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
