### PR TITLE
Fix trait processing Fan state without percentage_step

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1397,7 +1397,9 @@ class FanSpeedTrait(_Trait):
         if state.domain == fan.DOMAIN:
             speed_count = min(
                 FAN_SPEED_MAX_SPEED_COUNT,
-                round(100 / (self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP) or 1.0)),
+                round(
+                    100 / (self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP) or 1.0)
+                ),
             )
             self._ordered_speed = [
                 f"{speed}/{speed_count}" for speed in range(1, speed_count + 1)

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1397,7 +1397,7 @@ class FanSpeedTrait(_Trait):
         if state.domain == fan.DOMAIN:
             speed_count = min(
                 FAN_SPEED_MAX_SPEED_COUNT,
-                round(100 / self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP, 100)),
+                round(100 / (self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP) or 1.0)),
             )
             self._ordered_speed = [
                 f"{speed}/{speed_count}" for speed in range(1, speed_count + 1)

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1397,7 +1397,7 @@ class FanSpeedTrait(_Trait):
         if state.domain == fan.DOMAIN:
             speed_count = min(
                 FAN_SPEED_MAX_SPEED_COUNT,
-                round(100 / self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP) or 1.0),
+                round(100 / self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP, 100)),
             )
             self._ordered_speed = [
                 f"{speed}/{speed_count}" for speed in range(1, speed_count + 1)

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1640,7 +1640,7 @@ async def test_fan_speed_without_percentage_step(hass):
     # If a fan state has (temporary) no percentage_step attribute return 1 available
     assert trt.query_attributes() == {
         "currentFanSpeedPercent": 0,
-        "currentFanSpeedSetting": "1/1",
+        "currentFanSpeedSetting": "1/5",
     }
 
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1618,6 +1618,32 @@ async def test_fan_speed(hass):
     assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage": 10}
 
 
+async def test_fan_speed_without_percentage_step(hass):
+    """Test FanSpeed trait speed control percentage step for fan domain."""
+    assert helpers.get_google_type(fan.DOMAIN, None) is not None
+    assert trait.FanSpeedTrait.supported(fan.DOMAIN, fan.SUPPORT_SET_SPEED, None, None)
+
+    trt = trait.FanSpeedTrait(
+        hass,
+        State(
+            "fan.living_room_fan",
+            STATE_ON,
+        ),
+        BASIC_CONFIG,
+    )
+
+    assert trt.sync_attributes() == {
+        "reversible": False,
+        "supportsFanSpeedPercent": True,
+        "availableFanSpeeds": ANY,
+    }
+    # If a fan state has (temporary) no percentage_step attribute return 1 available
+    assert trt.query_attributes() == {
+        "currentFanSpeedPercent": 0,
+        "currentFanSpeedSetting": "1/1",
+    }
+
+
 @pytest.mark.parametrize(
     "percentage,percentage_step, speed, speeds, percentage_result",
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In some cases fan entities temporary can have a state without the `percentage_state` attribute. When the trait is queried the current code fails when this `percentage_state` attribute is temporary `None` (see example log).
This PR ensures that `one` speed returned in these cases.

Example log: 
```log
2022-08-26 09:53:14.007 ERROR (MainThread) [homeassistant.components.google_assistant.smart_home] Unexpected error
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/components/google_assistant/smart_home.py", line 58, in _process
    result = await handler(hass, data, inputs[0].get("payload"))
  File "/workspaces/core/homeassistant/components/google_assistant/smart_home.py", line 107, in async_devices_sync
    devices = await async_devices_sync_response(hass, data.config, agent_user_id)
  File "/workspaces/core/homeassistant/components/google_assistant/smart_home.py", line 76, in async_devices_sync_response
    entities = async_get_entities(hass, config)
  File "/workspaces/core/homeassistant/components/google_assistant/helpers.py", line 727, in async_get_entities
    if entity.is_supported():
  File "/workspaces/core/homeassistant/components/google_assistant/helpers.py", line 554, in is_supported
    bool(self.traits()),
  File "/workspaces/core/homeassistant/components/google_assistant/helpers.py", line 520, in traits
    self._traits = [
  File "/workspaces/core/homeassistant/components/google_assistant/helpers.py", line 521, in <listcomp>
    Trait(self.hass, state, self.config)
  File "/workspaces/core/homeassistant/components/google_assistant/trait.py", line 1400, in __init__
    round(100 / self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP) or 1.0),
TypeError: unsupported operand type(s) for /: 'int' and 'NoneType'
2022-08-26 09:53:14.009 ERROR (MainThread) [homeassistant.components.google_assistant.smart_home] Error handling message {'inputs': [{'intent': 'action.devices.SYNC'}], 'requestId': '17671037166343832099'}: {'errorCode': 'unknownError'}
2022-08-26 09:53:14.078 ERROR (MainThread) [homeassistant.components.google_assistant.http] Request for https://homegraph.googleapis.com/v1/devices:requestSync failed: 500
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
