### PR TITLE
Add basic media_player to Fully Kiosk Browser integration

### DIFF
--- a/homeassistant/components/fully_kiosk/__init__.py
+++ b/homeassistant/components/fully_kiosk/__init__.py
@@ -9,6 +9,7 @@ from .coordinator import FullyKioskDataUpdateCoordinator
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.MEDIA_PLAYER,
     Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/fully_kiosk/const.py
+++ b/homeassistant/components/fully_kiosk/const.py
@@ -5,6 +5,8 @@ from datetime import timedelta
 import logging
 from typing import Final
 
+from homeassistant.components.media_player.const import MediaPlayerEntityFeature
+
 DOMAIN: Final = "fully_kiosk"
 
 LOGGER = logging.getLogger(__package__)
@@ -13,3 +15,9 @@ UPDATE_INTERVAL = timedelta(seconds=30)
 DEFAULT_PORT = 2323
 
 AUDIOMANAGER_STREAM_MUSIC = 3
+
+MEDIA_SUPPORT_FULLYKIOSK = (
+    MediaPlayerEntityFeature.PLAY_MEDIA
+    | MediaPlayerEntityFeature.STOP
+    | MediaPlayerEntityFeature.VOLUME_SET
+)

--- a/homeassistant/components/fully_kiosk/const.py
+++ b/homeassistant/components/fully_kiosk/const.py
@@ -20,4 +20,5 @@ MEDIA_SUPPORT_FULLYKIOSK = (
     MediaPlayerEntityFeature.PLAY_MEDIA
     | MediaPlayerEntityFeature.STOP
     | MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.BROWSE_MEDIA
 )

--- a/homeassistant/components/fully_kiosk/const.py
+++ b/homeassistant/components/fully_kiosk/const.py
@@ -11,3 +11,5 @@ LOGGER = logging.getLogger(__package__)
 UPDATE_INTERVAL = timedelta(seconds=30)
 
 DEFAULT_PORT = 2323
+
+AUDIOMANAGER_STREAM_MUSIC = 3

--- a/homeassistant/components/fully_kiosk/media_player.py
+++ b/homeassistant/components/fully_kiosk/media_player.py
@@ -1,0 +1,65 @@
+"""Fully Kiosk Browser media player."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components import media_source
+from homeassistant.components.media_player import MediaPlayerEntity
+from homeassistant.components.media_player.browse_media import (
+    async_process_play_media_url,
+)
+from homeassistant.components.media_player.const import MediaPlayerEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import AUDIOMANAGER_STREAM_MUSIC, DOMAIN
+from .coordinator import FullyKioskDataUpdateCoordinator
+from .entity import FullyKioskEntity
+
+MEDIA_SUPPORT_FULLYKIOSK = (
+    MediaPlayerEntityFeature.PLAY_MEDIA
+    | MediaPlayerEntityFeature.STOP
+    | MediaPlayerEntityFeature.VOLUME_SET
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Fully Kiosk Browser media player entity."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities([FullyMediaPlayer(coordinator)])
+
+
+class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
+    """Representation of a Fully Kiosk Browser media player entity."""
+
+    def __init__(self, coordinator: FullyKioskDataUpdateCoordinator) -> None:
+        """Initialize the media player entity."""
+        super().__init__(coordinator)
+        self._attr_name = "Media Player"
+        self._attr_unique_id = f"{coordinator.data['deviceID']}-mediaplayer"
+        self._attr_supported_features = MEDIA_SUPPORT_FULLYKIOSK
+
+    async def async_play_media(
+        self, media_type: str, media_id: str, **kwargs: Any
+    ) -> None:
+        """Play a piece of media."""
+        if media_source.is_media_source_id(media_id):
+            play_item = await media_source.async_resolve_media(self.hass, media_id)
+            media_id = async_process_play_media_url(self.hass, play_item.url)
+
+        await self.coordinator.fully.playSound(media_id, AUDIOMANAGER_STREAM_MUSIC)
+
+    async def async_media_stop(self) -> None:
+        """Stop playing media."""
+        await self.coordinator.fully.stopSound()
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level, range 0..1."""
+        await self.coordinator.fully.setAudioVolume(
+            int(volume * 100), AUDIOMANAGER_STREAM_MUSIC
+        )

--- a/homeassistant/components/fully_kiosk/media_player.py
+++ b/homeassistant/components/fully_kiosk/media_player.py
@@ -8,20 +8,13 @@ from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.browse_media import (
     async_process_play_media_url,
 )
-from homeassistant.components.media_player.const import MediaPlayerEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import AUDIOMANAGER_STREAM_MUSIC, DOMAIN
+from .const import AUDIOMANAGER_STREAM_MUSIC, DOMAIN, MEDIA_SUPPORT_FULLYKIOSK
 from .coordinator import FullyKioskDataUpdateCoordinator
 from .entity import FullyKioskEntity
-
-MEDIA_SUPPORT_FULLYKIOSK = (
-    MediaPlayerEntityFeature.PLAY_MEDIA
-    | MediaPlayerEntityFeature.STOP
-    | MediaPlayerEntityFeature.VOLUME_SET
-)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/fully_kiosk/media_player.py
+++ b/homeassistant/components/fully_kiosk/media_player.py
@@ -6,6 +6,7 @@ from typing import Any
 from homeassistant.components import media_source
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.browse_media import (
+    BrowseMedia,
     async_process_play_media_url,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -30,12 +31,12 @@ async def async_setup_entry(
 class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
     """Representation of a Fully Kiosk Browser media player entity."""
 
+    _attr_supported_features = MEDIA_SUPPORT_FULLYKIOSK
+
     def __init__(self, coordinator: FullyKioskDataUpdateCoordinator) -> None:
         """Initialize the media player entity."""
         super().__init__(coordinator)
-        self._attr_name = "Media Player"
         self._attr_unique_id = f"{coordinator.data['deviceID']}-mediaplayer"
-        self._attr_supported_features = MEDIA_SUPPORT_FULLYKIOSK
 
     async def async_play_media(
         self, media_type: str, media_id: str, **kwargs: Any
@@ -55,4 +56,16 @@ class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
         """Set volume level, range 0..1."""
         await self.coordinator.fully.setAudioVolume(
             int(volume * 100), AUDIOMANAGER_STREAM_MUSIC
+        )
+
+    async def async_browse_media(
+        self,
+        media_content_type: str | None = None,
+        media_content_id: str | None = None,
+    ) -> BrowseMedia:
+        """Implement the WebSocket media browsing helper."""
+        return await media_source.async_browse_media(
+            self.hass,
+            media_content_id,
+            content_filter=lambda item: item.media_content_type.startswith("audio/"),
         )

--- a/homeassistant/components/fully_kiosk/media_player.py
+++ b/homeassistant/components/fully_kiosk/media_player.py
@@ -43,7 +43,9 @@ class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
     ) -> None:
         """Play a piece of media."""
         if media_source.is_media_source_id(media_id):
-            play_item = await media_source.async_resolve_media(self.hass, media_id)
+            play_item = await media_source.async_resolve_media(
+                self.hass, media_id, self.entity_id
+            )
             media_id = async_process_play_media_url(self.hass, play_item.url)
 
         await self.coordinator.fully.playSound(media_id, AUDIOMANAGER_STREAM_MUSIC)

--- a/homeassistant/components/fully_kiosk/media_player.py
+++ b/homeassistant/components/fully_kiosk/media_player.py
@@ -10,6 +10,7 @@ from homeassistant.components.media_player.browse_media import (
     async_process_play_media_url,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_IDLE, STATE_PLAYING
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -32,6 +33,8 @@ class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
     """Representation of a Fully Kiosk Browser media player entity."""
 
     _attr_supported_features = MEDIA_SUPPORT_FULLYKIOSK
+    _attr_assumed_state = True
+    _attr_state = STATE_IDLE
 
     def __init__(self, coordinator: FullyKioskDataUpdateCoordinator) -> None:
         """Initialize the media player entity."""
@@ -49,16 +52,22 @@ class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
             media_id = async_process_play_media_url(self.hass, play_item.url)
 
         await self.coordinator.fully.playSound(media_id, AUDIOMANAGER_STREAM_MUSIC)
+        self._attr_state = STATE_PLAYING
+        self.async_write_ha_state()
 
     async def async_media_stop(self) -> None:
         """Stop playing media."""
         await self.coordinator.fully.stopSound()
+        self._attr_state = STATE_IDLE
+        self.async_write_ha_state()
 
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self.coordinator.fully.setAudioVolume(
             int(volume * 100), AUDIOMANAGER_STREAM_MUSIC
         )
+        self._attr_volume_level = volume
+        self.async_write_ha_state()
 
     async def async_browse_media(
         self,

--- a/tests/components/fully_kiosk/test_media_player.py
+++ b/tests/components/fully_kiosk/test_media_player.py
@@ -19,10 +19,10 @@ async def test_buttons(
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
 
-    state = hass.states.get("media_player.amazon_fire_media_player")
+    state = hass.states.get("media_player.amazon_fire")
     assert state
 
-    entry = entity_registry.async_get("media_player.amazon_fire_media_player")
+    entry = entity_registry.async_get("media_player.amazon_fire")
     assert entry
     assert entry.unique_id == "abcdef-123456-mediaplayer"
     assert entry.supported_features == MEDIA_SUPPORT_FULLYKIOSK
@@ -31,7 +31,7 @@ async def test_buttons(
         media_player.DOMAIN,
         "play_media",
         {
-            ATTR_ENTITY_ID: "media_player.amazon_fire_media_player",
+            ATTR_ENTITY_ID: "media_player.amazon_fire",
             "media_content_type": "music",
             "media_content_id": "test.mp3",
         },
@@ -43,7 +43,7 @@ async def test_buttons(
         media_player.DOMAIN,
         "media_stop",
         {
-            ATTR_ENTITY_ID: "media_player.amazon_fire_media_player",
+            ATTR_ENTITY_ID: "media_player.amazon_fire",
         },
         blocking=True,
     )
@@ -53,7 +53,7 @@ async def test_buttons(
         media_player.DOMAIN,
         "volume_set",
         {
-            ATTR_ENTITY_ID: "media_player.amazon_fire_media_player",
+            ATTR_ENTITY_ID: "media_player.amazon_fire",
             "volume_level": 0.5,
         },
         blocking=True,

--- a/tests/components/fully_kiosk/test_media_player.py
+++ b/tests/components/fully_kiosk/test_media_player.py
@@ -1,0 +1,73 @@
+"""Test the Fully Kiosk Browser media player."""
+from unittest.mock import MagicMock
+
+from homeassistant.components.fully_kiosk.const import DOMAIN, MEDIA_SUPPORT_FULLYKIOSK
+import homeassistant.components.media_player as media_player
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_buttons(
+    hass: HomeAssistant,
+    mock_fully_kiosk: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test standard Fully Kiosk buttons."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    state = hass.states.get("media_player.amazon_fire_media_player")
+    assert state
+
+    entry = entity_registry.async_get("media_player.amazon_fire_media_player")
+    assert entry
+    assert entry.unique_id == "abcdef-123456-mediaplayer"
+    assert entry.supported_features == MEDIA_SUPPORT_FULLYKIOSK
+
+    await hass.services.async_call(
+        media_player.DOMAIN,
+        "play_media",
+        {
+            ATTR_ENTITY_ID: "media_player.amazon_fire_media_player",
+            "media_content_type": "music",
+            "media_content_id": "test.mp3",
+        },
+        blocking=True,
+    )
+    assert len(mock_fully_kiosk.playSound.mock_calls) == 1
+
+    await hass.services.async_call(
+        media_player.DOMAIN,
+        "media_stop",
+        {
+            ATTR_ENTITY_ID: "media_player.amazon_fire_media_player",
+        },
+        blocking=True,
+    )
+    assert len(mock_fully_kiosk.stopSound.mock_calls) == 1
+
+    await hass.services.async_call(
+        media_player.DOMAIN,
+        "volume_set",
+        {
+            ATTR_ENTITY_ID: "media_player.amazon_fire_media_player",
+            "volume_level": 0.5,
+        },
+        blocking=True,
+    )
+    assert len(mock_fully_kiosk.setAudioVolume.mock_calls) == 1
+
+    assert entry.device_id
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry
+    assert device_entry.configuration_url == "http://192.168.1.234:2323"
+    assert device_entry.entry_type is None
+    assert device_entry.hw_version is None
+    assert device_entry.identifiers == {(DOMAIN, "abcdef-123456")}
+    assert device_entry.manufacturer == "amzn"
+    assert device_entry.model == "KFDOWI"
+    assert device_entry.name == "Amazon Fire"
+    assert device_entry.sw_version == "1.42.5"

--- a/tests/components/fully_kiosk/test_media_player.py
+++ b/tests/components/fully_kiosk/test_media_player.py
@@ -10,12 +10,12 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from tests.common import MockConfigEntry
 
 
-async def test_buttons(
+async def test_media_player(
     hass: HomeAssistant,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
-    """Test standard Fully Kiosk buttons."""
+    """Test standard Fully Kiosk media player."""
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
 


### PR DESCRIPTION
## Proposed change
Adds a basic media_player entity to the Fully Kiosk Browser integration, that allows for playing media files, stopping playback, and setting the volume level.

The Fully Kiosk Browser app does not currently offer a way to get feedback on the current volume level of the device or playback status.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23874

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
