### PR TITLE
Add Stream & Thumb feature to Telegram send_video

### DIFF
--- a/homeassistant/components/telegram_bot/services.yaml
+++ b/homeassistant/components/telegram_bot/services.yaml
@@ -251,6 +251,24 @@ send_video:
       example: "/path/to/the/video.mp4"
       selector:
         text:
+    thumb_url:
+      name: Thumb URL
+      description: >-
+        Remote path to a thumb image.
+        (Videos bigger than ~15mb won't auto-generate a thumb image,
+        so you may want to explicitly upload one)
+      example: "http://example.org/path/to/the/thumb.jpg"
+      selector:
+        text:
+    thumb_file:
+      name: Thumb File
+      description: >-
+        Local path to a thumb image.
+        (Videos bigger than ~15mb won't auto-generate a thumb image,
+        so you may want to explicitly upload one)
+      example: "/path/to/the/thumb.jpg"
+      selector:
+        text:
     caption:
       example: "My video"
       selector:
@@ -287,6 +305,49 @@ send_video:
     verify_ssl:
       selector:
         boolean:
+    supports_streaming:
+      name: Supports Streaming
+      description: >-
+        Pass `true` if the uploaded video is suitable for streaming.
+        Default is false/none.
+        Videos with more than ~15mb won't auto-download or autoplay.
+        So this feature is very useful for bigger videos.
+      example: true
+      selector:
+        boolean:
+    duration:
+      name: Duration
+      description: Duration of the video clip (Required if using 'Supports Streaming')
+      example: 60
+      selector:
+        number:
+          min: 1
+          max: 3600
+          unit_of_measurement: seconds
+    width:
+      name: Width
+      description: >-
+        Width of the video clip
+        (Required if using 'Supports Streaming',
+        if the width is unknown, you can use any number, like `1`)
+      example: 1
+      selector:
+        number:
+          min: 1
+          max: 3600
+          unit_of_measurement: pixels
+    height:
+      name: Height
+      description: >-
+        Height of the video clip
+        (Required if using 'Supports Streaming',
+        if the height is unknown, you can use any number, like `1`)
+      example: 1
+      selector:
+        number:
+          min: 1
+          max: 3600
+          unit_of_measurement: pixels
     timeout:
       selector:
         number:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Add option to send videos with streaming capabilities
- Add option to explicitly upload a thumb for the video

When sending bigger videos (or even smaller ones, depending on the client settings), the video won't be autodowloaded, nor autoplayed, and it won't auto-generate a thumb image.
This PR adds the options, so the video can be stream watched in the telegram client without having to first download the whole file.
Also, now you can explicitly upload the thumb image that is gonna be used for the video, which is what you see on the before you fully download the file.

Service call example

```yaml
service: telegram_bot.send_video
data:
  url: https://blueiris.localdomain:81/clips/@23456789.mp4
  caption: My video
  target: ###chat_id####
  timeout: 2000
  supports_streaming: true
  duration: 60
  width: 1
  height: 1
  thumb_url: https://blueiris.localdomain:81/alerts/@12345678.jpg
```


| Before the PR | After the PR |
|---|---|
| ![image](https://user-images.githubusercontent.com/25059996/185766154-8a2ce163-6793-40cf-b6c5-79a628e82309.png) | ![image](https://user-images.githubusercontent.com/25059996/185766161-68419410-dae0-48df-a577-28f29fac6ad8.png) |

The duration, width and height need to be present to the stream feature to work. But they don't need to be accurate.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23826

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
