### PR TITLE
Fix grid_export_limit unit for DT inverters

### DIFF
--- a/homeassistant/components/goodwe/number.py
+++ b/homeassistant/components/goodwe/number.py
@@ -25,6 +25,7 @@ class GoodweNumberEntityDescriptionBase:
 
     getter: Callable[[Inverter], Awaitable[int]]
     setter: Callable[[Inverter, int], Awaitable[None]]
+    filter: Callable[[Inverter], bool]
 
 
 @dataclass
@@ -35,17 +36,33 @@ class GoodweNumberEntityDescription(
 
 
 NUMBERS = (
+    # non DT inverters (limit in W)
     GoodweNumberEntityDescription(
         key="grid_export_limit",
         name="Grid export limit",
         icon="mdi:transmission-tower",
         entity_category=EntityCategory.CONFIG,
         native_unit_of_measurement=POWER_WATT,
-        getter=lambda inv: inv.get_grid_export_limit(),
-        setter=lambda inv, val: inv.set_grid_export_limit(val),
         native_step=100,
         native_min_value=0,
         native_max_value=10000,
+        getter=lambda inv: inv.get_grid_export_limit(),
+        setter=lambda inv, val: inv.set_grid_export_limit(val),
+        filter=lambda inv: type(inv).__name__ != "DT",
+    ),
+    # DT inverters (limit is in %)
+    GoodweNumberEntityDescription(
+        key="grid_export_limit",
+        name="Grid export limit",
+        icon="mdi:transmission-tower",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=PERCENTAGE,
+        native_step=1,
+        native_min_value=0,
+        native_max_value=100,
+        getter=lambda inv: inv.get_grid_export_limit(),
+        setter=lambda inv, val: inv.set_grid_export_limit(val),
+        filter=lambda inv: type(inv).__name__ == "DT",
     ),
     GoodweNumberEntityDescription(
         key="battery_discharge_depth",
@@ -53,11 +70,12 @@ NUMBERS = (
         icon="mdi:battery-arrow-down",
         entity_category=EntityCategory.CONFIG,
         native_unit_of_measurement=PERCENTAGE,
-        getter=lambda inv: inv.get_ongrid_battery_dod(),
-        setter=lambda inv, val: inv.set_ongrid_battery_dod(val),
         native_step=1,
         native_min_value=0,
         native_max_value=99,
+        getter=lambda inv: inv.get_ongrid_battery_dod(),
+        setter=lambda inv, val: inv.set_ongrid_battery_dod(val),
+        filter=lambda inv: True,
     ),
 )
 
@@ -73,7 +91,7 @@ async def async_setup_entry(
 
     entities = []
 
-    for description in NUMBERS:
+    for description in filter(lambda dsc: dsc.filter(inverter), NUMBERS):
         try:
             current_value = await description.getter(inverter)
         except (InverterError, ValueError):
@@ -82,7 +100,7 @@ async def async_setup_entry(
             continue
 
         entities.append(
-            InverterNumberEntity(device_info, description, inverter, current_value),
+            InverterNumberEntity(device_info, description, inverter, current_value)
         )
 
     async_add_entities(entities)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Unlike other inverters models, DT family of inverters does not use exact power (in W) in their 'grid_export_limit' parameter,
but uses percentage of their nominal output.
Fix the grid_export_limit related select entity to use proper unit and limits for DT inverters.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
