### PR TITLE
Add ability to ignore devices for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
     CONF_ALL_UPDATES,
+    CONF_IGNORED,
     CONF_OVERRIDE_CHOST,
     DEFAULT_SCAN_INTERVAL,
     DEVICES_FOR_SUBSCRIBE,
@@ -35,11 +36,11 @@ from .const import (
     OUTDATED_LOG_MESSAGE,
     PLATFORMS,
 )
-from .data import ProtectData, async_ufp_instance_for_config_entry_ids
+from .data import ProtectData
 from .discovery import async_start_discovery
 from .migrate import async_migrate_data
 from .services import async_cleanup_services, async_setup_services
-from .utils import _async_unifi_mac_from_hass, async_get_devices
+from .utils import async_unifi_mac, convert_mac_list
 from .views import ThumbnailProxyView, VideoProxyView
 
 _LOGGER = logging.getLogger(__name__)
@@ -106,6 +107,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update options."""
+
+    data: ProtectData = hass.data[DOMAIN][entry.entry_id]
+    changed = data.async_get_changed_options(entry)
+
+    if len(changed.keys()) == 1 and CONF_IGNORED in changed:
+        new_macs = convert_mac_list(entry.options.get(CONF_IGNORED, ""))
+        added_macs = new_macs - data.ignored_macs
+        removed_macs = data.ignored_macs - new_macs
+        # if only ignored macs are added, we can handle without reloading
+        if not removed_macs and added_macs:
+            data.async_add_new_ignored_macs(added_macs)
+            return
+
     await hass.config_entries.async_reload(entry.entry_id)
 
 
@@ -125,15 +139,15 @@ async def async_remove_config_entry_device(
 ) -> bool:
     """Remove ufp config entry from a device."""
     unifi_macs = {
-        _async_unifi_mac_from_hass(connection[1])
+        async_unifi_mac(connection[1])
         for connection in device_entry.connections
         if connection[0] == dr.CONNECTION_NETWORK_MAC
     }
-    api = async_ufp_instance_for_config_entry_ids(hass, {config_entry.entry_id})
-    assert api is not None
-    if api.bootstrap.nvr.mac in unifi_macs:
+    data: ProtectData = hass.data[DOMAIN][config_entry.entry_id]
+    if data.api.bootstrap.nvr.mac in unifi_macs:
         return False
-    for device in async_get_devices(api.bootstrap, DEVICES_THAT_ADOPT):
+    for device in data.get_by_types(DEVICES_THAT_ADOPT):
         if device.is_adopted_by_us and device.mac in unifi_macs:
-            return False
+            data.async_ignore_mac(device.mac)
+            break
     return True

--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -35,6 +35,7 @@ from homeassistant.util.network import is_ip_address
 from .const import (
     CONF_ALL_UPDATES,
     CONF_DISABLE_RTSP,
+    CONF_IGNORED,
     CONF_MAX_MEDIA,
     CONF_OVERRIDE_CHOST,
     DEFAULT_MAX_MEDIA,
@@ -46,7 +47,7 @@ from .const import (
 )
 from .data import async_last_update_was_successful
 from .discovery import async_start_discovery
-from .utils import _async_resolve, _async_short_mac, _async_unifi_mac_from_hass
+from .utils import _async_resolve, async_short_mac, async_unifi_mac, convert_mac_list
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,7 +121,7 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle integration discovery."""
         self._discovered_device = discovery_info
-        mac = _async_unifi_mac_from_hass(discovery_info["hw_addr"])
+        mac = async_unifi_mac(discovery_info["hw_addr"])
         await self.async_set_unique_id(mac)
         source_ip = discovery_info["source_ip"]
         direct_connect_domain = discovery_info["direct_connect_domain"]
@@ -182,7 +183,7 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         placeholders = {
             "name": discovery_info["hostname"]
             or discovery_info["platform"]
-            or f"NVR {_async_short_mac(discovery_info['hw_addr'])}",
+            or f"NVR {async_short_mac(discovery_info['hw_addr'])}",
             "ip_address": discovery_info["source_ip"],
         }
         self.context["title_placeholders"] = placeholders
@@ -224,6 +225,7 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_ALL_UPDATES: False,
                 CONF_OVERRIDE_CHOST: False,
                 CONF_MAX_MEDIA: DEFAULT_MAX_MEDIA,
+                CONF_IGNORED: "",
             },
         )
 
@@ -365,33 +367,45 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
+
+        values = user_input or self.config_entry.options
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_DISABLE_RTSP,
+                    default=values.get(CONF_DISABLE_RTSP, False),
+                ): bool,
+                vol.Optional(
+                    CONF_ALL_UPDATES,
+                    default=values.get(CONF_ALL_UPDATES, False),
+                ): bool,
+                vol.Optional(
+                    CONF_OVERRIDE_CHOST,
+                    default=values.get(CONF_OVERRIDE_CHOST, False),
+                ): bool,
+                vol.Optional(
+                    CONF_MAX_MEDIA,
+                    default=values.get(CONF_MAX_MEDIA, DEFAULT_MAX_MEDIA),
+                ): vol.All(vol.Coerce(int), vol.Range(min=100, max=10000)),
+                vol.Optional(
+                    CONF_IGNORED,
+                    default=values.get(CONF_IGNORED, ""),
+                ): str,
+            }
+        )
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            try:
+                convert_mac_list(user_input.get(CONF_IGNORED, ""), raise_exception=True)
+            except vol.Invalid:
+                errors[CONF_IGNORED] = "invalid_mac_list"
+
+            if not errors:
+                return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_DISABLE_RTSP,
-                        default=self.config_entry.options.get(CONF_DISABLE_RTSP, False),
-                    ): bool,
-                    vol.Optional(
-                        CONF_ALL_UPDATES,
-                        default=self.config_entry.options.get(CONF_ALL_UPDATES, False),
-                    ): bool,
-                    vol.Optional(
-                        CONF_OVERRIDE_CHOST,
-                        default=self.config_entry.options.get(
-                            CONF_OVERRIDE_CHOST, False
-                        ),
-                    ): bool,
-                    vol.Optional(
-                        CONF_MAX_MEDIA,
-                        default=self.config_entry.options.get(
-                            CONF_MAX_MEDIA, DEFAULT_MAX_MEDIA
-                        ),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=100, max=10000)),
-                }
-            ),
+            data_schema=schema,
+            errors=errors,
         )

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -20,6 +20,7 @@ CONF_DISABLE_RTSP = "disable_rtsp"
 CONF_ALL_UPDATES = "all_updates"
 CONF_OVERRIDE_CHOST = "override_connection_host"
 CONF_MAX_MEDIA = "max_media"
+CONF_IGNORED = "ignored_devices"
 
 CONFIG_OPTIONS = [
     CONF_ALL_UPDATES,

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     CONF_DISABLE_RTSP,
+    CONF_IGNORED,
     CONF_MAX_MEDIA,
     DEFAULT_MAX_MEDIA,
     DEVICES_THAT_ADOPT,
@@ -36,7 +37,11 @@ from .const import (
     DISPATCH_CHANNELS,
     DOMAIN,
 )
-from .utils import async_dispatch_id as _ufpd, async_get_devices_by_type
+from .utils import (
+    async_dispatch_id as _ufpd,
+    async_get_devices_by_type,
+    convert_mac_list,
+)
 
 _LOGGER = logging.getLogger(__name__)
 ProtectDeviceType = Union[ProtectAdoptableDeviceModel, NVR]
@@ -67,6 +72,7 @@ class ProtectData:
 
         self._hass = hass
         self._entry = entry
+        self._existing_options = dict(entry.options)
         self._hass = hass
         self._update_interval = update_interval
         self._subscriptions: dict[str, list[Callable[[ProtectDeviceType], None]]] = {}
@@ -74,6 +80,8 @@ class ProtectData:
         self._unsub_interval: CALLBACK_TYPE | None = None
         self._unsub_websocket: CALLBACK_TYPE | None = None
         self._auth_failures = 0
+        self._ignored_macs: set[str] | None = None
+        self._ignore_update_cancel: Callable[[], None] | None = None
 
         self.last_update_success = False
         self.api = protect
@@ -88,6 +96,51 @@ class ProtectData:
         """Max number of events to load at once."""
         return self._entry.options.get(CONF_MAX_MEDIA, DEFAULT_MAX_MEDIA)
 
+    @property
+    def ignored_macs(self) -> set[str]:
+        """Set of ignored MAC addresses."""
+
+        if self._ignored_macs is None:
+            self._ignored_macs = convert_mac_list(
+                self._entry.options.get(CONF_IGNORED, "")
+            )
+
+        return self._ignored_macs
+
+    @callback
+    def async_get_changed_options(self, entry: ConfigEntry) -> dict[str, Any]:
+        """Get changed options for when entry is updated."""
+
+        changed: dict[str, Any] = {}
+        for key in entry.options:
+            if key not in self._existing_options:
+                changed[key] = entry.options[key]
+            elif self._existing_options[key] != entry.options[key]:
+                changed[key] = entry.options[key]
+
+        return changed
+
+    @callback
+    def async_ignore_mac(self, mac: str) -> None:
+        """Ignores a MAC address for a UniFi Protect device."""
+
+        new_macs = (self._ignored_macs or set()).copy()
+        new_macs.add(mac)
+        _LOGGER.debug("Updating ignored_devices option: %s", self.ignored_macs)
+        options = dict(self._entry.options)
+        options[CONF_IGNORED] = ",".join(new_macs)
+        self._hass.config_entries.async_update_entry(self._entry, options=options)
+
+    @callback
+    def async_add_new_ignored_macs(self, new_macs: set[str]) -> None:
+        """Add new ignored MAC addresses and ensures the devices are removed."""
+
+        for mac in new_macs:
+            device = self.api.bootstrap.get_device_from_mac(mac)
+            if device is not None:
+                self._async_remove_device(device)
+        self._ignored_macs = None
+
     def get_by_types(
         self, device_types: Iterable[ModelType], ignore_unadopted: bool = True
     ) -> Generator[ProtectAdoptableDeviceModel, None, None]:
@@ -99,6 +152,8 @@ class ProtectData:
             for device in devices:
                 if ignore_unadopted and not device.is_adopted_by_us:
                     continue
+                if device.mac in self.ignored_macs:
+                    continue
                 yield device
 
     async def async_setup(self) -> None:
@@ -107,6 +162,11 @@ class ProtectData:
             self._async_process_ws_message
         )
         await self.async_refresh()
+
+        for mac in self.ignored_macs:
+            device = self.api.bootstrap.get_device_from_mac(mac)
+            if device is not None:
+                self._async_remove_device(device)
 
     async def async_stop(self, *args: Any) -> None:
         """Stop processing data."""
@@ -172,6 +232,7 @@ class ProtectData:
 
     @callback
     def _async_remove_device(self, device: ProtectAdoptableDeviceModel) -> None:
+
         registry = dr.async_get(self._hass)
         device_entry = registry.async_get_device(
             identifiers=set(), connections={(dr.CONNECTION_NETWORK_MAC, device.mac)}
@@ -296,13 +357,13 @@ class ProtectData:
 
 
 @callback
-def async_ufp_instance_for_config_entry_ids(
+def async_ufp_data_for_config_entry_ids(
     hass: HomeAssistant, config_entry_ids: set[str]
-) -> ProtectApiClient | None:
+) -> ProtectData | None:
     """Find the UFP instance for the config entry ids."""
     domain_data = hass.data[DOMAIN]
     for config_entry_id in config_entry_ids:
         if config_entry_id in domain_data:
             protect_data: ProtectData = domain_data[config_entry_id]
-            return protect_data.api
+            return protect_data
     return None

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.service import async_extract_referenced_entity_ids
 from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from .const import ATTR_MESSAGE, DOMAIN
-from .data import async_ufp_instance_for_config_entry_ids
+from .data import async_ufp_data_for_config_entry_ids
 
 SERVICE_ADD_DOORBELL_TEXT = "add_doorbell_text"
 SERVICE_REMOVE_DOORBELL_TEXT = "remove_doorbell_text"
@@ -70,8 +70,8 @@ def _async_get_ufp_instance(hass: HomeAssistant, device_id: str) -> ProtectApiCl
         return _async_get_ufp_instance(hass, device_entry.via_device_id)
 
     config_entry_ids = device_entry.config_entries
-    if ufp_instance := async_ufp_instance_for_config_entry_ids(hass, config_entry_ids):
-        return ufp_instance
+    if ufp_data := async_ufp_data_for_config_entry_ids(hass, config_entry_ids):
+        return ufp_data.api
 
     raise HomeAssistantError(f"No device found for device id: {device_id}")
 

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -51,7 +51,7 @@
           "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)",
           "override_connection_host": "Override Connection Host",
           "max_media": "Max number of event to load for Media Browser (increases RAM usage)",
-          "ignored_devices": "Comma list of MAC addresses of devices to ignore"
+          "ignored_devices": "Comma separated list of MAC addresses of devices to ignore"
         }
       }
     },

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -50,9 +50,13 @@
           "disable_rtsp": "Disable the RTSP stream",
           "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)",
           "override_connection_host": "Override Connection Host",
-          "max_media": "Max number of event to load for Media Browser (increases RAM usage)"
+          "max_media": "Max number of event to load for Media Browser (increases RAM usage)",
+          "ignored_devices": "Comma list of MAC addresses of devices to ignore"
         }
       }
+    },
+    "error": {
+      "invalid_mac_list": "Must be a list of MAC addresses seperated by commas"
     }
   }
 }

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -42,11 +42,15 @@
         }
     },
     "options": {
+        "error": {
+            "invalid_mac_list": "Must be a list of MAC addresses seperated by commas"
+        },
         "step": {
             "init": {
                 "data": {
                     "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)",
                     "disable_rtsp": "Disable the RTSP stream",
+                    "ignored_devices": "Comma list of MAC addresses of devices to ignore",
                     "max_media": "Max number of event to load for Media Browser (increases RAM usage)",
                     "override_connection_host": "Override Connection Host"
                 },

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -50,7 +50,7 @@
                 "data": {
                     "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)",
                     "disable_rtsp": "Disable the RTSP stream",
-                    "ignored_devices": "Comma list of MAC addresses of devices to ignore",
+                    "ignored_devices": "Comma separated list of MAC addresses of devices to ignore",
                     "max_media": "Max number of event to load for Media Browser (increases RAM usage)",
                     "override_connection_host": "Override Connection Host"
                 },

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -68,6 +68,7 @@ def mock_ufp_config_entry():
             "port": 443,
             "verify_ssl": False,
         },
+        options={"ignored_devices": "FFFFFFFFFFFF,test"},
         version=2,
     )
 

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.components import dhcp, ssdp
 from homeassistant.components.unifiprotect.const import (
     CONF_ALL_UPDATES,
     CONF_DISABLE_RTSP,
+    CONF_IGNORED,
     CONF_OVERRIDE_CHOST,
     DOMAIN,
 )
@@ -270,7 +271,51 @@ async def test_form_options(hass: HomeAssistant, ufp_client: ProtectApiClient) -
         "disable_rtsp": True,
         "override_connection_host": True,
         "max_media": 1000,
+        "ignored_devices": "",
     }
+
+
+async def test_form_options_invalid_mac(
+    hass: HomeAssistant, ufp_client: ProtectApiClient
+) -> None:
+    """Test we handle options flows."""
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.1.1.1",
+            "username": "test-username",
+            "password": "test-password",
+            "id": "UnifiProtect",
+            "port": 443,
+            "verify_ssl": False,
+            "max_media": 1000,
+        },
+        version=2,
+        unique_id=dr.format_mac(MAC_ADDR),
+    )
+    mock_config.add_to_hass(hass)
+
+    with _patch_discovery(), patch(
+        "homeassistant.components.unifiprotect.ProtectApiClient"
+    ) as mock_api:
+        mock_api.return_value = ufp_client
+
+        await hass.config_entries.async_setup(mock_config.entry_id)
+        await hass.async_block_till_done()
+        assert mock_config.state == config_entries.ConfigEntryState.LOADED
+
+    result = await hass.config_entries.options.async_init(mock_config.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert not result["errors"]
+    assert result["step_id"] == "init"
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_IGNORED: "test,test2"},
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {CONF_IGNORED: "invalid_mac_list"}
 
 
 @pytest.mark.parametrize(

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -7,20 +7,21 @@ from unittest.mock import AsyncMock, patch
 
 import aiohttp
 from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
-from pyunifiprotect.data import NVR, Bootstrap, Light
+from pyunifiprotect.data import NVR, Bootstrap, Doorlock, Light, Sensor
 
 from homeassistant.components.unifiprotect.const import (
     CONF_DISABLE_RTSP,
+    CONF_IGNORED,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from . import _patch_discovery
-from .utils import MockUFPFixture, init_entry, time_changed
+from .utils import MockUFPFixture, get_device_from_ufp_device, init_entry, time_changed
 
 from tests.common import MockConfigEntry
 
@@ -211,27 +212,37 @@ async def test_device_remove_devices(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     light: Light,
+    doorlock: Doorlock,
+    sensor: Sensor,
     hass_ws_client: Callable[
         [HomeAssistant], Awaitable[aiohttp.ClientWebSocketResponse]
     ],
 ) -> None:
     """Test we can only remove a device that no longer exists."""
 
-    await init_entry(hass, ufp, [light])
-    assert await async_setup_component(hass, "config", {})
-    entity_id = "light.test_light"
-    entry_id = ufp.entry.entry_id
+    sensor.mac = "FFFFFFFFFFFF"
 
-    registry: er.EntityRegistry = er.async_get(hass)
-    entity = registry.async_get(entity_id)
-    assert entity is not None
+    await init_entry(hass, ufp, [light, doorlock, sensor], regenerate_ids=False)
+    assert await async_setup_component(hass, "config", {})
+
+    entry_id = ufp.entry.entry_id
     device_registry = dr.async_get(hass)
 
-    live_device_entry = device_registry.async_get(entity.device_id)
+    light_device = get_device_from_ufp_device(hass, light)
+    assert light_device is not None
     assert (
-        await remove_device(await hass_ws_client(hass), live_device_entry.id, entry_id)
-        is False
+        await remove_device(await hass_ws_client(hass), light_device.id, entry_id)
+        is True
     )
+
+    doorlock_device = get_device_from_ufp_device(hass, doorlock)
+    assert (
+        await remove_device(await hass_ws_client(hass), doorlock_device.id, entry_id)
+        is True
+    )
+
+    sensor_device = get_device_from_ufp_device(hass, sensor)
+    assert sensor_device is None
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=entry_id,
@@ -241,6 +252,10 @@ async def test_device_remove_devices(
         await remove_device(await hass_ws_client(hass), dead_device_entry.id, entry_id)
         is True
     )
+
+    await time_changed(hass, 60)
+    entry = hass.config_entries.async_get_entry(entry_id)
+    entry.options[CONF_IGNORED] == f"{light.mac},{doorlock.mac}"
 
 
 async def test_device_remove_devices_nvr(

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -23,7 +23,7 @@ from pyunifiprotect.test_util.anonymize import random_hex
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, split_entity_id
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import EntityDescription
 import homeassistant.util.dt as dt_util
 
@@ -229,3 +229,13 @@ async def adopt_devices(
         ufp.ws_msg(mock_msg)
 
     await hass.async_block_till_done()
+
+
+def get_device_from_ufp_device(
+    hass: HomeAssistant, device: ProtectAdoptableDeviceModel
+) -> dr.DeviceEntry | None:
+    """Return all device by type."""
+    registry = dr.async_get(hass)
+    return registry.async_get_device(
+        identifiers=set(), connections={(dr.CONNECTION_NETWORK_MAC, device.mac)}
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a new Option for the Config Entry for a list of MAC addresses of devices that will be ignored by Home Assistant. This also now allows any delete to be deleted at any time and they will automatically be added to the list of ignored MAC addresses.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23899

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
