### PR TITLE
Add configurable update interval to OpenWeather

### DIFF
--- a/homeassistant/components/openweathermap/config_flow.py
+++ b/homeassistant/components/openweathermap/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_MODE,
     CONF_NAME,
+    CONF_SCAN_INTERVAL,
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -22,9 +23,11 @@ from .const import (
     DEFAULT_FORECAST_MODE,
     DEFAULT_LANGUAGE,
     DEFAULT_NAME,
+    DEFAULT_WEATHER_UPDATE_INTERVAL,
     DOMAIN,
     FORECAST_MODES,
     LANGUAGES,
+    WEATHER_MIN_UPDATE_INTERVAL,
 )
 
 
@@ -84,6 +87,9 @@ class OpenWeatherMapConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
                     LANGUAGES
                 ),
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_WEATHER_UPDATE_INTERVAL
+                ): vol.All(cv.positive_int, vol.Clamp(min=WEATHER_MIN_UPDATE_INTERVAL)),
             }
         )
 
@@ -124,6 +130,12 @@ class OpenWeatherMapOptionsFlow(config_entries.OptionsFlow):
                         self.config_entry.data.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
                     ),
                 ): vol.In(LANGUAGES),
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=self.config_entry.data.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_WEATHER_UPDATE_INTERVAL
+                    ),
+                ): vol.All(cv.positive_int, vol.Clamp(min=WEATHER_MIN_UPDATE_INTERVAL)),
             }
         )
 

--- a/homeassistant/components/openweathermap/const.py
+++ b/homeassistant/components/openweathermap/const.py
@@ -37,12 +37,14 @@ from homeassistant.const import (
 DOMAIN = "openweathermap"
 DEFAULT_NAME = "OpenWeatherMap"
 DEFAULT_LANGUAGE = "en"
+DEFAULT_WEATHER_UPDATE_INTERVAL = 10
 ATTRIBUTION = "Data provided by OpenWeatherMap"
 MANUFACTURER = "OpenWeather"
 CONF_LANGUAGE = "language"
 CONFIG_FLOW_VERSION = 2
 ENTRY_NAME = "name"
 ENTRY_WEATHER_COORDINATOR = "weather_coordinator"
+WEATHER_MIN_UPDATE_INTERVAL = 1
 ATTR_API_PRECIPITATION = "precipitation"
 ATTR_API_PRECIPITATION_KIND = "precipitation_kind"
 ATTR_API_DATETIME = "datetime"

--- a/homeassistant/components/openweathermap/strings.json
+++ b/homeassistant/components/openweathermap/strings.json
@@ -15,7 +15,8 @@
           "latitude": "[%key:common::config_flow::data::latitude%]",
           "longitude": "[%key:common::config_flow::data::longitude%]",
           "mode": "[%key:common::config_flow::data::mode%]",
-          "name": "Name"
+          "name": "Name",
+          "scan_interval": "Update interval in minutes"
         },
         "description": "To generate API key go to https://openweathermap.org/appid"
       }
@@ -26,7 +27,8 @@
       "init": {
         "data": {
           "language": "Language",
-          "mode": "[%key:common::config_flow::data::mode%]"
+          "mode": "[%key:common::config_flow::data::mode%]",
+          "scan_interval": "Update interval in minutes"
         }
       }
     }

--- a/homeassistant/components/openweathermap/weather_update_coordinator.py
+++ b/homeassistant/components/openweathermap/weather_update_coordinator.py
@@ -52,13 +52,11 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-WEATHER_UPDATE_INTERVAL = timedelta(minutes=10)
-
 
 class WeatherUpdateCoordinator(DataUpdateCoordinator):
     """Weather data update coordinator."""
 
-    def __init__(self, owm, latitude, longitude, forecast_mode, hass):
+    def __init__(self, owm, latitude, longitude, forecast_mode, update_interval, hass):
         """Initialize coordinator."""
         self._owm_client = owm
         self._latitude = latitude
@@ -69,7 +67,10 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             self._forecast_limit = 15
 
         super().__init__(
-            hass, _LOGGER, name=DOMAIN, update_interval=WEATHER_UPDATE_INTERVAL
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(minutes=update_interval),
         )
 
     async def _async_update_data(self):

--- a/tests/components/openweathermap/test_config_flow.py
+++ b/tests/components/openweathermap/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant.components.openweathermap.const import (
     CONF_LANGUAGE,
     DEFAULT_FORECAST_MODE,
     DEFAULT_LANGUAGE,
+    DEFAULT_WEATHER_UPDATE_INTERVAL,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
@@ -17,6 +18,7 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_MODE,
     CONF_NAME,
+    CONF_SCAN_INTERVAL,
 )
 
 from tests.common import MockConfigEntry
@@ -28,6 +30,7 @@ CONFIG = {
     CONF_LONGITUDE: 40,
     CONF_MODE: DEFAULT_FORECAST_MODE,
     CONF_LANGUAGE: DEFAULT_LANGUAGE,
+    CONF_SCAN_INTERVAL: DEFAULT_WEATHER_UPDATE_INTERVAL,
 }
 
 VALID_YAML_CONFIG = {CONF_API_KEY: "foo"}
@@ -101,6 +104,7 @@ async def test_form_options(hass):
         assert config_entry.options == {
             CONF_MODE: "daily",
             CONF_LANGUAGE: DEFAULT_LANGUAGE,
+            CONF_SCAN_INTERVAL: DEFAULT_WEATHER_UPDATE_INTERVAL,
         }
 
         await hass.async_block_till_done()
@@ -120,6 +124,7 @@ async def test_form_options(hass):
         assert config_entry.options == {
             CONF_MODE: "onecall_daily",
             CONF_LANGUAGE: DEFAULT_LANGUAGE,
+            CONF_SCAN_INTERVAL: DEFAULT_WEATHER_UPDATE_INTERVAL,
         }
 
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the integration updates every 10 minutes, with the free API of OpenWeather they allow 60 calls / hour. The new API 3.0 will allow 1000/calls per day (about 1 call every 2 minutes). Further, more calls are allowed if one is willing to pay.
This change will allow the user to set the update interval based on the type of plan they have and thus number of calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
