### PR TITLE
Index bluetooth matchers to resolve performance concerns with many adapters/remotes

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -209,6 +209,7 @@ async def async_get_adapter_from_address(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the bluetooth integration."""
     integration_matcher = IntegrationMatcher(await async_get_bluetooth(hass))
+    integration_matcher.async_setup()
     manager = BluetoothManager(hass, integration_matcher)
     manager.async_setup()
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, manager.async_stop)

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -136,7 +136,6 @@ class BluetoothManager:
             str, list[Callable[[str], None]]
         ] = {}
         self._callback_index = BluetoothCallbackMatcherIndex()
-        self._connectable_callback_index = BluetoothCallbackMatcherIndex()
         self._bleak_callbacks: list[
             tuple[AdvertisementDataCallback, dict[str, set[str]]]
         ] = []
@@ -280,20 +279,10 @@ class BluetoothManager:
             matched_domains,
         )
 
-        callbacks: set[BluetoothCallback] = {
+        for callback in {
             match[CALLBACK]
-            for match in self._get_callback_index_by_type(False).match_callbacks(
-                service_info
-            )
-        }
-        if connectable:
-            callbacks.update(
-                match[CALLBACK]
-                for match in self._get_callback_index_by_type(True).match_callbacks(
-                    service_info
-                )
-            )
-        for callback in callbacks:
+            for match in self._callback_index.match_callbacks(service_info)
+        }:
             try:
                 callback(service_info, BluetoothChange.ADVERTISEMENT)
             except Exception:  # pylint: disable=broad-except
@@ -342,14 +331,13 @@ class BluetoothManager:
             callback_matcher[CONNECTABLE] = matcher.get(CONNECTABLE, True)
 
         connectable = callback_matcher[CONNECTABLE]
-        callback_index = self._get_callback_index_by_type(connectable)
-        callback_index.add_with_address(callback_matcher)
-        callback_index.build()
+        self._callback_index.add_with_address(callback_matcher)
+        self._callback_index.build()
 
         @hass_callback
         def _async_remove_callback() -> None:
-            callback_index.remove_with_address(callback_matcher)
-            callback_index.build()
+            self._callback_index.remove_with_address(callback_matcher)
+            self._callback_index.build()
 
         # If we have history for the subscriber, we can trigger the callback
         # immediately with the last packet so the subscriber can see the
@@ -413,12 +401,6 @@ class BluetoothManager:
     ) -> dict[str, BluetoothServiceInfoBleak]:
         """Return the history by type."""
         return self._connectable_history if connectable else self._history
-
-    def _get_callback_index_by_type(
-        self, connectable: bool
-    ) -> BluetoothCallbackMatcherIndex:
-        """Return the callbacks by type."""
-        return self._connectable_callback_index if connectable else self._callback_index
 
     def async_register_scanner(
         self, scanner: BaseHaScanner, connectable: bool

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -280,11 +280,19 @@ class BluetoothManager:
             matched_domains,
         )
 
-        callbacks: set[BluetoothCallback] = set()
-        for connectable_callback in (True, False):
-            callback_index = self._get_callback_index_by_type(connectable_callback)
-            for match in callback_index.match_callbacks(service_info):
-                callbacks.add(match[CALLBACK])
+        callbacks: set[BluetoothCallback] = {
+            match[CALLBACK]
+            for match in self._get_callback_index_by_type(False).match_callbacks(
+                service_info
+            )
+        }
+        if connectable:
+            callbacks.update(
+                match[CALLBACK]
+                for match in self._get_callback_index_by_type(True).match_callbacks(
+                    service_info
+                )
+            )
         for callback in callbacks:
             try:
                 callback(service_info, BluetoothChange.ADVERTISEMENT)

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -253,7 +253,7 @@ class BluetoothManager:
         device = service_info.device
         connectable = service_info.connectable
         address = device.address
-        all_history = self._get_history_by_type(connectable)
+        all_history = self._connectable_history if connectable else self._history
         old_service_info = all_history.get(address)
         if old_service_info and _prefer_previous_adv(old_service_info, service_info):
             return

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -328,12 +328,10 @@ class BluetoothManager:
 
         connectable = callback_matcher[CONNECTABLE]
         self._callback_index.add_with_address(callback_matcher)
-        self._callback_index.build()
 
         @hass_callback
         def _async_remove_callback() -> None:
             self._callback_index.remove_with_address(callback_matcher)
-            self._callback_index.build()
 
         # If we have history for the subscriber, we can trigger the callback
         # immediately with the last packet so the subscriber can see the

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -288,8 +288,6 @@ class BluetoothManager:
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Error in bluetooth callback")
 
-        if not matched_domains:
-            return
         for domain in matched_domains:
             discovery_flow.async_create_flow(
                 self.hass,

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -279,10 +279,8 @@ class BluetoothManager:
             matched_domains,
         )
 
-        for callback in {
-            match[CALLBACK]
-            for match in self._callback_index.match_callbacks(service_info)
-        }:
+        for match in self._callback_index.match_callbacks(service_info):
+            callback = match[CALLBACK]
             try:
                 callback(service_info, BluetoothChange.ADVERTISEMENT)
             except Exception:  # pylint: disable=broad-except

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -156,7 +156,7 @@ class BluetoothMatcherIndex:
     """Bluetooth matcher for the bluetooth integration.
 
     The indexer puts each matcher in the bucket that it is most
-    likely to matcher. This allows us to only check the service infos
+    likely to match. This allows us to only check the service infos
     against each bucket to see if we should match against the data.
 
     This is optimized for cases were no service infos will be matched in

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -117,17 +117,12 @@ class IntegrationMatcher:
         self._matched.pop(address, None)
         self._matched_connectable.pop(address, None)
 
-    def _get_matched_by_type(
-        self, connectable: bool
-    ) -> MutableMapping[str, IntegrationMatchHistory]:
-        """Return the matches by type."""
-        return self._matched_connectable if connectable else self._matched
-
     def match_domains(self, service_info: BluetoothServiceInfoBleak) -> set[str]:
         """Return the domains that are matched."""
         device = service_info.device
         advertisement_data = service_info.advertisement
-        matched = self._get_matched_by_type(service_info.connectable)
+        connectable = service_info.connectable
+        matched = self._matched_connectable if connectable else self._matched
         matched_domains: set[str] = set()
         if (previous_match := matched.get(device.address)) and seen_all_fields(
             previous_match, advertisement_data

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -171,7 +171,12 @@ class BluetoothMatcherIndex:
         self.manufacturer_id_set: set[int] = set()
 
     def add(self, matcher: _MatcherTypes) -> None:
-        """Add a matcher to the index."""
+        """Add a matcher to the index.
+
+        Matchers must end up only in one bucket.
+
+        We put them in the bucket that they are most likely to match.
+        """
         if LOCAL_NAME in matcher:
             self.local_name.setdefault(
                 _local_name_to_index_key(matcher[LOCAL_NAME]), []
@@ -195,7 +200,11 @@ class BluetoothMatcherIndex:
             return
 
     def remove(self, matcher: _MatcherTypes) -> None:
-        """Remove a matcher from the index."""
+        """Remove a matcher from the index.
+
+        Matchers only end up in one bucket, so once we have
+        removed one, we are done.
+        """
         if LOCAL_NAME in matcher:
             self.local_name[_local_name_to_index_key(matcher[LOCAL_NAME])].remove(
                 matcher
@@ -269,7 +278,12 @@ class BluetoothCallbackMatcherIndex(BluetoothMatcherIndex):
         self.address: dict[str, list[BluetoothCallbackMatcherWithCallback]] = {}
 
     def add_with_address(self, matcher: BluetoothCallbackMatcherWithCallback) -> None:
-        """Add a matcher to the index."""
+        """Add a matcher to the index.
+
+        Matchers must end up only in one bucket.
+
+        We put them in the bucket that they are most likely to match.
+        """
         if ADDRESS in matcher:
             self.address.setdefault(matcher[ADDRESS], []).append(matcher)
             return
@@ -279,7 +293,11 @@ class BluetoothCallbackMatcherIndex(BluetoothMatcherIndex):
     def remove_with_address(
         self, matcher: BluetoothCallbackMatcherWithCallback
     ) -> None:
-        """Remove a matcher from the index."""
+        """Remove a matcher from the index.
+
+        Matchers only end up in one bucket, so once we have
+        removed one, we are done.
+        """
         if ADDRESS in matcher:
             self.address[matcher[ADDRESS]].remove(matcher)
             return

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -165,10 +165,10 @@ class BluetoothMatcherIndex:
 
     def __init__(self) -> None:
         """Initialize the matcher index."""
-        self.local_name: dict[str, list[_MatcherTypes]] = {}
-        self.service_uuid: dict[str, list[_MatcherTypes]] = {}
-        self.service_data_uuid: dict[str, list[_MatcherTypes]] = {}
-        self.manufacturer_id: dict[int, list[_MatcherTypes]] = {}
+        self.local_name: dict[str, list[BluetoothMatcherOptional]] = {}
+        self.service_uuid: dict[str, list[BluetoothMatcherOptional]] = {}
+        self.service_data_uuid: dict[str, list[BluetoothMatcherOptional]] = {}
+        self.manufacturer_id: dict[int, list[BluetoothMatcherOptional]] = {}
         self.service_uuid_set: set[str] = set()
         self.service_data_uuid_set: set[str] = set()
         self.manufacturer_id_set: set[int] = set()
@@ -232,7 +232,9 @@ class BluetoothMatcherIndex:
         self.service_data_uuid_set = set(self.service_data_uuid)
         self.manufacturer_id_set = set(self.manufacturer_id)
 
-    def _match(self, service_info: BluetoothServiceInfoBleak) -> list[_MatcherTypes]:
+    def _match(
+        self, service_info: BluetoothServiceInfoBleak
+    ) -> list[BluetoothMatcherOptional]:
         """Check for a match."""
         matches = []
         if len(service_info.name) >= LOCAL_NAME_MIN_MATCH_LENGTH:
@@ -341,7 +343,7 @@ def _local_name_to_index_key(local_name: str) -> str:
 
 
 def ble_device_matches(
-    matcher: BluetoothMatcher | BluetoothCallbackMatcherWithCallback,
+    matcher: BluetoothMatcherOptional,
     service_info: BluetoothServiceInfoBleak,
 ) -> bool:
     """Check if a ble device and advertisement_data matches the matcher."""

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -158,7 +158,15 @@ _MatcherTypes = Union[BluetoothMatcher, BluetoothCallbackMatcherWithCallback]
 
 
 class BluetoothMatcherIndex:
-    """Bluetooth matcher for the bluetooth integration."""
+    """Bluetooth matcher for the bluetooth integration.
+
+    The indexer puts each matcher in the bucket that it is most
+    likely to matcher. This allows us to only check the service infos
+    against each bucket to see if we should match against the data.
+
+    This is optimized for cases were no service infos will be matched in
+    any bucket and we can quickly reject the service info as not matching.
+    """
 
     def __init__(self) -> None:
         """Initialize the matcher index."""

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -312,24 +312,15 @@ class BluetoothCallbackMatcherIndex(BluetoothMatcherIndex):
 
         super().remove(matcher)
 
-    def _match_addresses(
-        self, service_info: BluetoothServiceInfoBleak
-    ) -> list[BluetoothCallbackMatcherWithCallback]:
-        """Check for a match."""
-        return [
-            matcher
-            for matcher in self.address.get(service_info.address, [])
-            if ble_device_matches(matcher, service_info)
-        ]
-
     def match_callbacks(
         self, service_info: BluetoothServiceInfoBleak
     ) -> list[BluetoothCallbackMatcherWithCallback]:
         """Check for a match."""
-        return cast(
-            list[BluetoothCallbackMatcherWithCallback],
-            self._match(service_info).extend(self._match_addresses(service_info)),
-        )
+        matches = self._match(service_info)
+        for matcher in self.address.get(service_info.address, []):
+            if ble_device_matches(matcher, service_info):
+                matches.append(matcher)
+        return cast(list[BluetoothCallbackMatcherWithCallback], matches)
 
 
 def _local_name_to_index_key(local_name: str) -> str:

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -292,6 +292,7 @@ class BluetoothCallbackMatcherIndex(
             return
 
         super().add(matcher)
+        self.build()
 
     def remove_with_address(
         self, matcher: BluetoothCallbackMatcherWithCallback
@@ -306,6 +307,7 @@ class BluetoothCallbackMatcherIndex(
             return
 
         super().remove(matcher)
+        self.build()
 
     def match_callbacks(
         self, service_info: BluetoothServiceInfoBleak

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from fnmatch import translate
 from functools import lru_cache
-import logging
 import re
 from typing import TYPE_CHECKING, Final, TypedDict, Union, cast
 
@@ -34,8 +33,6 @@ MANUFACTURER_ID: Final = "manufacturer_id"
 MANUFACTURER_DATA_START: Final = "manufacturer_data_start"
 
 LOCAL_NAME_MIN_MATCH_LENGTH = 3
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class BluetoothCallbackMatcherOptional(TypedDict, total=False):
@@ -303,12 +300,15 @@ def _local_name_to_index_key(local_name: str) -> str:
     """
     if len(local_name) < LOCAL_NAME_MIN_MATCH_LENGTH:
         raise ValueError(
-            f"Local name matchers must be at least {LOCAL_NAME_MIN_MATCH_LENGTH} characters long ({local_name})"
+            "Local name matchers must be at least "
+            f"{LOCAL_NAME_MIN_MATCH_LENGTH} characters long ({local_name})"
         )
     match_part = local_name[:LOCAL_NAME_MIN_MATCH_LENGTH]
     if "*" in match_part or "[" in match_part:
         raise ValueError(
-            f"Local name matchers may not have wildcards in the first {LOCAL_NAME_MIN_MATCH_LENGTH} characters because they would match too broadly ({local_name})"
+            "Local name matchers may not have patterns in the first "
+            f"{LOCAL_NAME_MIN_MATCH_LENGTH} characters because they "
+            f"would match too broadly ({local_name})"
         )
     return match_part
 

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -319,10 +319,7 @@ class BluetoothCallbackMatcherIndex(BluetoothMatcherIndex):
         return [
             matcher
             for matcher in self.address.get(service_info.address, [])
-            # Shortcut the match if the matcher is only looking for a specific address
-            # and connectable
-            if set(matcher) == {ADDRESS, CONNECTABLE}
-            or ble_device_matches(matcher, service_info)
+            if ble_device_matches(matcher, service_info)
         ]
 
     def match_callbacks(

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -176,16 +176,23 @@ class BluetoothMatcherIndex:
             self.local_name.setdefault(
                 _local_name_to_index_key(matcher[LOCAL_NAME]), []
             ).append(matcher)
+            return
+
         if SERVICE_UUID in matcher:
             self.service_uuid.setdefault(matcher[SERVICE_UUID], []).append(matcher)
+            return
+
         if SERVICE_DATA_UUID in matcher:
             self.service_data_uuid.setdefault(matcher[SERVICE_DATA_UUID], []).append(
                 matcher
             )
+            return
+
         if MANUFACTURER_ID in matcher:
             self.manufacturer_id.setdefault(matcher[MANUFACTURER_ID], []).append(
                 matcher
             )
+            return
 
     def remove(self, matcher: _MatcherTypes) -> None:
         """Remove a matcher from the index."""
@@ -193,12 +200,19 @@ class BluetoothMatcherIndex:
             self.local_name[_local_name_to_index_key(matcher[LOCAL_NAME])].remove(
                 matcher
             )
+            return
+
         if SERVICE_UUID in matcher:
             self.service_uuid[matcher[SERVICE_UUID]].remove(matcher)
+            return
+
         if SERVICE_DATA_UUID in matcher:
             self.service_data_uuid[matcher[SERVICE_DATA_UUID]].remove(matcher)
+            return
+
         if MANUFACTURER_ID in matcher:
             self.manufacturer_id[matcher[MANUFACTURER_ID]].remove(matcher)
+            return
 
     def build(self) -> None:
         """Rebuild the index sets."""
@@ -258,6 +272,8 @@ class BluetoothCallbackMatcherIndex(BluetoothMatcherIndex):
         """Add a matcher to the index."""
         if ADDRESS in matcher:
             self.address.setdefault(matcher[ADDRESS], []).append(matcher)
+            return
+
         super().add(matcher)
 
     def remove_with_address(
@@ -266,6 +282,8 @@ class BluetoothCallbackMatcherIndex(BluetoothMatcherIndex):
         """Remove a matcher from the index."""
         if ADDRESS in matcher:
             self.address[matcher[ADDRESS]].remove(matcher)
+            return
+
         super().remove(matcher)
 
     def _match_addresses(
@@ -319,8 +337,10 @@ def ble_device_matches(
 ) -> bool:
     """Check if a ble device and advertisement_data matches the matcher."""
     device = service_info.device
-    if (address := matcher.get(ADDRESS)) is not None and device.address != address:
-        return False
+
+    # Do don't check address here since all callers already
+    # check the address and we don't want to double check
+    # since it would result in an unreachable reject case.
 
     if matcher.get(CONNECTABLE, True) and not service_info.connectable:
         return False

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -374,28 +374,26 @@ def ble_device_matches(
     advertisement_data = service_info.advertisement
     if (
         service_uuid := matcher.get(SERVICE_UUID)
-    ) is not None and service_uuid not in advertisement_data.service_uuids:
+    ) and service_uuid not in advertisement_data.service_uuids:
         return False
 
     if (
         service_data_uuid := matcher.get(SERVICE_DATA_UUID)
-    ) is not None and service_data_uuid not in advertisement_data.service_data:
+    ) and service_data_uuid not in advertisement_data.service_data:
         return False
 
-    if (
-        manfacturer_id := matcher.get(MANUFACTURER_ID)
-    ) is not None and manfacturer_id not in advertisement_data.manufacturer_data:
-        return False
-
-    if (manufacturer_data_start := matcher.get(MANUFACTURER_DATA_START)) is not None:
-        manufacturer_data_start_bytes = bytearray(manufacturer_data_start)
-        if not any(
-            manufacturer_data.startswith(manufacturer_data_start_bytes)
-            for manufacturer_data in advertisement_data.manufacturer_data.values()
-        ):
+    if manfacturer_id := matcher.get(MANUFACTURER_ID):
+        if manfacturer_id not in advertisement_data.manufacturer_data:
             return False
+        if manufacturer_data_start := matcher.get(MANUFACTURER_DATA_START):
+            manufacturer_data_start_bytes = bytearray(manufacturer_data_start)
+            if not any(
+                manufacturer_data.startswith(manufacturer_data_start_bytes)
+                for manufacturer_data in advertisement_data.manufacturer_data.values()
+            ):
+                return False
 
-    if (local_name := matcher.get(LOCAL_NAME)) is not None and (
+    if (local_name := matcher.get(LOCAL_NAME)) and (
         (device_name := advertisement_data.local_name or device.name) is None
         or not _memorized_fnmatch(
             device_name,

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -331,7 +331,7 @@ class BluetoothCallbackMatcherIndex(BluetoothMatcherIndex):
         """Check for a match."""
         return cast(
             list[BluetoothCallbackMatcherWithCallback],
-            [*super()._match(service_info), *self._match_addresses(service_info)],
+            self._match(service_info).extend(self._match_addresses(service_info)),
         )
 
 

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -26,6 +26,13 @@ from homeassistant.components.bluetooth.const import (
     SOURCE_LOCAL,
     UNAVAILABLE_TRACK_SECONDS,
 )
+from homeassistant.components.bluetooth.match import (
+    ADDRESS,
+    LOCAL_NAME,
+    MANUFACTURER_ID,
+    SERVICE_DATA_UUID,
+    SERVICE_UUID,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
@@ -987,8 +994,6 @@ async def test_register_callbacks(hass, mock_bleak_scanner_start, enable_bluetoo
     ) -> None:
         """Fake subscriber for the BleakScanner."""
         callbacks.append((service_info, change))
-        if len(callbacks) >= 3:
-            raise ValueError
 
     with patch(
         "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
@@ -1001,7 +1006,7 @@ async def test_register_callbacks(hass, mock_bleak_scanner_start, enable_bluetoo
         cancel = bluetooth.async_register_callback(
             hass,
             _fake_subscriber,
-            {"service_uuids": {"cba20d00-224d-11e6-9fb8-0002a5d5c51b"}},
+            {SERVICE_UUID: "cba20d00-224d-11e6-9fb8-0002a5d5c51b"},
             BluetoothScanningMode.ACTIVE,
         )
 
@@ -1026,17 +1031,15 @@ async def test_register_callbacks(hass, mock_bleak_scanner_start, enable_bluetoo
         empty_device = BLEDevice("11:22:33:44:55:66", "empty")
         empty_adv = AdvertisementData(local_name="empty")
 
-        # 3rd callback raises ValueError but is still tracked
         inject_advertisement(hass, empty_device, empty_adv)
         await hass.async_block_till_done()
 
         cancel()
 
-        # 4th callback should not be tracked since we canceled
         inject_advertisement(hass, empty_device, empty_adv)
         await hass.async_block_till_done()
 
-    assert len(callbacks) == 3
+    assert len(callbacks) == 1
 
     service_info: BluetoothServiceInfo = callbacks[0][0]
     assert service_info.name == "wohand"
@@ -1044,17 +1047,63 @@ async def test_register_callbacks(hass, mock_bleak_scanner_start, enable_bluetoo
     assert service_info.manufacturer == "Nordic Semiconductor ASA"
     assert service_info.manufacturer_id == 89
 
-    service_info: BluetoothServiceInfo = callbacks[1][0]
-    assert service_info.name == "empty"
-    assert service_info.source == SOURCE_LOCAL
-    assert service_info.manufacturer is None
-    assert service_info.manufacturer_id is None
 
-    service_info: BluetoothServiceInfo = callbacks[2][0]
-    assert service_info.name == "empty"
+async def test_register_callbacks_raises_exception(
+    hass, mock_bleak_scanner_start, enable_bluetooth, caplog
+):
+    """Test registering a callback that raises ValueError."""
+    mock_bt = []
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo,
+        change: BluetoothChange,
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+        raise ValueError
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ), patch.object(hass.config_entries.flow, "async_init"):
+        await async_setup_with_default_adapter(hass)
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        cancel = bluetooth.async_register_callback(
+            hass,
+            _fake_subscriber,
+            {SERVICE_UUID: "cba20d00-224d-11e6-9fb8-0002a5d5c51b"},
+            BluetoothScanningMode.ACTIVE,
+        )
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_adv = AdvertisementData(
+            local_name="wohand",
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+            manufacturer_data={89: b"\xd8.\xad\xcd\r\x85"},
+            service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x10c"},
+        )
+
+        inject_advertisement(hass, switchbot_device, switchbot_adv)
+
+        cancel()
+
+        inject_advertisement(hass, switchbot_device, switchbot_adv)
+        await hass.async_block_till_done()
+
+    assert len(callbacks) == 1
+
+    service_info: BluetoothServiceInfo = callbacks[0][0]
+    assert service_info.name == "wohand"
     assert service_info.source == SOURCE_LOCAL
-    assert service_info.manufacturer is None
-    assert service_info.manufacturer_id is None
+    assert service_info.manufacturer == "Nordic Semiconductor ASA"
+    assert service_info.manufacturer_id == 89
+
+    assert "ValueError" in caplog.text
 
 
 async def test_register_callback_by_address(
@@ -1124,7 +1173,7 @@ async def test_register_callback_by_address(
         cancel = bluetooth.async_register_callback(
             hass,
             _fake_subscriber,
-            {"address": "44:44:33:11:23:45"},
+            {ADDRESS: "44:44:33:11:23:45"},
             BluetoothScanningMode.ACTIVE,
         )
         cancel()
@@ -1134,7 +1183,7 @@ async def test_register_callback_by_address(
         cancel = bluetooth.async_register_callback(
             hass,
             _fake_subscriber,
-            {"address": "44:44:33:11:23:45"},
+            {ADDRESS: "44:44:33:11:23:45"},
             BluetoothScanningMode.ACTIVE,
         )
         cancel()
@@ -1146,6 +1195,415 @@ async def test_register_callback_by_address(
         assert service_info.name == "wohand"
         assert service_info.manufacturer == "Nordic Semiconductor ASA"
         assert service_info.manufacturer_id == 89
+
+
+async def test_register_callback_by_manufacturer_id(
+    hass, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Test registering a callback by manufacturer_id."""
+    mock_bt = []
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo, change: BluetoothChange
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+
+    with patch.object(hass.config_entries.flow, "async_init"):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        cancel = bluetooth.async_register_callback(
+            hass,
+            _fake_subscriber,
+            {MANUFACTURER_ID: 76},
+            BluetoothScanningMode.ACTIVE,
+        )
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        apple_device = BLEDevice("44:44:33:11:23:45", "apple")
+        apple_adv = AdvertisementData(
+            local_name="apple",
+            manufacturer_data={76: b"\xd8.\xad\xcd\r\x85"},
+        )
+
+        inject_advertisement(hass, apple_device, apple_adv)
+
+        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_adv = AdvertisementData(local_name="empty")
+
+        inject_advertisement(hass, empty_device, empty_adv)
+        await hass.async_block_till_done()
+
+        cancel()
+
+    assert len(callbacks) == 1
+
+    service_info: BluetoothServiceInfo = callbacks[0][0]
+    assert service_info.name == "apple"
+    assert service_info.manufacturer == "Apple, Inc."
+    assert service_info.manufacturer_id == 76
+
+
+async def test_register_callback_by_manufacturer_id_and_address(
+    hass, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Test registering a callback by manufacturer_id and address."""
+    mock_bt = []
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo, change: BluetoothChange
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+
+    with patch.object(hass.config_entries.flow, "async_init"):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        cancel = bluetooth.async_register_callback(
+            hass,
+            _fake_subscriber,
+            {MANUFACTURER_ID: 76, ADDRESS: "44:44:33:11:23:45"},
+            BluetoothScanningMode.ACTIVE,
+        )
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        apple_device = BLEDevice("44:44:33:11:23:45", "apple")
+        apple_adv = AdvertisementData(
+            local_name="apple",
+            manufacturer_data={76: b"\xd8.\xad\xcd\r\x85"},
+        )
+
+        inject_advertisement(hass, apple_device, apple_adv)
+
+        yale_device = BLEDevice("44:44:33:11:23:45", "apple")
+        yale_adv = AdvertisementData(
+            local_name="yale",
+            manufacturer_data={465: b"\xd8.\xad\xcd\r\x85"},
+        )
+
+        inject_advertisement(hass, yale_device, yale_adv)
+        await hass.async_block_till_done()
+
+        other_apple_device = BLEDevice("44:44:33:11:23:22", "apple")
+        other_apple_adv = AdvertisementData(
+            local_name="apple",
+            manufacturer_data={76: b"\xd8.\xad\xcd\r\x85"},
+        )
+        inject_advertisement(hass, other_apple_device, other_apple_adv)
+
+        cancel()
+
+    assert len(callbacks) == 1
+
+    service_info: BluetoothServiceInfo = callbacks[0][0]
+    assert service_info.name == "apple"
+    assert service_info.manufacturer == "Apple, Inc."
+    assert service_info.manufacturer_id == 76
+
+
+async def test_register_callback_by_service_uuid_and_address(
+    hass, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Test registering a callback by service_uuid and address."""
+    mock_bt = []
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo, change: BluetoothChange
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+
+    with patch.object(hass.config_entries.flow, "async_init"):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        cancel = bluetooth.async_register_callback(
+            hass,
+            _fake_subscriber,
+            {
+                SERVICE_UUID: "cba20d00-224d-11e6-9fb8-0002a5d5c51b",
+                ADDRESS: "44:44:33:11:23:45",
+            },
+            BluetoothScanningMode.ACTIVE,
+        )
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        switchbot_dev = BLEDevice("44:44:33:11:23:45", "switchbot")
+        switchbot_adv = AdvertisementData(
+            local_name="switchbot",
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        )
+
+        inject_advertisement(hass, switchbot_dev, switchbot_adv)
+
+        switchbot_missing_service_uuid_dev = BLEDevice("44:44:33:11:23:45", "switchbot")
+        switchbot_missing_service_uuid_adv = AdvertisementData(
+            local_name="switchbot",
+        )
+
+        inject_advertisement(
+            hass, switchbot_missing_service_uuid_dev, switchbot_missing_service_uuid_adv
+        )
+        await hass.async_block_till_done()
+
+        service_uuid_wrong_address_dev = BLEDevice("44:44:33:11:23:22", "switchbot2")
+        service_uuid_wrong_address_adv = AdvertisementData(
+            local_name="switchbot2",
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        )
+        inject_advertisement(
+            hass, service_uuid_wrong_address_dev, service_uuid_wrong_address_adv
+        )
+
+        cancel()
+
+    assert len(callbacks) == 1
+
+    service_info: BluetoothServiceInfo = callbacks[0][0]
+    assert service_info.name == "switchbot"
+
+
+async def test_register_callback_by_service_data_uuid_and_address(
+    hass, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Test registering a callback by service_data_uuid and address."""
+    mock_bt = []
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo, change: BluetoothChange
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+
+    with patch.object(hass.config_entries.flow, "async_init"):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        cancel = bluetooth.async_register_callback(
+            hass,
+            _fake_subscriber,
+            {
+                SERVICE_DATA_UUID: "cba20d00-224d-11e6-9fb8-0002a5d5c51b",
+                ADDRESS: "44:44:33:11:23:45",
+            },
+            BluetoothScanningMode.ACTIVE,
+        )
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        switchbot_dev = BLEDevice("44:44:33:11:23:45", "switchbot")
+        switchbot_adv = AdvertisementData(
+            local_name="switchbot",
+            service_data={"cba20d00-224d-11e6-9fb8-0002a5d5c51b": b"x"},
+        )
+
+        inject_advertisement(hass, switchbot_dev, switchbot_adv)
+
+        switchbot_missing_service_uuid_dev = BLEDevice("44:44:33:11:23:45", "switchbot")
+        switchbot_missing_service_uuid_adv = AdvertisementData(
+            local_name="switchbot",
+        )
+
+        inject_advertisement(
+            hass, switchbot_missing_service_uuid_dev, switchbot_missing_service_uuid_adv
+        )
+        await hass.async_block_till_done()
+
+        service_uuid_wrong_address_dev = BLEDevice("44:44:33:11:23:22", "switchbot2")
+        service_uuid_wrong_address_adv = AdvertisementData(
+            local_name="switchbot2",
+            service_data={"cba20d00-224d-11e6-9fb8-0002a5d5c51b": b"x"},
+        )
+        inject_advertisement(
+            hass, service_uuid_wrong_address_dev, service_uuid_wrong_address_adv
+        )
+
+        cancel()
+
+    assert len(callbacks) == 1
+
+    service_info: BluetoothServiceInfo = callbacks[0][0]
+    assert service_info.name == "switchbot"
+
+
+async def test_register_callback_by_local_name(
+    hass, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Test registering a callback by local_name."""
+    mock_bt = []
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo, change: BluetoothChange
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+
+    with patch.object(hass.config_entries.flow, "async_init"):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        cancel = bluetooth.async_register_callback(
+            hass,
+            _fake_subscriber,
+            {LOCAL_NAME: "apple"},
+            BluetoothScanningMode.ACTIVE,
+        )
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        apple_device = BLEDevice("44:44:33:11:23:45", "apple")
+        apple_adv = AdvertisementData(
+            local_name="apple",
+            manufacturer_data={76: b"\xd8.\xad\xcd\r\x85"},
+        )
+
+        inject_advertisement(hass, apple_device, apple_adv)
+
+        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_adv = AdvertisementData(local_name="empty")
+
+        inject_advertisement(hass, empty_device, empty_adv)
+
+        apple_device_2 = BLEDevice("44:44:33:11:23:45", "apple")
+        apple_adv_2 = AdvertisementData(
+            local_name="apple2",
+            manufacturer_data={76: b"\xd8.\xad\xcd\r\x85"},
+        )
+        inject_advertisement(hass, apple_device_2, apple_adv_2)
+
+        await hass.async_block_till_done()
+
+        cancel()
+
+    assert len(callbacks) == 1
+
+    service_info: BluetoothServiceInfo = callbacks[0][0]
+    assert service_info.name == "apple"
+    assert service_info.manufacturer == "Apple, Inc."
+    assert service_info.manufacturer_id == 76
+
+
+async def test_register_callback_by_local_name_overly_broad(
+    hass, mock_bleak_scanner_start, enable_bluetooth, caplog
+):
+    """Test registering a callback by local_name that is too broad."""
+    mock_bt = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo, change: BluetoothChange
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+
+    with pytest.raises(ValueError):
+        bluetooth.async_register_callback(
+            hass,
+            _fake_subscriber,
+            {LOCAL_NAME: "a"},
+            BluetoothScanningMode.ACTIVE,
+        )
+
+    with pytest.raises(ValueError):
+        bluetooth.async_register_callback(
+            hass,
+            _fake_subscriber,
+            {LOCAL_NAME: "ab*"},
+            BluetoothScanningMode.ACTIVE,
+        )
+
+
+async def test_register_callback_by_service_data_uuid(
+    hass, mock_bleak_scanner_start, enable_bluetooth
+):
+    """Test registering a callback by service_data_uuid."""
+    mock_bt = []
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo, change: BluetoothChange
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+
+    with patch.object(hass.config_entries.flow, "async_init"):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        cancel = bluetooth.async_register_callback(
+            hass,
+            _fake_subscriber,
+            {SERVICE_DATA_UUID: "0000fe95-0000-1000-8000-00805f9b34fb"},
+            BluetoothScanningMode.ACTIVE,
+        )
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        apple_device = BLEDevice("44:44:33:11:23:45", "xiaomi")
+        apple_adv = AdvertisementData(
+            local_name="xiaomi",
+            service_data={
+                "0000fe95-0000-1000-8000-00805f9b34fb": b"\xd8.\xad\xcd\r\x85"
+            },
+        )
+
+        inject_advertisement(hass, apple_device, apple_adv)
+
+        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_adv = AdvertisementData(local_name="empty")
+
+        inject_advertisement(hass, empty_device, empty_adv)
+        await hass.async_block_till_done()
+
+        cancel()
+
+    assert len(callbacks) == 1
+
+    service_info: BluetoothServiceInfo = callbacks[0][0]
+    assert service_info.name == "xiaomi"
 
 
 async def test_register_callback_survives_reload(
@@ -1169,7 +1627,7 @@ async def test_register_callback_survives_reload(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
-    bluetooth.async_register_callback(
+    cancel = bluetooth.async_register_callback(
         hass,
         _fake_subscriber,
         {"address": "44:44:33:11:23:45"},
@@ -1203,6 +1661,7 @@ async def test_register_callback_survives_reload(
     assert service_info.name == "wohand"
     assert service_info.manufacturer == "Nordic Semiconductor ASA"
     assert service_info.manufacturer_id == 89
+    cancel()
 
 
 async def test_process_advertisements_bail_on_good_advertisement(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Index bluetooth matchers to resolve performance concerns with many adapters/remotes

`bluetooth.async_register_callback` will now reject overly broad `local_name` matchers that are less than 3 characters in length or contain patterns in the first 3 characters.

While its technically a breaking change, no integration was doing this anyways so I didn't document it as such since it would be noise.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1449

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
