### PR TITLE
Add support for Hatch Rest noise machine and light

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -452,8 +452,8 @@ build.json @home-assistant/supervisor
 /tests/components/harmony/ @ehendrix23 @bramkragten @bdraco @mkeesey @Aohzan
 /homeassistant/components/hassio/ @home-assistant/supervisor
 /tests/components/hassio/ @home-assistant/supervisor
-/homeassistant/components/hdmi_cec/ @inytar
-/tests/components/hdmi_cec/ @inytar
+/homeassistant/components/hatchrest/ @ViViDboarder
+/tests/components/hatchrest/ @ViViDboarder
 /homeassistant/components/heatmiser/ @andylockran
 /homeassistant/components/heos/ @andrewsayre
 /tests/components/heos/ @andrewsayre

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -454,6 +454,8 @@ build.json @home-assistant/supervisor
 /tests/components/hassio/ @home-assistant/supervisor
 /homeassistant/components/hatchrest/ @ViViDboarder
 /tests/components/hatchrest/ @ViViDboarder
+/homeassistant/components/hdmi_cec/ @inytar
+/tests/components/hdmi_cec/ @inytar
 /homeassistant/components/heatmiser/ @andylockran
 /homeassistant/components/heos/ @andrewsayre
 /tests/components/heos/ @andrewsayre

--- a/homeassistant/components/hatchrest/__init__.py
+++ b/homeassistant/components/hatchrest/__init__.py
@@ -1,0 +1,124 @@
+"""The hatchrest integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+import async_timeout
+from bleak.exc import BleakError
+from pyhatchbabyrest import PyHatchBabyRestAsync, connect_async
+
+from homeassistant.components import bluetooth
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+PLATFORMS: list[Platform] = [
+    Platform.SWITCH,
+]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up hatchrest from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
+    address = entry.data["address"]
+    ble_device = bluetooth.async_ble_device_from_address(hass, address.upper())
+    if not ble_device:
+        raise ConfigEntryNotReady(
+            f"Could not find Hatch Rest device with address {address}"
+        )
+
+    hass.data[DOMAIN][entry.entry_id] = HatchRestCoordinator(
+        hass, entry.unique_id, await connect_async(ble_device)
+    )
+
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+class HatchRestCoordinator(DataUpdateCoordinator):
+    """Coordinator for interacting with a Hatch Rest device."""
+
+    def __init__(
+        self, hass: HomeAssistant, unique_id: str | None, device: PyHatchBabyRestAsync
+    ) -> None:
+        """Initialize coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="hatchrest",
+            update_interval=timedelta(seconds=30),
+        )
+        self.unique_id = unique_id
+        self.device = device
+
+    async def _async_update_data(self) -> None:
+        """Get updated data from device."""
+        try:
+            async with async_timeout.timeout(10):
+                await self.device.refresh_data()
+        except TimeoutError as exc:
+            raise UpdateFailed(
+                "connection timed out while fetching data from device"
+            ) from exc
+        except BleakError as exc:
+            raise UpdateFailed("failed getting data from device") from exc
+
+
+class HatchRestEntity(CoordinatorEntity):
+    """Base entity for a Hatch Rest device."""
+
+    def __init__(
+        self,
+        coordinator: HatchRestCoordinator,
+    ) -> None:
+        """Initialize entity coordinator and id."""
+        super().__init__(coordinator)
+        self._device = coordinator.device
+        self._attr_unique_id = coordinator.unique_id
+
+    @property
+    def name(self):
+        """Name of the Hatch Rest device."""
+        return self._device.name
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Provide info about the Hatch Rest device for all entities."""
+        return (
+            {
+                "identifiers": {(DOMAIN, self.unique_id)},
+                "name": super().name,
+                "manufacturer": "Hatch",
+                "model": "Rest",
+            }
+            if self.unique_id
+            else {}
+        )

--- a/homeassistant/components/hatchrest/__init__.py
+++ b/homeassistant/components/hatchrest/__init__.py
@@ -11,7 +11,7 @@ from pyhatchbabyrest import PyHatchBabyRestAsync, connect_async
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, Platform
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -107,8 +107,8 @@ class HatchRestEntity(CoordinatorEntity):
         """Provide info about the Hatch Rest device for all entities."""
         assert self.unique_id is not None
         return {
-                "identifiers": {(DOMAIN, self.unique_id)},
-                "name": self.device_name,
-                "manufacturer": "Hatch",
-                "model": "Rest",
-            }
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.device_name,
+            "manufacturer": "Hatch",
+            "model": "Rest",
+        }

--- a/homeassistant/components/hatchrest/__init__.py
+++ b/homeassistant/components/hatchrest/__init__.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import logging
 
 import async_timeout
-from bleak.exc import BleakError
+from bleak import BleakError
 from pyhatchbabyrest import PyHatchBabyRestAsync, connect_async
 
 from homeassistant.components import bluetooth
@@ -102,21 +102,13 @@ class HatchRestEntity(CoordinatorEntity):
         """Name of the Hatch Rest device."""
         return self._device.name
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self.async_write_ha_state()
-
     @property
     def device_info(self) -> DeviceInfo:
         """Provide info about the Hatch Rest device for all entities."""
-        return (
-            {
+        assert self.unique_id is not None
+        return {
                 "identifiers": {(DOMAIN, self.unique_id)},
                 "name": self.device_name,
                 "manufacturer": "Hatch",
                 "model": "Rest",
             }
-            if self.unique_id
-            else {}
-        )

--- a/homeassistant/components/hatchrest/__init__.py
+++ b/homeassistant/components/hatchrest/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -105,9 +106,18 @@ class HatchRestEntity(CoordinatorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Provide info about the Hatch Rest device for all entities."""
-        assert self.unique_id is not None
+        # These should never be null or empty
+        if not all((self._device.address, self.unique_id)):
+            raise ValueError("Missing bluetooth address for hatch rest device")
+
+        assert self._device.address
+        assert self.unique_id
+
         return {
             "identifiers": {(DOMAIN, self.unique_id)},
+            "connections": {
+                (device_registry.CONNECTION_BLUETOOTH, self._device.address)
+            },
             "name": self.device_name,
             "manufacturer": "Hatch",
             "model": "Rest",

--- a/homeassistant/components/hatchrest/__init__.py
+++ b/homeassistant/components/hatchrest/__init__.py
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = HatchRestCoordinator(
-        hass, entry.unique_id, await connect_async(ble_device)
+        hass, entry.unique_id, await connect_async(ble_device, scan_now=False)
     )
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/hatchrest/config_flow.py
+++ b/homeassistant/components/hatchrest/config_flow.py
@@ -1,0 +1,31 @@
+"""Discovery config flow for Hatch Rest device."""
+import logging
+
+from homeassistant import config_entries
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.device_registry import format_mac
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HatchRestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Bluetooth discovery config flow for Hatch Rest devices."""
+
+    VERSION = 1
+
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> FlowResult:
+        """Handle bluetooth discovery."""
+        _LOGGER.debug("Discovered hatch device: %s", discovery_info)
+        await self.async_set_unique_id(format_mac(discovery_info.address))
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=discovery_info.name,
+            data={CONF_ADDRESS: discovery_info.address},
+        )

--- a/homeassistant/components/hatchrest/config_flow.py
+++ b/homeassistant/components/hatchrest/config_flow.py
@@ -1,9 +1,14 @@
 """Discovery config flow for Hatch Rest device."""
+from __future__ import annotations
+
 import logging
+from typing import Any
+
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
-from homeassistant.const import CONF_ADDRESS
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.device_registry import format_mac
 
@@ -11,11 +16,38 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+MANUAL_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): str,
+        vol.Required(CONF_ADDRESS): str,
+    }
+)
+
 
 class HatchRestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Bluetooth discovery config flow for Hatch Rest devices."""
 
     VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle manual setup."""
+        if not user_input:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=MANUAL_SCHEMA,
+                errors=None,
+            )
+
+        address = user_input[CONF_ADDRESS]
+        await self.async_set_unique_id(format_mac(address))
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=user_input[CONF_NAME],
+            data={CONF_ADDRESS: address},
+        )
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak

--- a/homeassistant/components/hatchrest/const.py
+++ b/homeassistant/components/hatchrest/const.py
@@ -1,0 +1,3 @@
+"""Constants for the hatchrest integration."""
+
+DOMAIN = "hatchrest"

--- a/homeassistant/components/hatchrest/manifest.json
+++ b/homeassistant/components/hatchrest/manifest.json
@@ -1,0 +1,15 @@
+{
+  "domain": "hatchrest",
+  "name": "hatchrest",
+  "config_flow": true,
+  "dependencies": ["bluetooth"],
+  "documentation": "https://www.home-assistant.io/integrations/hatchrest",
+  "requirements": ["pyhatchbabyrest-hass==2.1.0"],
+  "bluetooth": [
+    {
+      "manufacturer_id": 1076
+    }
+  ],
+  "codeowners": ["@ViViDboarder"],
+  "iot_class": "local_polling"
+}

--- a/homeassistant/components/hatchrest/manifest.json
+++ b/homeassistant/components/hatchrest/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "documentation": "https://www.home-assistant.io/integrations/hatchrest",
-  "requirements": ["pyhatchbabyrest-hass==2.1.0"],
+  "requirements": ["pyhatchbabyrest==2.1.0"],
   "bluetooth": [
     {
       "manufacturer_id": 1076

--- a/homeassistant/components/hatchrest/strings.json
+++ b/homeassistant/components/hatchrest/strings.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "step": {
+      "confirm": {
+        "description": "[%key:common::config_flow::description::confirm_setup%]"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+    }
+  }
+}

--- a/homeassistant/components/hatchrest/strings.json
+++ b/homeassistant/components/hatchrest/strings.json
@@ -3,11 +3,18 @@
     "step": {
       "confirm": {
         "description": "[%key:common::config_flow::description::confirm_setup%]"
+      },
+      "user": {
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "address": "Bluetooth address"
+        }
       }
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     }
   }
 }

--- a/homeassistant/components/hatchrest/switch.py
+++ b/homeassistant/components/hatchrest/switch.py
@@ -1,0 +1,51 @@
+"""Switch platform for Hatch Rest."""
+from __future__ import annotations
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import HatchRestEntity
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Hatch Rest control switch."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities([HatchRestSwitch(coordinator)], True)
+
+
+class HatchRestSwitch(HatchRestEntity, SwitchEntity):
+    """Master control switch for Hatch Rest device."""
+
+    @property
+    def name(self) -> str:
+        """Hatch Rest switch name."""
+        return f"{super().name} Power"
+
+    @property
+    def is_on(self) -> bool:
+        """Power state of Hatch Rest device."""
+        return self._device.power
+
+    async def async_turn_on(self, **_):
+        """Turn on the Hatch Rest device."""
+        if not self.is_on:
+            await self._device.power_on()
+            self._device.power = True
+
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **_):
+        """Turn off the Hatch Rest device."""
+        if self.is_on:
+            await self._device.power_off()
+            self._device.power = False
+
+        self.async_write_ha_state()

--- a/homeassistant/components/hatchrest/switch.py
+++ b/homeassistant/components/hatchrest/switch.py
@@ -27,7 +27,7 @@ class HatchRestSwitch(HatchRestEntity, SwitchEntity):
     @property
     def name(self) -> str:
         """Hatch Rest switch name."""
-        return f"{super().name} Power"
+        return f"{super().device_name} power"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/hatchrest/translations/en.json
+++ b/homeassistant/components/hatchrest/translations/en.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+        "abort": {
+            "no_devices_found": "No devices found on the network",
+            "single_instance_allowed": "Already configured. Only a single configuration possible."
+        },
+        "step": {
+            "confirm": {
+                "description": "Do you want to start set up?"
+            }
+        }
+    }
+}

--- a/homeassistant/components/hatchrest/translations/en.json
+++ b/homeassistant/components/hatchrest/translations/en.json
@@ -1,12 +1,19 @@
 {
     "config": {
         "abort": {
+            "already_configured": "Service is already configured",
             "no_devices_found": "No devices found on the network",
             "single_instance_allowed": "Already configured. Only a single configuration possible."
         },
         "step": {
             "confirm": {
                 "description": "Do you want to start set up?"
+            },
+            "user": {
+                "data": {
+                    "address": "Bluetooth address",
+                    "name": "Name"
+                }
             }
         }
     }

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -131,6 +131,10 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
         "connectable": False,
     },
     {
+        "domain": "hatchrest",
+        "manufacturer_id": 1076
+    },
+    {
         "domain": "homekit_controller",
         "manufacturer_id": 76,
         "manufacturer_data_start": [

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -132,7 +132,7 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
     },
     {
         "domain": "hatchrest",
-        "manufacturer_id": 1076
+        "manufacturer_id": 1076,
     },
     {
         "domain": "homekit_controller",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -152,6 +152,7 @@ FLOWS = {
         "habitica",
         "hangouts",
         "harmony",
+        "hatchrest",
         "heos",
         "here_travel_time",
         "hisense_aehw4a1",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2069,6 +2069,12 @@
       "config_flow": false,
       "iot_class": "local_polling"
     },
+    "hatchrest": {
+      "name": "hatchrest",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "havana_shade": {
       "name": "Havana Shade",
       "integration_type": "virtual",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1597,6 +1597,9 @@ pygtfs==0.1.7
 # homeassistant.components.hvv_departures
 pygti==0.9.3
 
+# homeassistant.components.hatchrest
+pyhatchbabyrest-hass==2.1.0
+
 # homeassistant.components.version
 pyhaversion==22.8.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1598,7 +1598,7 @@ pygtfs==0.1.7
 pygti==0.9.3
 
 # homeassistant.components.hatchrest
-pyhatchbabyrest-hass==2.1.0
+pyhatchbabyrest==2.1.0
 
 # homeassistant.components.version
 pyhaversion==22.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1122,6 +1122,9 @@ pyfttt==0.3
 # homeassistant.components.hvv_departures
 pygti==0.9.3
 
+# homeassistant.components.hatchrest
+pyhatchbabyrest-hass==2.1.0
+
 # homeassistant.components.version
 pyhaversion==22.8.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1123,7 +1123,7 @@ pyfttt==0.3
 pygti==0.9.3
 
 # homeassistant.components.hatchrest
-pyhatchbabyrest-hass==2.1.0
+pyhatchbabyrest==2.1.0
 
 # homeassistant.components.version
 pyhaversion==22.8.0

--- a/tests/components/hatchrest/__init__.py
+++ b/tests/components/hatchrest/__init__.py
@@ -1,0 +1,32 @@
+"""Tests for the hatchrest integration."""
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.components.hatchrest.const import DOMAIN
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.helpers.device_registry import format_mac
+
+from tests.common import MockConfigEntry
+
+VALID_HATCHREST = BluetoothServiceInfoBleak.from_advertisement(
+    BLEDevice("00:00:00:00:00:00", "Hatch Baby Rest"),
+    AdvertisementData(
+        local_name="Hatch Baby Rest",
+        address="00:00:00:00:00:00",
+        rssi=-50,
+        manufacturer_data={1076: b"\x00"},
+        service_data={},
+        service_uuids=[],
+        source="local",
+    ),
+    source="local",
+)
+
+VALID_HATCHREST_ENTRY = MockConfigEntry(
+    domain=DOMAIN,
+    data={
+        CONF_ADDRESS: VALID_HATCHREST.address,
+    },
+    unique_id=format_mac(VALID_HATCHREST.address),
+)

--- a/tests/components/hatchrest/__init__.py
+++ b/tests/components/hatchrest/__init__.py
@@ -1,6 +1,5 @@
 """Tests for the hatchrest integration."""
 from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.components.hatchrest.const import DOMAIN
@@ -8,19 +7,25 @@ from homeassistant.const import CONF_ADDRESS
 from homeassistant.helpers.device_registry import format_mac
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import generate_advertisement_data
 
-VALID_HATCHREST = BluetoothServiceInfoBleak.from_advertisement(
-    BLEDevice("00:00:00:00:00:00", "Hatch Baby Rest"),
-    AdvertisementData(
+VALID_HATCHREST = BluetoothServiceInfoBleak(
+    name="Hatch Baby Rest",
+    address="00:00:00:00:00:00",
+    manufacturer_data={1076: b"\x00"},
+    service_data={},
+    service_uuids=[],
+    rssi=-60,
+    source="local",
+    advertisement=generate_advertisement_data(
         local_name="Hatch Baby Rest",
-        address="00:00:00:00:00:00",
-        rssi=-50,
         manufacturer_data={1076: b"\x00"},
         service_data={},
         service_uuids=[],
-        source="local",
     ),
-    source="local",
+    device=BLEDevice("00:00:00:00:00:00", "Hatch Baby Rest"),
+    time=0,
+    connectable=True,
 )
 
 VALID_HATCHREST_ENTRY = MockConfigEntry(

--- a/tests/components/hatchrest/conftest.py
+++ b/tests/components/hatchrest/conftest.py
@@ -1,0 +1,8 @@
+"""Session fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_bluetooth(enable_bluetooth):
+    """Auto mock bluetooth."""

--- a/tests/components/hatchrest/test_config_flow.py
+++ b/tests/components/hatchrest/test_config_flow.py
@@ -1,0 +1,38 @@
+"""Tests for the hatchrest config flow."""
+
+
+from homeassistant import config_entries
+from homeassistant.components.hatchrest.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from . import VALID_HATCHREST, VALID_HATCHREST_ENTRY
+
+
+async def test_async_step_bluetooth_valid(hass: HomeAssistant):
+    """Test setup of valid bluetooth device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=VALID_HATCHREST,
+    )
+    await hass.async_block_till_done()
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    assert result.get("data", {}).get("address") == VALID_HATCHREST.address
+
+
+async def test_async_step_bluetooth_duplicate(hass: HomeAssistant):
+    """Test setup of duplicate bluetooth device."""
+    entry = VALID_HATCHREST_ENTRY
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=VALID_HATCHREST,
+    )
+    await hass.async_block_till_done()
+
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"


### PR DESCRIPTION
This is a work in progress. Things I have yet to do:

- [x] Get upstream changes merged (or publish fork of package)
    - https://github.com/kjoconnor/pyhatchbabyrest/pull/6
    - https://github.com/kjoconnor/pyhatchbabyrest/pull/5
- [x] Bump dependency version
- [x] Add logo
- [x] Write tests
- [ ] Make platinum🏆

Things I'd appreciate early feedback on:

Entity types. Does it make sense to use a Select and Siren? How should I handle volume? Would a Media Player be better?

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a few entities because there doesn't appear to be a great
fitting entity type.

Light: Controls light features
Select: Choose sound setting (because Siren has no UI element for this)
Siren: Turn on sound (also supports selection via service call)
Switch: Turn off the entire device. Can also be accomplished by turning
off both light and sound

What is missing is a UI element to control volume, thought it can be
done via a service call to the Siren.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (https://github.com/home-assistant/home-assistant.io/pull/24120)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
