### PR TITLE
Add alarmed binary sensor to Risco integration

### DIFF
--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -100,7 +100,7 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
 
     async def _zone(zone_id: int, zone: Zone) -> None:
         _LOGGER.debug("Risco zone update for %d", zone_id)
-        dispatcher_send(hass, zone_update_signal(zone_id))
+        async_dispatcher_send(hass, zone_update_signal(zone_id))
 
     entry.async_on_unload(risco.add_zone_handler(_zone))
 

--- a/homeassistant/components/risco/binary_sensor.py
+++ b/homeassistant/components/risco/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Risco alarm zones."""
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import Any
 
 from pyrisco.common import Zone
@@ -24,6 +24,10 @@ SERVICE_BYPASS_ZONE = "bypass_zone"
 SERVICE_UNBYPASS_ZONE = "unbypass_zone"
 
 
+def _unique_id_for_local(system_id: str, zone_id: int) -> str:
+    return f"{system_id}_zone_{zone_id}_local"
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -39,9 +43,11 @@ async def async_setup_entry(
     if is_local(config_entry):
         local_data: LocalData = hass.data[DOMAIN][config_entry.entry_id]
         async_add_entities(
-            RiscoLocalBinarySensor(
-                local_data.system.id, zone_id, zone, local_data.zone_updates
-            )
+            RiscoLocalBinarySensor(local_data, zone_id, zone)
+            for zone_id, zone in local_data.system.zones.items()
+        )
+        async_add_entities(
+            RiscoLocalAlarmedBinarySensor(local_data, zone_id, zone)
             for zone_id, zone in local_data.system.zones.items()
         )
     else:
@@ -118,18 +124,11 @@ class RiscoLocalBinarySensor(RiscoBinarySensor):
 
     _attr_should_poll = False
 
-    def __init__(
-        self,
-        system_id: str,
-        zone_id: int,
-        zone: Zone,
-        zone_updates: dict[int, Callable[[], Any]],
-    ) -> None:
+    def __init__(self, local_data: LocalData, zone_id: int, zone: Zone) -> None:
         """Init the zone."""
         super().__init__(zone_id=zone_id, zone=zone)
-        self._system_id = system_id
-        self._zone_updates = zone_updates
-        self._attr_unique_id = f"{system_id}_zone_{zone_id}_local"
+        self._local_data = local_data
+        self._attr_unique_id = _unique_id_for_local(local_data.system.id, zone_id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Risco",
@@ -138,7 +137,7 @@ class RiscoLocalBinarySensor(RiscoBinarySensor):
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
-        self._zone_updates[self._zone_id] = self.async_write_ha_state
+        self.async_on_remove(self._local_data.add_zone_entity(self._zone_id, self))
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
@@ -150,3 +149,39 @@ class RiscoLocalBinarySensor(RiscoBinarySensor):
 
     async def _bypass(self, bypass: bool) -> None:
         await self._zone.bypass(bypass)
+
+
+class RiscoLocalAlarmedBinarySensor(BinarySensorEntity):
+    """Representation whether a zone in Risco local is currently triggering an alarm."""
+
+    _attr_should_poll = False
+
+    def __init__(self, local_data: LocalData, zone_id: int, zone: Zone) -> None:
+        """Init the zone."""
+        super().__init__()
+        self._local_data = local_data
+        self._zone_id = zone_id
+        self._zone = zone
+        self._attr_has_entity_name = True
+        self._attr_name = "Alarmed"
+        device_unique_id = _unique_id_for_local(local_data.system.id, zone_id)
+        self._attr_unique_id = device_unique_id + "_alarmed"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_unique_id)},
+            manufacturer="Risco",
+            name=self._zone.name,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to updates."""
+        self.async_on_remove(self._local_data.add_zone_entity(self._zone_id, self))
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return the state attributes."""
+        return {"zone_id": self._zone_id}
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if sensor is on."""
+        return self._zone.alarmed

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -167,6 +167,7 @@ async def _check_local_state(
         new_callable=PropertyMock(return_value=bypassed),
     ):
         await callback(zone_id, zones[zone_id])
+        await hass.async_block_till_done()
 
         expected_triggered = STATE_ON if triggered else STATE_OFF
         assert hass.states.get(entity_id).state == expected_triggered
@@ -183,6 +184,7 @@ async def _check_alarmed_local_state(
         new_callable=PropertyMock(return_value=alarmed),
     ):
         await callback(zone_id, zones[zone_id])
+        await hass.async_block_till_done()
 
         expected_alarmed = STATE_ON if alarmed else STATE_OFF
         assert hass.states.get(entity_id).state == expected_alarmed

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -13,6 +13,8 @@ from .util import TEST_SITE_UUID, zone_mock
 
 FIRST_ENTITY_ID = "binary_sensor.zone_0"
 SECOND_ENTITY_ID = "binary_sensor.zone_1"
+FIRST_ALARMED_ENTITY_ID = FIRST_ENTITY_ID + "_alarmed"
+SECOND_ALARMED_ENTITY_ID = SECOND_ENTITY_ID + "_alarmed"
 
 
 @pytest.fixture
@@ -24,9 +26,13 @@ def two_zone_local():
     ), patch.object(
         zone_mocks[0], "name", new_callable=PropertyMock(return_value="Zone 0")
     ), patch.object(
+        zone_mocks[0], "alarmed", new_callable=PropertyMock(return_value=False)
+    ), patch.object(
         zone_mocks[1], "id", new_callable=PropertyMock(return_value=1)
     ), patch.object(
         zone_mocks[1], "name", new_callable=PropertyMock(return_value="Zone 1")
+    ), patch.object(
+        zone_mocks[1], "alarmed", new_callable=PropertyMock(return_value=False)
     ), patch(
         "homeassistant.components.risco.RiscoLocal.partitions",
         new_callable=PropertyMock(return_value={}),
@@ -126,6 +132,8 @@ async def test_error_on_connect(hass, connect_with_error, local_config_entry):
     registry = er.async_get(hass)
     assert not registry.async_is_registered(FIRST_ENTITY_ID)
     assert not registry.async_is_registered(SECOND_ENTITY_ID)
+    assert not registry.async_is_registered(FIRST_ALARMED_ENTITY_ID)
+    assert not registry.async_is_registered(SECOND_ALARMED_ENTITY_ID)
 
 
 async def test_local_setup(hass, two_zone_local, setup_risco_local):
@@ -133,6 +141,8 @@ async def test_local_setup(hass, two_zone_local, setup_risco_local):
     registry = er.async_get(hass)
     assert registry.async_is_registered(FIRST_ENTITY_ID)
     assert registry.async_is_registered(SECOND_ENTITY_ID)
+    assert registry.async_is_registered(FIRST_ALARMED_ENTITY_ID)
+    assert registry.async_is_registered(SECOND_ALARMED_ENTITY_ID)
 
     registry = dr.async_get(hass)
     device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_0_local")})
@@ -161,6 +171,21 @@ async def _check_local_state(
         expected_triggered = STATE_ON if triggered else STATE_OFF
         assert hass.states.get(entity_id).state == expected_triggered
         assert hass.states.get(entity_id).attributes["bypassed"] == bypassed
+        assert hass.states.get(entity_id).attributes["zone_id"] == zone_id
+
+
+async def _check_alarmed_local_state(
+    hass, zones, alarmed, entity_id, zone_id, callback
+):
+    with patch.object(
+        zones[zone_id],
+        "alarmed",
+        new_callable=PropertyMock(return_value=alarmed),
+    ):
+        await callback(zone_id, zones[zone_id])
+
+        expected_alarmed = STATE_ON if alarmed else STATE_OFF
+        assert hass.states.get(entity_id).state == expected_alarmed
         assert hass.states.get(entity_id).attributes["zone_id"] == zone_id
 
 
@@ -201,6 +226,28 @@ async def test_local_states(
     )
     await _check_local_state(
         hass, two_zone_local, False, False, SECOND_ENTITY_ID, 1, callback
+    )
+
+
+async def test_alarmed_local_states(
+    hass, two_zone_local, _mock_zone_handler, setup_risco_local
+):
+    """Test the various alarm states."""
+    callback = _mock_zone_handler.call_args.args[0]
+
+    assert callback is not None
+
+    await _check_alarmed_local_state(
+        hass, two_zone_local, True, FIRST_ALARMED_ENTITY_ID, 0, callback
+    )
+    await _check_alarmed_local_state(
+        hass, two_zone_local, False, FIRST_ALARMED_ENTITY_ID, 0, callback
+    )
+    await _check_alarmed_local_state(
+        hass, two_zone_local, True, SECOND_ALARMED_ENTITY_ID, 1, callback
+    )
+    await _check_alarmed_local_state(
+        hass, two_zone_local, False, SECOND_ALARMED_ENTITY_ID, 1, callback
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on the [introduction of the local version of the Risco integration](https://github.com/home-assistant/core/pull/75874), this PR adds an `alarmed` binary sensor to the local version, which is on when the relevant zone is triggering an alarm.

The cloud version doesn't have a direct equivalent, but this information can be obtained through events (which aren't supported in the local version), so this (sort of) promotes feature parity. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24315

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
