### PR TITLE
Fix Tuya mc device support

### DIFF
--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -187,8 +187,9 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
     # https://developer.tuya.com/en/docs/iot/s?id=K9gf48r5zjsy9
     "mc": (
         TuyaBinarySensorEntityDescription(
-            key=DPCode.DOORCONTACT_STATE,
+            key=DPCode.STATUS,
             device_class=BinarySensorDeviceClass.DOOR,
+            on_value="open",
         ),
     ),
     # Door Window Sensor

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -1,7 +1,6 @@
 """Support for Tuya binary sensors."""
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 
 from tuya_iot import TuyaDevice, TuyaDeviceManager
@@ -30,7 +29,7 @@ class TuyaBinarySensorEntityDescription(BinarySensorEntityDescription):
     dpcode: DPCode | None = None
 
     # Value or values to consider binary sensor to be "on"
-    on_value: bool | float | int | str | Sequence = True
+    on_value: bool | float | int | str | set[bool | float | int | str] = True
 
 
 # Commonly used sensors
@@ -190,7 +189,7 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
         TuyaBinarySensorEntityDescription(
             key=DPCode.STATUS,
             device_class=BinarySensorDeviceClass.DOOR,
-            on_value=["open", "opened"],
+            on_value={"open", "opened"},
         ),
     ),
     # Door Window Sensor
@@ -396,9 +395,7 @@ class TuyaBinarySensorEntity(TuyaEntity, BinarySensorEntity):
         if dpcode not in self.device.status:
             return False
 
-        if isinstance(self.entity_description.on_value, Sequence) and not isinstance(
-            self.entity_description.on_value, str
-        ):
+        if isinstance(self.entity_description.on_value, set):
             return self.device.status[dpcode] in self.entity_description.on_value
 
         return self.device.status[dpcode] == self.entity_description.on_value


### PR DESCRIPTION
## Proposed change
The support for mc devices introduced in #66044 assumed the response format would be identical to that of mcs devices. Turns out this is actually not the case – at least not currently (unfortunately there is no version history on the [Tuya mc docs](https://developer.tuya.com/en/docs/iot/s?id=K9gf48r5zjsy9), so I don't know if/when this changed).

This PR updates the binary door sensor entity for a device of the mc category to the response format described in the [Tuya mc docs](https://developer.tuya.com/en/docs/iot/s?id=K9gf48r5zjsy9) (the different response format used by mcs devices is [here](https://developer.tuya.com/en/docs/iot/s?id=K9gf48hm02l8m) for reference). I have tested this against my own mc device, which now works as expected.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
