### PR TITLE
Hide bluetooth passive option if its not available on the host system

### DIFF
--- a/homeassistant/components/bluetooth/config_flow.py
+++ b/homeassistant/components/bluetooth/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow to configure the Bluetooth integration."""
 from __future__ import annotations
 
-import platform
 from typing import TYPE_CHECKING, Any, cast
 
 import voluptuous as vol
@@ -11,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.core import callback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
+from . import models
 from .const import (
     ADAPTER_ADDRESS,
     CONF_ADAPTER,
@@ -134,7 +134,7 @@ class BluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def async_supports_options_flow(cls, config_entry: ConfigEntry) -> bool:
         """Return options flow support for this handler."""
-        return platform.system() == "Linux"
+        return bool(models.MANAGER and models.MANAGER.supports_passive_scan)
 
 
 class OptionsFlowHandler(OptionsFlow):

--- a/homeassistant/components/bluetooth/const.py
+++ b/homeassistant/components/bluetooth/const.py
@@ -59,8 +59,10 @@ class AdapterDetails(TypedDict, total=False):
     address: str
     sw_version: str
     hw_version: str
+    passive_scan: bool
 
 
 ADAPTER_ADDRESS: Final = "address"
 ADAPTER_SW_VERSION: Final = "sw_version"
 ADAPTER_HW_VERSION: Final = "hw_version"
+ADAPTER_PASSIVE_SCAN: Final = "passive_scan"

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     ADAPTER_ADDRESS,
+    ADAPTER_PASSIVE_SCAN,
     STALE_ADVERTISEMENT_SECONDS,
     UNAVAILABLE_TRACK_SECONDS,
     AdapterDetails,
@@ -146,6 +147,11 @@ class BluetoothManager:
         self._scanners: list[BaseHaScanner] = []
         self._connectable_scanners: list[BaseHaScanner] = []
         self._adapters: dict[str, AdapterDetails] = {}
+
+    @property
+    def supports_passive_scan(self) -> bool:
+        """Return if passive scan is supported."""
+        return any(adapter[ADAPTER_PASSIVE_SCAN] for adapter in self._adapters.values())
 
     async def async_diagnostics(self) -> dict[str, Any]:
         """Diagnostics for the manager."""

--- a/homeassistant/components/bluetooth/strings.json
+++ b/homeassistant/components/bluetooth/strings.json
@@ -29,9 +29,8 @@
   "options": {
     "step": {
       "init": {
-        "description": "Passive listening requires BlueZ 5.63 or later with experimental features enabled.",
         "data": {
-          "passive": "Passive listening"
+          "passive": "Passive scanning"
         }
       }
     }

--- a/homeassistant/components/bluetooth/translations/en.json
+++ b/homeassistant/components/bluetooth/translations/en.json
@@ -9,9 +9,6 @@
             "bluetooth_confirm": {
                 "description": "Do you want to setup {name}?"
             },
-            "enable_bluetooth": {
-                "description": "Do you want to setup Bluetooth?"
-            },
             "multiple_adapters": {
                 "data": {
                     "adapter": "Adapter"
@@ -33,10 +30,8 @@
         "step": {
             "init": {
                 "data": {
-                    "adapter": "The Bluetooth Adapter to use for scanning",
-                    "passive": "Passive listening"
-                },
-                "description": "Passive listening requires BlueZ 5.63 or later with experimental features enabled."
+                    "passive": "Passive scanning"
+                }
             }
         }
     }

--- a/homeassistant/components/bluetooth/util.py
+++ b/homeassistant/components/bluetooth/util.py
@@ -24,6 +24,7 @@ async def async_get_bluetooth_adapters() -> dict[str, AdapterDetails]:
             WINDOWS_DEFAULT_BLUETOOTH_ADAPTER: AdapterDetails(
                 address=DEFAULT_ADDRESS,
                 sw_version=platform.release(),
+                passive_scan=False,
             )
         }
     if platform.system() == "Darwin":
@@ -31,6 +32,7 @@ async def async_get_bluetooth_adapters() -> dict[str, AdapterDetails]:
             MACOS_DEFAULT_BLUETOOTH_ADAPTER: AdapterDetails(
                 address=DEFAULT_ADDRESS,
                 sw_version=platform.release(),
+                passive_scan=False,
             )
         }
     from bluetooth_adapters import (  # pylint: disable=import-outside-toplevel
@@ -45,6 +47,7 @@ async def async_get_bluetooth_adapters() -> dict[str, AdapterDetails]:
             address=adapter1["Address"],
             sw_version=adapter1["Name"],  # This is actually the BlueZ version
             hw_version=adapter1["Modalias"],
+            passive_scan="org.bluez.AdvertisementMonitorManager1" in details,
         )
     return adapters
 

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -42,7 +42,11 @@ def one_adapter_fixture():
                     "Address": "00:00:00:00:00:01",
                     "Name": "BlueZ 4.63",
                     "Modalias": "usbid:1234",
-                }
+                },
+                "org.bluez.AdvertisementMonitorManager1": {
+                    "SupportedMonitorTypes": ["or_patterns"],
+                    "SupportedFeatures": [],
+                },
             },
         },
     ):
@@ -74,7 +78,11 @@ def two_adapters_fixture():
                     "Address": "00:00:00:00:00:02",
                     "Name": "BlueZ 4.63",
                     "Modalias": "usbid:1234",
-                }
+                },
+                "org.bluez.AdvertisementMonitorManager1": {
+                    "SupportedMonitorTypes": ["or_patterns"],
+                    "SupportedFeatures": [],
+                },
             },
         },
     ):

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -31,7 +31,16 @@ async def test_diagnostics(
         return_value={
             "org.bluez": {
                 "/org/bluez/hci0": {
-                    "Interfaces": {"org.bluez.Adapter1": {"Discovering": False}}
+                    "org.bluez.Adapter1": {
+                        "Name": "BlueZ 5.63",
+                        "Alias": "BlueZ 5.63",
+                        "Modalias": "usb:v1D6Bp0246d0540",
+                        "Discovering": False,
+                    },
+                    "org.bluez.AdvertisementMonitorManager1": {
+                        "SupportedMonitorTypes": ["or_patterns"],
+                        "SupportedFeatures": [],
+                    },
                 }
             }
         },
@@ -57,18 +66,29 @@ async def test_diagnostics(
                 "hci0": {
                     "address": "00:00:00:00:00:01",
                     "hw_version": "usbid:1234",
+                    "passive_scan": False,
                     "sw_version": "BlueZ 4.63",
                 },
                 "hci1": {
                     "address": "00:00:00:00:00:02",
                     "hw_version": "usbid:1234",
+                    "passive_scan": True,
                     "sw_version": "BlueZ 4.63",
                 },
             },
             "dbus": {
                 "org.bluez": {
                     "/org/bluez/hci0": {
-                        "Interfaces": {"org.bluez.Adapter1": {"Discovering": False}}
+                        "org.bluez.Adapter1": {
+                            "Alias": "BlueZ " "5.63",
+                            "Discovering": False,
+                            "Modalias": "usb:v1D6Bp0246d0540",
+                            "Name": "BlueZ " "5.63",
+                        },
+                        "org.bluez.AdvertisementMonitorManager1": {
+                            "SupportedFeatures": [],
+                            "SupportedMonitorTypes": ["or_patterns"],
+                        },
                     }
                 }
             },
@@ -77,11 +97,13 @@ async def test_diagnostics(
                     "hci0": {
                         "address": "00:00:00:00:00:01",
                         "hw_version": "usbid:1234",
+                        "passive_scan": False,
                         "sw_version": "BlueZ 4.63",
                     },
                     "hci1": {
                         "address": "00:00:00:00:00:02",
                         "hw_version": "usbid:1234",
+                        "passive_scan": True,
                         "sw_version": "BlueZ 4.63",
                     },
                 },


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We now have a way to determine in advance if passive
  scanning is supported by BlueZ


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
