### PR TITLE
Refactor MQTT tests to use modern platform schema part 1

### DIFF
--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import alarm_control_panel
+from homeassistant.components import alarm_control_panel, mqtt
 from homeassistant.components.mqtt.alarm_control_panel import (
     MQTT_ALARM_ATTRIBUTES_BLOCKED,
 )
@@ -65,13 +65,23 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
-from tests.common import assert_setup_component, async_fire_mqtt_message
+from tests.common import async_fire_mqtt_message
 from tests.components.alarm_control_panel import common
 
 CODE_NUMBER = "1234"
 CODE_TEXT = "HELLO_CODE"
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {
+        alarm_control_panel.DOMAIN: {
+            "name": "test",
+            "state_topic": "alarm/state",
+            "command_topic": "alarm/command",
+        }
+    }
+}
+
+DEFAULT_CONFIG_LEGACY = {
     alarm_control_panel.DOMAIN: {
         "platform": "mqtt",
         "name": "test",
@@ -81,6 +91,20 @@ DEFAULT_CONFIG = {
 }
 
 DEFAULT_CONFIG_CODE = {
+    mqtt.DOMAIN: {
+        alarm_control_panel.DOMAIN: {
+            "name": "test",
+            "state_topic": "alarm/state",
+            "command_topic": "alarm/command",
+            "code": "0123",
+            "code_arm_required": True,
+        }
+    }
+}
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_CODE_LEGACY = {
     alarm_control_panel.DOMAIN: {
         "platform": "mqtt",
         "name": "test",
@@ -92,24 +116,26 @@ DEFAULT_CONFIG_CODE = {
 }
 
 DEFAULT_CONFIG_REMOTE_CODE = {
-    alarm_control_panel.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "state_topic": "alarm/state",
-        "command_topic": "alarm/command",
-        "code": "REMOTE_CODE",
-        "code_arm_required": True,
+    mqtt.DOMAIN: {
+        alarm_control_panel.DOMAIN: {
+            "name": "test",
+            "state_topic": "alarm/state",
+            "command_topic": "alarm/command",
+            "code": "REMOTE_CODE",
+            "code_arm_required": True,
+        }
     }
 }
 
 DEFAULT_CONFIG_REMOTE_CODE_TEXT = {
-    alarm_control_panel.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "state_topic": "alarm/state",
-        "command_topic": "alarm/command",
-        "code": "REMOTE_CODE_TEXT",
-        "code_arm_required": True,
+    mqtt.DOMAIN: {
+        alarm_control_panel.DOMAIN: {
+            "name": "test",
+            "state_topic": "alarm/state",
+            "command_topic": "alarm/command",
+            "code": "REMOTE_CODE_TEXT",
+            "code_arm_required": True,
+        }
     }
 }
 
@@ -123,47 +149,62 @@ def alarm_control_panel_platform_only():
         yield
 
 
-async def test_fail_setup_without_state_topic(hass, mqtt_mock_entry_no_yaml_config):
-    """Test for failing with no state topic."""
-    with assert_setup_component(0, alarm_control_panel.DOMAIN) as config:
-        assert await async_setup_component(
-            hass,
-            alarm_control_panel.DOMAIN,
+@pytest.mark.parametrize(
+    "config,valid",
+    [
+        (
             {
-                alarm_control_panel.DOMAIN: {
-                    "platform": "mqtt",
-                    "command_topic": "alarm/command",
+                mqtt.DOMAIN: {
+                    alarm_control_panel.DOMAIN: {
+                        "name": "test",
+                        "command_topic": "alarm/command",
+                    }
                 }
             },
-        )
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_no_yaml_config()
-        assert not config[alarm_control_panel.DOMAIN]
-
-
-async def test_fail_setup_without_command_topic(hass, mqtt_mock_entry_no_yaml_config):
-    """Test failing with no command topic."""
-    with assert_setup_component(0, alarm_control_panel.DOMAIN) as config:
-        assert await async_setup_component(
-            hass,
-            alarm_control_panel.DOMAIN,
+            False,
+        ),
+        (
             {
-                alarm_control_panel.DOMAIN: {
-                    "platform": "mqtt",
-                    "state_topic": "alarm/state",
+                mqtt.DOMAIN: {
+                    alarm_control_panel.DOMAIN: {
+                        "name": "test",
+                        "state_topic": "alarm/state",
+                    }
                 }
             },
+            False,
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    alarm_control_panel.DOMAIN: {
+                        "name": "test",
+                        "command_topic": "alarm/command",
+                        "state_topic": "alarm/state",
+                    }
+                }
+            },
+            True,
+        ),
+    ],
+)
+async def test_fail_setup_without_state_or_command_topic(hass, config, valid):
+    """Test for failing setup with no state or command topic."""
+    assert (
+        await async_setup_component(
+            hass,
+            mqtt.DOMAIN,
+            config,
         )
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_no_yaml_config()
-        assert not config[alarm_control_panel.DOMAIN]
+        is valid
+    )
 
 
 async def test_update_state_via_state_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test updating with via state topic."""
     assert await async_setup_component(
         hass,
-        alarm_control_panel.DOMAIN,
+        mqtt.DOMAIN,
         DEFAULT_CONFIG,
     )
     await hass.async_block_till_done()
@@ -195,7 +236,7 @@ async def test_ignore_update_state_if_unknown_via_state_topic(
     """Test ignoring updates via state topic."""
     assert await async_setup_component(
         hass,
-        alarm_control_panel.DOMAIN,
+        mqtt.DOMAIN,
         DEFAULT_CONFIG,
     )
     await hass.async_block_till_done()
@@ -227,7 +268,7 @@ async def test_publish_mqtt_no_code(
     """Test publishing of MQTT messages when no code is configured."""
     assert await async_setup_component(
         hass,
-        alarm_control_panel.DOMAIN,
+        mqtt.DOMAIN,
         DEFAULT_CONFIG,
     )
     await hass.async_block_till_done()
@@ -261,7 +302,7 @@ async def test_publish_mqtt_with_code(
     """Test publishing of MQTT messages when code is configured."""
     assert await async_setup_component(
         hass,
-        alarm_control_panel.DOMAIN,
+        mqtt.DOMAIN,
         DEFAULT_CONFIG_CODE,
     )
     await hass.async_block_till_done()
@@ -314,7 +355,7 @@ async def test_publish_mqtt_with_remote_code(
     """Test publishing of MQTT messages when remode code is configured."""
     assert await async_setup_component(
         hass,
-        alarm_control_panel.DOMAIN,
+        mqtt.DOMAIN,
         DEFAULT_CONFIG_REMOTE_CODE,
     )
     await hass.async_block_till_done()
@@ -358,7 +399,7 @@ async def test_publish_mqtt_with_remote_code_text(
     """Test publishing of MQTT messages when remote text code is configured."""
     assert await async_setup_component(
         hass,
-        alarm_control_panel.DOMAIN,
+        mqtt.DOMAIN,
         DEFAULT_CONFIG_REMOTE_CODE_TEXT,
     )
     await hass.async_block_till_done()
@@ -405,10 +446,10 @@ async def test_publish_mqtt_with_code_required_false(
     code_trigger_required = False
     """
     config = copy.deepcopy(DEFAULT_CONFIG_CODE)
-    config[alarm_control_panel.DOMAIN][disable_code] = False
+    config[mqtt.DOMAIN][alarm_control_panel.DOMAIN][disable_code] = False
     assert await async_setup_component(
         hass,
-        alarm_control_panel.DOMAIN,
+        mqtt.DOMAIN,
         config,
     )
     await hass.async_block_till_done()
@@ -453,13 +494,13 @@ async def test_disarm_publishes_mqtt_with_template(
     When command_template set to output json
     """
     config = copy.deepcopy(DEFAULT_CONFIG_CODE)
-    config[alarm_control_panel.DOMAIN]["code"] = "0123"
-    config[alarm_control_panel.DOMAIN][
+    config[mqtt.DOMAIN][alarm_control_panel.DOMAIN]["code"] = "0123"
+    config[mqtt.DOMAIN][alarm_control_panel.DOMAIN][
         "command_template"
     ] = '{"action":"{{ action }}","code":"{{ code }}"}'
     assert await async_setup_component(
         hass,
-        alarm_control_panel.DOMAIN,
+        mqtt.DOMAIN,
         config,
     )
     await hass.async_block_till_done()
@@ -477,19 +518,20 @@ async def test_update_state_via_state_topic_template(
     """Test updating with template_value via state topic."""
     assert await async_setup_component(
         hass,
-        alarm_control_panel.DOMAIN,
+        mqtt.DOMAIN,
         {
-            alarm_control_panel.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "test-topic",
-                "state_topic": "test-topic",
-                "value_template": "\
+            mqtt.DOMAIN: {
+                alarm_control_panel.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "test-topic",
+                    "state_topic": "test-topic",
+                    "value_template": "\
                 {% if (value | int)  == 100 %}\
                   armed_away\
                 {% else %}\
                    disarmed\
                 {% endif %}",
+                }
             }
         },
     )
@@ -508,9 +550,9 @@ async def test_update_state_via_state_topic_template(
 async def test_attributes_code_number(hass, mqtt_mock_entry_with_yaml_config):
     """Test attributes which are not supported by the vacuum."""
     config = copy.deepcopy(DEFAULT_CONFIG)
-    config[alarm_control_panel.DOMAIN]["code"] = CODE_NUMBER
+    config[mqtt.DOMAIN][alarm_control_panel.DOMAIN]["code"] = CODE_NUMBER
 
-    assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, config)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -524,9 +566,9 @@ async def test_attributes_code_number(hass, mqtt_mock_entry_with_yaml_config):
 async def test_attributes_remote_code_number(hass, mqtt_mock_entry_with_yaml_config):
     """Test attributes which are not supported by the vacuum."""
     config = copy.deepcopy(DEFAULT_CONFIG_REMOTE_CODE)
-    config[alarm_control_panel.DOMAIN]["code"] = "REMOTE_CODE"
+    config[mqtt.DOMAIN][alarm_control_panel.DOMAIN]["code"] = "REMOTE_CODE"
 
-    assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, config)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -540,9 +582,9 @@ async def test_attributes_remote_code_number(hass, mqtt_mock_entry_with_yaml_con
 async def test_attributes_code_text(hass, mqtt_mock_entry_with_yaml_config):
     """Test attributes which are not supported by the vacuum."""
     config = copy.deepcopy(DEFAULT_CONFIG)
-    config[alarm_control_panel.DOMAIN]["code"] = CODE_TEXT
+    config[mqtt.DOMAIN][alarm_control_panel.DOMAIN]["code"] = CODE_TEXT
 
-    assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, config)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -561,7 +603,7 @@ async def test_availability_when_connection_lost(
         hass,
         mqtt_mock_entry_with_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG_CODE,
+        DEFAULT_CONFIG_CODE_LEGACY,
     )
 
 
@@ -571,7 +613,7 @@ async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config
         hass,
         mqtt_mock_entry_with_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG_CODE,
+        DEFAULT_CONFIG_CODE_LEGACY,
     )
 
 
@@ -581,7 +623,7 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
         hass,
         mqtt_mock_entry_with_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG_CODE,
+        DEFAULT_CONFIG_CODE_LEGACY,
     )
 
 
@@ -591,7 +633,7 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
         hass,
         mqtt_mock_entry_with_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG_CODE,
+        DEFAULT_CONFIG_CODE_LEGACY,
     )
 
 
@@ -603,7 +645,7 @@ async def test_setting_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_with_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -615,7 +657,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_ALARM_ATTRIBUTES_BLOCKED,
     )
 
@@ -626,7 +668,7 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
         hass,
         mqtt_mock_entry_with_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -639,7 +681,7 @@ async def test_update_with_json_attrs_not_dict(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -652,7 +694,7 @@ async def test_update_with_json_attrs_bad_JSON(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -663,7 +705,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
         mqtt_mock_entry_no_yaml_config,
         caplog,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -694,7 +736,7 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_discovery_removal_alarm(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test removal of discovered alarm_control_panel."""
-    data = json.dumps(DEFAULT_CONFIG[alarm_control_panel.DOMAIN])
+    data = json.dumps(DEFAULT_CONFIG_LEGACY[alarm_control_panel.DOMAIN])
     await help_test_discovery_removal(
         hass, mqtt_mock_entry_no_yaml_config, caplog, alarm_control_panel.DOMAIN, data
     )
@@ -704,8 +746,8 @@ async def test_discovery_update_alarm_topic_and_template(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered alarm_control_panel."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[alarm_control_panel.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[alarm_control_panel.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[alarm_control_panel.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[alarm_control_panel.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
     config1["state_topic"] = "alarm/state1"
@@ -739,8 +781,8 @@ async def test_discovery_update_alarm_template(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered alarm_control_panel."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[alarm_control_panel.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[alarm_control_panel.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[alarm_control_panel.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[alarm_control_panel.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
     config1["state_topic"] = "alarm/state1"
@@ -772,7 +814,7 @@ async def test_discovery_update_unchanged_alarm(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered alarm_control_panel."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[alarm_control_panel.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[alarm_control_panel.DOMAIN])
     config1["name"] = "Beer"
 
     data1 = json.dumps(config1)
@@ -824,7 +866,7 @@ async def test_encoding_subscribable_topics(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG[alarm_control_panel.DOMAIN],
+        DEFAULT_CONFIG_LEGACY[alarm_control_panel.DOMAIN],
         topic,
         value,
     )
@@ -836,7 +878,7 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_
         hass,
         mqtt_mock_entry_no_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -846,21 +888,27 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_
         hass,
         mqtt_mock_entry_no_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, alarm_control_panel.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        alarm_control_panel.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, alarm_control_panel.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        alarm_control_panel.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -870,14 +918,17 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_co
         hass,
         mqtt_mock_entry_with_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, alarm_control_panel.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        alarm_control_panel.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -887,7 +938,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         alarm_control_panel.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         alarm_control_panel.SERVICE_ALARM_DISARM,
         command_payload="DISARM",
     )
@@ -930,7 +981,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = alarm_control_panel.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
 
     await help_test_publishing_with_custom_encoding(
         hass,
@@ -951,7 +1002,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = alarm_control_panel.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -960,14 +1011,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = alarm_control_panel.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = alarm_control_panel.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -977,7 +1028,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = alarm_control_panel.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = alarm_control_panel.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -117,8 +117,8 @@ DEFAULT_CONFIG_REMOTE_CODE_TEXT = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[alarm_control_panel.DOMAIN]["platform"] = mqtt.DOMAIN
 DEFAULT_CONFIG_CODE_LEGACY = copy.deepcopy(DEFAULT_CONFIG_CODE[mqtt.DOMAIN])
@@ -1019,8 +1019,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = alarm_control_panel.DOMAIN

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -81,15 +81,6 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    alarm_control_panel.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "state_topic": "alarm/state",
-        "command_topic": "alarm/command",
-    }
-}
-
 DEFAULT_CONFIG_CODE = {
     mqtt.DOMAIN: {
         alarm_control_panel.DOMAIN: {
@@ -99,19 +90,6 @@ DEFAULT_CONFIG_CODE = {
             "code": "0123",
             "code_arm_required": True,
         }
-    }
-}
-
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
-DEFAULT_CONFIG_CODE_LEGACY = {
-    alarm_control_panel.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "state_topic": "alarm/state",
-        "command_topic": "alarm/command",
-        "code": "0123",
-        "code_arm_required": True,
     }
 }
 
@@ -138,6 +116,13 @@ DEFAULT_CONFIG_REMOTE_CODE_TEXT = {
         }
     }
 }
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[alarm_control_panel.DOMAIN]["platform"] = mqtt.DOMAIN
+DEFAULT_CONFIG_CODE_LEGACY = copy.deepcopy(DEFAULT_CONFIG_CODE[mqtt.DOMAIN])
+DEFAULT_CONFIG_CODE_LEGACY[alarm_control_panel.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -56,9 +56,11 @@ from tests.common import (
 )
 
 DEFAULT_CONFIG = {
-    binary_sensor.DOMAIN: {
-        "name": "test",
-        "state_topic": "test-topic",
+    mqtt.DOMAIN: {
+        binary_sensor.DOMAIN: {
+            "name": "test",
+            "state_topic": "test-topic",
+        }
     }
 }
 
@@ -1103,7 +1105,7 @@ async def test_skip_restoring_state_with_over_due_expire_trigger(
 
     freezer.move_to("2022-02-02 12:02:00+01:00")
     domain = binary_sensor.DOMAIN
-    config3 = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config3 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][domain])
     config3["name"] = "test3"
     config3["expire_after"] = 10
     config3["state_topic"] = "test-topic3"

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -64,13 +64,10 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    binary_sensor.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "state_topic": "test-topic",
-    }
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[binary_sensor.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -64,8 +64,8 @@ DEFAULT_CONFIG = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[binary_sensor.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -1141,8 +1141,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = binary_sensor.DOMAIN

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import binary_sensor
+from homeassistant.components import binary_sensor, mqtt
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
     STATE_OFF,
@@ -50,13 +50,19 @@ from .test_common import (
 )
 
 from tests.common import (
-    assert_setup_component,
     async_fire_mqtt_message,
     async_fire_time_changed,
     mock_restore_cache,
 )
 
 DEFAULT_CONFIG = {
+    binary_sensor.DOMAIN: {
+        "name": "test",
+        "state_topic": "test-topic",
+    }
+}
+
+DEFAULT_CONFIG_LEGACY = {
     binary_sensor.DOMAIN: {
         "platform": "mqtt",
         "name": "test",
@@ -78,15 +84,16 @@ async def test_setting_sensor_value_expires_availability_topic(
     """Test the expiration of the value."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "expire_after": 4,
-                "force_update": True,
-                "availability_topic": "availability-topic",
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "expire_after": 4,
+                    "force_update": True,
+                    "availability_topic": "availability-topic",
+                }
             }
         },
     )
@@ -270,14 +277,15 @@ async def test_setting_sensor_value_via_mqtt_message(
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "payload_on": "ON",
-                "payload_off": "OFF",
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                }
             }
         },
     )
@@ -307,14 +315,15 @@ async def test_invalid_sensor_value_via_mqtt_message(
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "payload_on": "ON",
-                "payload_off": "OFF",
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                }
             }
         },
     )
@@ -348,16 +357,17 @@ async def test_setting_sensor_value_via_mqtt_message_and_template(
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "payload_on": "ON",
-                "payload_off": "OFF",
-                "value_template": '{%if is_state(entity_id,"on")-%}OFF'
-                "{%-else-%}ON{%-endif%}",
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                    "value_template": '{%if is_state(entity_id,"on")-%}OFF'
+                    "{%-else-%}ON{%-endif%}",
+                }
             }
         },
     )
@@ -382,15 +392,16 @@ async def test_setting_sensor_value_via_mqtt_message_and_template2(
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "payload_on": "ON",
-                "payload_off": "OFF",
-                "value_template": "{{value | upper}}",
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                    "value_template": "{{value | upper}}",
+                }
             }
         },
     )
@@ -420,16 +431,17 @@ async def test_setting_sensor_value_via_mqtt_message_and_template_and_raw_state_
     """Test processing a raw value via MQTT."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "encoding": "",
-                "state_topic": "test-topic",
-                "payload_on": "ON",
-                "payload_off": "OFF",
-                "value_template": "{%if value|unpack('b')-%}ON{%else%}OFF{%-endif-%}",
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "encoding": "",
+                    "state_topic": "test-topic",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                    "value_template": "{%if value|unpack('b')-%}ON{%else%}OFF{%-endif-%}",
+                }
             }
         },
     )
@@ -454,15 +466,16 @@ async def test_setting_sensor_value_via_mqtt_message_empty_template(
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "payload_on": "ON",
-                "payload_off": "OFF",
-                "value_template": '{%if value == "ABC"%}ON{%endif%}',
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                    "value_template": '{%if value == "ABC"%}ON{%endif%}',
+                }
             }
         },
     )
@@ -486,13 +499,14 @@ async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of a valid sensor class."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "device_class": "motion",
-                "state_topic": "test-topic",
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "device_class": "motion",
+                    "state_topic": "test-topic",
+                }
             }
         },
     )
@@ -503,25 +517,22 @@ async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("device_class") == "motion"
 
 
-async def test_invalid_device_class(hass, mqtt_mock_entry_no_yaml_config):
+async def test_invalid_device_class(hass, caplog):
     """Test the setting of an invalid sensor class."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "device_class": "abc123",
-                "state_topic": "test-topic",
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "device_class": "abc123",
+                    "state_topic": "test-topic",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
-    state = hass.states.get("binary_sensor.test")
-    assert state is None
+    assert "Invalid config for [mqtt]: expected BinarySensorDeviceClass" in caplog.text
 
 
 async def test_availability_when_connection_lost(
@@ -529,28 +540,40 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -558,14 +581,15 @@ async def test_force_update_disabled(hass, mqtt_mock_entry_with_yaml_config):
     """Test force update option."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "payload_on": "ON",
-                "payload_off": "OFF",
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                }
             }
         },
     )
@@ -594,15 +618,16 @@ async def test_force_update_enabled(hass, mqtt_mock_entry_with_yaml_config):
     """Test force update option."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "payload_on": "ON",
-                "payload_off": "OFF",
-                "force_update": True,
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                    "force_update": True,
+                }
             }
         },
     )
@@ -631,16 +656,17 @@ async def test_off_delay(hass, mqtt_mock_entry_with_yaml_config):
     """Test off_delay option."""
     assert await async_setup_component(
         hass,
-        binary_sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            binary_sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "payload_on": "ON",
-                "payload_off": "OFF",
-                "off_delay": 30,
-                "force_update": True,
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                    "off_delay": 30,
+                    "force_update": True,
+                }
             }
         },
     )
@@ -680,14 +706,20 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -700,7 +732,7 @@ async def test_update_with_json_attrs_not_dict(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         binary_sensor.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -713,7 +745,7 @@ async def test_update_with_json_attrs_bad_JSON(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         binary_sensor.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -724,7 +756,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
         mqtt_mock_entry_no_yaml_config,
         caplog,
         binary_sensor.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -755,7 +787,7 @@ async def test_discovery_removal_binary_sensor(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test removal of discovered binary_sensor."""
-    data = json.dumps(DEFAULT_CONFIG[binary_sensor.DOMAIN])
+    data = json.dumps(DEFAULT_CONFIG_LEGACY[binary_sensor.DOMAIN])
     await help_test_discovery_removal(
         hass, mqtt_mock_entry_no_yaml_config, caplog, binary_sensor.DOMAIN, data
     )
@@ -765,8 +797,8 @@ async def test_discovery_update_binary_sensor_topic_template(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered binary_sensor."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[binary_sensor.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[binary_sensor.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[binary_sensor.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[binary_sensor.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
     config1["state_topic"] = "sensor/state1"
@@ -802,8 +834,8 @@ async def test_discovery_update_binary_sensor_template(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered binary_sensor."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[binary_sensor.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[binary_sensor.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[binary_sensor.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[binary_sensor.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
     config1["state_topic"] = "sensor/state1"
@@ -861,7 +893,7 @@ async def test_encoding_subscribable_topics(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         binary_sensor.DOMAIN,
-        DEFAULT_CONFIG[binary_sensor.DOMAIN],
+        DEFAULT_CONFIG_LEGACY[binary_sensor.DOMAIN],
         topic,
         value,
         attribute,
@@ -873,7 +905,7 @@ async def test_discovery_update_unchanged_binary_sensor(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered binary_sensor."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[binary_sensor.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[binary_sensor.DOMAIN])
     config1["name"] = "Beer"
 
     data1 = json.dumps(config1)
@@ -908,42 +940,60 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT binary sensor device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT binary sensor device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, binary_sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -953,7 +1003,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         binary_sensor.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         None,
     )
 
@@ -961,7 +1011,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = binary_sensor.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -970,7 +1020,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = binary_sensor.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -991,11 +1041,11 @@ async def test_cleanup_triggers_and_restoring_state(
 ):
     """Test cleanup old triggers at reloading and restoring the state."""
     domain = binary_sensor.DOMAIN
-    config1 = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
     config1["name"] = "test1"
     config1["expire_after"] = 30
     config1["state_topic"] = "test-topic1"
-    config2 = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
     config2["name"] = "test2"
     config2["expire_after"] = 5
     config2["state_topic"] = "test-topic2"
@@ -1065,17 +1115,18 @@ async def test_skip_restoring_state_with_over_due_expire_trigger(
     )
     mock_restore_cache(hass, (fake_state,))
 
-    with assert_setup_component(1, domain):
-        assert await async_setup_component(hass, domain, {domain: config3})
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_with_yaml_config()
+    assert await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {domain: config3}}
+    )
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
     assert "Skip state recovery after reload for binary_sensor.test3" in caplog.text
 
 
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = binary_sensor.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -1085,7 +1136,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = binary_sensor.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = binary_sensor.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_button.py
+++ b/tests/components/mqtt/test_button.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import button
+from homeassistant.components import button, mqtt
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
@@ -42,7 +42,9 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
-DEFAULT_CONFIG = {
+DEFAULT_CONFIG = {button.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
+
+DEFAULT_CONFIG_LEGACY = {
     button.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
 
@@ -59,15 +61,16 @@ async def test_sending_mqtt_commands(hass, mqtt_mock_entry_with_yaml_config):
     """Test the sending MQTT commands."""
     assert await async_setup_component(
         hass,
-        button.DOMAIN,
+        mqtt.DOMAIN,
         {
-            button.DOMAIN: {
-                "command_topic": "command-topic",
-                "name": "test",
-                "object_id": "test_button",
-                "payload_press": "beer press",
-                "platform": "mqtt",
-                "qos": "2",
+            mqtt.DOMAIN: {
+                button.DOMAIN: {
+                    "command_topic": "command-topic",
+                    "name": "test",
+                    "object_id": "test_button",
+                    "payload_press": "beer press",
+                    "qos": "2",
+                }
             }
         },
     )
@@ -97,14 +100,15 @@ async def test_command_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the sending of MQTT commands through a command template."""
     assert await async_setup_component(
         hass,
-        button.DOMAIN,
+        mqtt.DOMAIN,
         {
-            button.DOMAIN: {
-                "command_topic": "command-topic",
-                "command_template": '{ "{{ value }}": "{{ entity_id }}" }',
-                "name": "test",
-                "payload_press": "milky_way_press",
-                "platform": "mqtt",
+            mqtt.DOMAIN: {
+                button.DOMAIN: {
+                    "command_topic": "command-topic",
+                    "command_template": '{ "{{ value }}": "{{ entity_id }}" }',
+                    "name": "test",
+                    "payload_press": "milky_way_press",
+                }
             }
         },
     )
@@ -133,14 +137,14 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -193,7 +197,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -202,14 +206,14 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG, None
+        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY, None
     )
 
 
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -218,7 +222,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, button.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        button.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -227,14 +235,22 @@ async def test_update_with_json_attrs_bad_JSON(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, button.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        button.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, button.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        button.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -271,8 +287,8 @@ async def test_discovery_removal_button(hass, mqtt_mock_entry_no_yaml_config, ca
 
 async def test_discovery_update_button(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered button."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[button.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[button.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[button.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[button.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
 
@@ -321,35 +337,35 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT button device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT button device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -359,59 +375,54 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         button.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         button.SERVICE_PRESS,
         command_payload="PRESS",
         state_topic=None,
     )
 
 
-async def test_invalid_device_class(hass, mqtt_mock_entry_no_yaml_config):
+async def test_invalid_device_class(hass):
     """Test device_class option with invalid value."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        button.DOMAIN,
+        mqtt.DOMAIN,
         {
-            button.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "device_class": "foobarnotreal",
+            mqtt.DOMAIN: {
+                button.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "device_class": "foobarnotreal",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
-    state = hass.states.get("button.test")
-    assert state is None
 
 
 async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     """Test device_class option with valid values."""
     assert await async_setup_component(
         hass,
-        button.DOMAIN,
+        mqtt.DOMAIN,
         {
-            button.DOMAIN: [
-                {
-                    "platform": "mqtt",
-                    "name": "Test 1",
-                    "command_topic": "test-topic",
-                    "device_class": "update",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "Test 2",
-                    "command_topic": "test-topic",
-                    "device_class": "restart",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "Test 3",
-                    "command_topic": "test-topic",
-                },
-            ]
+            mqtt.DOMAIN: {
+                button.DOMAIN: [
+                    {
+                        "name": "Test 1",
+                        "command_topic": "test-topic",
+                        "device_class": "update",
+                    },
+                    {
+                        "name": "Test 2",
+                        "command_topic": "test-topic",
+                        "device_class": "restart",
+                    },
+                    {
+                        "name": "Test 3",
+                        "command_topic": "test-topic",
+                    },
+                ]
+            }
         },
     )
     await hass.async_block_till_done()
@@ -443,7 +454,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = button.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
 
     await help_test_publishing_with_custom_encoding(
         hass,
@@ -462,7 +473,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = button.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -471,14 +482,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = button.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = button.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -488,7 +499,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = button.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = button.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_button.py
+++ b/tests/components/mqtt/test_button.py
@@ -46,9 +46,10 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {button.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    button.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[button.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_button.py
+++ b/tests/components/mqtt/test_button.py
@@ -42,7 +42,9 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
-DEFAULT_CONFIG = {button.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
+DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {button.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
+}
 
 DEFAULT_CONFIG_LEGACY = {
     button.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}

--- a/tests/components/mqtt/test_button.py
+++ b/tests/components/mqtt/test_button.py
@@ -46,8 +46,8 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {button.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[button.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -508,8 +508,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = button.DOMAIN

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -43,7 +43,7 @@ from .test_common import (
 
 from tests.common import async_fire_mqtt_message
 
-DEFAULT_CONFIG = {camera.DOMAIN: {"name": "test", "topic": "test_topic"}}
+DEFAULT_CONFIG = {mqtt.DOMAIN: {camera.DOMAIN: {"name": "test", "topic": "test_topic"}}}
 
 DEFAULT_CONFIG_LEGACY = {
     camera.DOMAIN: {"platform": "mqtt", "name": "test", "topic": "test_topic"}

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -45,9 +45,10 @@ from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {mqtt.DOMAIN: {camera.DOMAIN: {"name": "test", "topic": "test_topic"}}}
 
-DEFAULT_CONFIG_LEGACY = {
-    camera.DOMAIN: {"platform": "mqtt", "name": "test", "topic": "test_topic"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[camera.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -45,8 +45,8 @@ from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {mqtt.DOMAIN: {camera.DOMAIN: {"name": "test", "topic": "test_topic"}}}
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[camera.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -450,8 +450,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = camera.DOMAIN

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -87,29 +87,10 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    climate.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "mode_command_topic": "mode-topic",
-        "temperature_command_topic": "temperature-topic",
-        "temperature_low_command_topic": "temperature-low-topic",
-        "temperature_high_command_topic": "temperature-high-topic",
-        "fan_mode_command_topic": "fan-mode-topic",
-        "swing_mode_command_topic": "swing-mode-topic",
-        "aux_command_topic": "aux-topic",
-        "preset_mode_command_topic": "preset-mode-topic",
-        "preset_modes": [
-            "eco",
-            "away",
-            "boost",
-            "comfort",
-            "home",
-            "sleep",
-            "activity",
-        ],
-    }
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[climate.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -6,7 +6,7 @@ from unittest.mock import call, patch
 import pytest
 import voluptuous as vol
 
-from homeassistant.components import climate
+from homeassistant.components import climate, mqtt
 from homeassistant.components.climate import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP
 from homeassistant.components.climate.const import (
     ATTR_AUX_HEAT,
@@ -16,10 +16,9 @@ from homeassistant.components.climate.const import (
     ATTR_SWING_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    CURRENT_HVAC_ACTIONS,
-    DOMAIN as CLIMATE_DOMAIN,
     PRESET_ECO,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.components.mqtt.climate import MQTT_CLIMATE_ATTRIBUTES_BLOCKED
@@ -62,8 +61,34 @@ from tests.components.climate import common
 
 ENTITY_CLIMATE = "climate.test"
 
+
 DEFAULT_CONFIG = {
-    CLIMATE_DOMAIN: {
+    mqtt.DOMAIN: {
+        climate.DOMAIN: {
+            "name": "test",
+            "mode_command_topic": "mode-topic",
+            "temperature_command_topic": "temperature-topic",
+            "temperature_low_command_topic": "temperature-low-topic",
+            "temperature_high_command_topic": "temperature-high-topic",
+            "fan_mode_command_topic": "fan-mode-topic",
+            "swing_mode_command_topic": "swing-mode-topic",
+            "aux_command_topic": "aux-topic",
+            "preset_mode_command_topic": "preset-mode-topic",
+            "preset_modes": [
+                "eco",
+                "away",
+                "boost",
+                "comfort",
+                "home",
+                "sleep",
+                "activity",
+            ],
+        }
+    }
+}
+
+DEFAULT_CONFIG_LEGACY = {
+    climate.DOMAIN: {
         "platform": "mqtt",
         "name": "test",
         "mode_command_topic": "mode-topic",
@@ -96,7 +121,7 @@ def climate_platform_only():
 
 async def test_setup_params(hass, mqtt_mock_entry_with_yaml_config):
     """Test the initial parameters."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -109,18 +134,14 @@ async def test_setup_params(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("max_temp") == DEFAULT_MAX_TEMP
 
 
-async def test_preset_none_in_preset_modes(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+async def test_preset_none_in_preset_modes(hass, caplog):
     """Test the preset mode payload reset configuration."""
-    config = copy.deepcopy(DEFAULT_CONFIG[CLIMATE_DOMAIN])
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][climate.DOMAIN])
     config["preset_modes"].append("none")
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, {CLIMATE_DOMAIN: config})
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-    assert "Invalid config for [climate.mqtt]: not a valid value" in caplog.text
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state is None
+    assert not await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {climate.DOMAIN: config}}
+    )
+    assert "Invalid config for [mqtt]: not a valid value" in caplog.text
 
 
 # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
@@ -136,22 +157,19 @@ async def test_preset_none_in_preset_modes(
         ("hold_mode_state_template", "{{ value_json }}"),
     ],
 )
-async def test_preset_modes_deprecation_guard(
-    hass, mqtt_mock_entry_no_yaml_config, caplog, parameter, config_value
-):
+async def test_preset_modes_deprecation_guard(hass, caplog, parameter, config_value):
     """Test the configuration for invalid legacy parameters."""
-    config = copy.deepcopy(DEFAULT_CONFIG[CLIMATE_DOMAIN])
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][climate.DOMAIN])
     config[parameter] = config_value
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, {CLIMATE_DOMAIN: config})
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state is None
+    assert not await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {climate.DOMAIN: config}}
+    )
+    assert f"[{parameter}] is an invalid option for [mqtt]. Check: mqtt->mqtt->climate->0->{parameter}"
 
 
 async def test_supported_features(hass, mqtt_mock_entry_with_yaml_config):
     """Test the supported_features."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -170,7 +188,7 @@ async def test_supported_features(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_get_hvac_modes(hass, mqtt_mock_entry_with_yaml_config):
     """Test that the operation list returns the correct modes."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -193,7 +211,7 @@ async def test_set_operation_bad_attr_and_state(
 
     Also check the state.
     """
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -210,7 +228,7 @@ async def test_set_operation_bad_attr_and_state(
 
 async def test_set_operation(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting of new operation mode."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -225,9 +243,9 @@ async def test_set_operation(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_set_operation_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting operation mode in pessimistic mode."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["mode_state_topic"] = "mode-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -249,9 +267,9 @@ async def test_set_operation_pessimistic(hass, mqtt_mock_entry_with_yaml_config)
 
 async def test_set_operation_with_power_command(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting of new operation mode with power command enabled."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["power_command_topic"] = "power-command"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -276,7 +294,7 @@ async def test_set_operation_with_power_command(hass, mqtt_mock_entry_with_yaml_
 
 async def test_set_fan_mode_bad_attr(hass, mqtt_mock_entry_with_yaml_config, caplog):
     """Test setting fan mode without required attribute."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -293,9 +311,9 @@ async def test_set_fan_mode_bad_attr(hass, mqtt_mock_entry_with_yaml_config, cap
 
 async def test_set_fan_mode_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting of new fan mode in pessimistic mode."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["fan_mode_state_topic"] = "fan-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -317,7 +335,7 @@ async def test_set_fan_mode_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_set_fan_mode(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting of new fan mode."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -331,7 +349,7 @@ async def test_set_fan_mode(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_set_swing_mode_bad_attr(hass, mqtt_mock_entry_with_yaml_config, caplog):
     """Test setting swing mode without required attribute."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -348,9 +366,9 @@ async def test_set_swing_mode_bad_attr(hass, mqtt_mock_entry_with_yaml_config, c
 
 async def test_set_swing_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting swing mode in pessimistic mode."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["swing_mode_state_topic"] = "swing-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -372,7 +390,7 @@ async def test_set_swing_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_set_swing(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting of new swing mode."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -386,7 +404,7 @@ async def test_set_swing(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_set_target_temperature(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting the target temperature."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -425,9 +443,9 @@ async def test_set_target_temperature_pessimistic(
     hass, mqtt_mock_entry_with_yaml_config
 ):
     """Test setting the target temperature."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temperature_state_topic"] = "temperature-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -449,7 +467,7 @@ async def test_set_target_temperature_pessimistic(
 
 async def test_set_target_temperature_low_high(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting the low/high target temperature."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -467,10 +485,10 @@ async def test_set_target_temperature_low_highpessimistic(
     hass, mqtt_mock_entry_with_yaml_config
 ):
     """Test setting the low/high target temperature."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temperature_low_state_topic"] = "temperature-low-state"
     config["climate"]["temperature_high_state_topic"] = "temperature-high-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -505,9 +523,9 @@ async def test_set_target_temperature_low_highpessimistic(
 
 async def test_receive_mqtt_temperature(hass, mqtt_mock_entry_with_yaml_config):
     """Test getting the current temperature via MQTT."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["current_temperature_topic"] = "current_temperature"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -518,9 +536,9 @@ async def test_receive_mqtt_temperature(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_handle_action_received(hass, mqtt_mock_entry_with_yaml_config):
     """Test getting the action received via MQTT."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["action_topic"] = "action"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -531,7 +549,7 @@ async def test_handle_action_received(hass, mqtt_mock_entry_with_yaml_config):
     assert hvac_action is None
     # Redefine actions according to https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action
     actions = ["off", "heating", "cooling", "drying", "idle", "fan"]
-    assert all(elem in actions for elem in CURRENT_HVAC_ACTIONS)
+    assert all(elem in actions for elem in HVACAction)
     for action in actions:
         async_fire_mqtt_message(hass, "action", action)
         state = hass.states.get(ENTITY_CLIMATE)
@@ -543,8 +561,8 @@ async def test_set_preset_mode_optimistic(
     hass, mqtt_mock_entry_with_yaml_config, caplog
 ):
     """Test setting of the preset mode."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -591,9 +609,9 @@ async def test_set_preset_mode_pessimistic(
     hass, mqtt_mock_entry_with_yaml_config, caplog
 ):
     """Test setting of the preset mode."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["preset_mode_state_topic"] = "preset-mode-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -636,9 +654,9 @@ async def test_set_preset_mode_pessimistic(
 
 async def test_set_aux_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting of the aux heating in pessimistic mode."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["aux_state_topic"] = "aux-state"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -664,7 +682,7 @@ async def test_set_aux_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_set_aux(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting of the aux heating."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -687,28 +705,28 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -716,13 +734,13 @@ async def test_get_target_temperature_low_high_with_templates(
     hass, mqtt_mock_entry_with_yaml_config, caplog
 ):
     """Test getting temperature high/low with templates."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temperature_low_state_topic"] = "temperature-state"
     config["climate"]["temperature_high_state_topic"] = "temperature-state"
     config["climate"]["temperature_low_state_template"] = "{{ value_json.temp_low }}"
     config["climate"]["temperature_high_state_template"] = "{{ value_json.temp_high }}"
 
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -751,7 +769,7 @@ async def test_get_target_temperature_low_high_with_templates(
 
 async def test_get_with_templates(hass, mqtt_mock_entry_with_yaml_config, caplog):
     """Test getting various attributes with templates."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     # By default, just unquote the JSON-strings
     config["climate"]["value_template"] = "{{ value_json }}"
     config["climate"]["action_template"] = "{{ value_json }}"
@@ -768,7 +786,7 @@ async def test_get_with_templates(hass, mqtt_mock_entry_with_yaml_config, caplog
     config["climate"]["aux_state_topic"] = "aux-state"
     config["climate"]["current_temperature_topic"] = "current-temperature"
     config["climate"]["preset_mode_state_topic"] = "current-preset-mode"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -850,7 +868,7 @@ async def test_get_with_templates(hass, mqtt_mock_entry_with_yaml_config, caplog
 
 async def test_set_and_templates(hass, mqtt_mock_entry_with_yaml_config, caplog):
     """Test setting various attributes with templates."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     # Create simple templates
     config["climate"]["fan_mode_command_template"] = "fan_mode: {{ value }}"
     config["climate"]["preset_mode_command_template"] = "preset_mode: {{ value }}"
@@ -860,7 +878,7 @@ async def test_set_and_templates(hass, mqtt_mock_entry_with_yaml_config, caplog)
     config["climate"]["temperature_high_command_template"] = "temp_hi: {{ value }}"
     config["climate"]["temperature_low_command_template"] = "temp_lo: {{ value }}"
 
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -928,10 +946,10 @@ async def test_set_and_templates(hass, mqtt_mock_entry_with_yaml_config, caplog)
 
 async def test_min_temp_custom(hass, mqtt_mock_entry_with_yaml_config):
     """Test a custom min temp."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["min_temp"] = 26
 
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -944,10 +962,10 @@ async def test_min_temp_custom(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_max_temp_custom(hass, mqtt_mock_entry_with_yaml_config):
     """Test a custom max temp."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["max_temp"] = 60
 
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -960,10 +978,10 @@ async def test_max_temp_custom(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_temp_step_custom(hass, mqtt_mock_entry_with_yaml_config):
     """Test a custom temp step."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temp_step"] = 0.01
 
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -976,11 +994,11 @@ async def test_temp_step_custom(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_temperature_unit(hass, mqtt_mock_entry_with_yaml_config):
     """Test that setting temperature unit converts temperature values."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temperature_unit"] = "F"
     config["climate"]["current_temperature_topic"] = "current_temperature"
 
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -995,7 +1013,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -1006,8 +1024,8 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
-        CLIMATE_DOMAIN,
-        DEFAULT_CONFIG,
+        climate.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_CLIMATE_ATTRIBUTES_BLOCKED,
     )
 
@@ -1015,7 +1033,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -1024,7 +1042,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        climate.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -1033,21 +1055,29 @@ async def test_update_with_json_attrs_bad_JSON(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        climate.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        climate.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     """Test unique id option only creates one climate per unique_id."""
     config = {
-        CLIMATE_DOMAIN: [
+        climate.DOMAIN: [
             {
                 "platform": "mqtt",
                 "name": "Test 1",
@@ -1065,7 +1095,7 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
         ]
     }
     await help_test_unique_id(
-        hass, mqtt_mock_entry_with_yaml_config, CLIMATE_DOMAIN, config
+        hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, config
     )
 
 
@@ -1095,12 +1125,12 @@ async def test_encoding_subscribable_topics(
     attribute_value,
 ):
     """Test handling of incoming encoded payload."""
-    config = copy.deepcopy(DEFAULT_CONFIG[CLIMATE_DOMAIN])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[climate.DOMAIN])
     await help_test_encoding_subscribable_topics(
         hass,
         mqtt_mock_entry_with_yaml_config,
         caplog,
-        CLIMATE_DOMAIN,
+        climate.DOMAIN,
         config,
         topic,
         value,
@@ -1111,9 +1141,9 @@ async def test_encoding_subscribable_topics(
 
 async def test_discovery_removal_climate(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test removal of discovered climate."""
-    data = json.dumps(DEFAULT_CONFIG[CLIMATE_DOMAIN])
+    data = json.dumps(DEFAULT_CONFIG_LEGACY[climate.DOMAIN])
     await help_test_discovery_removal(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, CLIMATE_DOMAIN, data
+        hass, mqtt_mock_entry_no_yaml_config, caplog, climate.DOMAIN, data
     )
 
 
@@ -1122,7 +1152,7 @@ async def test_discovery_update_climate(hass, mqtt_mock_entry_no_yaml_config, ca
     config1 = {"name": "Beer"}
     config2 = {"name": "Milk"}
     await help_test_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, CLIMATE_DOMAIN, config1, config2
+        hass, mqtt_mock_entry_no_yaml_config, caplog, climate.DOMAIN, config1, config2
     )
 
 
@@ -1138,7 +1168,7 @@ async def test_discovery_update_unchanged_climate(
             hass,
             mqtt_mock_entry_no_yaml_config,
             caplog,
-            CLIMATE_DOMAIN,
+            climate.DOMAIN,
             data1,
             discovery_update,
         )
@@ -1150,42 +1180,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     data1 = '{ "name": "Beer", "power_command_topic": "test_topic#" }'
     data2 = '{ "name": "Milk", "power_command_topic": "test_topic" }'
     await help_test_discovery_broken(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, CLIMATE_DOMAIN, data1, data2
+        hass, mqtt_mock_entry_no_yaml_config, caplog, climate.DOMAIN, data1, data2
     )
 
 
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT climate device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT climate device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = {
-        CLIMATE_DOMAIN: {
+        climate.DOMAIN: {
             "platform": "mqtt",
             "name": "test",
             "mode_state_topic": "test-topic",
@@ -1195,7 +1225,7 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_co
     await help_test_entity_id_update_subscriptions(
         hass,
         mqtt_mock_entry_with_yaml_config,
-        CLIMATE_DOMAIN,
+        climate.DOMAIN,
         config,
         ["test-topic", "avty-topic"],
     )
@@ -1204,14 +1234,14 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_co
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, CLIMATE_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT debug info."""
     config = {
-        CLIMATE_DOMAIN: {
+        climate.DOMAIN: {
             "platform": "mqtt",
             "name": "test",
             "mode_command_topic": "command-topic",
@@ -1221,7 +1251,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     await help_test_entity_debug_info_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
-        CLIMATE_DOMAIN,
+        climate.DOMAIN,
         config,
         climate.SERVICE_TURN_ON,
         command_topic="command-topic",
@@ -1232,7 +1262,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
 
 async def test_precision_default(hass, mqtt_mock_entry_with_yaml_config):
     """Test that setting precision to tenths works as intended."""
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1246,9 +1276,9 @@ async def test_precision_default(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_precision_halves(hass, mqtt_mock_entry_with_yaml_config):
     """Test that setting precision to halves works as intended."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["precision"] = 0.5
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1262,9 +1292,9 @@ async def test_precision_halves(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_precision_whole(hass, mqtt_mock_entry_with_yaml_config):
     """Test that setting precision to whole works as intended."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["precision"] = 1.0
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1364,7 +1394,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = climate.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
     if topic != "preset_mode_command_topic":
         del config["preset_mode_command_topic"]
         del config["preset_modes"]
@@ -1385,8 +1415,8 @@ async def test_publishing_with_custom_encoding(
 
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
-    domain = CLIMATE_DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    domain = climate.DOMAIN
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -1394,15 +1424,15 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
-    domain = CLIMATE_DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    domain = climate.DOMAIN
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
-    platform = CLIMATE_DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    platform = climate.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -1412,7 +1442,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = climate.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = climate.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -87,8 +87,8 @@ DEFAULT_CONFIG = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[climate.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -1429,8 +1429,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = climate.DOMAIN

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import cover
+from homeassistant.components import cover, mqtt
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
@@ -81,6 +81,10 @@ from .test_common import (
 from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {cover.DOMAIN: {"name": "test", "state_topic": "test-topic"}}
+}
+
+DEFAULT_CONFIG_LEGACY = {
     cover.DOMAIN: {"platform": "mqtt", "name": "test", "state_topic": "test-topic"}
 }
 
@@ -96,17 +100,18 @@ async def test_state_via_state_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -134,19 +139,20 @@ async def test_opening_and_closing_state_via_custom_state_payload(
     """Test the controlling opening and closing state via a custom payload."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "state_opening": "34",
-                "state_closing": "--43",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "state_opening": "34",
+                    "state_closing": "--43",
+                }
             }
         },
     )
@@ -179,18 +185,19 @@ async def test_open_closed_state_from_position_optimistic(
     """Test the state after setting the position using optimistic mode."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "position-topic",
-                "set_position_topic": "set-position-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "optimistic": True,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "position-topic",
+                    "set_position_topic": "set-position-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "optimistic": True,
+                }
             }
         },
     )
@@ -227,19 +234,20 @@ async def test_position_via_position_topic(hass, mqtt_mock_entry_with_yaml_confi
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "get-position-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -265,20 +273,21 @@ async def test_state_via_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "value_template": "\
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "value_template": "\
                 {% if (value | multiply(0.01) | int) == 0  %}\
                   closed\
                 {% else %}\
                   open\
                 {% endif %}",
+                }
             }
         },
     )
@@ -303,20 +312,21 @@ async def test_state_via_template_and_entity_id(hass, mqtt_mock_entry_with_yaml_
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "value_template": '\
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "value_template": '\
                 {% if value == "open" or value == "closed"  %}\
                   {{ value }}\
                 {% else %}\
                   {{ states(entity_id) }}\
                 {% endif %}',
+                }
             }
         },
     )
@@ -345,15 +355,16 @@ async def test_state_via_template_with_json_value(
     """Test the controlling state via topic with JSON value."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "value_template": "{{ value_json.Var1 }}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "value_template": "{{ value_json.Var1 }}",
+                }
             }
         },
     )
@@ -387,20 +398,21 @@ async def test_position_via_template_and_entity_id(
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "position_template": '\
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "get-position-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "position_template": '\
                 {% if state_attr(entity_id, "current_position") == None %}\
                   {{ value }}\
                 {% else %}\
                   {{ state_attr(entity_id, "current_position") + value | int }}\
                 {% endif %}',
+                }
             }
         },
     )
@@ -442,8 +454,8 @@ async def test_optimistic_flag(
     """Test assumed_state is set correctly."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
-        {cover.DOMAIN: {**config, "platform": "mqtt", "name": "test", "qos": 0}},
+        mqtt.DOMAIN,
+        {mqtt.DOMAIN: {cover.DOMAIN: {**config, "name": "test", "qos": 0}}},
     )
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
@@ -460,13 +472,14 @@ async def test_optimistic_state_change(hass, mqtt_mock_entry_with_yaml_config):
     """Test changing state optimistically."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "qos": 0,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                }
             }
         },
     )
@@ -519,15 +532,16 @@ async def test_optimistic_state_change_with_position(
     """Test changing state optimistically."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "optimistic": True,
-                "command_topic": "command-topic",
-                "position_topic": "position-topic",
-                "qos": 0,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "optimistic": True,
+                    "command_topic": "command-topic",
+                    "position_topic": "position-topic",
+                    "qos": 0,
+                }
             }
         },
     )
@@ -583,14 +597,15 @@ async def test_send_open_cover_command(hass, mqtt_mock_entry_with_yaml_config):
     """Test the sending of open_cover."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 2,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 2,
+                }
             }
         },
     )
@@ -613,14 +628,15 @@ async def test_send_close_cover_command(hass, mqtt_mock_entry_with_yaml_config):
     """Test the sending of close_cover."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 2,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 2,
+                }
             }
         },
     )
@@ -643,14 +659,15 @@ async def test_send_stop__cover_command(hass, mqtt_mock_entry_with_yaml_config):
     """Test the sending of stop_cover."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 2,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 2,
+                }
             }
         },
     )
@@ -673,18 +690,19 @@ async def test_current_cover_position(hass, mqtt_mock_entry_with_yaml_config):
     """Test the current cover position."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "command_topic": "command-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "get-position-topic",
+                    "command_topic": "command-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -725,18 +743,19 @@ async def test_current_cover_position_inverted(hass, mqtt_mock_entry_with_yaml_c
     """Test the current cover position."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "command_topic": "command-topic",
-                "position_open": 0,
-                "position_closed": 100,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "get-position-topic",
+                    "command_topic": "command-topic",
+                    "position_open": 0,
+                    "position_closed": 100,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -784,44 +803,45 @@ async def test_current_cover_position_inverted(hass, mqtt_mock_entry_with_yaml_c
     assert hass.states.get("cover.test").state == STATE_CLOSED
 
 
-async def test_optimistic_position(hass, mqtt_mock_entry_no_yaml_config):
+async def test_optimistic_position(hass, caplog):
     """Test optimistic position is not supported."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
-    state = hass.states.get("cover.test")
-    assert state is None
+    assert (
+        "Invalid config for [mqtt]: 'set_position_topic' must be set together with 'position_topic'"
+        in caplog.text
+    )
 
 
 async def test_position_update(hass, mqtt_mock_entry_with_yaml_config):
     """Test cover position update from received MQTT message."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "get-position-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -853,20 +873,21 @@ async def test_set_position_templated(
     """Test setting cover position via template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "command_topic": "command-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "set_position_topic": "set-position-topic",
-                "set_position_template": pos_template,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "get-position-topic",
+                    "command_topic": "command-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "set_position_topic": "set-position-topic",
+                    "set_position_template": pos_template,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -891,17 +912,17 @@ async def test_set_position_templated_and_attributes(
     """Test setting cover position via template and using entities attributes."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "command_topic": "command-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "set_position_topic": "set-position-topic",
-                "set_position_template": '\
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "get-position-topic",
+                    "command_topic": "command-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "set_position_topic": "set-position-topic",
+                    "set_position_template": '\
                 {% if position > 99 %}\
                   {% if state_attr(entity_id, "current_position") == None %}\
                     {{ 5 }}\
@@ -911,9 +932,10 @@ async def test_set_position_templated_and_attributes(
                 {% else %}\
                   {{ 42 }}\
                 {% endif %}',
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -934,22 +956,23 @@ async def test_set_tilt_templated(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting cover tilt position via template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "command_topic": "command-topic",
-                "tilt_command_topic": "tilt-command-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "set_position_topic": "set-position-topic",
-                "set_position_template": "{{position-1}}",
-                "tilt_command_template": "{{tilt_position+1}}",
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "get-position-topic",
+                    "command_topic": "command-topic",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "set_position_topic": "set-position-topic",
+                    "set_position_template": "{{position-1}}",
+                    "tilt_command_template": "{{tilt_position+1}}",
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -974,26 +997,27 @@ async def test_set_tilt_templated_and_attributes(
     """Test setting cover tilt position via template and using entities attributes."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "command_topic": "command-topic",
-                "tilt_command_topic": "tilt-command-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "set_position_topic": "set-position-topic",
-                "set_position_template": "{{position-1}}",
-                "tilt_command_template": "{"
-                '"entity_id": "{{ entity_id }}",'
-                '"value": {{ value }},'
-                '"tilt_position": {{ tilt_position }}'
-                "}",
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "get-position-topic",
+                    "command_topic": "command-topic",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "set_position_topic": "set-position-topic",
+                    "set_position_template": "{{position-1}}",
+                    "tilt_command_template": "{"
+                    '"entity_id": "{{ entity_id }}",'
+                    '"value": {{ value }},'
+                    '"tilt_position": {{ tilt_position }}'
+                    "}",
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -1061,17 +1085,18 @@ async def test_set_position_untemplated(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting cover position via template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "position-topic",
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "position-topic",
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -1094,19 +1119,20 @@ async def test_set_position_untemplated_custom_percentage_range(
     """Test setting cover position via template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "position-topic",
-                "position_open": 0,
-                "position_closed": 100,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "position_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "position-topic",
+                    "position_open": 0,
+                    "position_closed": 100,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -1127,17 +1153,18 @@ async def test_no_command_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test with no command topic."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command",
-                "tilt_status_topic": "tilt-status",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command",
+                    "tilt_status_topic": "tilt-status",
+                }
             }
         },
     )
@@ -1151,16 +1178,17 @@ async def test_no_payload_close(hass, mqtt_mock_entry_with_yaml_config):
     """Test with no close payload."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": None,
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": None,
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -1174,16 +1202,17 @@ async def test_no_payload_open(hass, mqtt_mock_entry_with_yaml_config):
     """Test with no open payload."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": None,
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": None,
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                }
             }
         },
     )
@@ -1197,16 +1226,17 @@ async def test_no_payload_stop(hass, mqtt_mock_entry_with_yaml_config):
     """Test with no stop payload."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": None,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": None,
+                }
             }
         },
     )
@@ -1220,18 +1250,19 @@ async def test_with_command_topic_and_tilt(hass, mqtt_mock_entry_with_yaml_confi
     """Test with command topic and tilt config."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "command_topic": "test",
-                "platform": "mqtt",
-                "name": "test",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command",
-                "tilt_status_topic": "tilt-status",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "command_topic": "test",
+                    "name": "test",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command",
+                    "tilt_status_topic": "tilt-status",
+                }
             }
         },
     )
@@ -1245,19 +1276,20 @@ async def test_tilt_defaults(hass, mqtt_mock_entry_with_yaml_config):
     """Test the defaults."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command",
-                "tilt_status_topic": "tilt-status",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command",
+                    "tilt_status_topic": "tilt-status",
+                }
             }
         },
     )
@@ -1273,19 +1305,20 @@ async def test_tilt_via_invocation_defaults(hass, mqtt_mock_entry_with_yaml_conf
     """Test tilt defaults on close/open."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                }
             }
         },
     )
@@ -1356,21 +1389,22 @@ async def test_tilt_given_value(hass, mqtt_mock_entry_with_yaml_config):
     """Test tilting to a given value."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_opened_value": 80,
-                "tilt_closed_value": 25,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_opened_value": 80,
+                    "tilt_closed_value": 25,
+                }
             }
         },
     )
@@ -1445,22 +1479,23 @@ async def test_tilt_given_value_optimistic(hass, mqtt_mock_entry_with_yaml_confi
     """Test tilting to a given value."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_opened_value": 80,
-                "tilt_closed_value": 25,
-                "tilt_optimistic": True,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_opened_value": 80,
+                    "tilt_closed_value": 25,
+                    "tilt_optimistic": True,
+                }
             }
         },
     )
@@ -1522,24 +1557,25 @@ async def test_tilt_given_value_altered_range(hass, mqtt_mock_entry_with_yaml_co
     """Test tilting to a given value."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_opened_value": 25,
-                "tilt_closed_value": 0,
-                "tilt_min": 0,
-                "tilt_max": 50,
-                "tilt_optimistic": True,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_opened_value": 25,
+                    "tilt_closed_value": 0,
+                    "tilt_min": 0,
+                    "tilt_max": 50,
+                    "tilt_optimistic": True,
+                }
             }
         },
     )
@@ -1599,19 +1635,20 @@ async def test_tilt_via_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test tilt by updating status via MQTT."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                }
             }
         },
     )
@@ -1637,22 +1674,23 @@ async def test_tilt_via_topic_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test tilt by updating status via MQTT and template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_status_template": "{{ (value | multiply(0.01)) | int }}",
-                "tilt_opened_value": 400,
-                "tilt_closed_value": 125,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_status_template": "{{ (value | multiply(0.01)) | int }}",
+                    "tilt_opened_value": 400,
+                    "tilt_closed_value": 125,
+                }
             }
         },
     )
@@ -1680,22 +1718,23 @@ async def test_tilt_via_topic_template_json_value(
     """Test tilt by updating status via MQTT and template with JSON value."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_status_template": "{{ value_json.Var1 }}",
-                "tilt_opened_value": 400,
-                "tilt_closed_value": 125,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_status_template": "{{ value_json.Var1 }}",
+                    "tilt_opened_value": 400,
+                    "tilt_closed_value": 125,
+                }
             }
         },
     )
@@ -1727,21 +1766,22 @@ async def test_tilt_via_topic_altered_range(hass, mqtt_mock_entry_with_yaml_conf
     """Test tilt status via MQTT with altered tilt range."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_min": 0,
-                "tilt_max": 50,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_min": 0,
+                    "tilt_max": 50,
+                }
             }
         },
     )
@@ -1776,21 +1816,22 @@ async def test_tilt_status_out_of_range_warning(
     """Test tilt status via MQTT tilt out of range warning message."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_min": 0,
-                "tilt_max": 50,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_min": 0,
+                    "tilt_max": 50,
+                }
             }
         },
     )
@@ -1810,21 +1851,22 @@ async def test_tilt_status_not_numeric_warning(
     """Test tilt status via MQTT tilt not numeric warning message."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_min": 0,
-                "tilt_max": 50,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_min": 0,
+                    "tilt_max": 50,
+                }
             }
         },
     )
@@ -1842,21 +1884,22 @@ async def test_tilt_via_topic_altered_range_inverted(
     """Test tilt status via MQTT with altered tilt range and inverted tilt position."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_min": 50,
-                "tilt_max": 0,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_min": 50,
+                    "tilt_max": 0,
+                }
             }
         },
     )
@@ -1891,24 +1934,25 @@ async def test_tilt_via_topic_template_altered_range(
     """Test tilt status via MQTT and template with altered tilt range."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_status_template": "{{ (value | multiply(0.01)) | int }}",
-                "tilt_opened_value": 400,
-                "tilt_closed_value": 125,
-                "tilt_min": 0,
-                "tilt_max": 50,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_status_template": "{{ (value | multiply(0.01)) | int }}",
+                    "tilt_opened_value": 400,
+                    "tilt_closed_value": 125,
+                    "tilt_min": 0,
+                    "tilt_max": 50,
+                }
             }
         },
     )
@@ -1941,19 +1985,20 @@ async def test_tilt_position(hass, mqtt_mock_entry_with_yaml_config):
     """Test tilt via method invocation."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                }
             }
         },
     )
@@ -1976,20 +2021,21 @@ async def test_tilt_position_templated(hass, mqtt_mock_entry_with_yaml_config):
     """Test tilt position via template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_command_template": "{{100-32}}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_command_template": "{{100-32}}",
+                }
             }
         },
     )
@@ -2012,23 +2058,24 @@ async def test_tilt_position_altered_range(hass, mqtt_mock_entry_with_yaml_confi
     """Test tilt via method invocation with altered range."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "payload_open": "OPEN",
-                "payload_close": "CLOSE",
-                "payload_stop": "STOP",
-                "tilt_command_topic": "tilt-command-topic",
-                "tilt_status_topic": "tilt-status-topic",
-                "tilt_opened_value": 400,
-                "tilt_closed_value": 125,
-                "tilt_min": 0,
-                "tilt_max": 50,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "payload_open": "OPEN",
+                    "payload_close": "CLOSE",
+                    "payload_stop": "STOP",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "tilt_status_topic": "tilt-status-topic",
+                    "tilt_opened_value": 400,
+                    "tilt_closed_value": 125,
+                    "tilt_min": 0,
+                    "tilt_max": 50,
+                }
             }
         },
     )
@@ -2396,28 +2443,28 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -2425,13 +2472,14 @@ async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of a valid device class."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "device_class": "garage",
-                "state_topic": "test-topic",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "device_class": "garage",
+                    "state_topic": "test-topic",
+                }
             }
         },
     )
@@ -2442,25 +2490,22 @@ async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("device_class") == "garage"
 
 
-async def test_invalid_device_class(hass, mqtt_mock_entry_no_yaml_config):
+async def test_invalid_device_class(hass, caplog):
     """Test the setting of an invalid device class."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "device_class": "abc123",
-                "state_topic": "test-topic",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "device_class": "abc123",
+                    "state_topic": "test-topic",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
-    state = hass.states.get("cover.test")
-    assert state is None
+    assert "Invalid config for [mqtt]: expected CoverDeviceClass" in caplog.text
 
 
 async def test_setting_attribute_via_mqtt_json_message(
@@ -2468,7 +2513,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -2480,7 +2525,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
         cover.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_COVER_ATTRIBUTES_BLOCKED,
     )
 
@@ -2488,7 +2533,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -2497,7 +2542,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, cover.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        cover.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -2506,14 +2555,22 @@ async def test_update_with_json_attrs_bad_json(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, cover.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        cover.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, cover.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        cover.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -2588,42 +2645,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT cover device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT cover device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -2633,7 +2690,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         cover.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         SERVICE_OPEN_COVER,
         command_payload="OPEN",
     )
@@ -2645,19 +2702,20 @@ async def test_state_and_position_topics_state_not_set_via_position_topic(
     """Test state is not set via position topic when both state and position topics are set."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "position_topic": "get-position-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "state_open": "OPEN",
-                "state_closed": "CLOSE",
-                "command_topic": "command-topic",
-                "qos": 0,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "position_topic": "get-position-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "state_open": "OPEN",
+                    "state_closed": "CLOSE",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                }
             }
         },
     )
@@ -2705,20 +2763,21 @@ async def test_set_state_via_position_using_stopped_state(
     """Test the controlling state via position topic using stopped state."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "position_topic": "get-position-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "state_open": "OPEN",
-                "state_closed": "CLOSE",
-                "state_stopped": "STOPPED",
-                "command_topic": "command-topic",
-                "qos": 0,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "position_topic": "get-position-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "state_open": "OPEN",
+                    "state_closed": "CLOSE",
+                    "state_stopped": "STOPPED",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                }
             }
         },
     )
@@ -2761,16 +2820,17 @@ async def test_position_via_position_topic_template(
     """Test position by updating status via position template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "get-position-topic",
-                "position_template": "{{ (value | multiply(0.01)) | int }}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "position_topic": "get-position-topic",
+                    "position_template": "{{ (value | multiply(0.01)) | int }}",
+                }
             }
         },
     )
@@ -2798,16 +2858,17 @@ async def test_position_via_position_topic_template_json_value(
     """Test position by updating status via position template with a JSON value."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "get-position-topic",
-                "position_template": "{{ value_json.Var1 }}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "position_topic": "get-position-topic",
+                    "position_template": "{{ value_json.Var1 }}",
+                }
             }
         },
     )
@@ -2839,21 +2900,22 @@ async def test_position_template_with_entity_id(hass, mqtt_mock_entry_with_yaml_
     """Test position by updating status via position template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "get-position-topic",
-                "position_template": '\
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "position_topic": "get-position-topic",
+                    "position_template": '\
                 {% if state_attr(entity_id, "current_position") != None %}\
                     {{ value | int + state_attr(entity_id, "current_position") }} \
                 {% else %} \
                     {{ value }} \
                 {% endif %}',
+                }
             }
         },
     )
@@ -2881,16 +2943,17 @@ async def test_position_via_position_topic_template_return_json(
     """Test position by updating status via position template and returning json."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "get-position-topic",
-                "position_template": '{{ {"position" : value} | tojson }}',
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "position_topic": "get-position-topic",
+                    "position_template": '{{ {"position" : value} | tojson }}',
+                }
             }
         },
     )
@@ -2911,16 +2974,17 @@ async def test_position_via_position_topic_template_return_json_warning(
     """Test position by updating status via position template returning json without position attribute."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "get-position-topic",
-                "position_template": '{{ {"pos" : value} | tojson }}',
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "position_topic": "get-position-topic",
+                    "position_template": '{{ {"pos" : value} | tojson }}',
+                }
             }
         },
     )
@@ -2941,17 +3005,18 @@ async def test_position_and_tilt_via_position_topic_template_return_json(
     """Test position and tilt by updating the position via position template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "get-position-topic",
-                "position_template": '\
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "position_topic": "get-position-topic",
+                    "position_template": '\
                 {{ {"position" : value, "tilt_position" : (value | int / 2)| int } | tojson }}',
+                }
             }
         },
     )
@@ -2984,27 +3049,28 @@ async def test_position_via_position_topic_template_all_variables(
     """Test position by updating status via position template."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "get-position-topic",
-                "tilt_command_topic": "tilt-command-topic",
-                "position_open": 99,
-                "position_closed": 1,
-                "tilt_min": 11,
-                "tilt_max": 22,
-                "position_template": "\
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "position_topic": "get-position-topic",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "position_open": 99,
+                    "position_closed": 1,
+                    "tilt_min": 11,
+                    "tilt_max": 22,
+                    "position_template": "\
                 {% if value | int < tilt_max %}\
                     {{ tilt_min }}\
                 {% endif %}\
                 {% if value | int > position_closed %}\
                     {{ position_open }}\
                 {% endif %}",
+                }
             }
         },
     )
@@ -3031,20 +3097,21 @@ async def test_set_state_via_stopped_state_no_position_topic(
     """Test the controlling state via stopped state when no position topic."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "state_open": "OPEN",
-                "state_closed": "CLOSE",
-                "state_stopped": "STOPPED",
-                "state_opening": "OPENING",
-                "state_closing": "CLOSING",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "optimistic": False,
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "state_open": "OPEN",
+                    "state_closed": "CLOSE",
+                    "state_stopped": "STOPPED",
+                    "state_opening": "OPENING",
+                    "state_closing": "CLOSING",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                    "optimistic": False,
+                }
             }
         },
     )
@@ -3083,16 +3150,17 @@ async def test_position_via_position_topic_template_return_invalid_json(
     """Test position by updating status via position template and returning invalid json."""
     assert await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "get-position-topic",
-                "position_template": '{{ {"position" : invalid_json} }}',
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "position_topic": "get-position-topic",
+                    "position_template": '{{ {"position" : invalid_json} }}',
+                }
             }
         },
     )
@@ -3104,74 +3172,65 @@ async def test_position_via_position_topic_template_return_invalid_json(
     assert ("Payload '{'position': Undefined}' is not numeric") in caplog.text
 
 
-async def test_set_position_topic_without_get_position_topic_error(
-    hass, caplog, mqtt_mock_entry_no_yaml_config
-):
+async def test_set_position_topic_without_get_position_topic_error(hass, caplog):
     """Test error when set_position_topic is used without position_topic."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "value_template": "{{100-62}}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "set_position_topic": "set-position-topic",
+                    "value_template": "{{100-62}}",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
     assert (
         f"'{CONF_SET_POSITION_TOPIC}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
     ) in caplog.text
 
 
 async def test_value_template_without_state_topic_error(
-    hass, caplog, mqtt_mock_entry_no_yaml_config
+    hass,
+    caplog,
 ):
     """Test error when value_template is used and state_topic is missing."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "value_template": "{{100-62}}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "value_template": "{{100-62}}",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
     assert (
         f"'{CONF_VALUE_TEMPLATE}' must be set together with '{CONF_STATE_TOPIC}'."
     ) in caplog.text
 
 
-async def test_position_template_without_position_topic_error(
-    hass, caplog, mqtt_mock_entry_no_yaml_config
-):
+async def test_position_template_without_position_topic_error(hass, caplog):
     """Test error when position_template is used and position_topic is missing."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "position_template": "{{100-52}}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "position_template": "{{100-52}}",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
     assert (
         f"'{CONF_GET_POSITION_TEMPLATE}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
         in caplog.text
@@ -3179,74 +3238,65 @@ async def test_position_template_without_position_topic_error(
 
 
 async def test_set_position_template_without_set_position_topic(
-    hass, caplog, mqtt_mock_entry_no_yaml_config
+    hass,
+    caplog,
 ):
     """Test error when set_position_template is used and set_position_topic is missing."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "set_position_template": "{{100-42}}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "set_position_template": "{{100-42}}",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
     assert (
         f"'{CONF_SET_POSITION_TEMPLATE}' must be set together with '{CONF_SET_POSITION_TOPIC}'."
         in caplog.text
     )
 
 
-async def test_tilt_command_template_without_tilt_command_topic(
-    hass, caplog, mqtt_mock_entry_no_yaml_config
-):
+async def test_tilt_command_template_without_tilt_command_topic(hass, caplog):
     """Test error when tilt_command_template is used and tilt_command_topic is missing."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "tilt_command_template": "{{100-32}}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "tilt_command_template": "{{100-32}}",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
     assert (
         f"'{CONF_TILT_COMMAND_TEMPLATE}' must be set together with '{CONF_TILT_COMMAND_TOPIC}'."
         in caplog.text
     )
 
 
-async def test_tilt_status_template_without_tilt_status_topic_topic(
-    hass, caplog, mqtt_mock_entry_no_yaml_config
-):
+async def test_tilt_status_template_without_tilt_status_topic_topic(hass, caplog):
     """Test error when tilt_status_template is used and tilt_status_topic is missing."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        cover.DOMAIN,
+        mqtt.DOMAIN,
         {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "tilt_status_template": "{{100-22}}",
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "tilt_status_template": "{{100-22}}",
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-
     assert (
         f"'{CONF_TILT_STATUS_TEMPLATE}' must be set together with '{CONF_TILT_STATUS_TOPIC}'."
         in caplog.text
@@ -3291,7 +3341,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = cover.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     config["position_topic"] = "some-position-topic"
 
     await help_test_publishing_with_custom_encoding(
@@ -3311,7 +3361,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = cover.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -3320,7 +3370,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = cover.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -3348,7 +3398,7 @@ async def test_encoding_subscribable_topics(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         cover.DOMAIN,
-        DEFAULT_CONFIG[cover.DOMAIN],
+        DEFAULT_CONFIG_LEGACY[cover.DOMAIN],
         topic,
         value,
         attribute,
@@ -3360,7 +3410,7 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = cover.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -3370,7 +3420,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = cover.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = cover.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -84,9 +84,10 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {cover.DOMAIN: {"name": "test", "state_topic": "test-topic"}}
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    cover.DOMAIN: {"platform": "mqtt", "name": "test", "state_topic": "test-topic"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[cover.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -84,8 +84,8 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {cover.DOMAIN: {"name": "test", "state_topic": "test-topic"}}
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[cover.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -3427,8 +3427,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = cover.DOMAIN

--- a/tests/components/mqtt/test_device_tracker_discovery.py
+++ b/tests/components/mqtt/test_device_tracker_discovery.py
@@ -27,8 +27,8 @@ DEFAULT_CONFIG = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[device_tracker.DOMAIN]["platform"] = mqtt.DOMAIN
 

--- a/tests/components/mqtt/test_device_tracker_discovery.py
+++ b/tests/components/mqtt/test_device_tracker_discovery.py
@@ -1,5 +1,6 @@
 """The tests for the  MQTT device_tracker platform."""
 
+import copy
 from unittest.mock import patch
 
 import pytest
@@ -26,12 +27,10 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    device_tracker.DOMAIN: {
-        "name": "test",
-        "state_topic": "test-topic",
-    }
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[device_tracker.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -76,14 +76,10 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    fan.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "state_topic": "state-topic",
-        "command_topic": "command-topic",
-    }
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[fan.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -1522,7 +1522,7 @@ async def test_attributes(hass, mqtt_mock_entry_with_yaml_config, caplog):
                 "percentage_command_topic": "percentage-command-topic",
             },
             True,
-            fan.SUPPORT_OSCILLATE | fan.SUPPORT_PRESET_MODE,
+            fan.SUPPORT_OSCILLATE | fan.SUPPORT_SET_SPEED,
         ),
         (
             "test9",
@@ -1608,14 +1608,14 @@ async def test_attributes(hass, mqtt_mock_entry_with_yaml_config, caplog):
         (
             "test16",
             {
-                "name": "test7reset_payload_in_preset_modes_b",
+                "name": "test16",
                 "command_topic": "command-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "preset_modes": ["whoosh", "silent", "auto", "None"],
                 "payload_reset_preset_mode": "normal",
             },
             True,
-            fan.SUPPORT_SET_SPEED,
+            fan.SUPPORT_PRESET_MODE,
         ),
     ],
 )
@@ -1625,7 +1625,10 @@ async def test_supported_features(
     """Test optimistic mode without state topic."""
 
     assert (
-        await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config}) is success
+        await async_setup_component(
+            hass, mqtt.DOMAIN, {mqtt.DOMAIN: {fan.DOMAIN: config}}
+        )
+        is success
     )
     if success:
         await hass.async_block_till_done()
@@ -1633,11 +1636,6 @@ async def test_supported_features(
 
         state = hass.states.get(f"fan.{name}")
         assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == features
-
-    state = hass.states.get("fan.test7reset_payload_in_preset_modes_a")
-    assert state is None
-    state = hass.states.get("fan.test7reset_payload_in_preset_modes_b")
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == fan.SUPPORT_PRESET_MODE
 
 
 async def test_availability_when_connection_lost(

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -76,8 +76,8 @@ DEFAULT_CONFIG = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[fan.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -1967,8 +1967,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = fan.DOMAIN

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -78,8 +78,8 @@ DEFAULT_CONFIG = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[humidifier.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -1350,8 +1350,8 @@ async def test_unload_config_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_p
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = humidifier.DOMAIN

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from voluptuous.error import MultipleInvalid
 
-from homeassistant.components import humidifier
+from homeassistant.components import humidifier, mqtt
 from homeassistant.components.humidifier import (
     ATTR_HUMIDITY,
     ATTR_MODE,
@@ -68,6 +68,17 @@ from .test_common import (
 from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {
+        humidifier.DOMAIN: {
+            "name": "test",
+            "state_topic": "state-topic",
+            "command_topic": "command-topic",
+            "target_humidity_command_topic": "humidity-command-topic",
+        }
+    }
+}
+
+DEFAULT_CONFIG_LEGACY = {
     humidifier.DOMAIN: {
         "platform": "mqtt",
         "name": "test",
@@ -126,16 +137,17 @@ async def async_set_humidity(
     await hass.services.async_call(DOMAIN, SERVICE_SET_HUMIDITY, data, blocking=True)
 
 
-async def test_fail_setup_if_no_command_topic(hass, mqtt_mock_entry_no_yaml_config):
+async def test_fail_setup_if_no_command_topic(hass, caplog):
     """Test if command fails with command topic."""
-    assert await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        humidifier.DOMAIN,
-        {humidifier.DOMAIN: {"platform": "mqtt", "name": "test"}},
+        mqtt.DOMAIN,
+        {mqtt.DOMAIN: {humidifier.DOMAIN: {"name": "test"}}},
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-    assert hass.states.get("humidifier.test") is None
+    assert (
+        "Invalid config for [mqtt]: required key not provided @ data['mqtt']['humidifier'][0]['command_topic']. Got None"
+        in caplog.text
+    )
 
 
 async def test_controlling_state_via_topic(
@@ -144,29 +156,30 @@ async def test_controlling_state_via_topic(
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        humidifier.DOMAIN,
+        mqtt.DOMAIN,
         {
-            humidifier.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_off": "StAtE_OfF",
-                "payload_on": "StAtE_On",
-                "target_humidity_state_topic": "humidity-state-topic",
-                "target_humidity_command_topic": "humidity-command-topic",
-                "mode_state_topic": "mode-state-topic",
-                "mode_command_topic": "mode-command-topic",
-                "modes": [
-                    "auto",
-                    "comfort",
-                    "home",
-                    "eco",
-                    "sleep",
-                    "baby",
-                ],
-                "payload_reset_humidity": "rEset_humidity",
-                "payload_reset_mode": "rEset_mode",
+            mqtt.DOMAIN: {
+                humidifier.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_off": "StAtE_OfF",
+                    "payload_on": "StAtE_On",
+                    "target_humidity_state_topic": "humidity-state-topic",
+                    "target_humidity_command_topic": "humidity-command-topic",
+                    "mode_state_topic": "mode-state-topic",
+                    "mode_command_topic": "mode-command-topic",
+                    "modes": [
+                        "auto",
+                        "comfort",
+                        "home",
+                        "eco",
+                        "sleep",
+                        "baby",
+                    ],
+                    "payload_reset_humidity": "rEset_humidity",
+                    "payload_reset_mode": "rEset_mode",
+                }
             }
         },
     )
@@ -248,25 +261,26 @@ async def test_controlling_state_via_topic_and_json_message(
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
-        humidifier.DOMAIN,
+        mqtt.DOMAIN,
         {
-            humidifier.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "target_humidity_state_topic": "humidity-state-topic",
-                "target_humidity_command_topic": "humidity-command-topic",
-                "mode_state_topic": "mode-state-topic",
-                "mode_command_topic": "mode-command-topic",
-                "modes": [
-                    "auto",
-                    "eco",
-                    "baby",
-                ],
-                "state_value_template": "{{ value_json.val }}",
-                "target_humidity_state_template": "{{ value_json.val }}",
-                "mode_state_template": "{{ value_json.val }}",
+            mqtt.DOMAIN: {
+                humidifier.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "target_humidity_state_topic": "humidity-state-topic",
+                    "target_humidity_command_topic": "humidity-command-topic",
+                    "mode_state_topic": "mode-state-topic",
+                    "mode_command_topic": "mode-command-topic",
+                    "modes": [
+                        "auto",
+                        "eco",
+                        "baby",
+                    ],
+                    "state_value_template": "{{ value_json.val }}",
+                    "target_humidity_state_template": "{{ value_json.val }}",
+                    "mode_state_template": "{{ value_json.val }}",
+                }
             }
         },
     )
@@ -336,25 +350,26 @@ async def test_controlling_state_via_topic_and_json_message_shared_topic(
     """Test the controlling state via topic and JSON message using a shared topic."""
     assert await async_setup_component(
         hass,
-        humidifier.DOMAIN,
+        mqtt.DOMAIN,
         {
-            humidifier.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "shared-state-topic",
-                "command_topic": "command-topic",
-                "target_humidity_state_topic": "shared-state-topic",
-                "target_humidity_command_topic": "percentage-command-topic",
-                "mode_state_topic": "shared-state-topic",
-                "mode_command_topic": "mode-command-topic",
-                "modes": [
-                    "auto",
-                    "eco",
-                    "baby",
-                ],
-                "state_value_template": "{{ value_json.state }}",
-                "target_humidity_state_template": "{{ value_json.humidity }}",
-                "mode_state_template": "{{ value_json.mode }}",
+            mqtt.DOMAIN: {
+                humidifier.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "shared-state-topic",
+                    "command_topic": "command-topic",
+                    "target_humidity_state_topic": "shared-state-topic",
+                    "target_humidity_command_topic": "percentage-command-topic",
+                    "mode_state_topic": "shared-state-topic",
+                    "mode_command_topic": "mode-command-topic",
+                    "modes": [
+                        "auto",
+                        "eco",
+                        "baby",
+                    ],
+                    "state_value_template": "{{ value_json.state }}",
+                    "target_humidity_state_template": "{{ value_json.humidity }}",
+                    "mode_state_template": "{{ value_json.mode }}",
+                }
             }
         },
     )
@@ -414,21 +429,22 @@ async def test_sending_mqtt_commands_and_optimistic(
     """Test optimistic mode without state topic."""
     assert await async_setup_component(
         hass,
-        humidifier.DOMAIN,
+        mqtt.DOMAIN,
         {
-            humidifier.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "payload_off": "StAtE_OfF",
-                "payload_on": "StAtE_On",
-                "target_humidity_command_topic": "humidity-command-topic",
-                "mode_command_topic": "mode-command-topic",
-                "modes": [
-                    "eco",
-                    "auto",
-                    "baby",
-                ],
+            mqtt.DOMAIN: {
+                humidifier.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "payload_off": "StAtE_OfF",
+                    "payload_on": "StAtE_On",
+                    "target_humidity_command_topic": "humidity-command-topic",
+                    "mode_command_topic": "mode-command-topic",
+                    "modes": [
+                        "eco",
+                        "auto",
+                        "baby",
+                    ],
+                }
             }
         },
     )
@@ -510,22 +526,23 @@ async def test_sending_mqtt_command_templates_(
     """Testing command templates with optimistic mode without state topic."""
     assert await async_setup_component(
         hass,
-        humidifier.DOMAIN,
+        mqtt.DOMAIN,
         {
-            humidifier.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "command_template": "state: {{ value }}",
-                "target_humidity_command_topic": "humidity-command-topic",
-                "target_humidity_command_template": "humidity: {{ value }}",
-                "mode_command_topic": "mode-command-topic",
-                "mode_command_template": "mode: {{ value }}",
-                "modes": [
-                    "auto",
-                    "eco",
-                    "sleep",
-                ],
+            mqtt.DOMAIN: {
+                humidifier.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "command_template": "state: {{ value }}",
+                    "target_humidity_command_topic": "humidity-command-topic",
+                    "target_humidity_command_template": "humidity: {{ value }}",
+                    "mode_command_topic": "mode-command-topic",
+                    "mode_command_template": "mode: {{ value }}",
+                    "modes": [
+                        "auto",
+                        "eco",
+                        "sleep",
+                    ],
+                }
             }
         },
     )
@@ -607,23 +624,24 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(
     """Test optimistic mode with state topic and turn on attributes."""
     assert await async_setup_component(
         hass,
-        humidifier.DOMAIN,
+        mqtt.DOMAIN,
         {
-            humidifier.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "target_humidity_state_topic": "humidity-state-topic",
-                "target_humidity_command_topic": "humidity-command-topic",
-                "mode_command_topic": "mode-command-topic",
-                "mode_state_topic": "mode-state-topic",
-                "modes": [
-                    "auto",
-                    "eco",
-                    "baby",
-                ],
-                "optimistic": True,
+            mqtt.DOMAIN: {
+                humidifier.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "target_humidity_state_topic": "humidity-state-topic",
+                    "target_humidity_command_topic": "humidity-command-topic",
+                    "mode_command_topic": "mode-command-topic",
+                    "mode_state_topic": "mode-state-topic",
+                    "modes": [
+                        "auto",
+                        "eco",
+                        "baby",
+                    ],
+                    "optimistic": True,
+                }
             }
         },
     )
@@ -737,7 +755,7 @@ async def test_encoding_subscribable_topics(
     attribute_value,
 ):
     """Test handling of incoming encoded payload."""
-    config = copy.deepcopy(DEFAULT_CONFIG[humidifier.DOMAIN])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[humidifier.DOMAIN])
     config["modes"] = ["eco", "auto"]
     config[CONF_MODE_COMMAND_TOPIC] = "humidifier/some_mode_command_topic"
     await help_test_encoding_subscribable_topics(
@@ -757,18 +775,19 @@ async def test_attributes(hass, mqtt_mock_entry_with_yaml_config, caplog):
     """Test attributes."""
     assert await async_setup_component(
         hass,
-        humidifier.DOMAIN,
+        mqtt.DOMAIN,
         {
-            humidifier.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "mode_command_topic": "mode-command-topic",
-                "target_humidity_command_topic": "humidity-command-topic",
-                "modes": [
-                    "eco",
-                    "baby",
-                ],
+            mqtt.DOMAIN: {
+                humidifier.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "mode_command_topic": "mode-command-topic",
+                    "target_humidity_command_topic": "humidity-command-topic",
+                    "modes": [
+                        "eco",
+                        "baby",
+                    ],
+                }
             }
         },
     )
@@ -799,157 +818,182 @@ async def test_attributes(hass, mqtt_mock_entry_with_yaml_config, caplog):
     assert state.attributes.get(humidifier.ATTR_MODE) is None
 
 
-async def test_invalid_configurations(hass, mqtt_mock_entry_with_yaml_config, caplog):
-    """Test invalid configurations."""
-    assert await async_setup_component(
-        hass,
-        humidifier.DOMAIN,
-        {
-            humidifier.DOMAIN: [
-                {
-                    "platform": "mqtt",
-                    "name": "test_valid_1",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test_valid_2",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                    "device_class": "humidifier",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test_valid_3",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                    "device_class": "dehumidifier",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test_invalid_device_class",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                    "device_class": "notsupporedSpeci@l",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test_mode_command_without_modes",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                    "mode_command_topic": "mode-command-topic",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test_invalid_humidity_min_max_1",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                    "min_humidity": 0,
-                    "max_humidity": 101,
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test_invalid_humidity_min_max_2",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                    "max_humidity": 20,
-                    "min_humidity": 40,
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test_invalid_mode_is_reset",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                    "mode_command_topic": "mode-command-topic",
-                    "modes": ["eco", "None"],
-                },
-            ]
-        },
+@pytest.mark.parametrize(
+    "config,valid",
+    [
+        (
+            {
+                "name": "test_valid_1",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+            },
+            True,
+        ),
+        (
+            {
+                "name": "test_valid_2",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+                "device_class": "humidifier",
+            },
+            True,
+        ),
+        (
+            {
+                "name": "test_valid_3",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+                "device_class": "dehumidifier",
+            },
+            True,
+        ),
+        (
+            {
+                "name": "test_invalid_device_class",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+                "device_class": "notsupporedSpeci@l",
+            },
+            False,
+        ),
+        (
+            {
+                "name": "test_mode_command_without_modes",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+                "mode_command_topic": "mode-command-topic",
+            },
+            False,
+        ),
+        (
+            {
+                "name": "test_invalid_humidity_min_max_1",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+                "min_humidity": 0,
+                "max_humidity": 101,
+            },
+            False,
+        ),
+        (
+            {
+                "name": "test_invalid_humidity_min_max_2",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+                "max_humidity": 20,
+                "min_humidity": 40,
+            },
+            False,
+        ),
+        (
+            {
+                "name": "test_invalid_mode_is_reset",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+                "mode_command_topic": "mode-command-topic",
+                "modes": ["eco", "None"],
+            },
+            False,
+        ),
+    ],
+)
+async def test_validity_configurations(hass, config, valid):
+    """Test validity of configurations."""
+    assert (
+        await async_setup_component(
+            hass,
+            mqtt.DOMAIN,
+            {mqtt.DOMAIN: {humidifier.DOMAIN: config}},
+        )
+        is valid
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
-    assert hass.states.get("humidifier.test_valid_1") is not None
-    assert hass.states.get("humidifier.test_valid_2") is not None
-    assert hass.states.get("humidifier.test_valid_3") is not None
-    assert hass.states.get("humidifier.test_invalid_device_class") is None
-    assert hass.states.get("humidifier.test_mode_command_without_modes") is None
-    assert "not all values in the same group of inclusion" in caplog.text
-    caplog.clear()
-
-    assert hass.states.get("humidifier.test_invalid_humidity_min_max_1") is None
-    assert hass.states.get("humidifier.test_invalid_humidity_min_max_2") is None
-    assert hass.states.get("humidifier.test_invalid_mode_is_reset") is None
 
 
-async def test_supported_features(hass, mqtt_mock_entry_with_yaml_config):
+@pytest.mark.parametrize(
+    "name,config,success,features",
+    [
+        (
+            "test1",
+            {
+                "name": "test1",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+            },
+            True,
+            0,
+        ),
+        (
+            "test2",
+            {
+                "name": "test2",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+                "mode_command_topic": "mode-command-topic",
+                "modes": ["eco", "auto"],
+            },
+            True,
+            humidifier.SUPPORT_MODES,
+        ),
+        (
+            "test3",
+            {
+                "name": "test3",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+            },
+            True,
+            0,
+        ),
+        (
+            "test4",
+            {
+                "name": "test4",
+                "command_topic": "command-topic",
+                "target_humidity_command_topic": "humidity-command-topic",
+                "mode_command_topic": "mode-command-topic",
+                "modes": ["eco", "auto"],
+            },
+            True,
+            humidifier.SUPPORT_MODES,
+        ),
+        (
+            "test5",
+            {
+                "name": "test5",
+                "command_topic": "command-topic",
+            },
+            False,
+            None,
+        ),
+        (
+            "test6",
+            {
+                "name": "test6",
+                "target_humidity_command_topic": "humidity-command-topic",
+            },
+            False,
+            None,
+        ),
+    ],
+)
+async def test_supported_features(
+    hass, mqtt_mock_entry_with_yaml_config, name, config, success, features
+):
     """Test supported features."""
-    assert await async_setup_component(
-        hass,
-        humidifier.DOMAIN,
-        {
-            humidifier.DOMAIN: [
-                {
-                    "platform": "mqtt",
-                    "name": "test1",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test2",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                    "mode_command_topic": "mode-command-topic",
-                    "modes": ["eco", "auto"],
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test3",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test4",
-                    "command_topic": "command-topic",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                    "mode_command_topic": "mode-command-topic",
-                    "modes": ["eco", "auto"],
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test5",
-                    "command_topic": "command-topic",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test6",
-                    "target_humidity_command_topic": "humidity-command-topic",
-                },
-            ]
-        },
+    assert (
+        await async_setup_component(
+            hass,
+            mqtt.DOMAIN,
+            {mqtt.DOMAIN: {humidifier.DOMAIN: config}},
+        )
+        is success
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+    if success:
+        await hass.async_block_till_done()
+        await mqtt_mock_entry_with_yaml_config()
 
-    state = hass.states.get("humidifier.test1")
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 0
-
-    state = hass.states.get("humidifier.test2")
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == humidifier.SUPPORT_MODES
-
-    state = hass.states.get("humidifier.test3")
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 0
-
-    state = hass.states.get("humidifier.test4")
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == humidifier.SUPPORT_MODES
-
-    state = hass.states.get("humidifier.test5")
-    assert state is None
-
-    state = hass.states.get("humidifier.test6")
-    assert state is None
+        state = hass.states.get(f"humidifier.{name}")
+        assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == features
 
 
 async def test_availability_when_connection_lost(
@@ -957,14 +1001,14 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -974,7 +1018,7 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
         hass,
         mqtt_mock_entry_with_yaml_config,
         humidifier.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         True,
         "state-topic",
         "1",
@@ -987,7 +1031,7 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
         hass,
         mqtt_mock_entry_with_yaml_config,
         humidifier.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         True,
         "state-topic",
         "1",
@@ -999,7 +1043,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -1011,7 +1055,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
         humidifier.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_HUMIDIFIER_ATTRIBUTES_BLOCKED,
     )
 
@@ -1019,7 +1063,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -1032,7 +1076,7 @@ async def test_update_with_json_attrs_not_dict(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         humidifier.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -1045,14 +1089,18 @@ async def test_update_with_json_attrs_bad_json(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         humidifier.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        humidifier.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -1148,42 +1196,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT fan device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT fan device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -1193,7 +1241,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         humidifier.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         humidifier.SERVICE_TURN_ON,
     )
 
@@ -1243,7 +1291,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = humidifier.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
     if topic == "mode_command_topic":
         config["modes"] = ["auto", "eco"]
 
@@ -1264,7 +1312,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = humidifier.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -1273,14 +1321,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = humidifier.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = humidifier.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -1288,21 +1336,33 @@ async def test_setup_manual_entity_from_yaml(hass):
 
 
 async def test_config_schema_validation(hass):
-    """Test invalid platform options in the config schema do pass the config validation."""
+    """Test invalid platform options in the config schema do not pass the config validation."""
     platform = humidifier.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][platform])
     config["name"] = "test"
-    del config["platform"]
-    CONFIG_SCHEMA({DOMAIN: {platform: config}})
-    CONFIG_SCHEMA({DOMAIN: {platform: [config]}})
+    CONFIG_SCHEMA({mqtt.DOMAIN: {platform: config}})
+    CONFIG_SCHEMA({mqtt.DOMAIN: {platform: [config]}})
     with pytest.raises(MultipleInvalid):
-        CONFIG_SCHEMA({"mqtt": {"humidifier": [{"bla": "bla"}]}})
+        CONFIG_SCHEMA({mqtt.DOMAIN: {platform: [{"bla": "bla"}]}})
 
 
 async def test_unload_config_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = humidifier.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = humidifier.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -78,15 +78,10 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    humidifier.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "state_topic": "state-topic",
-        "command_topic": "command-topic",
-        "target_humidity_command_topic": "humidity-command-topic",
-    }
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[humidifier.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -281,6 +281,7 @@ async def test_command_template_value(hass):
     assert cmd_tpl.async_render(None, variables=variables) == "beer"
 
 
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SELECT])
 async def test_command_template_variables(hass, mqtt_mock_entry_with_yaml_config):
     """Test the rendering of entity variables."""
     topic = "test/select"
@@ -290,14 +291,15 @@ async def test_command_template_variables(hass, mqtt_mock_entry_with_yaml_config
 
     assert await async_setup_component(
         hass,
-        "select",
+        mqtt.DOMAIN,
         {
-            "select": {
-                "platform": "mqtt",
-                "command_topic": topic,
-                "name": "Test Select",
-                "options": ["milk", "beer"],
-                "command_template": '{"option": "{{ value }}", "entity_id": "{{ entity_id }}", "name": "{{ name }}", "this_object_state": "{{ this.state }}"}',
+            mqtt.DOMAIN: {
+                "select": {
+                    "command_topic": topic,
+                    "name": "Test Select",
+                    "options": ["milk", "beer"],
+                    "command_template": '{"option": "{{ value }}", "entity_id": "{{ entity_id }}", "name": "{{ name }}", "this_object_state": "{{ this.state }}"}',
+                }
             }
         },
     )
@@ -2087,20 +2089,19 @@ async def test_mqtt_ws_get_device_debug_info(
     await mqtt_mock_entry_no_yaml_config()
     config_sensor = {
         "device": {"identifiers": ["0AFFD2"]},
-        "platform": "mqtt",
         "state_topic": "foobar/sensor",
         "unique_id": "unique",
     }
     config_trigger = {
         "automation_type": "trigger",
         "device": {"identifiers": ["0AFFD2"]},
-        "platform": "mqtt",
         "topic": "test-topic1",
         "type": "foo",
         "subtype": "bar",
     }
     data_sensor = json.dumps(config_sensor)
     data_trigger = json.dumps(config_trigger)
+    config_sensor["platform"] = config_trigger["platform"] = mqtt.DOMAIN
 
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data_sensor)
     async_fire_mqtt_message(
@@ -2151,11 +2152,11 @@ async def test_mqtt_ws_get_device_debug_info_binary(
     await mqtt_mock_entry_no_yaml_config()
     config = {
         "device": {"identifiers": ["0AFFD2"]},
-        "platform": "mqtt",
         "topic": "foobar/image",
         "unique_id": "unique",
     }
     data = json.dumps(config)
+    config["platform"] = mqtt.DOMAIN
 
     async_fire_mqtt_message(hass, "homeassistant/camera/bla/config", data)
     await hass.async_block_till_done()
@@ -2397,7 +2398,9 @@ async def test_debug_info_non_mqtt(
             device_id=device_entry.id,
         )
 
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"platform": "test"}})
+    assert await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {DOMAIN: {"platform": "test"}}}
+    )
 
     debug_info_data = debug_info.info_for_device(hass, device_entry.id)
     assert len(debug_info_data["entities"]) == 0
@@ -2409,7 +2412,6 @@ async def test_debug_info_wildcard(hass, mqtt_mock_entry_no_yaml_config):
     await mqtt_mock_entry_no_yaml_config()
     config = {
         "device": {"identifiers": ["helloworld"]},
-        "platform": "mqtt",
         "name": "test",
         "state_topic": "sensor/#",
         "unique_id": "veryunique",
@@ -2456,7 +2458,6 @@ async def test_debug_info_filter_same(hass, mqtt_mock_entry_no_yaml_config):
     await mqtt_mock_entry_no_yaml_config()
     config = {
         "device": {"identifiers": ["helloworld"]},
-        "platform": "mqtt",
         "name": "test",
         "state_topic": "sensor/#",
         "unique_id": "veryunique",
@@ -2515,7 +2516,6 @@ async def test_debug_info_same_topic(hass, mqtt_mock_entry_no_yaml_config):
     await mqtt_mock_entry_no_yaml_config()
     config = {
         "device": {"identifiers": ["helloworld"]},
-        "platform": "mqtt",
         "name": "test",
         "state_topic": "sensor/status",
         "availability_topic": "sensor/status",
@@ -2568,7 +2568,6 @@ async def test_debug_info_qos_retain(hass, mqtt_mock_entry_no_yaml_config):
     await mqtt_mock_entry_no_yaml_config()
     config = {
         "device": {"identifiers": ["helloworld"]},
-        "platform": "mqtt",
         "name": "test",
         "state_topic": "sensor/#",
         "unique_id": "veryunique",
@@ -2708,6 +2707,8 @@ async def test_subscribe_connection_status(
     assert mqtt_connected_calls[1] is False
 
 
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
 async def test_one_deprecation_warning_per_platform(
     hass, mqtt_mock_entry_with_yaml_config, caplog
 ):
@@ -2801,6 +2802,8 @@ async def test_reload_entry_with_new_config(hass, tmp_path):
         "mqtt": {
             "light": [{"name": "test_new_modern", "command_topic": "test-topic_new"}]
         },
+        # YAML configuration under the platform key is deprecated.
+        # Support and will be removed as with HA 2022.12
         "light": [
             {
                 "platform": "mqtt",
@@ -2826,6 +2829,8 @@ async def test_disabling_and_enabling_entry(hass, tmp_path, caplog):
         "mqtt": {
             "light": [{"name": "test_new_modern", "command_topic": "test-topic_new"}]
         },
+        # YAML configuration under the platform key is deprecated.
+        # Support and will be removed as with HA 2022.12
         "light": [
             {
                 "platform": "mqtt",

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2707,8 +2707,8 @@ async def test_subscribe_connection_status(
     assert mqtt_connected_calls[1] is False
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_one_deprecation_warning_per_platform(
     hass, mqtt_mock_entry_with_yaml_config, caplog
 ):
@@ -2802,8 +2802,8 @@ async def test_reload_entry_with_new_config(hass, tmp_path):
         "mqtt": {
             "light": [{"name": "test_new_modern", "command_topic": "test-topic_new"}]
         },
-        # YAML configuration under the platform key is deprecated.
-        # Support and will be removed as with HA 2022.12
+        # Test deprecated YAML configuration under the platform key
+        # Scheduled to be removed in HA core 2022.12
         "light": [
             {
                 "platform": "mqtt",
@@ -2829,8 +2829,8 @@ async def test_disabling_and_enabling_entry(hass, tmp_path, caplog):
         "mqtt": {
             "light": [{"name": "test_new_modern", "command_topic": "test-topic_new"}]
         },
-        # YAML configuration under the platform key is deprecated.
-        # Support and will be removed as with HA 2022.12
+        # Test deprecated YAML configuration under the platform key
+        # Scheduled to be removed in HA core 2022.12
         "light": [
             {
                 "platform": "mqtt",

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -89,31 +89,14 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    vacuum.DOMAIN: {
-        CONF_PLATFORM: "mqtt",
-        CONF_NAME: "mqtttest",
-        CONF_COMMAND_TOPIC: "vacuum/command",
-        mqttvacuum.CONF_SEND_COMMAND_TOPIC: "vacuum/send_command",
-        mqttvacuum.CONF_BATTERY_LEVEL_TOPIC: "vacuum/state",
-        mqttvacuum.CONF_BATTERY_LEVEL_TEMPLATE: "{{ value_json.battery_level }}",
-        mqttvacuum.CONF_CHARGING_TOPIC: "vacuum/state",
-        mqttvacuum.CONF_CHARGING_TEMPLATE: "{{ value_json.charging }}",
-        mqttvacuum.CONF_CLEANING_TOPIC: "vacuum/state",
-        mqttvacuum.CONF_CLEANING_TEMPLATE: "{{ value_json.cleaning }}",
-        mqttvacuum.CONF_DOCKED_TOPIC: "vacuum/state",
-        mqttvacuum.CONF_DOCKED_TEMPLATE: "{{ value_json.docked }}",
-        mqttvacuum.CONF_ERROR_TOPIC: "vacuum/state",
-        mqttvacuum.CONF_ERROR_TEMPLATE: "{{ value_json.error }}",
-        mqttvacuum.CONF_FAN_SPEED_TOPIC: "vacuum/state",
-        mqttvacuum.CONF_FAN_SPEED_TEMPLATE: "{{ value_json.fan_speed }}",
-        mqttvacuum.CONF_SET_FAN_SPEED_TOPIC: "vacuum/set_fan_speed",
-        mqttvacuum.CONF_FAN_SPEED_LIST: ["min", "medium", "high", "max"],
-    }
-}
-
 DEFAULT_CONFIG_2 = {mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test"}}}
-DEFAULT_CONFIG_2_LEGACY = {vacuum.DOMAIN: {"platform": "mqtt", "name": "test"}}
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[vacuum.DOMAIN][CONF_PLATFORM] = mqtt.DOMAIN
+DEFAULT_CONFIG_2_LEGACY = deepcopy(DEFAULT_CONFIG_2[mqtt.DOMAIN])
+DEFAULT_CONFIG_2_LEGACY[vacuum.DOMAIN][CONF_PLATFORM] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -91,8 +91,8 @@ DEFAULT_CONFIG = {
 
 DEFAULT_CONFIG_2 = {mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test"}}}
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[vacuum.DOMAIN][CONF_PLATFORM] = mqtt.DOMAIN
 DEFAULT_CONFIG_2_LEGACY = deepcopy(DEFAULT_CONFIG_2[mqtt.DOMAIN])
@@ -1014,8 +1014,8 @@ async def test_setup_manual_entity_from_yaml(hass):
     assert hass.states.get(f"{platform}.test") is not None
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = vacuum.DOMAIN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The tests for the MQTT schema rely mainly on yaml the deprecated platform schema. When this is going to be removed with HA 2022.12.0 we need to update the tests to use the modern schema.
This PR will be the start of adopting the the modern schema.

For al platform tests a new `DEFAULT_CONFIG` will be defined, a clone without the `platform` attribute.
`DEFAULT_CONFIG_LEGACY` will hold the default config for the deprecated schema.
A new test will be added temporary to still test setup with the deprecated schema: `test_setup_with_legacy_schema`.
So all (common)tests that are not converted yet to the new schema will use `DEFAULT_CONFIG_LEGACY` config until the common code is migrated.
I'll use one commit per platform to begin with. Common tests will be updated later. Finally when the support for config under the platform key is removed all tests referring to the old schema will be labeled with deprecation comment.  

Part 1 covers the specific platform tests (see changed files) and tests from `test_init.py`.
Part 2 will cover the other platforms: https://github.com/home-assistant/core/pull/77525

A PR for the common tests can be found here: https://github.com/home-assistant/core/pull/77583

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
