### PR TITLE
Update forecast.solar sensor values exactly when reported API values change

### DIFF
--- a/homeassistant/components/forecast_solar/__init__.py
+++ b/homeassistant/components/forecast_solar/__init__.py
@@ -1,16 +1,26 @@
 """The Forecast.Solar integration."""
 from __future__ import annotations
 
-from datetime import timedelta
+import asyncio
+from datetime import datetime, timedelta
 import logging
+import random
 
-from forecast_solar import Estimate, ForecastSolar
+from aiohttp import ClientResponseError
+import async_timeout
+from forecast_solar import (
+    Estimate,
+    ForecastSolar,
+    ForecastSolarError,
+    ForecastSolarRatelimit,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt
 
 from .const import (
     CONF_AZIMUTH,
@@ -22,6 +32,8 @@ from .const import (
 )
 
 PLATFORMS = [Platform.SENSOR]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -54,12 +66,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if api_key is not None:
         update_interval = timedelta(minutes=30)
 
-    coordinator: DataUpdateCoordinator[Estimate] = DataUpdateCoordinator(
-        hass,
-        logging.getLogger(__name__),
-        name=DOMAIN,
-        update_method=forecast.estimate,
-        update_interval=update_interval,
+    coordinator: DataUpdateCoordinator[Estimate] = UpdateCoordinator(
+        hass, logging.getLogger(__name__), forecast, update_interval
     )
     await coordinator.async_config_entry_first_refresh()
 
@@ -84,3 +92,103 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update options."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+class UpdateCoordinator(DataUpdateCoordinator[Estimate]):
+    """Update coordinator for Forecast.Solar."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: logging.Logger,
+        api: ForecastSolar,
+        api_interval: timedelta,
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            hass,
+            logger,
+            name=DOMAIN,
+            update_interval=timedelta(minutes=1),
+            update_method=self.update,
+        )
+        self.api = api
+        self.api_update_interval: timedelta = api_interval
+        self.next_scheduled_api_query: datetime | None = None
+        self.last_api_update_success: datetime | None = None
+
+    async def update(self) -> Estimate:
+        """Fetch new data from API if within rate limit and update sensor values if needed."""
+
+        now = datetime.now(tz=dt.get_time_zone(self.hass.config.time_zone))
+        estimate = self.data
+        update_error = None
+        # Update the estimate from the API if within rate limit
+        if (
+            self.next_scheduled_api_query is None
+            or now >= self.next_scheduled_api_query
+        ):
+            async with async_timeout.timeout(10):
+                _LOGGER.debug("Querying forecast.solar API")
+                try:
+                    estimate = await self.api.estimate()
+                    self.last_api_update_success = now
+                except ForecastSolarRatelimit as error:
+                    # We hit a rate limit, be more cautious
+                    _LOGGER.info("Hit rate limit on forecast.solar API")
+                    update_error = error
+                except (
+                    ForecastSolarError,
+                    ClientResponseError,
+                    asyncio.TimeoutError,
+                ) as error:
+                    _LOGGER.warning(
+                        "Failed to query forecast.solar API, using cached values. Reason: %s",
+                        error,
+                    )
+                    update_error = error
+
+            # Delay the next update by a small random offset to even out the load on the API
+            self.next_scheduled_api_query = (
+                now
+                + self.api_update_interval
+                + timedelta(seconds=random.randint(0, 60))
+            )
+
+        # If values are stale for too long, report an error
+        # This most likely happens if the internet connection drops or forecast.solar has an outage
+        # Note: This could also happen when the integration is loaded initially, which would lead to
+        # reloading the integration and potentially failing again?
+        if self.last_api_update_success is None or (
+            now - self.last_api_update_success
+        ) > timedelta(hours=6):
+            raise UpdateFailed(update_error)
+
+        # Find the next change point in the reported estimates
+        # Replace microsecond = 0 to match the behaviour of HA scheduling -- otherwise, we might
+        # unnecessarily run at xx:59:59.yyy
+        now = datetime.now(tz=dt.get_time_zone(self.hass.config.time_zone)).replace(
+            microsecond=0
+        )
+        next_value_update = min(
+            (timestamp for timestamp in estimate.watts.keys() if timestamp > now),
+            default=now + timedelta(minutes=1),
+        )
+
+        # Run this method again when the next interesting thing happens (either update API or
+        # update sensor values)
+        next_update_interval = (
+            min(self.next_scheduled_api_query, next_value_update) - now
+        )
+        # Safeguard to rate-limit calls to this method
+        if next_update_interval < timedelta(seconds=1):
+            next_update_interval = timedelta(seconds=1)
+        _LOGGER.debug(
+            "Next estimate value change is at %s, next API query at %s, scheduling next update in %s",
+            next_value_update.astimezone(now.tzinfo),
+            self.next_scheduled_api_query,
+            next_update_interval,
+        )
+
+        self.update_interval = next_update_interval
+        return estimate

--- a/homeassistant/components/forecast_solar/__init__.py
+++ b/homeassistant/components/forecast_solar/__init__.py
@@ -1,26 +1,19 @@
 """The Forecast.Solar integration."""
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
-import random
 
-from aiohttp import ClientResponseError
-import async_timeout
 from forecast_solar import (
     Estimate,
     ForecastSolar,
-    ForecastSolarError,
-    ForecastSolarRatelimit,
 )
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_AZIMUTH,
@@ -30,10 +23,9 @@ from .const import (
     CONF_MODULES_POWER,
     DOMAIN,
 )
+from .coordinator import ForecastSolarUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -66,7 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if api_key is not None:
         update_interval = timedelta(minutes=30)
 
-    coordinator: DataUpdateCoordinator[Estimate] = UpdateCoordinator(
+    coordinator: DataUpdateCoordinator[Estimate] = ForecastSolarUpdateCoordinator(
         hass, logging.getLogger(__name__), forecast, update_interval
     )
     await coordinator.async_config_entry_first_refresh()
@@ -92,103 +84,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update options."""
     await hass.config_entries.async_reload(entry.entry_id)
-
-
-class UpdateCoordinator(DataUpdateCoordinator[Estimate]):
-    """Update coordinator for Forecast.Solar."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        logger: logging.Logger,
-        api: ForecastSolar,
-        api_interval: timedelta,
-    ) -> None:
-        """Initialize."""
-        super().__init__(
-            hass,
-            logger,
-            name=DOMAIN,
-            update_interval=timedelta(minutes=1),
-            update_method=self.update,
-        )
-        self.api = api
-        self.api_update_interval: timedelta = api_interval
-        self.next_scheduled_api_query: datetime | None = None
-        self.last_api_update_success: datetime | None = None
-
-    async def update(self) -> Estimate:
-        """Fetch new data from API if within rate limit and update sensor values if needed."""
-
-        now = datetime.now(tz=dt.get_time_zone(self.hass.config.time_zone))
-        estimate = self.data
-        update_error = None
-        # Update the estimate from the API if within rate limit
-        if (
-            self.next_scheduled_api_query is None
-            or now >= self.next_scheduled_api_query
-        ):
-            async with async_timeout.timeout(10):
-                _LOGGER.debug("Querying forecast.solar API")
-                try:
-                    estimate = await self.api.estimate()
-                    self.last_api_update_success = now
-                except ForecastSolarRatelimit as error:
-                    # We hit a rate limit, be more cautious
-                    _LOGGER.info("Hit rate limit on forecast.solar API")
-                    update_error = error
-                except (
-                    ForecastSolarError,
-                    ClientResponseError,
-                    asyncio.TimeoutError,
-                ) as error:
-                    _LOGGER.warning(
-                        "Failed to query forecast.solar API, using cached values. Reason: %s",
-                        error,
-                    )
-                    update_error = error
-
-            # Delay the next update by a small random offset to even out the load on the API
-            self.next_scheduled_api_query = (
-                now
-                + self.api_update_interval
-                + timedelta(seconds=random.randint(0, 60))
-            )
-
-        # If values are stale for too long, report an error
-        # This most likely happens if the internet connection drops or forecast.solar has an outage
-        # Note: This could also happen when the integration is loaded initially, which would lead to
-        # reloading the integration and potentially failing again?
-        if self.last_api_update_success is None or (
-            now - self.last_api_update_success
-        ) > timedelta(hours=6):
-            raise UpdateFailed(update_error)
-
-        # Find the next change point in the reported estimates
-        # Replace microsecond = 0 to match the behaviour of HA scheduling -- otherwise, we might
-        # unnecessarily run at xx:59:59.yyy
-        now = datetime.now(tz=dt.get_time_zone(self.hass.config.time_zone)).replace(
-            microsecond=0
-        )
-        next_value_update = min(
-            (timestamp for timestamp in estimate.watts.keys() if timestamp > now),
-            default=now + timedelta(minutes=1),
-        )
-
-        # Run this method again when the next interesting thing happens (either update API or
-        # update sensor values)
-        next_update_interval = (
-            min(self.next_scheduled_api_query, next_value_update) - now
-        )
-        # Safeguard to rate-limit calls to this method
-        if next_update_interval < timedelta(seconds=1):
-            next_update_interval = timedelta(seconds=1)
-        _LOGGER.debug(
-            "Next estimate value change is at %s, next API query at %s, scheduling next update in %s",
-            next_value_update.astimezone(now.tzinfo),
-            self.next_scheduled_api_query,
-            next_update_interval,
-        )
-
-        self.update_interval = next_update_interval
-        return estimate

--- a/homeassistant/components/forecast_solar/const.py
+++ b/homeassistant/components/forecast_solar/const.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import logging
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import ENERGY_KILO_WATT_HOUR, POWER_WATT
 
 from .models import ForecastSolarSensorEntityDescription
+
+LOGGER: logging.Logger = logging.getLogger(__package__)
 
 DOMAIN = "forecast_solar"
 

--- a/homeassistant/components/forecast_solar/coordinator.py
+++ b/homeassistant/components/forecast_solar/coordinator.py
@@ -1,0 +1,163 @@
+"""The Forecast.Solar integration."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from datetime import datetime, timedelta
+
+import async_timeout
+from aiohttp import ClientResponseError
+from forecast_solar import (
+    Estimate,
+    ForecastSolar,
+    ForecastSolarConnectionError,
+    ForecastSolarError,
+    ForecastSolarRatelimit,
+)
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt
+
+from .const import (
+    LOGGER,
+    DOMAIN
+)
+
+
+class ForecastSolarUpdateCoordinator(DataUpdateCoordinator[Estimate]):
+    """Update coordinator for Forecast.Solar."""
+
+    def __init__(
+            self,
+            hass: HomeAssistant,
+            logger: logging.Logger,
+            api: ForecastSolar,
+            api_interval: timedelta,
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            hass,
+            logger,
+            name=DOMAIN,
+            update_interval=timedelta(minutes=1),
+            update_method=self.update,
+        )
+        self.api = api
+        # TODO In case there are multiple instances, they should share the api_interval
+        self.api_update_interval: timedelta = api_interval
+        self.current_api_estimate: Estimate | None = None
+        self.last_api_error: Exception | None = None
+        self.last_api_success_time: datetime | None = None
+        self.next_api_query_time: datetime | None = None
+        self.next_value_update_time: datetime | None = None
+
+    async def update(self) -> Estimate:
+        """Fetch new data from API if within rate limit and update sensor values if needed."""
+
+        now = datetime.now(tz=dt.get_time_zone(self.hass.config.time_zone))
+
+        # Update the estimate from the API if within rate limit
+        if self.next_api_query_time is None or now >= self.next_api_query_time:
+            LOGGER.debug("Querying forecast.solar API")
+            try:
+                async with async_timeout.timeout(10):
+                    self.current_api_estimate = await self.api.estimate()
+                self.last_api_success_time = now
+            except ForecastSolarRatelimit as error:
+                # We hit a rate limit, be more cautious
+                LOGGER.info("Hit rate limit on forecast.solar API")
+                self.last_api_error = error
+            except (ForecastSolarConnectionError, asyncio.TimeoutError) as error:
+                LOGGER.warning(
+                    "Failed to connect to forecast.solar API, using cached values. Reason: %s",
+                    error,
+                )
+                # Try again sooner
+                self.next_api_query_time = now + timedelta(minutes=2)
+                self.last_api_error = error
+            except (ForecastSolarError, ClientResponseError) as error:
+                LOGGER.warning(
+                    "Failed to query forecast.solar API, using cached values. Reason: %s",
+                    error,
+                )
+                self.last_api_error = error
+
+            # Change the next update by a small random offset to even out the load on the API
+            # Since we delay updates until roughly before the value changes, it is ok to subtract
+            # a small random time here
+            now = datetime.now(tz=dt.get_time_zone(self.hass.config.time_zone))
+            self.next_api_query_time = (
+                    now
+                    + self.api_update_interval
+                    - timedelta(seconds=random.randint(0, 120))
+            )
+
+        # If values are stale for too long, report an error
+        # This most likely happens if the internet connection drops or forecast.solar has an outage
+        # Note: This could also happen when the integration is loaded initially, which would lead to
+        # reloading the integration and potentially failing again?
+        if self.last_api_success_time is None or (
+                now - self.last_api_success_time > timedelta(hours=6)
+        ):
+            raise UpdateFailed(self.last_api_error)
+
+        # self.last_api_update_success is not None here
+        assert self.current_api_estimate is not None
+
+        # Update the reported values only if we are at a "value change time", otherwise changes
+        # in the values reported by the API lead to a change of values during the hour
+        if self.next_value_update_time is None or now >= self.next_value_update_time:
+            current_estimate: Estimate = self.current_api_estimate
+
+            # Find the next change point in the reported estimates
+            self.next_value_update_time = min(
+                (
+                    timestamp
+                    for timestamp in current_estimate.watts.keys()
+                    if timestamp > now
+                ),
+                default=now + timedelta(minutes=1),
+            ).astimezone(now.tzinfo)
+
+            # Delay querying right before the value change to have the most recent values +
+            # some randomness to not overload the API -- but only if the last success is recent
+            if now - self.last_api_success_time < timedelta(
+                    hours=1
+            ) and self.next_api_query_time < self.next_value_update_time - timedelta(
+                seconds=300
+            ):
+                LOGGER.debug(
+                    "Delaying next API query to align with value update at %s",
+                    self.next_value_update_time,
+                )
+                self.next_api_query_time = self.next_value_update_time - timedelta(
+                    seconds=random.randint(60, 300)
+                )
+        else:
+            # Have not reached a "value change time", keep the old values
+            current_estimate = self.data
+
+        # Run this method again when the next interesting thing happens (either query the API or
+        # update sensor values). Replace microsecond = 0 to match the behaviour of HA scheduling,
+        # otherwise, we might run at times like xx:59:59.yyy
+        next_update_interval = min(
+            self.next_api_query_time, self.next_value_update_time
+        ) - now.replace(microsecond=0)
+
+        # Safeguard to rate-limit calls to this method
+        if next_update_interval < timedelta(seconds=1):
+            next_update_interval = timedelta(seconds=1)
+        if next_update_interval > timedelta(hours=2):
+            next_update_interval = timedelta(hours=2)
+
+        LOGGER.debug(
+            "Next estimate value change is at %s, next API query at %s, scheduling next update in %s",
+            self.next_value_update_time,
+            self.next_api_query_time,
+            next_update_interval,
+        )
+
+        self.update_interval = next_update_interval
+        return current_estimate

--- a/homeassistant/components/forecast_solar/coordinator.py
+++ b/homeassistant/components/forecast_solar/coordinator.py
@@ -2,12 +2,11 @@
 from __future__ import annotations
 
 import asyncio
-import logging
-import random
 from datetime import datetime, timedelta
+import logging
 
-import async_timeout
 from aiohttp import ClientResponseError
+import async_timeout
 from forecast_solar import (
     Estimate,
     ForecastSolar,
@@ -20,21 +19,18 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt
 
-from .const import (
-    LOGGER,
-    DOMAIN
-)
+from .const import DOMAIN, LOGGER
 
 
 class ForecastSolarUpdateCoordinator(DataUpdateCoordinator[Estimate]):
     """Update coordinator for Forecast.Solar."""
 
     def __init__(
-            self,
-            hass: HomeAssistant,
-            logger: logging.Logger,
-            api: ForecastSolar,
-            api_interval: timedelta,
+        self,
+        hass: HomeAssistant,
+        logger: logging.Logger,
+        api: ForecastSolar,
+        api_interval: timedelta,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -45,7 +41,8 @@ class ForecastSolarUpdateCoordinator(DataUpdateCoordinator[Estimate]):
             update_method=self.update,
         )
         self.api = api
-        # TODO In case there are multiple instances, they should share the api_interval
+        # Note: In case there are multiple instances, they probably should share the api_interval, since the rate-limit
+        # is shared, too. However, the limits are quite generous, and you can get away with 6-12 planes
         self.api_update_interval: timedelta = api_interval
         self.current_api_estimate: Estimate | None = None
         self.last_api_error: Exception | None = None
@@ -53,61 +50,59 @@ class ForecastSolarUpdateCoordinator(DataUpdateCoordinator[Estimate]):
         self.next_api_query_time: datetime | None = None
         self.next_value_update_time: datetime | None = None
 
+    def _now(self) -> datetime:
+        return datetime.now(tz=dt.get_time_zone(self.hass.config.time_zone))
+
     async def update(self) -> Estimate:
         """Fetch new data from API if within rate limit and update sensor values if needed."""
 
-        now = datetime.now(tz=dt.get_time_zone(self.hass.config.time_zone))
-
         # Update the estimate from the API if within rate limit
-        if self.next_api_query_time is None or now >= self.next_api_query_time:
+
+        if self.next_api_query_time is None or self.next_api_query_time <= self._now():
             LOGGER.debug("Querying forecast.solar API")
+
+            api_error: Exception | None = None
             try:
                 async with async_timeout.timeout(10):
                     self.current_api_estimate = await self.api.estimate()
-                self.last_api_success_time = now
+                self.last_api_success_time = self._now()
             except ForecastSolarRatelimit as error:
-                # We hit a rate limit, be more cautious
                 LOGGER.info("Hit rate limit on forecast.solar API")
-                self.last_api_error = error
+                api_error = error
             except (ForecastSolarConnectionError, asyncio.TimeoutError) as error:
                 LOGGER.warning(
                     "Failed to connect to forecast.solar API, using cached values. Reason: %s",
                     error,
                 )
-                # Try again sooner
-                self.next_api_query_time = now + timedelta(minutes=2)
-                self.last_api_error = error
+                api_error = error
             except (ForecastSolarError, ClientResponseError) as error:
                 LOGGER.warning(
                     "Failed to query forecast.solar API, using cached values. Reason: %s",
                     error,
                 )
-                self.last_api_error = error
+                api_error = error
 
-            # Change the next update by a small random offset to even out the load on the API
-            # Since we delay updates until roughly before the value changes, it is ok to subtract
-            # a small random time here
-            now = datetime.now(tz=dt.get_time_zone(self.hass.config.time_zone))
-            self.next_api_query_time = (
-                    now
-                    + self.api_update_interval
-                    - timedelta(seconds=random.randint(0, 120))
-            )
+            # Note: Also sets last_api_error to None if query is successful
+            self.last_api_error = api_error
+            self.next_api_query_time = self._now() + self.api_update_interval
+
+            # if isinstance(api_error, (ForecastSolarConnectionError, asyncio.TimeoutError)):
+            # We couldn't connect, so lets try again sooner
+            # self.next_api_query_time = self._now() + timedelta(minutes=2)
 
         # If values are stale for too long, report an error
         # This most likely happens if the internet connection drops or forecast.solar has an outage
         # Note: This could also happen when the integration is loaded initially, which would lead to
         # reloading the integration and potentially failing again?
         if self.last_api_success_time is None or (
-                now - self.last_api_success_time > timedelta(hours=6)
+            self._now() - self.last_api_success_time > timedelta(hours=6)
         ):
             raise UpdateFailed(self.last_api_error)
-
-        # self.last_api_update_success is not None here
         assert self.current_api_estimate is not None
 
         # Update the reported values only if we are at a "value change time", otherwise changes
         # in the values reported by the API lead to a change of values during the hour
+        now = self._now()
         if self.next_value_update_time is None or now >= self.next_value_update_time:
             current_estimate: Estimate = self.current_api_estimate
 
@@ -120,21 +115,6 @@ class ForecastSolarUpdateCoordinator(DataUpdateCoordinator[Estimate]):
                 ),
                 default=now + timedelta(minutes=1),
             ).astimezone(now.tzinfo)
-
-            # Delay querying right before the value change to have the most recent values +
-            # some randomness to not overload the API -- but only if the last success is recent
-            if now - self.last_api_success_time < timedelta(
-                    hours=1
-            ) and self.next_api_query_time < self.next_value_update_time - timedelta(
-                seconds=300
-            ):
-                LOGGER.debug(
-                    "Delaying next API query to align with value update at %s",
-                    self.next_value_update_time,
-                )
-                self.next_api_query_time = self.next_value_update_time - timedelta(
-                    seconds=random.randint(60, 300)
-                )
         else:
             # Have not reached a "value change time", keep the old values
             current_estimate = self.data
@@ -142,6 +122,7 @@ class ForecastSolarUpdateCoordinator(DataUpdateCoordinator[Estimate]):
         # Run this method again when the next interesting thing happens (either query the API or
         # update sensor values). Replace microsecond = 0 to match the behaviour of HA scheduling,
         # otherwise, we might run at times like xx:59:59.yyy
+        assert self.next_api_query_time is not None
         next_update_interval = min(
             self.next_api_query_time, self.next_value_update_time
         ) - now.replace(microsecond=0)

--- a/homeassistant/components/forecast_solar/energy.py
+++ b/homeassistant/components/forecast_solar/energy.py
@@ -10,7 +10,10 @@ async def async_get_solar_forecast(
     hass: HomeAssistant, config_entry_id: str
 ) -> dict[str, dict[str, float | int]] | None:
     """Get solar forecast for a config entry ID."""
-    if (coordinator := hass.data[DOMAIN].get(config_entry_id)) is None:
+    if (
+        DOMAIN not in hass.data
+        or (coordinator := hass.data[DOMAIN].get(config_entry_id)) is None
+    ):
         return None
 
     return {

--- a/homeassistant/components/forecast_solar/sensor.py
+++ b/homeassistant/components/forecast_solar/sensor.py
@@ -12,8 +12,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import UpdateCoordinator
 from .const import DOMAIN, SENSORS
+from .coordinator import ForecastSolarUpdateCoordinator
 from .models import ForecastSolarSensorEntityDescription
 
 
@@ -21,7 +21,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Defer sensor setup to the shared sensor module."""
-    coordinator: UpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: ForecastSolarUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
         ForecastSolarSensorEntity(
@@ -33,7 +33,9 @@ async def async_setup_entry(
     )
 
 
-class ForecastSolarSensorEntity(CoordinatorEntity[UpdateCoordinator], SensorEntity):
+class ForecastSolarSensorEntity(
+    CoordinatorEntity[ForecastSolarUpdateCoordinator], SensorEntity
+):
     """Defines a Forecast.Solar sensor."""
 
     entity_description: ForecastSolarSensorEntityDescription
@@ -43,7 +45,7 @@ class ForecastSolarSensorEntity(CoordinatorEntity[UpdateCoordinator], SensorEnti
         self,
         *,
         entry_id: str,
-        coordinator: UpdateCoordinator,
+        coordinator: ForecastSolarUpdateCoordinator,
         entity_description: ForecastSolarSensorEntityDescription,
     ) -> None:
         """Initialize Forecast.Solar sensor."""

--- a/homeassistant/components/forecast_solar/sensor.py
+++ b/homeassistant/components/forecast_solar/sensor.py
@@ -10,11 +10,9 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import UpdateCoordinator
 from .const import DOMAIN, SENSORS
 from .models import ForecastSolarSensorEntityDescription
 
@@ -23,7 +21,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Defer sensor setup to the shared sensor module."""
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: UpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
         ForecastSolarSensorEntity(
@@ -35,7 +33,7 @@ async def async_setup_entry(
     )
 
 
-class ForecastSolarSensorEntity(CoordinatorEntity, SensorEntity):
+class ForecastSolarSensorEntity(CoordinatorEntity[UpdateCoordinator], SensorEntity):
     """Defines a Forecast.Solar sensor."""
 
     entity_description: ForecastSolarSensorEntityDescription
@@ -45,7 +43,7 @@ class ForecastSolarSensorEntity(CoordinatorEntity, SensorEntity):
         self,
         *,
         entry_id: str,
-        coordinator: DataUpdateCoordinator,
+        coordinator: UpdateCoordinator,
         entity_description: ForecastSolarSensorEntityDescription,
     ) -> None:
         """Initialize Forecast.Solar sensor."""


### PR DESCRIPTION
## Proposed change

Currently, forecast.solar updates its sensor values every hour, however the API returns values that take effect at a specific time. For example, forecast.solar API may report that at 14:00 the solar power will be 1000W and at 15:00 it will be 2000W. If the forecast.solar integration is loaded at, say, 14:37, it will report 1000W until 15:37 and then update to 2000W for another hour. This change modifies the update interval to always run whenever either the reported value changes or the API can be queried again for new data (respecting the rate limiting).

Marked as WIP since I'm still running longer tests locally (see that it also works correctly around sunset, where forecast.solar gives more frequent updates).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #72181
- This PR is related to issue: potentially related to #74375 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure