### PR TITLE
Add a callback for data flow handler removal

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -343,7 +343,7 @@ class FlowManager(abc.ABC):
         try:
             flow.async_remove()
         except Exception as err:  # pylint: disable=broad-except
-            _LOGGER.warning("Error removing %s config flow: %r", flow.handler, err)
+            _LOGGER.exception("Error removing %s config flow: %s", flow.handler, err)
 
     async def _async_handle_step(
         self,

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -332,14 +332,11 @@ class FlowManager(abc.ABC):
         """Remove a flow from in progress."""
         if (flow := self._progress.pop(flow_id, None)) is None:
             raise UnknownFlow
-
-        try:
-            flow.async_remove()
-        finally:
-            handler = flow.handler
-            self._handler_progress_index[handler].remove(flow.flow_id)
-            if not self._handler_progress_index[handler]:
-                del self._handler_progress_index[handler]
+        handler = flow.handler
+        self._handler_progress_index[handler].remove(flow.flow_id)
+        if not self._handler_progress_index[handler]:
+            del self._handler_progress_index[handler]
+        flow.async_remove()
 
     async def _async_handle_step(
         self,

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -332,10 +332,14 @@ class FlowManager(abc.ABC):
         """Remove a flow from in progress."""
         if (flow := self._progress.pop(flow_id, None)) is None:
             raise UnknownFlow
-        handler = flow.handler
-        self._handler_progress_index[handler].remove(flow.flow_id)
-        if not self._handler_progress_index[handler]:
-            del self._handler_progress_index[handler]
+
+        try:
+            flow.async_remove()
+        finally:
+            handler = flow.handler
+            self._handler_progress_index[handler].remove(flow.flow_id)
+            if not self._handler_progress_index[handler]:
+                del self._handler_progress_index[handler]
 
     async def _async_handle_step(
         self,
@@ -567,6 +571,10 @@ class FlowHandler:
             menu_options=menu_options,
             description_placeholders=description_placeholders,
         )
+
+    @callback
+    def async_remove(self) -> None:
+        """Notification that the config flow has been removed."""
 
 
 @callback

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -1,6 +1,6 @@
 """Test the flow classes."""
 import asyncio
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 import voluptuous as vol
@@ -157,30 +157,11 @@ async def test_abort_calls_async_remove(manager):
         async def async_step_init(self, user_input=None):
             return self.async_abort(reason="reason")
 
-    with patch.object(TestFlow, "async_remove") as mock_async_remove:
-        await manager.async_init("test")
+        async_remove = Mock()
 
-    mock_async_remove.assert_called_once()
+    await manager.async_init("test")
 
-    assert len(manager.async_progress()) == 0
-    assert len(manager.mock_created_entries) == 0
-
-
-async def test_async_remove_with_failure_still_cleans_up(manager):
-    """Test that async_remove throwing an error still lets the manager clean up progress."""
-
-    @manager.mock_reg_handler("test")
-    class TestFlow(data_entry_flow.FlowHandler):
-        async def async_step_init(self, user_input=None):
-            return self.async_abort(reason="reason")
-
-    with patch.object(
-        TestFlow, "async_remove", side_effect=RuntimeError()
-    ) as mock_async_remove:
-        with pytest.raises(RuntimeError):
-            await manager.async_init("test")
-
-    mock_async_remove.assert_called_once()
+    TestFlow.async_remove.assert_called_once()
 
     assert len(manager.async_progress()) == 0
     assert len(manager.mock_created_entries) == 0

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -181,7 +181,7 @@ async def test_abort_calls_async_remove_with_exception(manager, caplog):
     with caplog.at_level(logging.ERROR):
         await manager.async_init("test")
 
-    assert "Error removing test config flow: RuntimeError('error')" in caplog.text
+    assert "Error removing test config flow: error" in caplog.text
 
     TestFlow.async_remove.assert_called_once()
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -178,7 +178,7 @@ async def test_abort_calls_async_remove_with_exception(manager, caplog):
 
         async_remove = Mock(side_effect=[RuntimeError("error")])
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         await manager.async_init("test")
 
     assert "Error removing test config flow: RuntimeError('error')" in caplog.text

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -149,6 +149,43 @@ async def test_abort_removes_instance(manager):
     assert len(manager.mock_created_entries) == 0
 
 
+async def test_abort_calls_async_remove(manager):
+    """Test that abort calls the async_remove FlowHandler method."""
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        async def async_step_init(self, user_input=None):
+            return self.async_abort(reason="reason")
+
+    with patch.object(TestFlow, "async_remove") as mock_async_remove:
+        await manager.async_init("test")
+
+    mock_async_remove.assert_called_once()
+
+    assert len(manager.async_progress()) == 0
+    assert len(manager.mock_created_entries) == 0
+
+
+async def test_async_remove_with_failure_still_cleans_up(manager):
+    """Test that async_remove throwing an error still lets the manager clean up progress."""
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        async def async_step_init(self, user_input=None):
+            return self.async_abort(reason="reason")
+
+    with patch.object(
+        TestFlow, "async_remove", side_effect=RuntimeError()
+    ) as mock_async_remove:
+        with pytest.raises(RuntimeError):
+            await manager.async_init("test")
+
+    mock_async_remove.assert_called_once()
+
+    assert len(manager.async_progress()) == 0
+    assert len(manager.mock_created_entries) == 0
+
+
 async def test_create_saves_data(manager):
     """Test creating a config entry."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a `FlowHandler.async_remove` callback that is called after the flow is removed (i.e. it completes or is closed).

This is useful if the flow handler needs to clean up state. In my use case, this re-loads the ZHA integration after an options flow has finished or was cancelled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
