### PR TITLE
Update qingping matcher to support additional models

### DIFF
--- a/homeassistant/components/qingping/binary_sensor.py
+++ b/homeassistant/components/qingping/binary_sensor.py
@@ -35,6 +35,10 @@ BINARY_SENSOR_DESCRIPTIONS = {
         key=QingpingBinarySensorDeviceClass.LIGHT,
         device_class=BinarySensorDeviceClass.LIGHT,
     ),
+    QingpingBinarySensorDeviceClass.DOOR: BinarySensorEntityDescription(
+        key=QingpingBinarySensorDeviceClass.DOOR,
+        device_class=BinarySensorDeviceClass.DOOR,
+    ),
 }
 
 

--- a/homeassistant/components/qingping/manifest.json
+++ b/homeassistant/components/qingping/manifest.json
@@ -3,7 +3,12 @@
   "name": "Qingping",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/qingping",
-  "bluetooth": [{ "local_name": "Qingping*", "connectable": false }],
+  "bluetooth": [
+    {
+      "service_data_uuid": "0000fdcd-0000-1000-8000-00805f9b34fb",
+      "connectable": false
+    }
+  ],
   "requirements": ["qingping-ble==0.3.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@bdraco"],

--- a/homeassistant/components/qingping/manifest.json
+++ b/homeassistant/components/qingping/manifest.json
@@ -4,6 +4,8 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/qingping",
   "bluetooth": [
+    { "local_name": "Qingping*", "connectable": false },
+    { "local_name": "Lee Guitars*", "connectable": false },
     {
       "service_data_uuid": "0000fdcd-0000-1000-8000-00805f9b34fb",
       "connectable": false

--- a/homeassistant/components/qingping/manifest.json
+++ b/homeassistant/components/qingping/manifest.json
@@ -11,7 +11,7 @@
       "connectable": false
     }
   ],
-  "requirements": ["qingping-ble==0.3.0"],
+  "requirements": ["qingping-ble==0.5.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@bdraco"],
   "iot_class": "local_push"

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -115,6 +115,16 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
     },
     {
         "domain": "qingping",
+        "local_name": "Qingping*",
+        "connectable": False
+    },
+    {
+        "domain": "qingping",
+        "local_name": "Lee Guitars*",
+        "connectable": False
+    },
+    {
+        "domain": "qingping",
         "service_data_uuid": "0000fdcd-0000-1000-8000-00805f9b34fb",
         "connectable": False
     },

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -115,7 +115,7 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
     },
     {
         "domain": "qingping",
-        "local_name": "Qingping*",
+        "service_data_uuid": "0000fdcd-0000-1000-8000-00805f9b34fb",
         "connectable": False
     },
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2070,7 +2070,7 @@ pyzbar==0.1.7
 pyzerproc==0.4.8
 
 # homeassistant.components.qingping
-qingping-ble==0.3.0
+qingping-ble==0.5.0
 
 # homeassistant.components.qnap
 qnapstats==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1418,7 +1418,7 @@ pyws66i==1.1
 pyzerproc==0.4.8
 
 # homeassistant.components.qingping
-qingping-ble==0.3.0
+qingping-ble==0.5.0
 
 # homeassistant.components.rachio
 rachiopy==1.0.3


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Not all Qingping devices have their name start with Qingping so we need the lib to figure it out for us

`Core Bluetooth: 1411EDAC-55F5-3B4B-691E-2C534ED456DE AdvertisementData(local_name='Lee Guitars Thermo-Hygrometer', service_data={'0000fdcd-0000-1000-8000-00805f9b34fb': b'\x8a\x0f\xd1,c4-X\x01\x04\x00\x01\x12\x02\x02\x01('}) connectable: True match: set()`

https://github.com/Bluetooth-Devices/qingping-ble/compare/v0.3.0...v0.5.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23867

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
