### PR TITLE
Add diagnostics to Fully Kiosk Browser integration

### DIFF
--- a/homeassistant/components/fully_kiosk/diagnostics.py
+++ b/homeassistant/components/fully_kiosk/diagnostics.py
@@ -1,6 +1,8 @@
 """Provides diagnostics for Fully Kiosk Browser."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.diagnostics.util import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -34,7 +36,7 @@ SETTINGS_TO_REDACT = {
 
 async def async_get_device_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry, device: dr.DeviceEntry
-) -> dict:
+) -> dict[str, Any]:
     """Return device diagnostics."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
     data = coordinator.data

--- a/homeassistant/components/fully_kiosk/diagnostics.py
+++ b/homeassistant/components/fully_kiosk/diagnostics.py
@@ -20,6 +20,8 @@ DEVICE_INFO_TO_REDACT = {
     "deviceID",
     "startUrl",
     "currentPage",
+    "SSID",
+    "BSSID",
 }
 SETTINGS_TO_REDACT = {
     "startURL",
@@ -31,6 +33,24 @@ SETTINGS_TO_REDACT = {
     "authUsername",
     "mqttBrokerUrl",
     "kioskPin",
+    "wifiSSID",
+    "screensaverWallpaperURL",
+    "barcodeScanTargetUrl",
+    "launcherBgUrl",
+    "clientCaUrl",
+    "urlWhitelist",
+    "alarmSoundFileUrl",
+    "errorURL",
+    "actionBarIconUrl",
+    "kioskWifiPin",
+    "knoxApnConfig",
+    "injectJsCode",
+    "mdmApnConfig",
+    "mdmProxyConfig",
+    "wifiEnterpriseIdentity",
+    "sebExamKey",
+    "sebConfigKey",
+    "kioskPinEnc",
 }
 
 

--- a/homeassistant/components/fully_kiosk/diagnostics.py
+++ b/homeassistant/components/fully_kiosk/diagnostics.py
@@ -1,0 +1,42 @@
+"""Provides diagnostics for Fully Kiosk Browser."""
+from __future__ import annotations
+
+from homeassistant.components.diagnostics.util import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .const import DOMAIN
+
+DEVICE_INFO_TO_REDACT = {
+    "serial",
+    "Mac",
+    "ip6",
+    "hostname6",
+    "ip4",
+    "hostname4",
+    "deviceID",
+    "startUrl",
+    "currentPage",
+}
+SETTINGS_TO_REDACT = {
+    "startURL",
+    "mqttBrokerPassword",
+    "mqttBrokerUsername",
+    "remoteAdminPassword",
+    "wifiKey",
+    "authPassword",
+    "authUsername",
+    "mqttBrokerUrl",
+    "kioskPin",
+}
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry, device: dr.DeviceEntry
+) -> dict:
+    """Return device diagnostics."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    data = coordinator.data
+    data["settings"] = async_redact_data(data["settings"], SETTINGS_TO_REDACT)
+    return async_redact_data(data, DEVICE_INFO_TO_REDACT)

--- a/tests/components/fully_kiosk/test_diagnostics.py
+++ b/tests/components/fully_kiosk/test_diagnostics.py
@@ -1,0 +1,41 @@
+"""Test the Fully Kiosk Browser diagnostics."""
+from unittest.mock import MagicMock
+
+from aiohttp import ClientSession
+
+from homeassistant.components.diagnostics.const import REDACTED
+from homeassistant.components.fully_kiosk.const import DOMAIN
+from homeassistant.components.fully_kiosk.diagnostics import (
+    DEVICE_INFO_TO_REDACT,
+    SETTINGS_TO_REDACT,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_device
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+    mock_fully_kiosk: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test standard Fully Kiosk buttons."""
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device({(DOMAIN, "abcdef-123456")})
+
+    diagnostics = await get_diagnostics_for_device(
+        hass, hass_client, init_integration, device
+    )
+
+    assert diagnostics
+    for key in DEVICE_INFO_TO_REDACT:
+        assert diagnostics[key] == REDACTED
+    for key in SETTINGS_TO_REDACT:
+        assert (
+            diagnostics["settings"][key] == REDACTED
+            or diagnostics["settings"][key] == ""
+        )

--- a/tests/components/fully_kiosk/test_diagnostics.py
+++ b/tests/components/fully_kiosk/test_diagnostics.py
@@ -33,9 +33,11 @@ async def test_diagnostics(
 
     assert diagnostics
     for key in DEVICE_INFO_TO_REDACT:
-        assert diagnostics[key] == REDACTED
+        if hasattr(diagnostics, key):
+            assert diagnostics[key] == REDACTED
     for key in SETTINGS_TO_REDACT:
-        assert (
-            diagnostics["settings"][key] == REDACTED
-            or diagnostics["settings"][key] == ""
-        )
+        if hasattr(diagnostics["settings"], key):
+            assert (
+                diagnostics["settings"][key] == REDACTED
+                or diagnostics["settings"][key] == ""
+            )

--- a/tests/components/fully_kiosk/test_diagnostics.py
+++ b/tests/components/fully_kiosk/test_diagnostics.py
@@ -22,7 +22,7 @@ async def test_diagnostics(
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
-    """Test standard Fully Kiosk buttons."""
+    """Test Fully Kiosk diagnostics."""
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_device({(DOMAIN, "abcdef-123456")})


### PR DESCRIPTION
## Proposed change
Adds device diagnostics to the Fully Kiosk Browser integration to dump the current device info and settings from the coordinator.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
