### PR TITLE
WIP adding media to entities

### DIFF
--- a/homeassistant/components/media_source/const.py
+++ b/homeassistant/components/media_source/const.py
@@ -14,6 +14,11 @@ MEDIA_CLASS_MAP = {
     "video": MEDIA_CLASS_VIDEO,
     "image": MEDIA_CLASS_IMAGE,
 }
+MEDIA_MIME_TYPE_MAP = {
+    MEDIA_CLASS_MUSIC: "audio",
+    MEDIA_CLASS_VIDEO: "video",
+    MEDIA_CLASS_IMAGE: "image",
+}
 URI_SCHEME = "media-source://"
 URI_SCHEME_REGEX = re.compile(
     r"^media-source:\/\/(?:(?P<domain>(?!_)[\da-z_]+(?<!_))(?:\/(?P<identifier>(?!\/).+))?)?$"

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -1,7 +1,14 @@
 """Recorder constants."""
 
 from homeassistant.backports.enum import StrEnum
-from homeassistant.const import ATTR_ATTRIBUTION, ATTR_RESTORED, ATTR_SUPPORTED_FEATURES
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_AUDIO_URLS,
+    ATTR_IMAGE_URLS,
+    ATTR_RESTORED,
+    ATTR_SUPPORTED_FEATURES,
+    ATTR_VIDEO_URLS,
+)
 from homeassistant.helpers.json import (  # noqa: F401 pylint: disable=unused-import
     JSON_DUMP,
 )
@@ -25,7 +32,14 @@ MAX_ROWS_TO_PURGE = 998
 
 DB_WORKER_PREFIX = "DbWorker"
 
-ALL_DOMAIN_EXCLUDE_ATTRS = {ATTR_ATTRIBUTION, ATTR_RESTORED, ATTR_SUPPORTED_FEATURES}
+ALL_DOMAIN_EXCLUDE_ATTRS = {
+    ATTR_ATTRIBUTION,
+    ATTR_RESTORED,
+    ATTR_SUPPORTED_FEATURES,
+    ATTR_AUDIO_URLS,
+    ATTR_IMAGE_URLS,
+    ATTR_VIDEO_URLS,
+}
 
 ATTR_KEEP_DAYS = "keep_days"
 ATTR_REPACK = "repack"

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -260,7 +260,9 @@ class ProtectData:
 
     @callback
     def async_subscribe_device_id(
-        self, mac: str, update_callback: Callable[[ProtectDeviceType], None]
+        self,
+        mac: str,
+        update_callback: Callable[[ProtectDeviceType], Coroutine[Any, Any, None]],
     ) -> CALLBACK_TYPE:
         """Add an callback subscriber."""
         if not self._subscriptions:
@@ -276,7 +278,9 @@ class ProtectData:
 
     @callback
     def async_unsubscribe_device_id(
-        self, mac: str, update_callback: Callable[[ProtectDeviceType], None]
+        self,
+        mac: str,
+        update_callback: Callable[[ProtectDeviceType], Coroutine[Any, Any, None]],
     ) -> None:
         """Remove a callback subscriber."""
         self._subscriptions[mac].remove(update_callback)

--- a/homeassistant/components/unifiprotect/media_player.py
+++ b/homeassistant/components/unifiprotect/media_player.py
@@ -122,7 +122,7 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
         ):
             _LOGGER.debug("Stopping playback for %s Speaker", self.device.display_name)
             await self.device.stop_audio()
-            self._async_updated_event(self.device)
+            await self._async_updated_event(self.device)
 
     async def async_play_media(
         self, media_type: str, media_id: str, **kwargs: Any
@@ -148,11 +148,11 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
             raise HomeAssistantError(err) from err
         else:
             # update state after starting player
-            self._async_updated_event(self.device)
+            await self._async_updated_event(self.device)
             # wait until player finishes to update state again
             await self.device.wait_until_audio_completes()
 
-        self._async_updated_event(self.device)
+        await self._async_updated_event(self.device)
 
     async def async_browse_media(
         self, media_content_type: str | None = None, media_content_id: str | None = None

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -470,6 +470,11 @@ ATTR_TEMPERATURE: Final = "temperature"
 # Persons attribute
 ATTR_PERSONS: Final = "persons"
 
+# Media URLs
+ATTR_AUDIO_URLS: Final = "audio_urls"
+ATTR_IMAGE_URLS: Final = "image_urls"
+ATTR_VIDEO_URLS: Final = "video_urls"
+
 # #### UNITS OF MEASUREMENT ####
 # Apparent power units
 POWER_VOLT_AMPERE: Final = "VA"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**Still work in progress. Looking for feedback on implementation at the moment.** This PR will likely be closed and then broken up into multiple smaller PRs after discussion. I wanted to have everything in a single PR to make it more helpful to see "how this will be used".

### Summary 

Add ability to let any entity resolve media items. Architecture discussion: https://github.com/home-assistant/architecture/discussions/705

The idea is to allow integrations to add media to any entity rather than requiring the entity to be a camera entity. This _could_ also be used to later update camera entities to change how they expose `entity_picture` and possibly even expose streaming URLs to allow automations, other integrations, and third-party applications lower-level access to media from entities.

### Example Use Case
(surveillance/UniFi Protect)

A security camera may commonly have a "motion detection" binary sensor or a sensor for object detection. These are both examples of entities that are not camera entities (the device itself would likely have a camera entity as well), but they may conditionally have images or video clips that can be exposed as media items.

Example attributes:

```yaml
event_score: 0
device_class: motion
friendly_name: AI Theta Motion
image_urls:
  image/jpeg:
    - /api/unifiprotect/thumbnail/61b3f5c303c8a703e70003ea/630aef9301602b03e70159c0-630aea5b002e2b03e701566d
```

This data can then be used for sending notifications to devices.

### Notes

* Again, still WIP. Looking on general feedback on implemention. This PR will need to be closed, broken up into smaller ones and cleaned up (cyclic imports between `helpers.entity` and `components.media_source`).
* The attributes added for media items are excluded from recorder, so it is not written to the database (no auth tokens in DB)
* The media URLs are not currently signed, so they cannot be used as is in automations. Ideally future case is to allow `notify` platform to "attach" an entity and it can handle signing, but for now, we need another option. Thoughts on options:
    1. Add URL signer template filter so users can sign the URLs themselves. This would also allow users to sign URLs for various other things.
    2. Sign URLs as part of generating attributes. This could lead requiring signed URL to have extended expiration. Ideally it would not be longer then ~1 hour or so.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
