### PR TITLE
Awair local use config entry name + add measurement state class

### DIFF
--- a/homeassistant/components/awair/__init__.py
+++ b/homeassistant/components/awair/__init__.py
@@ -37,6 +37,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     if CONF_HOST in config_entry.data:
         coordinator = AwairLocalDataUpdateCoordinator(hass, config_entry, session)
+        config_entry.async_on_unload(
+            config_entry.add_update_listener(_async_update_listener)
+        )
     else:
         coordinator = AwairCloudDataUpdateCoordinator(hass, config_entry, session)
 
@@ -48,6 +51,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    coordinator: AwairLocalDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    if entry.title != coordinator.title:
+        await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -73,6 +83,7 @@ class AwairDataUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Set up the AwairDataUpdateCoordinator class."""
         self._config_entry = config_entry
+        self.title = config_entry.title
 
         super().__init__(hass, LOGGER, name=DOMAIN, update_interval=update_interval)
 

--- a/homeassistant/components/awair/const.py
+++ b/homeassistant/components/awair/const.py
@@ -8,7 +8,11 @@ import logging
 from python_awair.air_data import AirData
 from python_awair.devices import AwairBaseDevice
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_BILLION,
@@ -61,6 +65,7 @@ SENSOR_TYPE_SCORE = AwairSensorEntityDescription(
     native_unit_of_measurement=PERCENTAGE,
     name="Awair score",
     unique_id_tag="score",  # matches legacy format
+    state_class=SensorStateClass.MEASUREMENT,
 )
 
 SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
@@ -70,6 +75,7 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         name="Humidity",
         unique_id_tag="HUMID",  # matches legacy format
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     AwairSensorEntityDescription(
         key=API_LUX,
@@ -77,6 +83,7 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
         native_unit_of_measurement=LIGHT_LUX,
         name="Illuminance",
         unique_id_tag="illuminance",
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     AwairSensorEntityDescription(
         key=API_SPL_A,
@@ -84,6 +91,7 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
         native_unit_of_measurement=SOUND_PRESSURE_WEIGHTED_DBA,
         name="Sound level",
         unique_id_tag="sound_level",
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     AwairSensorEntityDescription(
         key=API_VOC,
@@ -91,6 +99,7 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_BILLION,
         name="Volatile organic compounds",
         unique_id_tag="VOC",  # matches legacy format
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     AwairSensorEntityDescription(
         key=API_TEMP,
@@ -98,6 +107,7 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
         native_unit_of_measurement=TEMP_CELSIUS,
         name="Temperature",
         unique_id_tag="TEMP",  # matches legacy format
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     AwairSensorEntityDescription(
         key=API_CO2,
@@ -105,6 +115,7 @@ SENSOR_TYPES: tuple[AwairSensorEntityDescription, ...] = (
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
         name="Carbon dioxide",
         unique_id_tag="CO2",  # matches legacy format
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 )
 
@@ -115,6 +126,7 @@ SENSOR_TYPES_DUST: tuple[AwairSensorEntityDescription, ...] = (
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         name="PM2.5",
         unique_id_tag="PM25",  # matches legacy format
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     AwairSensorEntityDescription(
         key=API_PM10,
@@ -122,6 +134,7 @@ SENSOR_TYPES_DUST: tuple[AwairSensorEntityDescription, ...] = (
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         name="PM10",
         unique_id_tag="PM10",  # matches legacy format
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 )
 

--- a/homeassistant/components/awair/sensor.py
+++ b/homeassistant/components/awair/sensor.py
@@ -1,17 +1,14 @@
 """Support for Awair sensors."""
 from __future__ import annotations
 
+from typing import cast
+
 from python_awair.air_data import AirData
 from python_awair.devices import AwairBaseDevice, AwairLocalDevice
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_ATTRIBUTION,
-    ATTR_CONNECTIONS,
-    ATTR_NAME,
-    ATTR_SW_VERSION,
-)
+from homeassistant.const import ATTR_ATTRIBUTION, ATTR_CONNECTIONS, ATTR_SW_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
@@ -78,6 +75,7 @@ class AwairSensor(CoordinatorEntity[AwairDataUpdateCoordinator], SensorEntity):
     """Defines an Awair sensor entity."""
 
     entity_description: AwairSensorEntityDescription
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -89,14 +87,6 @@ class AwairSensor(CoordinatorEntity[AwairDataUpdateCoordinator], SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._device = device
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the sensor."""
-        if self._device.name:
-            return f"{self._device.name} {self.entity_description.name}"
-
-        return self.entity_description.name
 
     @property
     def unique_id(self) -> str:
@@ -204,10 +194,12 @@ class AwairSensor(CoordinatorEntity[AwairDataUpdateCoordinator], SensorEntity):
             identifiers={(DOMAIN, self._device.uuid)},
             manufacturer="Awair",
             model=self._device.model,
+            name=(
+                self._device.name
+                or cast(ConfigEntry, self.coordinator.config_entry).title
+                or f"{self._device.model} ({self._device.device_id})"
+            ),
         )
-
-        if self._device.name:
-            info[ATTR_NAME] = self._device.name
 
         if self._device.mac_address:
             info[ATTR_CONNECTIONS] = {

--- a/homeassistant/components/awair/sensor.py
+++ b/homeassistant/components/awair/sensor.py
@@ -8,7 +8,7 @@ from python_awair.devices import AwairBaseDevice, AwairLocalDevice
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ATTRIBUTION, ATTR_CONNECTIONS, ATTR_SW_VERSION
+from homeassistant.const import ATTR_CONNECTIONS, ATTR_SW_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
@@ -76,6 +76,7 @@ class AwairSensor(CoordinatorEntity[AwairDataUpdateCoordinator], SensorEntity):
 
     entity_description: AwairSensorEntityDescription
     _attr_has_entity_name = True
+    _attr_attribution = ATTRIBUTION
 
     def __init__(
         self,
@@ -177,7 +178,7 @@ class AwairSensor(CoordinatorEntity[AwairDataUpdateCoordinator], SensorEntity):
         https://docs.developer.getawair.com/?version=latest#awair-score-and-index
         """
         sensor_type = self.entity_description.key
-        attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
+        attrs: dict = {}
         if not self._air_data:
             return attrs
         if sensor_type in self._air_data.indices:

--- a/tests/components/awair/__init__.py
+++ b/tests/components/awair/__init__.py
@@ -1,1 +1,22 @@
 """Tests for the awair component."""
+
+
+from unittest.mock import patch
+
+from homeassistant.components.awair import DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_awair(hass: HomeAssistant, fixtures, unique_id, data) -> ConfigEntry:
+    """Add Awair devices to hass, using specified fixtures for data."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=unique_id, data=data)
+    with patch("python_awair.AwairClient.query", side_effect=fixtures):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    return entry

--- a/tests/components/awair/test_init.py
+++ b/tests/components/awair/test_init.py
@@ -1,0 +1,26 @@
+"""Test Awair init."""
+from unittest.mock import patch
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import setup_awair
+from .const import LOCAL_CONFIG, LOCAL_UNIQUE_ID
+
+
+async def test_local_awair_sensors(hass: HomeAssistant, local_devices, local_data):
+    """Test expected sensors on a local Awair."""
+    fixtures = [local_devices, local_data]
+    entry = await setup_awair(hass, fixtures, LOCAL_UNIQUE_ID, LOCAL_CONFIG)
+
+    dev_reg = dr.async_get(hass)
+    device_entry = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)[0]
+
+    assert device_entry.name == "Mock Title"
+
+    with patch("python_awair.AwairClient.query", side_effect=fixtures):
+        hass.config_entries.async_update_entry(entry, title="Hello World")
+        await hass.async_block_till_done()
+
+    device_entry = dev_reg.async_get(device_entry.id)
+    assert device_entry.name == "Hello World"

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -209,7 +209,7 @@ async def test_local_awair_sensors(hass: HomeAssistant, local_devices, local_dat
     assert_expected_properties(
         hass,
         registry,
-        "sensor.awair_score",
+        "sensor.mock_title_awair_score",
         f"{local_devices['device_uuid']}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "94",
         {},

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.awair.const import (
     API_SPL_A,
     API_TEMP,
     API_VOC,
-    DOMAIN,
     SENSOR_TYPE_SCORE,
     SENSOR_TYPES,
     SENSOR_TYPES_DUST,
@@ -30,6 +29,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
+from . import setup_awair
 from .const import (
     AWAIR_UUID,
     CLOUD_CONFIG,
@@ -38,21 +38,9 @@ from .const import (
     LOCAL_UNIQUE_ID,
 )
 
-from tests.common import MockConfigEntry
-
 SENSOR_TYPES_MAP = {
     desc.key: desc for desc in (SENSOR_TYPE_SCORE, *SENSOR_TYPES, *SENSOR_TYPES_DUST)
 }
-
-
-async def setup_awair(hass: HomeAssistant, fixtures, unique_id, data):
-    """Add Awair devices to hass, using specified fixtures for data."""
-
-    entry = MockConfigEntry(domain=DOMAIN, unique_id=unique_id, data=data)
-    with patch("python_awair.AwairClient.query", side_effect=fixtures):
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
 
 def assert_expected_properties(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Awair local API does not expose device name. This makes it fallback to config entry name or model + unique ID.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
