### PR TITLE
Fix level controllable output controls in deCONZ

### DIFF
--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from pydeconz.interfaces.lights import CoverAction
+from pydeconz.models import ResourceType
 from pydeconz.models.event import EventType
 from pydeconz.models.light.cover import Cover
 
@@ -23,9 +24,9 @@ from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
 
 DECONZ_TYPE_TO_DEVICE_CLASS = {
-    "Level controllable output": CoverDeviceClass.DAMPER,
-    "Window covering controller": CoverDeviceClass.SHADE,
-    "Window covering device": CoverDeviceClass.SHADE,
+    ResourceType.LEVEL_CONTROLLABLE_OUTPUT.value: CoverDeviceClass.DAMPER,
+    ResourceType.WINDOW_COVERING_CONTROLLER.value: CoverDeviceClass.SHADE,
+    ResourceType.WINDOW_COVERING_DEVICE.value: CoverDeviceClass.SHADE,
 }
 
 
@@ -71,6 +72,8 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
 
         self._attr_device_class = DECONZ_TYPE_TO_DEVICE_CLASS.get(cover.type)
 
+        self.legacy_mode = cover.type == ResourceType.LEVEL_CONTROLLABLE_OUTPUT.value
+
     @property
     def current_cover_position(self) -> int:
         """Return the current position of the cover."""
@@ -87,6 +90,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
         await self.gateway.api.lights.covers.set_state(
             id=self._device.resource_id,
             lift=position,
+            legacy_mode=self.legacy_mode,
         )
 
     async def async_open_cover(self, **kwargs: Any) -> None:
@@ -94,6 +98,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
         await self.gateway.api.lights.covers.set_state(
             id=self._device.resource_id,
             action=CoverAction.OPEN,
+            legacy_mode=self.legacy_mode,
         )
 
     async def async_close_cover(self, **kwargs: Any) -> None:
@@ -101,6 +106,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
         await self.gateway.api.lights.covers.set_state(
             id=self._device.resource_id,
             action=CoverAction.CLOSE,
+            legacy_mode=self.legacy_mode,
         )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
@@ -108,6 +114,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
         await self.gateway.api.lights.covers.set_state(
             id=self._device.resource_id,
             action=CoverAction.STOP,
+            legacy_mode=self.legacy_mode,
         )
 
     @property
@@ -123,6 +130,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
         await self.gateway.api.lights.covers.set_state(
             id=self._device.resource_id,
             tilt=position,
+            legacy_mode=self.legacy_mode,
         )
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
@@ -130,6 +138,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
         await self.gateway.api.lights.covers.set_state(
             id=self._device.resource_id,
             tilt=0,
+            legacy_mode=self.legacy_mode,
         )
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
@@ -137,6 +146,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
         await self.gateway.api.lights.covers.set_state(
             id=self._device.resource_id,
             tilt=100,
+            legacy_mode=self.legacy_mode,
         )
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
@@ -144,4 +154,5 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
         await self.gateway.api.lights.covers.set_state(
             id=self._device.resource_id,
             action=CoverAction.STOP,
+            legacy_mode=self.legacy_mode,
         )

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==103"],
+  "requirements": ["pydeconz==104"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1461,7 +1461,7 @@ pydaikin==2.7.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==103
+pydeconz==104
 
 # homeassistant.components.delijn
 pydelijn==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1004,7 +1004,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.7.0
 
 # homeassistant.components.deconz
-pydeconz==103
+pydeconz==104
 
 # homeassistant.components.dexcom
 pydexcom==0.2.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Library change https://github.com/Kane610/deconz/compare/v103...v104
Relevant change https://github.com/Kane610/deconz/commit/beb267487c376e91d2d630c62c0bd69066b9a5fc

When doing https://github.com/home-assistant/core/pull/74535 I thought all updated controls would work on devices I considered "cover" devices, not true for level controllable output devices, they still use the old controls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #77149
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
