### PR TITLE
Set quality scale to platinum in the NextDNS integration

### DIFF
--- a/homeassistant/components/nextdns/manifest.json
+++ b/homeassistant/components/nextdns/manifest.json
@@ -6,5 +6,6 @@
   "requirements": ["nextdns==1.1.0"],
   "config_flow": true,
   "iot_class": "cloud_polling",
-  "loggers": ["nextdns"]
+  "loggers": ["nextdns"],
+  "quality_scale": "platinum"
 }

--- a/tests/components/nextdns/test_switch.py
+++ b/tests/components/nextdns/test_switch.py
@@ -1,8 +1,12 @@
 """Test switch of NextDNS integration."""
+import asyncio
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from aiohttp import ClientError
+from aiohttp.client_exceptions import ClientConnectorError
 from nextdns import ApiError
+import pytest
 
 from homeassistant.components.nextdns.const import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -15,6 +19,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -977,3 +982,26 @@ async def test_availability(hass: HomeAssistant) -> None:
     assert state
     assert state.state != STATE_UNAVAILABLE
     assert state.state == STATE_ON
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ApiError(Mock()),
+        asyncio.TimeoutError,
+        ClientConnectorError(Mock(), Mock()),
+        ClientError,
+    ],
+)
+async def test_switch_failure(hass: HomeAssistant, exc: Exception) -> None:
+    """Tests that the turn on/off service throws HomeAssistantError."""
+    await init_integration(hass)
+
+    with patch("homeassistant.components.nextdns.NextDns.set_setting", side_effect=exc):
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: "switch.fake_profile_block_page"},
+                blocking=True,
+            )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The NextDNS integration is fully covered by tests and considering the platinum quality scale requirements, only the handling expired credentials is not met because at the moment it is not possible to change the NextDNS API key.

```
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
homeassistant/components/nextdns/__init__.py           79      0   100%
homeassistant/components/nextdns/binary_sensor.py      39      0   100%
homeassistant/components/nextdns/button.py             25      0   100%
homeassistant/components/nextdns/config_flow.py        43      0   100%
homeassistant/components/nextdns/const.py              14      0   100%
homeassistant/components/nextdns/diagnostics.py        18      0   100%
homeassistant/components/nextdns/sensor.py             41      0   100%
homeassistant/components/nextdns/switch.py             49      0   100%
homeassistant/components/nextdns/system_health.py      10      0   100%
---------------------------------------------------------------------------------
TOTAL                                                 318      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
