### PR TITLE
Suppress 404 in Bravia TV

### DIFF
--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -123,6 +123,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             await self.async_update_playing()
         except BraviaTVNotFound:
             self.connected = False
+            _LOGGER.debug("Update skipped, Bravia API service is reloading")
         except BraviaTVError as err:
             self.is_on = False
             self.connected = False

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -7,7 +7,7 @@ from functools import wraps
 import logging
 from typing import Any, Final, TypeVar
 
-from pybravia import BraviaTV, BraviaTVError
+from pybravia import BraviaTV, BraviaTVError, BraviaTVNotFound
 from typing_extensions import Concatenate, ParamSpec
 
 from homeassistant.components.media_player.const import (
@@ -121,6 +121,8 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 await self.async_update_sources()
             await self.async_update_volume()
             await self.async_update_playing()
+        except BraviaTVNotFound:
+            self.connected = False
         except BraviaTVError as err:
             self.is_on = False
             self.connected = False


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes, the`WebApiCore` service on Bravia TV is restarting. This happens randomly, 1-2 times in a couple of days. Probably the process is killing by AndroidTV due to lack of memory or in the cleanup process. It takes about 20-30 seconds to restart the service and the API returns 404 at that moment.

```
2022-08-18 05:57:03.014 DEBUG (MainThread) [braviatv.coordinator] Finished fetching braviatv data in 0.014 seconds (success: True)
2022-08-18 05:57:13.001 DEBUG (MainThread) [pybravia.client] Request http://192.168.1.20/sony/system, data: {'method': 'getPowerStatus', 'params': [], 'id': 1, 'version': '1.0'}, headers: {'Cache-Control': 'no-cache', 'Connection': 'keep-alive'}
2022-08-18 05:57:13.027 DEBUG (MainThread) [pybravia.client] Response status: 200
2022-08-18 05:57:13.027 DEBUG (MainThread) [pybravia.client] Response result: {'result': [{'status': 'standby'}], 'id': 1}
2022-08-18 05:57:13.028 DEBUG (MainThread) [braviatv.coordinator] Finished fetching braviatv data in 0.027 seconds (success: True)

--- During this period, the WebApiCore service on TV start restarting ---

2022-08-18 05:57:23.001 DEBUG (MainThread) [pybravia.client] Request http://192.168.1.20/sony/system, data: {'method': 'getPowerStatus', 'params': [], 'id': 1, 'version': '1.0'}, headers: {'Cache-Control': 'no-cache', 'Connection': 'keep-alive'}
2022-08-18 05:57:23.010 DEBUG (MainThread) [pybravia.client] Response status: 404
2022-08-18 05:57:23.010 ERROR (MainThread) [braviatv.coordinator] Error fetching braviatv data: Error communicating with device
2022-08-18 05:57:23.018 DEBUG (MainThread) [braviatv.coordinator] Finished fetching braviatv data in 0.017 seconds (success: False)

--- During this period, the WebApiCore on TV restarted ---

2022-08-18 05:57:33.002 DEBUG (MainThread) [pybravia.client] Connect with pin: 2880, psk: None, clientid: HomeAssistant, nickname: Home Assistant
2022-08-18 05:57:33.002 DEBUG (MainThread) [pybravia.client] Request http://192.168.1.20/sony/accessControl, data: {'method': 'actRegister', 'params': [{'clientid': 'HomeAssistant', 'nickname': 'Home Assistant', 'level': 'private'}, [{'value': 'yes', 'function': 'WOL'}]], 'id': 1, 'version': '1.0'}, headers: {'Authorization': 'Basic XXXXXXXXXXX', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive'}
2022-08-18 05:57:34.411 DEBUG (MainThread) [pybravia.client] Response status: 200
2022-08-18 05:57:34.411 DEBUG (MainThread) [pybravia.client] Response result: {'result': [], 'id': 1}
2022-08-18 05:57:34.412 DEBUG (MainThread) [pybravia.client] Request http://192.168.1.20/sony/system, data: {'method': 'getSystemInformation', 'params': [], 'id': 1, 'version': '1.0'}, headers: {'Cache-Control': 'no-cache', 'Connection': 'keep-alive'}
2022-08-18 05:57:35.291 DEBUG (MainThread) [pybravia.client] Response status: 200
2022-08-18 05:57:35.293 DEBUG (MainThread) [pybravia.client] Response result: {'result': [{'product': 'TV', 'region': 'XEU', 'language': 'eng', 'model': 'KE-55XH9096'...}], 'id': 1}
2022-08-18 05:57:35.294 DEBUG (MainThread) [pybravia.client] Connected
2022-08-18 05:57:35.294 DEBUG (MainThread) [pybravia.client] Request http://192.168.1.20/sony/system, data: {'method': 'getPowerStatus', 'params': [], 'id': 1, 'version': '1.0'}, headers: {'Cache-Control': 'no-cache', 'Connection': 'keep-alive'}
2022-08-18 05:57:35.320 DEBUG (MainThread) [pybravia.client] Response status: 200
2022-08-18 05:57:35.321 DEBUG (MainThread) [pybravia.client] Response result: {'result': [{'status': 'standby'}], 'id': 1}
2022-08-18 05:57:35.321 INFO (MainThread) [braviatv.coordinator] Fetching braviatv data recovered
```

This PR suppress 404 error (only in scheduled update) to avoid unexpected status change to unavailable and avoid unnecessary errors in the logs, that raise questions from users (https://github.com/home-assistant/core/issues/72345, https://github.com/home-assistant/core/issues/74658). 

Based on https://github.com/Drafteed/pybravia/issues/1#issuecomment-1226250037

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
