### PR TITLE
Set cv hass in hass fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,6 +227,8 @@ def hass(loop, load_registries, hass_storage, request):
 
     exceptions = []
     hass = loop.run_until_complete(async_test_home_assistant(loop, load_registries))
+    ha._cv_hass.set(hass)
+
     orig_exception_handler = loop.get_exception_handler()
     loop.set_exception_handler(exc_handle)
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, setup
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_HOMEASSISTANT_START
-from homeassistant.core import callback
+from homeassistant.core import async_get_hass, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
 from homeassistant.helpers.config_validation import (
@@ -39,6 +39,11 @@ def mock_handlers():
 
     with patch.dict(config_entries.HANDLERS, {"comp": MockFlowHandler}):
         yield
+
+
+async def test_hass_cv(hass):
+    """Test hass context variable."""
+    assert hass == async_get_hass()
 
 
 async def test_validate_component_config(hass):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, setup
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_HOMEASSISTANT_START
-from homeassistant.core import async_get_hass, callback
+from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
 from homeassistant.helpers.config_validation import (
@@ -39,11 +39,6 @@ def mock_handlers():
 
     with patch.dict(config_entries.HANDLERS, {"comp": MockFlowHandler}):
         yield
-
-
-async def test_hass_cv(hass):
-    """Test hass context variable."""
-    assert hass == async_get_hass()
 
 
 async def test_validate_component_config(hass):

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -26,4 +26,4 @@ async def test_hass_cv(hass):
     When tests are using the `hass`, this tests that the hass context variable was set
     in the fixture and that async_get_hass() works correctly.
     """
-    assert hass == async_get_hass()
+    assert async_get_hass() is hass

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -4,6 +4,8 @@ import socket
 import pytest
 import pytest_socket
 
+from homeassistant.core import async_get_hass
+
 
 def test_sockets_disabled():
     """Test we can't open sockets."""
@@ -16,3 +18,12 @@ def test_sockets_enabled(socket_enabled):
     mysocket = socket.socket()
     with pytest.raises(pytest_socket.SocketConnectBlockedError):
         mysocket.connect(("127.0.0.2", 1234))
+
+
+async def test_hass_cv(hass):
+    """Test hass context variable.
+
+    When tests are using the `hass`, this tests that the hass context variable was set
+    in the fixture and that async_get_hass() works correctly.
+    """
+    assert hass == async_get_hass()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During test `homeassistant.core.async_get_hass()` requires the cv_hass context variable to be set.
The `hass` fixture should initialize setting this variable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
