### PR TITLE
Allow override of Sonos event port

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -48,6 +48,7 @@ from .speaker import SonosSpeaker
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ADVERTISE_ADDR = "advertise_addr"
+CONF_LISTENER_PORT = "listener_port"
 CONF_INTERFACE_ADDR = "interface_addr"
 DISCOVERY_IGNORED_MODELS = ["Sonos Boost"]
 
@@ -61,6 +62,7 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Schema(
                         {
                             vol.Optional(CONF_ADVERTISE_ADDR): cv.string,
+                            vol.Optional(CONF_LISTENER_PORT): cv.port,
                             vol.Optional(CONF_INTERFACE_ADDR): cv.string,
                             vol.Optional(CONF_HOSTS): vol.All(
                                 cv.ensure_list_csv, [cv.string]
@@ -132,6 +134,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if advertise_addr := config.get(CONF_ADVERTISE_ADDR):
         soco_config.EVENT_ADVERTISE_IP = advertise_addr
+
+    if listener_port := config.get(CONF_LISTENER_PORT):
+        soco_config.EVENT_LISTENER_PORT = listener_port
 
     if deprecated_address := config.get(CONF_INTERFACE_ADDR):
         _LOGGER.warning(

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -45,7 +45,7 @@ async def test_configuring_sonos_creates_entry(hass: core.HomeAssistant):
         await async_setup_component(
             hass,
             sonos.DOMAIN,
-            {"sonos": {"media_player": {"interface_addr": "127.0.0.1"}}},
+            {"sonos": {"media_player": {"interface_addr": "127.0.0.1", "listener_port": 1234}}},
         )
         await hass.async_block_till_done()
 

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -45,7 +45,14 @@ async def test_configuring_sonos_creates_entry(hass: core.HomeAssistant):
         await async_setup_component(
             hass,
             sonos.DOMAIN,
-            {"sonos": {"media_player": {"interface_addr": "127.0.0.1", "listener_port": 1234}}},
+            {
+                "sonos": {
+                    "media_player": {
+                        "interface_addr": "127.0.0.1",
+                        "listener_port": 1234,
+                    }
+                }
+            },
         )
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The current Sonos integration opens a port on the host to allow the Sonos system to callback with events. The underlying library, SoCo, uses a default port of 1400 and allows overriding of this port via configuration, but that configuration is not surfaced in the Home Assistant integration. This pull request adds a new configuration option, `listener_port`, to allow overriding of the SoCo event port.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23890

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
