### PR TITLE
Fix covers moving state in HomeKit

### DIFF
--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -308,8 +308,8 @@ class OpeningDevice(OpeningDeviceBase, HomeAccessory):
         if isinstance(current_position, (float, int)):
             current_position = int(current_position)
             self.char_current_position.set_value(current_position)
-            # Writing target_position on moving cover
-            # will break moving state in HK.
+            # Writing target_position on a moving cover
+            # will break the moving state in HK.
             if not is_moving:
                 self.char_target_position.set_value(current_position)
 

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -166,7 +166,7 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 60
-    assert acc.char_target_position.value == 60
+    assert acc.char_target_position.value == 0
     assert acc.char_position_state.value == 1
 
     hass.states.async_set(
@@ -176,7 +176,7 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 70
-    assert acc.char_target_position.value == 70
+    assert acc.char_target_position.value == 0
     assert acc.char_position_state.value == 1
 
     hass.states.async_set(
@@ -186,7 +186,7 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 50
-    assert acc.char_target_position.value == 50
+    assert acc.char_target_position.value == 0
     assert acc.char_position_state.value == 0
 
     hass.states.async_set(


### PR DESCRIPTION
## Proposed change
This change will fix jitter and wrong state of "moving" covers/curtains in HomeKit.

<details>
<summary>Demo (before)</summary>
<img width="300" src="https://user-images.githubusercontent.com/11841379/185790389-587fd975-d711-436c-9610-a893617fc7a8.gif"> <img width="300" src="https://user-images.githubusercontent.com/11841379/185790392-ce2e9204-f4c1-4e12-8cc6-0874a960d5df.gif">
</details>

<details>
<summary>Demo (after)</summary>
<img width="300" src="https://user-images.githubusercontent.com/11841379/185790455-584b4f07-97ee-4a8b-b8fd-790371219731.gif">
<img width="300" src="https://user-images.githubusercontent.com/11841379/185790457-8b3f0f96-3684-42aa-8841-aca7c1ec9687.gif">
</details>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68643
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
