### PR TITLE
Fix bluetooth discovery when advertisement format changes

### DIFF
--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -49,8 +49,8 @@ class IntegrationMatchHistory:
     """Track which fields have been seen."""
 
     manufacturer_data: bool
-    service_data: bool
-    service_uuids: bool
+    service_data: set[str]
+    service_uuids: set[str]
 
 
 def seen_all_fields(
@@ -59,9 +59,15 @@ def seen_all_fields(
     """Return if we have seen all fields."""
     if not previous_match.manufacturer_data and advertisement_data.manufacturer_data:
         return False
-    if not previous_match.service_data and advertisement_data.service_data:
+    if advertisement_data.service_data and (
+        not previous_match.service_data
+        or not previous_match.service_data.issuperset(advertisement_data.service_data)
+    ):
         return False
-    if not previous_match.service_uuids and advertisement_data.service_uuids:
+    if advertisement_data.service_uuids and (
+        not previous_match.service_uuids
+        or not previous_match.service_uuids.issuperset(advertisement_data.service_uuids)
+    ):
         return False
     return True
 
@@ -114,13 +120,13 @@ class IntegrationMatcher:
             previous_match.manufacturer_data |= bool(
                 advertisement_data.manufacturer_data
             )
-            previous_match.service_data |= bool(advertisement_data.service_data)
-            previous_match.service_uuids |= bool(advertisement_data.service_uuids)
+            previous_match.service_data |= set(advertisement_data.service_data)
+            previous_match.service_uuids |= set(advertisement_data.service_uuids)
         else:
             matched[device.address] = IntegrationMatchHistory(
                 manufacturer_data=bool(advertisement_data.manufacturer_data),
-                service_data=bool(advertisement_data.service_data),
-                service_uuids=bool(advertisement_data.service_uuids),
+                service_data=set(advertisement_data.service_data),
+                service_uuids=set(advertisement_data.service_uuids),
             )
         return matched_domains
 

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -704,6 +704,87 @@ async def test_discovery_match_by_service_data_uuid_then_others(
         assert len(mock_config_flow.mock_calls) == 0
 
 
+async def test_discovery_match_by_service_data_uuid_when_format_changes(
+    hass, mock_bleak_scanner_start, macos_adapter
+):
+    """Test bluetooth discovery match by service_data_uuid when format changes."""
+    mock_bt = [
+        {
+            "domain": "xiaomi_ble",
+            "service_data_uuid": "0000fe95-0000-1000-8000-00805f9b34fb",
+        },
+        {
+            "domain": "qingping",
+            "service_data_uuid": "0000fdcd-0000-1000-8000-00805f9b34fb",
+        },
+    ]
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+
+    with patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        device = BLEDevice("44:44:33:11:23:45", "lock")
+        adv_without_service_data_uuid = AdvertisementData(
+            local_name="Qingping Temp RH M",
+            service_uuids=[],
+            manufacturer_data={},
+        )
+        xiaomi_format_adv = AdvertisementData(
+            local_name="Qingping Temp RH M",
+            service_data={
+                "0000fe95-0000-1000-8000-00805f9b34fb": b"0XH\x0b\x06\xa7%\x144-X\x08"
+            },
+        )
+        qingping_format_adv = AdvertisementData(
+            local_name="Qingping Temp RH M",
+            service_data={
+                "0000fdcd-0000-1000-8000-00805f9b34fb": b"\x08\x16\xa7%\x144-X\x01\x04\xdb\x00\xa6\x01\x02\x01d"
+            },
+        )
+        # 1st discovery should not generate a flow because the
+        # service_data_uuid is not in the advertisement
+        inject_advertisement(hass, device, adv_without_service_data_uuid)
+        await hass.async_block_till_done()
+        assert len(mock_config_flow.mock_calls) == 0
+        mock_config_flow.reset_mock()
+
+        # 2nd discovery should generate a flow because the
+        # service_data_uuid matches xiaomi format
+        inject_advertisement(hass, device, xiaomi_format_adv)
+        await hass.async_block_till_done()
+        assert len(mock_config_flow.mock_calls) == 1
+        assert mock_config_flow.mock_calls[0][1][0] == "xiaomi_ble"
+        mock_config_flow.reset_mock()
+
+        # 4th discovery should generate a flow because the
+        # service_data_uuid matches qingping format
+        inject_advertisement(hass, device, qingping_format_adv)
+        await hass.async_block_till_done()
+        assert len(mock_config_flow.mock_calls) == 1
+        assert mock_config_flow.mock_calls[0][1][0] == "qingping"
+        mock_config_flow.reset_mock()
+
+        # 5th discovery should not generate a flow because the
+        # we already saw an advertisement with the service_data_uuid
+        inject_advertisement(hass, device, qingping_format_adv)
+        await hass.async_block_till_done()
+        assert len(mock_config_flow.mock_calls) == 0
+        mock_config_flow.reset_mock()
+
+        # 6th discovery should not generate a flow because the
+        # we already saw an advertisement with the service_data_uuid
+        inject_advertisement(hass, device, xiaomi_format_adv)
+        await hass.async_block_till_done()
+        assert len(mock_config_flow.mock_calls) == 0
+        mock_config_flow.reset_mock()
+
+
 async def test_discovery_match_first_by_service_uuid_and_then_manufacturer_id(
     hass, mock_bleak_scanner_start, macos_adapter
 ):


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix bluetooth discovery when advertisement format changes

We need to check for new uuids appearing, otherwise if the user changes from xiaomi format to qingping format, the qingping integration will never discover the device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
