### PR TITLE
User config flow and custom panel for Dynalite integration

### DIFF
--- a/homeassistant/components/dynalite/__init__.py
+++ b/homeassistant/components/dynalite/__init__.py
@@ -54,6 +54,7 @@ from .const import (
     SERVICE_REQUEST_CHANNEL_LEVEL,
 )
 from .convert_config import convert_config
+from .panel import async_register_dynalite_frontend
 
 
 def num_string(value: int | str) -> str:
@@ -276,6 +277,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    await async_register_dynalite_frontend(hass)
 
     return True
 

--- a/homeassistant/components/dynalite/__init__.py
+++ b/homeassistant/components/dynalite/__init__.py
@@ -1,14 +1,11 @@
 """Support for the Dynalite networks."""
 from __future__ import annotations
 
-from typing import Any
-
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.cover import DEVICE_CLASSES_SCHEMA
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DEFAULT, CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
@@ -17,36 +14,10 @@ from homeassistant.helpers.typing import ConfigType
 # Loading the config flow file will register the flow
 from .bridge import DynaliteBridge
 from .const import (
-    ACTIVE_INIT,
-    ACTIVE_OFF,
-    ACTIVE_ON,
     ATTR_AREA,
     ATTR_CHANNEL,
     ATTR_HOST,
-    CONF_ACTIVE,
-    CONF_AREA,
-    CONF_AUTO_DISCOVER,
     CONF_BRIDGES,
-    CONF_CHANNEL,
-    CONF_CHANNEL_COVER,
-    CONF_CLOSE_PRESET,
-    CONF_DEVICE_CLASS,
-    CONF_DURATION,
-    CONF_FADE,
-    CONF_LEVEL,
-    CONF_NO_DEFAULT,
-    CONF_OPEN_PRESET,
-    CONF_POLL_TIMER,
-    CONF_PRESET,
-    CONF_ROOM_OFF,
-    CONF_ROOM_ON,
-    CONF_STOP_PRESET,
-    CONF_TEMPLATE,
-    CONF_TILT_TIME,
-    DEFAULT_CHANNEL_TYPE,
-    DEFAULT_NAME,
-    DEFAULT_PORT,
-    DEFAULT_TEMPLATES,
     DOMAIN,
     LOGGER,
     PLATFORMS,
@@ -55,121 +26,7 @@ from .const import (
 )
 from .convert_config import convert_config
 from .panel import async_register_dynalite_frontend
-
-
-def num_string(value: int | str) -> str:
-    """Test if value is a string of digits, aka an integer."""
-    new_value = str(value)
-    if new_value.isdigit():
-        return new_value
-    raise vol.Invalid("Not a string with numbers")
-
-
-CHANNEL_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_FADE): vol.Coerce(float),
-        vol.Optional(CONF_TYPE, default=DEFAULT_CHANNEL_TYPE): vol.Any(
-            "light", "switch"
-        ),
-    }
-)
-
-CHANNEL_SCHEMA = vol.Schema({num_string: CHANNEL_DATA_SCHEMA})
-
-PRESET_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_FADE): vol.Coerce(float),
-        vol.Optional(CONF_LEVEL): vol.Coerce(float),
-    }
-)
-
-PRESET_SCHEMA = vol.Schema({num_string: vol.Any(PRESET_DATA_SCHEMA, None)})
-
-TEMPLATE_ROOM_SCHEMA = vol.Schema(
-    {vol.Optional(CONF_ROOM_ON): num_string, vol.Optional(CONF_ROOM_OFF): num_string}
-)
-
-TEMPLATE_TIMECOVER_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_CHANNEL_COVER): num_string,
-        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-        vol.Optional(CONF_OPEN_PRESET): num_string,
-        vol.Optional(CONF_CLOSE_PRESET): num_string,
-        vol.Optional(CONF_STOP_PRESET): num_string,
-        vol.Optional(CONF_DURATION): vol.Coerce(float),
-        vol.Optional(CONF_TILT_TIME): vol.Coerce(float),
-    }
-)
-
-TEMPLATE_DATA_SCHEMA = vol.Any(TEMPLATE_ROOM_SCHEMA, TEMPLATE_TIMECOVER_SCHEMA)
-
-TEMPLATE_SCHEMA = vol.Schema({str: TEMPLATE_DATA_SCHEMA})
-
-
-def validate_area(config: dict[str, Any]) -> dict[str, Any]:
-    """Validate that template parameters are only used if area is using the relevant template."""
-    conf_set = set()
-    for configs in DEFAULT_TEMPLATES.values():
-        for conf in configs:
-            conf_set.add(conf)
-    if config.get(CONF_TEMPLATE):
-        for conf in DEFAULT_TEMPLATES[config[CONF_TEMPLATE]]:
-            conf_set.remove(conf)
-    for conf in conf_set:
-        if config.get(conf):
-            raise vol.Invalid(
-                f"{conf} should not be part of area {config[CONF_NAME]} config"
-            )
-    return config
-
-
-AREA_DATA_SCHEMA = vol.Schema(
-    vol.All(
-        {
-            vol.Required(CONF_NAME): cv.string,
-            vol.Optional(CONF_TEMPLATE): vol.In(DEFAULT_TEMPLATES),
-            vol.Optional(CONF_FADE): vol.Coerce(float),
-            vol.Optional(CONF_NO_DEFAULT): cv.boolean,
-            vol.Optional(CONF_CHANNEL): CHANNEL_SCHEMA,
-            vol.Optional(CONF_PRESET): PRESET_SCHEMA,
-            # the next ones can be part of the templates
-            vol.Optional(CONF_ROOM_ON): num_string,
-            vol.Optional(CONF_ROOM_OFF): num_string,
-            vol.Optional(CONF_CHANNEL_COVER): num_string,
-            vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-            vol.Optional(CONF_OPEN_PRESET): num_string,
-            vol.Optional(CONF_CLOSE_PRESET): num_string,
-            vol.Optional(CONF_STOP_PRESET): num_string,
-            vol.Optional(CONF_DURATION): vol.Coerce(float),
-            vol.Optional(CONF_TILT_TIME): vol.Coerce(float),
-        },
-        validate_area,
-    )
-)
-
-AREA_SCHEMA = vol.Schema({num_string: vol.Any(AREA_DATA_SCHEMA, None)})
-
-PLATFORM_DEFAULTS_SCHEMA = vol.Schema({vol.Optional(CONF_FADE): vol.Coerce(float)})
-
-
-BRIDGE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
-        vol.Optional(CONF_AUTO_DISCOVER, default=False): vol.Coerce(bool),
-        vol.Optional(CONF_POLL_TIMER, default=1.0): vol.Coerce(float),
-        vol.Optional(CONF_AREA): AREA_SCHEMA,
-        vol.Optional(CONF_DEFAULT): PLATFORM_DEFAULTS_SCHEMA,
-        vol.Optional(CONF_ACTIVE, default=False): vol.Any(
-            ACTIVE_ON, ACTIVE_OFF, ACTIVE_INIT, cv.boolean
-        ),
-        vol.Optional(CONF_PRESET): PRESET_SCHEMA,
-        vol.Optional(CONF_TEMPLATE): TEMPLATE_SCHEMA,
-    }
-)
+from .schema import BRIDGE_SCHEMA
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/dynalite/__init__.py
+++ b/homeassistant/components/dynalite/__init__.py
@@ -29,11 +29,14 @@ from .panel import async_register_dynalite_frontend
 from .schema import BRIDGE_SCHEMA
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {vol.Optional(CONF_BRIDGES): vol.All(cv.ensure_list, [BRIDGE_SCHEMA])}
-        )
-    },
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {
+            DOMAIN: vol.Schema(
+                {vol.Optional(CONF_BRIDGES): vol.All(cv.ensure_list, [BRIDGE_SCHEMA])}
+            ),
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -9,6 +9,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .bridge import DynaliteBridge
 from .const import DEFAULT_PORT, DOMAIN, LOGGER
@@ -26,8 +27,20 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_info: dict[str, Any]) -> FlowResult:
         """Import a new bridge as a config entry."""
-        LOGGER.debug("Starting async_step_import - %s", import_info)
+        LOGGER.debug("Starting async_step_import (deprecated) - %s", import_info)
+        # Raise an issue that this is deprecated and has been imported
+        async_create_issue(
+            self.hass,
+            DOMAIN,
+            "deprecated_yaml",
+            is_fixable=False,
+            is_persistent=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_yaml",
+        )
+
         host = import_info[CONF_HOST]
+        # Check if host already exists
         for entry in self._async_current_entries():
             if entry.data[CONF_HOST] == host:
                 self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 
 from typing import Any
 
+import voluptuous as vol
+
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_validation as cv
 
 from .bridge import DynaliteBridge
-from .const import DOMAIN, LOGGER
+from .const import DEFAULT_PORT, DOMAIN, LOGGER
 from .convert_config import convert_config
 
 
@@ -33,9 +36,36 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="already_configured")
 
         # New entry
-        bridge = DynaliteBridge(self.hass, convert_config(import_info))
+        return await self._try_create(import_info)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step when user initializes a integration."""
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            port = user_input[CONF_PORT]
+            return await self._try_create({CONF_HOST: host, CONF_PORT: port})
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): cv.string,
+                vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=schema)
+
+    async def _try_create(self, info: dict[str, Any]) -> FlowResult:
+        """Try to connect and if successful, create entry."""
+        host = info[CONF_HOST]
+        configured_hosts = [
+            entry.data[CONF_HOST] for entry in self._async_current_entries()
+        ]
+        if host in configured_hosts:
+            return self.async_abort(reason="already_configured")
+        bridge = DynaliteBridge(self.hass, convert_config(info))
         if not await bridge.async_setup():
-            LOGGER.error("Unable to setup bridge - import info=%s", import_info)
-            return self.async_abort(reason="no_connection")
-        LOGGER.debug("Creating entry for the bridge - %s", import_info)
-        return self.async_create_entry(title=host, data=import_info)
+            LOGGER.error("Unable to setup bridge - import info=%s", info)
+            return self.async_abort(reason="cannot_connect")
+        LOGGER.debug("Creating entry for the bridge - %s", info)
+        return self.async_create_entry(title=info[CONF_HOST], data=info)

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -43,9 +43,7 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Step when user initializes a integration."""
         if user_input is not None:
-            host = user_input[CONF_HOST]
-            port = user_input[CONF_PORT]
-            return await self._try_create({CONF_HOST: host, CONF_PORT: port})
+            return await self._try_create(user_input)
 
         schema = vol.Schema(
             {

--- a/homeassistant/components/dynalite/const.py
+++ b/homeassistant/components/dynalite/const.py
@@ -20,7 +20,6 @@ CONF_CHANNEL = "channel"
 CONF_CHANNEL_COVER = "channel_cover"
 CONF_CLOSE_PRESET = "close"
 CONF_DEVICE_CLASS = "class"
-CONF_DEV_PATH = "dev_path"  # TBD TODO
 CONF_DURATION = "duration"
 CONF_FADE = "fade"
 CONF_LEVEL = "level"

--- a/homeassistant/components/dynalite/const.py
+++ b/homeassistant/components/dynalite/const.py
@@ -20,6 +20,7 @@ CONF_CHANNEL = "channel"
 CONF_CHANNEL_COVER = "channel_cover"
 CONF_CLOSE_PRESET = "close"
 CONF_DEVICE_CLASS = "class"
+CONF_DEV_PATH = "dev_path"  # TBD TODO
 CONF_DURATION = "duration"
 CONF_FADE = "fade"
 CONF_LEVEL = "level"

--- a/homeassistant/components/dynalite/manifest.json
+++ b/homeassistant/components/dynalite/manifest.json
@@ -4,9 +4,9 @@
   "codeowners": ["@ziv1234"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dynalite",
+  "dependencies": ["http", "websocket_api"],
+  "requirements": ["dynalite_devices==0.1.47", "dynalite_panel==0.0.2"],
   "iot_class": "local_push",
   "loggers": ["dynalite_devices_lib"],
-  "requirements": ["dynalite_devices==0.1.47", "dynalite_panel==0.0.1"],
-  "dependencies": ["http", "websocket_api"],
   "after_dependencies": ["panel_custom"]
 }

--- a/homeassistant/components/dynalite/manifest.json
+++ b/homeassistant/components/dynalite/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://www.home-assistant.io/integrations/dynalite",
   "iot_class": "local_push",
   "loggers": ["dynalite_devices_lib"],
-  "requirements": ["dynalite_devices==0.1.47", "dynalite_panel==0.0.2"]
+  "requirements": ["dynalite_devices==0.1.47", "dynalite_panel==0.0.4"]
 }

--- a/homeassistant/components/dynalite/manifest.json
+++ b/homeassistant/components/dynalite/manifest.json
@@ -6,5 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/dynalite",
   "iot_class": "local_push",
   "loggers": ["dynalite_devices_lib"],
-  "requirements": ["dynalite_devices==0.1.47"]
+  "requirements": ["dynalite_devices==0.1.47", "dynalite_panel==0.0.1"],
+  "dependencies": ["http", "websocket_api"],
+  "after_dependencies": ["panel_custom"]
 }

--- a/homeassistant/components/dynalite/manifest.json
+++ b/homeassistant/components/dynalite/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "dynalite",
   "name": "Philips Dynalite",
+  "after_dependencies": ["panel_custom"],
   "codeowners": ["@ziv1234"],
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integrations/dynalite",
   "dependencies": ["http", "websocket_api"],
-  "requirements": ["dynalite_devices==0.1.47", "dynalite_panel==0.0.2"],
+  "documentation": "https://www.home-assistant.io/integrations/dynalite",
   "iot_class": "local_push",
   "loggers": ["dynalite_devices_lib"],
-  "after_dependencies": ["panel_custom"]
+  "requirements": ["dynalite_devices==0.1.47", "dynalite_panel==0.0.2"]
 }

--- a/homeassistant/components/dynalite/panel.py
+++ b/homeassistant/components/dynalite/panel.py
@@ -1,0 +1,32 @@
+"""Dynalite API interface for the frontend."""
+
+from dynalite_panel import get_build_id, locate_dir
+
+from homeassistant.components import panel_custom
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_DEV_PATH, DOMAIN
+
+URL_BASE = "/dynalite_static"
+
+
+async def async_register_dynalite_frontend(hass: HomeAssistant):
+    """Register the Dynalite frontend configuration panel."""
+    # Add to sidepanel if needed
+    if DOMAIN not in hass.data.get("frontend_panels", {}):
+        dev_path = hass.data.get(DOMAIN, {}).get(CONF_DEV_PATH)
+        is_dev = dev_path is not None
+        path = dev_path if dev_path else locate_dir()
+        build_id = get_build_id(is_dev)
+        hass.http.register_static_path(URL_BASE, path, cache_headers=not is_dev)
+
+        await panel_custom.async_register_panel(
+            hass=hass,
+            frontend_url_path=DOMAIN,
+            webcomponent_name="dynalite-panel",
+            sidebar_title=DOMAIN.capitalize(),
+            sidebar_icon="mdi:power",
+            module_url=f"{URL_BASE}/entrypoint-{build_id}.js",
+            embed_iframe=True,
+            require_admin=True,
+        )

--- a/homeassistant/components/dynalite/panel.py
+++ b/homeassistant/components/dynalite/panel.py
@@ -4,12 +4,36 @@ from dynalite_panel import get_build_id, locate_dir
 import voluptuous as vol
 
 from homeassistant.components import panel_custom, websocket_api
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.components.cover import DEVICE_CLASSES
+from homeassistant.const import CONF_DEFAULT, CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 
-from .const import CONF_AREA, CONF_DEV_PATH, DOMAIN
+from .const import (
+    CONF_ACTIVE,
+    CONF_AREA,
+    CONF_AUTO_DISCOVER,
+    CONF_DEV_PATH,
+    CONF_PRESET,
+    CONF_TEMPLATE,
+    DEFAULT_NAME,
+    DOMAIN,
+    LOGGER,
+)
+from .schema import BRIDGE_SCHEMA
 
 URL_BASE = "/dynalite_static"
+
+RELEVANT_CONFS = [
+    CONF_NAME,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_AUTO_DISCOVER,
+    CONF_AREA,
+    CONF_DEFAULT,
+    CONF_ACTIVE,
+    CONF_PRESET,
+    CONF_TEMPLATE,
+]
 
 
 @websocket_api.websocket_command(
@@ -22,26 +46,60 @@ def get_dynalite_config(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
 ) -> None:
     """Retrieve the Dynalite config for the frontend."""
-    relevant_confs = [CONF_HOST, CONF_PORT, CONF_AREA]
     entries = hass.config_entries.async_entries(DOMAIN)
-    relevant_config = [
-        {conf: entry.data[conf] for conf in relevant_confs if conf in entry.data}
+    relevant_config = {
+        entry.entry_id: {
+            conf: entry.data[conf] for conf in RELEVANT_CONFS if conf in entry.data
+        }
         for entry in entries
-    ]
-    connection.send_result(msg["id"], {"config": relevant_config})
+    }
+    dynalite_defaults = {"DEFAULT_NAME": DEFAULT_NAME, "DEVICE_CLASSES": DEVICE_CLASSES}
+    connection.send_result(
+        msg["id"], {"config": relevant_config, "default": dynalite_defaults}
+    )
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "dynalite/save-config",
+        vol.Required("entry_id"): str,
+        vol.Required("config"): BRIDGE_SCHEMA,
+    }
+)
+@callback
+def save_dynalite_config(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Retrieve the Dynalite config for the frontend."""
+    entry_id = msg["entry_id"]
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if not entry:
+        LOGGER.error(
+            "Dynalite - received updated config for invalid entry - %s", entry_id
+        )
+        return
+    message_conf = msg["config"]
+    message_data = {
+        conf: message_conf[conf] for conf in RELEVANT_CONFS if conf in message_conf
+    }
+    LOGGER.info("Updating Dynalite config entry=%s, data=%s", entry_id, message_data)
+    hass.config_entries.async_update_entry(entry, data=message_data)
+    connection.send_result(msg["id"], {})
 
 
 async def async_register_dynalite_frontend(hass: HomeAssistant):
     """Register the Dynalite frontend configuration panel."""
     # Add to sidepanel if needed
     websocket_api.async_register_command(hass, get_dynalite_config)
+    websocket_api.async_register_command(hass, save_dynalite_config)
     if DOMAIN not in hass.data.get("frontend_panels", {}):
         dev_path = hass.data.get(DOMAIN, {}).get(CONF_DEV_PATH)
         # is_dev = dev_path is not None XXX TODO
-        is_dev = True
         path = dev_path if dev_path else locate_dir()
-        build_id = get_build_id(is_dev)
-        hass.http.register_static_path(URL_BASE, path, cache_headers=not is_dev)
+        build_id = get_build_id()
+        hass.http.register_static_path(
+            URL_BASE, path, cache_headers=(build_id == "dev")
+        )
 
         await panel_custom.async_register_panel(
             hass=hass,

--- a/homeassistant/components/dynalite/panel.py
+++ b/homeassistant/components/dynalite/panel.py
@@ -102,7 +102,7 @@ async def async_register_dynalite_frontend(hass: HomeAssistant):
         path = locate_dir()
         build_id = get_build_id()
         hass.http.register_static_path(
-            URL_BASE, path, cache_headers=(build_id == "dev")
+            URL_BASE, path, cache_headers=(build_id != "dev")
         )
 
         await panel_custom.async_register_panel(

--- a/homeassistant/components/dynalite/panel.py
+++ b/homeassistant/components/dynalite/panel.py
@@ -1,21 +1,44 @@
 """Dynalite API interface for the frontend."""
 
 from dynalite_panel import get_build_id, locate_dir
+import voluptuous as vol
 
-from homeassistant.components import panel_custom
-from homeassistant.core import HomeAssistant
+from homeassistant.components import panel_custom, websocket_api
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant, callback
 
-from .const import CONF_DEV_PATH, DOMAIN
+from .const import CONF_AREA, CONF_DEV_PATH, DOMAIN
 
 URL_BASE = "/dynalite_static"
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "dynalite/get-config",
+    }
+)
+@callback
+def get_dynalite_config(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Retrieve the Dynalite config for the frontend."""
+    relevant_confs = [CONF_HOST, CONF_PORT, CONF_AREA]
+    entries = hass.config_entries.async_entries(DOMAIN)
+    relevant_config = [
+        {conf: entry.data[conf] for conf in relevant_confs if conf in entry.data}
+        for entry in entries
+    ]
+    connection.send_result(msg["id"], {"config": relevant_config})
 
 
 async def async_register_dynalite_frontend(hass: HomeAssistant):
     """Register the Dynalite frontend configuration panel."""
     # Add to sidepanel if needed
+    websocket_api.async_register_command(hass, get_dynalite_config)
     if DOMAIN not in hass.data.get("frontend_panels", {}):
         dev_path = hass.data.get(DOMAIN, {}).get(CONF_DEV_PATH)
-        is_dev = dev_path is not None
+        # is_dev = dev_path is not None XXX TODO
+        is_dev = True
         path = dev_path if dev_path else locate_dir()
         build_id = get_build_id(is_dev)
         hass.http.register_static_path(URL_BASE, path, cache_headers=not is_dev)

--- a/homeassistant/components/dynalite/panel.py
+++ b/homeassistant/components/dynalite/panel.py
@@ -41,6 +41,7 @@ RELEVANT_CONFS = [
         vol.Required("type"): "dynalite/get-config",
     }
 )
+@websocket_api.require_admin
 @callback
 def get_dynalite_config(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
@@ -70,6 +71,7 @@ def get_dynalite_config(
         vol.Required("config"): BRIDGE_SCHEMA,
     }
 )
+@websocket_api.require_admin
 @callback
 def save_dynalite_config(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
@@ -81,6 +83,7 @@ def save_dynalite_config(
         LOGGER.error(
             "Dynalite - received updated config for invalid entry - %s", entry_id
         )
+        connection.send_result(msg["id"], {"error": True})
         return
     message_conf = msg["config"]
     message_data = {

--- a/homeassistant/components/dynalite/schema.py
+++ b/homeassistant/components/dynalite/schema.py
@@ -1,0 +1,155 @@
+"""Schema for config entries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.cover import DEVICE_CLASSES_SCHEMA
+from homeassistant.const import CONF_DEFAULT, CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
+from homeassistant.helpers import config_validation as cv
+
+from .const import (
+    ACTIVE_INIT,
+    ACTIVE_OFF,
+    ACTIVE_ON,
+    CONF_ACTIVE,
+    CONF_AREA,
+    CONF_AUTO_DISCOVER,
+    CONF_CHANNEL,
+    CONF_CHANNEL_COVER,
+    CONF_CLOSE_PRESET,
+    CONF_DEVICE_CLASS,
+    CONF_DURATION,
+    CONF_FADE,
+    CONF_LEVEL,
+    CONF_NO_DEFAULT,
+    CONF_OPEN_PRESET,
+    CONF_POLL_TIMER,
+    CONF_PRESET,
+    CONF_ROOM_OFF,
+    CONF_ROOM_ON,
+    CONF_STOP_PRESET,
+    CONF_TEMPLATE,
+    CONF_TILT_TIME,
+    DEFAULT_CHANNEL_TYPE,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_TEMPLATES,
+)
+
+
+def num_string(value: str | int) -> str:
+    """Test if value is a string of digits, aka an integer."""
+    new_value = str(value)
+    if new_value.isdigit():
+        return new_value
+    raise vol.Invalid("Not a string with numbers")
+
+
+CHANNEL_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_FADE): vol.Coerce(float),
+        vol.Optional(CONF_TYPE, default=DEFAULT_CHANNEL_TYPE): vol.Any(
+            "light", "switch"
+        ),
+    }
+)
+
+CHANNEL_SCHEMA = vol.Schema({num_string: CHANNEL_DATA_SCHEMA})
+
+PRESET_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_FADE): vol.Coerce(float),
+        vol.Optional(CONF_LEVEL): vol.Coerce(float),
+    }
+)
+
+PRESET_SCHEMA = vol.Schema({num_string: vol.Any(PRESET_DATA_SCHEMA, None)})
+
+TEMPLATE_ROOM_SCHEMA = vol.Schema(
+    {vol.Optional(CONF_ROOM_ON): num_string, vol.Optional(CONF_ROOM_OFF): num_string}
+)
+
+TEMPLATE_TIMECOVER_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_CHANNEL_COVER): num_string,
+        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_OPEN_PRESET): num_string,
+        vol.Optional(CONF_CLOSE_PRESET): num_string,
+        vol.Optional(CONF_STOP_PRESET): num_string,
+        vol.Optional(CONF_DURATION): vol.Coerce(float),
+        vol.Optional(CONF_TILT_TIME): vol.Coerce(float),
+    }
+)
+
+TEMPLATE_DATA_SCHEMA = vol.Any(TEMPLATE_ROOM_SCHEMA, TEMPLATE_TIMECOVER_SCHEMA)
+
+TEMPLATE_SCHEMA = vol.Schema({str: TEMPLATE_DATA_SCHEMA})
+
+
+def validate_area(config: dict[str, Any]) -> dict[str, Any]:
+    """Validate that template parameters are only used if area is using the relevant template."""
+    conf_set = set()
+    for configs in DEFAULT_TEMPLATES.values():
+        for conf in configs:
+            conf_set.add(conf)
+    if config.get(CONF_TEMPLATE):
+        for conf in DEFAULT_TEMPLATES[config[CONF_TEMPLATE]]:
+            conf_set.remove(conf)
+    for conf in conf_set:
+        if config.get(conf):
+            raise vol.Invalid(
+                f"{conf} should not be part of area {config[CONF_NAME]} config"
+            )
+    return config
+
+
+AREA_DATA_SCHEMA = vol.Schema(
+    vol.All(
+        {
+            vol.Required(CONF_NAME): cv.string,
+            vol.Optional(CONF_TEMPLATE): vol.In(DEFAULT_TEMPLATES),
+            vol.Optional(CONF_FADE): vol.Coerce(float),
+            vol.Optional(CONF_NO_DEFAULT): cv.boolean,
+            vol.Optional(CONF_CHANNEL): CHANNEL_SCHEMA,
+            vol.Optional(CONF_PRESET): PRESET_SCHEMA,
+            # the next ones can be part of the templates
+            vol.Optional(CONF_ROOM_ON): num_string,
+            vol.Optional(CONF_ROOM_OFF): num_string,
+            vol.Optional(CONF_CHANNEL_COVER): num_string,
+            vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+            vol.Optional(CONF_OPEN_PRESET): num_string,
+            vol.Optional(CONF_CLOSE_PRESET): num_string,
+            vol.Optional(CONF_STOP_PRESET): num_string,
+            vol.Optional(CONF_DURATION): vol.Coerce(float),
+            vol.Optional(CONF_TILT_TIME): vol.Coerce(float),
+        },
+        validate_area,
+    )
+)
+
+AREA_SCHEMA = vol.Schema({num_string: vol.Any(AREA_DATA_SCHEMA, None)})
+
+PLATFORM_DEFAULTS_SCHEMA = vol.Schema({vol.Optional(CONF_FADE): vol.Coerce(float)})
+
+
+BRIDGE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Optional(CONF_AUTO_DISCOVER, default=False): vol.Coerce(bool),
+        vol.Optional(CONF_POLL_TIMER, default=1.0): vol.Coerce(float),
+        vol.Optional(CONF_AREA): AREA_SCHEMA,
+        vol.Optional(CONF_DEFAULT): PLATFORM_DEFAULTS_SCHEMA,
+        vol.Optional(CONF_ACTIVE, default=False): vol.Any(
+            ACTIVE_ON, ACTIVE_OFF, ACTIVE_INIT, cv.boolean
+        ),
+        vol.Optional(CONF_PRESET): PRESET_SCHEMA,
+        vol.Optional(CONF_TEMPLATE): TEMPLATE_SCHEMA,
+    }
+)

--- a/homeassistant/components/dynalite/strings.json
+++ b/homeassistant/components/dynalite/strings.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "title": "Configure Dynalite Connection",
+        "description": "Gateway address to connect to DYNET network"
+      }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    }
+  }
+}

--- a/homeassistant/components/dynalite/strings.json
+++ b/homeassistant/components/dynalite/strings.json
@@ -14,5 +14,11 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
+  },
+  "issues": {
+    "deprecated_yaml": {
+      "title": "The Dynalite YAML configuration is being removed",
+      "description": "Configuring Dynalite using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the Dynalite YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
+    }
   }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -626,7 +626,7 @@ dweepy==0.3.0
 dynalite_devices==0.1.47
 
 # homeassistant.components.dynalite
-dynalite_panel==0.0.2
+dynalite_panel==0.0.4
 
 # homeassistant.components.rainforest_eagle
 eagle100==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -626,7 +626,7 @@ dweepy==0.3.0
 dynalite_devices==0.1.47
 
 # homeassistant.components.dynalite
-dynalite_panel==0.0.1
+dynalite_panel==0.0.2
 
 # homeassistant.components.rainforest_eagle
 eagle100==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -625,6 +625,9 @@ dweepy==0.3.0
 # homeassistant.components.dynalite
 dynalite_devices==0.1.47
 
+# homeassistant.components.dynalite
+dynalite_panel==0.0.1
+
 # homeassistant.components.rainforest_eagle
 eagle100==0.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -497,7 +497,7 @@ dsmr_parser==0.33
 dynalite_devices==0.1.47
 
 # homeassistant.components.dynalite
-dynalite_panel==0.0.2
+dynalite_panel==0.0.4
 
 # homeassistant.components.rainforest_eagle
 eagle100==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -496,6 +496,9 @@ dsmr_parser==0.33
 # homeassistant.components.dynalite
 dynalite_devices==0.1.47
 
+# homeassistant.components.dynalite
+dynalite_panel==0.0.1
+
 # homeassistant.components.rainforest_eagle
 eagle100==0.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -497,7 +497,7 @@ dsmr_parser==0.33
 dynalite_devices==0.1.47
 
 # homeassistant.components.dynalite
-dynalite_panel==0.0.1
+dynalite_panel==0.0.2
 
 # homeassistant.components.rainforest_eagle
 eagle100==0.1.1

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import dynalite
 from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_PORT
 
 from tests.common import MockConfigEntry
 
@@ -66,7 +67,7 @@ async def test_existing_update(hass: HomeAssistant) -> None:
     port2 = 8888
     entry = MockConfigEntry(
         domain=dynalite.DOMAIN,
-        data={dynalite.CONF_HOST: host, dynalite.CONF_PORT: port1},
+        data={dynalite.CONF_HOST: host, CONF_PORT: port1},
     )
     entry.add_to_hass(hass)
     with patch(
@@ -80,7 +81,7 @@ async def test_existing_update(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             dynalite.DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={dynalite.CONF_HOST: host, dynalite.CONF_PORT: port2},
+            data={dynalite.CONF_HOST: host, CONF_PORT: port2},
         )
         await hass.async_block_till_done()
         assert mock_dyn_dev().configure.call_count == 2

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_get as async_get_issue_registry,
 )
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -24,7 +25,12 @@ from tests.common import MockConfigEntry
     ],
 )
 async def test_flow(
-    hass: HomeAssistant, first_con, second_con, exp_type, exp_result, exp_reason
+    hass: HomeAssistant,
+    first_con,
+    second_con,
+    exp_type,
+    exp_result,
+    exp_reason,
 ) -> None:
     """Run a flow with or without errors and return result."""
     registry = async_get_issue_registry(hass)
@@ -49,6 +55,16 @@ async def test_flow(
     issue = registry.async_get_issue(dynalite.DOMAIN, "deprecated_yaml")
     assert issue is not None
     assert issue.severity == IssueSeverity.WARNING
+
+
+async def test_deprecated(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Check that deprecation warning appears in caplog."""
+    await async_setup_component(
+        hass, dynalite.DOMAIN, {dynalite.DOMAIN: {dynalite.CONF_HOST: "aaa"}}
+    )
+    assert "The 'dynalite' option is deprecated" in caplog.text
 
 
 async def test_existing(hass: HomeAssistant) -> None:

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -5,8 +5,8 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import dynalite
-from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -7,6 +7,10 @@ from homeassistant import config_entries
 from homeassistant.components import dynalite
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_get as async_get_issue_registry,
+)
 
 from tests.common import MockConfigEntry
 
@@ -23,6 +27,9 @@ async def test_flow(
     hass: HomeAssistant, first_con, second_con, exp_type, exp_result, exp_reason
 ) -> None:
     """Run a flow with or without errors and return result."""
+    registry = async_get_issue_registry(hass)
+    issue = registry.async_get_issue(dynalite.DOMAIN, "deprecated_yaml")
+    assert issue is None
     host = "1.2.3.4"
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
@@ -39,6 +46,9 @@ async def test_flow(
         assert result["result"].state == exp_result
     if exp_reason:
         assert result["reason"] == exp_reason
+    issue = registry.async_get_issue(dynalite.DOMAIN, "deprecated_yaml")
+    assert issue is not None
+    assert issue.severity == IssueSeverity.WARNING
 
 
 async def test_existing(hass: HomeAssistant) -> None:

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry
     ("first_con", "second_con", "exp_type", "exp_result", "exp_reason"),
     [
         (True, True, "create_entry", config_entries.ConfigEntryState.LOADED, ""),
-        (False, False, "abort", None, "no_connection"),
+        (False, False, "abort", None, "cannot_connect"),
         (True, False, "create_entry", config_entries.ConfigEntryState.SETUP_RETRY, ""),
     ],
 )

--- a/tests/components/dynalite/test_panel.py
+++ b/tests/components/dynalite/test_panel.py
@@ -31,7 +31,7 @@ async def test_get_config(hass, hass_ws_client):
 
     await client.send_json(
         {
-            "id": "24",
+            "id": 24,
             "type": "dynalite/get-config",
         }
     )
@@ -86,7 +86,7 @@ async def test_save_config(hass, hass_ws_client):
 
     await client.send_json(
         {
-            "id": "24",
+            "id": 24,
             "type": "dynalite/save-config",
             "entry_id": entry2.entry_id,
             "config": {dynalite.CONF_HOST: host3, CONF_PORT: port3},
@@ -126,7 +126,7 @@ async def test_save_config_invalid_entry(hass, hass_ws_client):
     client = await hass_ws_client(hass)
     await client.send_json(
         {
-            "id": "24",
+            "id": 24,
             "type": "dynalite/save-config",
             "entry_id": "junk",
             "config": {dynalite.CONF_HOST: host2, CONF_PORT: port2},

--- a/tests/components/dynalite/test_panel.py
+++ b/tests/components/dynalite/test_panel.py
@@ -1,0 +1,141 @@
+"""Test websocket commands for the panel."""
+
+
+from unittest.mock import patch
+
+from homeassistant.components import dynalite
+from homeassistant.components.cover import DEVICE_CLASSES
+from homeassistant.const import CONF_PORT
+
+from tests.common import MockConfigEntry
+
+
+async def test_get_config(hass, hass_ws_client):
+    """Get the config via websocket."""
+    host = "1.2.3.4"
+    port = 765
+
+    entry = MockConfigEntry(
+        domain=dynalite.DOMAIN,
+        data={dynalite.CONF_HOST: host, CONF_PORT: port},
+    )
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {
+            "id": "24",
+            "type": "dynalite/get-config",
+        }
+    )
+
+    msg = await client.receive_json()
+    assert msg["success"]
+    result = msg["result"]
+    entry_id = entry.entry_id
+    assert result == {
+        "config": {entry_id: {dynalite.CONF_HOST: host, CONF_PORT: port}},
+        "default": {
+            "DEFAULT_NAME": dynalite.const.DEFAULT_NAME,
+            "DEFAULT_PORT": dynalite.const.DEFAULT_PORT,
+            "DEVICE_CLASSES": DEVICE_CLASSES,
+        },
+    }
+
+
+async def test_save_config(hass, hass_ws_client):
+    """Save the config via websocket."""
+    host1 = "1.2.3.4"
+    port1 = 765
+    host2 = "5.6.7.8"
+    port2 = 432
+    host3 = "5.3.2.1"
+    port3 = 543
+
+    entry1 = MockConfigEntry(
+        domain=dynalite.DOMAIN,
+        data={dynalite.CONF_HOST: host1, CONF_PORT: port1},
+    )
+    entry1.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry1.entry_id)
+        await hass.async_block_till_done()
+    entry2 = MockConfigEntry(
+        domain=dynalite.DOMAIN,
+        data={dynalite.CONF_HOST: host2, CONF_PORT: port2},
+    )
+    entry2.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry2.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {
+            "id": "24",
+            "type": "dynalite/save-config",
+            "entry_id": entry2.entry_id,
+            "config": {dynalite.CONF_HOST: host3, CONF_PORT: port3},
+        }
+    )
+
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {}
+
+    existing_entry = hass.config_entries.async_get_entry(entry1.entry_id)
+    assert existing_entry.data == {dynalite.CONF_HOST: host1, CONF_PORT: port1}
+    modified_entry = hass.config_entries.async_get_entry(entry2.entry_id)
+    assert modified_entry.data[dynalite.CONF_HOST] == host3
+    assert modified_entry.data[CONF_PORT] == port3
+
+
+async def test_save_config_invalid_entry(hass, hass_ws_client):
+    """Try to update nonexistent entry."""
+    host1 = "1.2.3.4"
+    port1 = 765
+    host2 = "5.6.7.8"
+    port2 = 432
+
+    entry = MockConfigEntry(
+        domain=dynalite.DOMAIN,
+        data={dynalite.CONF_HOST: host1, CONF_PORT: port1},
+    )
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": "24",
+            "type": "dynalite/save-config",
+            "entry_id": "junk",
+            "config": {dynalite.CONF_HOST: host2, CONF_PORT: port2},
+        }
+    )
+
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {"error": True}
+
+    existing_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert existing_entry.data == {dynalite.CONF_HOST: host1, CONF_PORT: port1}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The change deprecates the YAML configuration. it imports it into the UI and adds a repair issue, so it won't break a user configuration or change the existing behavior, but since it adds a "deprecation" warning, better to be explicit

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Dynalite configuration process is done today via YAML which we want to deprecate. However, the configuration is complex since it involved several items (Dynalite has no ability to query, so config has to be set manually).
This adds a user config flow to setup the basics (host / port). After this, a panel appears that can configure the various config entries in a straightforward interactive way

A few example screenshots:

Viewing all defined DYNET areas:
![image](https://user-images.githubusercontent.com/16467659/186098138-f7368be5-03d0-4f18-9dd9-596b36d385fa.png)

Configuring the system global settings:
![image](https://user-images.githubusercontent.com/16467659/186098374-3b307d2e-9590-4c39-bd3a-ef9a7daa7003.png)

Editing a specific DYNET area:
![image](https://user-images.githubusercontent.com/16467659/186098614-ba0c6c87-64dc-41d2-9aa6-9e95b11f729c.png)

Editing a DYNET channel:
![image](https://user-images.githubusercontent.com/16467659/186098674-2aabe374-af27-4bce-8ad4-350c0511fb2f.png)

Defining a new DYNET preset:
![image](https://user-images.githubusercontent.com/16467659/186098766-47f2ed96-1ec7-4397-9a39-cdf0d037b99f.png)

Switching between different systems (multiple config entries)
![image](https://user-images.githubusercontent.com/16467659/186098877-0992101a-d727-40bc-a4f2-6b2d62b345fb.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
