### PR TITLE
Improve automations and scripts error logging

### DIFF
--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -117,7 +117,7 @@ async def _try_async_validate_config_item(
         IntegrationNotFound,
         InvalidDeviceAutomationConfig,
     ) as ex:
-        async_log_exception(ex, DOMAIN, full_config or config, hass)
+        async_log_exception(ex, DOMAIN, config, hass)
         return None
 
     if isinstance(validated_config, blueprint.BlueprintInputs):

--- a/homeassistant/components/script/config.py
+++ b/homeassistant/components/script/config.py
@@ -95,7 +95,7 @@ async def _try_async_validate_config_item(hass, object_id, config, full_config=N
         cv.slug(object_id)
         config = await async_validate_config_item(hass, config, full_config)
     except (vol.Invalid, HomeAssistantError) as ex:
-        async_log_exception(ex, DOMAIN, full_config or config, hass)
+        async_log_exception(ex, DOMAIN, config, hass)
         return None
 
     if isinstance(config, BlueprintInputs):

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -542,7 +542,7 @@ def _format_config_error(
         f"line {getattr(domain_config, '__line__', '?')}). "
     )
     try:
-        message += f"Entry id: {config.get(ATTR_ID)}. Alias: {config.get(CONF_ALIAS)}. "
+        message += f"Entry id: {config.get(CONF_ID)}. Alias: {config.get(CONF_ALIAS)}. "
     except AttributeError:
         pass
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -82,6 +82,9 @@ AUTOMATION_CONFIG_PATH = "automations.yaml"
 SCRIPT_CONFIG_PATH = "scripts.yaml"
 SCENE_CONFIG_PATH = "scenes.yaml"
 
+DOMAIN_AUTOMATION = "automation"
+DOMAIN_SCRIPT = "script"
+
 LOAD_EXCEPTIONS = (ImportError, FileNotFoundError)
 INTEGRATION_LOAD_EXCEPTIONS = (
     IntegrationNotFound,
@@ -541,10 +544,8 @@ def _format_config_error(
         f" (See {getattr(domain_config, '__config_file__', '?')}, "
         f"line {getattr(domain_config, '__line__', '?')}). "
     )
-    try:
+    if domain in [DOMAIN_AUTOMATION, DOMAIN_SCRIPT]:
         message += f"Entry id: {config.get(CONF_ID)}. Alias: {config.get(CONF_ALIAS)}. "
-    except AttributeError:
-        pass
 
     if domain != CONF_CORE and link:
         message += f"Please check the docs at {link}"

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -23,6 +23,7 @@ from .const import (
     ATTR_ASSUMED_STATE,
     ATTR_FRIENDLY_NAME,
     ATTR_HIDDEN,
+    CONF_ALIAS,
     CONF_ALLOWLIST_EXTERNAL_DIRS,
     CONF_ALLOWLIST_EXTERNAL_URLS,
     CONF_AUTH_MFA_MODULES,
@@ -540,6 +541,10 @@ def _format_config_error(
         f" (See {getattr(domain_config, '__config_file__', '?')}, "
         f"line {getattr(domain_config, '__line__', '?')}). "
     )
+    if config.get(CONF_ID):
+        message += f"Entry id: {config.get(ATTR_ID)}. "
+    if config.get(CONF_ALIAS):
+        message += f"Alias: {config.get(CONF_ALIAS)}. "
 
     if domain != CONF_CORE and link:
         message += f"Please check the docs at {link}"

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -545,8 +545,12 @@ def _format_config_error(
         f"line {getattr(domain_config, '__line__', '?')}). "
     )
     if domain in [DOMAIN_AUTOMATION, DOMAIN_SCRIPT]:
-        message += f"Entry id: {config.get(CONF_ID)}. Alias: {config.get(CONF_ALIAS)}. "
-
+        try:
+            message += (
+                f"Entry id: {config.get(CONF_ID)}. Alias: {config.get(CONF_ALIAS)}. "
+            )
+        except AttributeError:
+            pass
     if domain != CONF_CORE and link:
         message += f"Please check the docs at {link}"
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -541,10 +541,10 @@ def _format_config_error(
         f" (See {getattr(domain_config, '__config_file__', '?')}, "
         f"line {getattr(domain_config, '__line__', '?')}). "
     )
-    if config.get(CONF_ID):
-        message += f"Entry id: {config.get(ATTR_ID)}. "
-    if config.get(CONF_ALIAS):
-        message += f"Alias: {config.get(CONF_ALIAS)}. "
+    try:
+        message += f"Entry id: {config.get(ATTR_ID)}. Alias: {config.get(CONF_ALIAS)}. "
+    except AttributeError:
+        pass
 
     if domain != CONF_CORE and link:
         message += f"Please check the docs at {link}"

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1348,6 +1348,57 @@ async def test_automation_bad_trigger(hass, caplog):
     assert "Integration 'automation' does not provide trigger support." in caplog.text
 
 
+async def test_automation_bad_trigger_2(hass, caplog):
+    """Test bad trigger configuration."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "id": "12345678",
+                "alias": "hello",
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "hello.world",
+                    "state": None,
+                },
+                "action": [],
+            }
+        },
+    )
+    assert "[state] is an invalid option for [automation]." in caplog.text
+    assert "Entry id: 12345678" in caplog.text
+    assert "Alias: hello" in caplog.text
+
+
+async def test_automation_bad_condition(hass, caplog):
+    """Test bad trigger configuration."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "id": "12345678",
+                "alias": "hello",
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "hello.world",
+                    "to": "Test",
+                },
+                "condition": {
+                    "condition": "state",
+                    "entity_id": "hello.world",
+                    "to": "test",
+                },
+                "action": [],
+            }
+        },
+    )
+    assert "[to] is an invalid option for [automation]." in caplog.text
+    assert "Entry id: 12345678" in caplog.text
+    assert "Alias: hello" in caplog.text
+
+
 async def test_automation_with_error_in_script(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
@@ -1376,7 +1427,7 @@ async def test_automation_with_error_in_script(
     assert issues[0]["issue_id"] == "automation.hello_service_not_found_test.automation"
 
 
-async def test_automation_with_error_in_script_2(hass, caplog):
+async def test_automation_with_error_in_script_2(hass: HomeAssistant, caplog: pytest.LogCaptureFixture):
     """Test automation with an error in script."""
     assert await async_setup_component(
         hass,

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1427,7 +1427,9 @@ async def test_automation_with_error_in_script(
     assert issues[0]["issue_id"] == "automation.hello_service_not_found_test.automation"
 
 
-async def test_automation_with_error_in_script_2(hass: HomeAssistant, caplog: pytest.LogCaptureFixture):
+async def test_automation_with_error_in_script_2(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation with an error in script."""
     assert await async_setup_component(
         hass,

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1223,16 +1223,14 @@ async def test_script_service_changed_entity_id(hass: HomeAssistant) -> None:
                     "sequence": {
                         "service": "test.script",
                         "data_template": {"entity_id": "{{ this.entity_id }}"},
-                    }
-                }
-            }
+                    },
+                },
+            },
         },
     )
-
     await hass.services.async_call(DOMAIN, "test", {"greeting": "world"})
 
     await hass.async_block_till_done()
-
     assert len(calls) == 1
     assert calls[0].data["entity_id"] == "script.custom_entity_id"
 
@@ -1248,3 +1246,29 @@ async def test_script_service_changed_entity_id(hass: HomeAssistant) -> None:
 
     assert len(calls) == 2
     assert calls[1].data["entity_id"] == "script.custom_entity_id_2"
+
+
+async def test_script_bad_condition(hass, caplog):
+    """Test bad trigger configuration."""
+    assert await async_setup_component(
+        hass,
+        script.DOMAIN,
+        {
+            script.DOMAIN: {
+                "hello": {
+                    "alias": "hello",
+                    "sequence": {
+                        "condition": {
+                            "condition": "state",
+                            "entity_id": "hello.world",
+                            "to": "test",
+                        },
+                        "service": "test.script",
+                    },
+                },
+            },
+        },
+    )
+
+    assert "Unexpected value for condition:" in caplog.text
+    assert "Alias: hello" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improving logging of script- and automation errors from included files.  Adding script/automation id and alias to error-messages.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Currently, when an error happens in a script or automation that is defined in an included file, the error is only a very general description of the problem, like `ERROR (MainThread) [homeassistant.config] Invalid config for [automation]: not a valid value for dictionary value @ data['action'][2]['entity_id']. Got None. (See ?, line ?).`, and if any references to a file/line is in the error, it only references the line in configuration.yaml where the `!include`-statement is.  This makes it very hard to find which script or automation is cauiong the error.

This PR adds a reference to the ID and Alias of the script or automation in question.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
