### PR TITLE
Allow data from un-connectable sources in fjäråskupan

### DIFF
--- a/homeassistant/components/fjaraskupan/__init__.py
+++ b/homeassistant/components/fjaraskupan/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -32,6 +33,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DISPATCH_DETECTION, DOMAIN
+
+
+class UnableToConnect(HomeAssistantError):
+    """Exception to indicate that we can not connect to device."""
+
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -75,28 +81,39 @@ class Coordinator(DataUpdateCoordinator[State]):
     async def _async_update_data(self) -> State:
         """Handle an explicit update request."""
         if self._refresh_was_scheduled:
-            if async_address_present(self.hass, self.device.address):
+            if async_address_present(self.hass, self.device.address, False):
                 return self.device.state
             raise UpdateFailed(
                 "No data received within schedule, and device is no longer present"
             )
 
-        await self.device.update()
+        if (
+            ble_device := async_ble_device_from_address(
+                self.hass, self.device.address, True
+            )
+        ) is None:
+            raise UpdateFailed("No connectable path to device")
+        async with self.device.connect(ble_device) as device:
+            await device.update()
         return self.device.state
 
     def detection_callback(self, service_info: BluetoothServiceInfoBleak) -> None:
         """Handle a new announcement of data."""
-        self.device.device = service_info.device
         self.device.detection_callback(service_info.device, service_info.advertisement)
         self.async_set_updated_data(self.device.state)
 
     @asynccontextmanager
     async def async_connect_and_update(self) -> AsyncIterator[Device]:
         """Provide an up to date device for use during connections."""
-        if ble_device := async_ble_device_from_address(self.hass, self.device.address):
-            self.device.device = ble_device
-        async with self.device:
-            yield self.device
+        if (
+            ble_device := async_ble_device_from_address(
+                self.hass, self.device.address, True
+            )
+        ) is None:
+            raise UnableToConnect("No connectable path to device")
+
+        async with self.device.connect(ble_device) as device:
+            yield device
 
         self.async_set_updated_data(self.device.state)
 
@@ -126,7 +143,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         else:
             _LOGGER.debug("Detected: %s", service_info)
 
-            device = Device(service_info.device)
+            device = Device(service_info.device.address)
             device_info = DeviceInfo(
                 connections={(dr.CONNECTION_BLUETOOTH, service_info.address)},
                 identifiers={(DOMAIN, service_info.address)},
@@ -149,6 +166,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             BluetoothCallbackMatcher(
                 manufacturer_id=20296,
                 manufacturer_data_start=[79, 68, 70, 74, 65, 82],
+                connectable=False,
             ),
             BluetoothScanningMode.ACTIVE,
         )

--- a/homeassistant/components/fjaraskupan/manifest.json
+++ b/homeassistant/components/fjaraskupan/manifest.json
@@ -3,13 +3,14 @@
   "name": "Fj\u00e4r\u00e5skupan",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/fjaraskupan",
-  "requirements": ["fjaraskupan==1.0.2"],
+  "requirements": ["fjaraskupan==2.0.0"],
   "codeowners": ["@elupus"],
   "iot_class": "local_polling",
   "loggers": ["bleak", "fjaraskupan"],
   "dependencies": ["bluetooth"],
   "bluetooth": [
     {
+      "connectable": false,
       "manufacturer_id": 20296,
       "manufacturer_data_start": [79, 68, 70, 74, 65, 82]
     }

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
     {
         "domain": "fjaraskupan",
+        "connectable": False,
         "manufacturer_id": 20296,
         "manufacturer_data_start": [
             79,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -667,7 +667,7 @@ fivem-api==0.1.2
 fixerio==1.0.0a0
 
 # homeassistant.components.fjaraskupan
-fjaraskupan==1.0.2
+fjaraskupan==2.0.0
 
 # homeassistant.components.flipr
 flipr-api==1.4.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -486,7 +486,7 @@ file-read-backwards==2.0.0
 fivem-api==0.1.2
 
 # homeassistant.components.fjaraskupan
-fjaraskupan==1.0.2
+fjaraskupan==2.0.0
 
 # homeassistant.components.flipr
 flipr-api==1.4.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow getting ble announcements from non connectable devices like esphome.

Library is updated for better support of this use case: https://github.com/elupus/fjaraskupan/releases/tag/2.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to pull: #77132

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
