### PR TITLE
Switch to new entity naming schema across zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -377,8 +377,9 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         # Entity class attributes
         self._attr_name = self.generate_name(
             include_value_name=True,
-            alternate_value_name=self.info.primary_value.property_name,
-            additional_info=[self.info.primary_value.metadata.states[self.state_key]],
+            alternate_value_name=self.info.primary_value.metadata.states[
+                self.state_key
+            ],
         )
         self._attr_unique_id = f"{self._attr_unique_id}.{self.state_key}"
 

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -376,10 +376,7 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
 
         # Entity class attributes
         self._attr_name = self.generate_name(
-            include_value_name=True,
-            alternate_value_name=self.info.primary_value.metadata.states[
-                self.state_key
-            ],
+            alternate_value_name=self.info.primary_value.metadata.states[self.state_key]
         )
         self._attr_unique_id = f"{self._attr_unique_id}.{self.state_key}"
 

--- a/homeassistant/components/zwave_js/button.py
+++ b/homeassistant/components/zwave_js/button.py
@@ -47,15 +47,14 @@ class ZWaveNodePingButton(ButtonEntity):
 
     _attr_should_poll = False
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
 
     def __init__(self, driver: Driver, node: ZwaveNode) -> None:
         """Initialize a ping Z-Wave device button entity."""
         self.node = node
-        name: str = (
-            node.name or node.device_config.description or f"Node {node.node_id}"
-        )
+
         # Entity class attributes
-        self._attr_name = f"{name}: Ping"
+        self._attr_name = "Ping"
         self._base_unique_id = get_valueless_base_unique_id(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.ping"
         # device may not be precreated in main handler yet

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -130,8 +130,6 @@ class ZWaveBaseEntity(Entity):
         name_prefix: str | None = None,
     ) -> str:
         """Generate entity name."""
-        if additional_info is None:
-            additional_info = []
         name = ""
         if (
             hasattr(self, "entity_description")
@@ -144,16 +142,17 @@ class ZWaveBaseEntity(Entity):
             name = f"{name_prefix} {name}".strip()
 
         value_name = ""
-        if include_value_name:
+        if alternate_value_name:
+            value_name = alternate_value_name
+        elif include_value_name:
             value_name = (
-                alternate_value_name
-                or self.info.primary_value.metadata.label
+                self.info.primary_value.metadata.label
                 or self.info.primary_value.property_key_name
                 or self.info.primary_value.property_name
                 or ""
             )
         name = f"{name} {value_name}".strip()
-        name = f"{name} {' '.join(additional_info)}".strip()
+        name = f"{name} {' '.join(additional_info or [])}".strip()
         # append endpoint if > 1
         if (
             self.info.primary_value.endpoint is not None

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -24,6 +24,7 @@ class ZWaveBaseEntity(Entity):
     """Generic Entity Class for a Z-Wave Device."""
 
     _attr_should_poll = False
+    _attr_has_entity_name = True
 
     def __init__(
         self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
@@ -126,18 +127,14 @@ class ZWaveBaseEntity(Entity):
         include_value_name: bool = False,
         alternate_value_name: str | None = None,
         additional_info: list[str] | None = None,
-        name_suffix: str | None = None,
+        name_prefix: str | None = None,
     ) -> str:
         """Generate entity name."""
         if additional_info is None:
             additional_info = []
-        name: str = (
-            self.info.node.name
-            or self.info.node.device_config.description
-            or f"Node {self.info.node.node_id}"
-        )
-        if name_suffix:
-            name = f"{name} {name_suffix}"
+        name = ""
+        if name_prefix:
+            name = name_prefix
         if include_value_name:
             value_name = (
                 alternate_value_name
@@ -145,7 +142,10 @@ class ZWaveBaseEntity(Entity):
                 or self.info.primary_value.property_key_name
                 or self.info.primary_value.property_name
             )
-            name = f"{name}: {value_name}"
+            if name:
+                name = f"{name}: {value_name}"
+            else:
+                name = value_name or ""
         for item in additional_info:
             if item:
                 name += f" - {item}"

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -133,22 +133,27 @@ class ZWaveBaseEntity(Entity):
         if additional_info is None:
             additional_info = []
         name = ""
+        if (
+            hasattr(self, "entity_description")
+            and self.entity_description
+            and self.entity_description.name
+        ):
+            name = self.entity_description.name
+
         if name_prefix:
-            name = name_prefix
+            name = f"{name_prefix} {name}".strip()
+
+        value_name = ""
         if include_value_name:
             value_name = (
                 alternate_value_name
                 or self.info.primary_value.metadata.label
                 or self.info.primary_value.property_key_name
                 or self.info.primary_value.property_name
+                or ""
             )
-            if name:
-                name = f"{name}: {value_name}"
-            else:
-                name = value_name or ""
-        for item in additional_info:
-            if item:
-                name += f" - {item}"
+        name = f"{name} {value_name}".strip()
+        name = f"{name} {' '.join(additional_info)}".strip()
         # append endpoint if > 1
         if (
             self.info.primary_value.endpoint is not None

--- a/homeassistant/components/zwave_js/number.py
+++ b/homeassistant/components/zwave_js/number.py
@@ -66,9 +66,7 @@ class ZwaveNumberEntity(ZWaveBaseEntity, NumberEntity):
             self._target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
 
         # Entity class attributes
-        self._attr_name = self.generate_name(
-            include_value_name=True, alternate_value_name=info.platform_hint
-        )
+        self._attr_name = self.generate_name(alternate_value_name=info.platform_hint)
 
     @property
     def native_min_value(self) -> float:

--- a/homeassistant/components/zwave_js/select.py
+++ b/homeassistant/components/zwave_js/select.py
@@ -107,9 +107,7 @@ class ZwaveDefaultToneSelectEntity(ZWaveBaseEntity, SelectEntity):
         )
 
         # Entity class attributes
-        self._attr_name = self.generate_name(
-            include_value_name=True, alternate_value_name=info.platform_hint
-        )
+        self._attr_name = self.generate_name(alternate_value_name=info.platform_hint)
 
     @property
     def options(self) -> list[str]:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -440,7 +440,7 @@ class ZWaveConfigParameterSensor(ZwaveSensorBase):
             include_value_name=True,
             alternate_value_name=self.info.primary_value.property_name,
             additional_info=[property_key_name] if property_key_name else None,
-            name_suffix="Config Parameter",
+            name_prefix="Config parameter",
         )
 
     @property
@@ -477,6 +477,7 @@ class ZWaveNodeStatusSensor(SensorEntity):
 
     _attr_should_poll = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
 
     def __init__(
         self, config_entry: ConfigEntry, driver: Driver, node: ZwaveNode
@@ -484,18 +485,13 @@ class ZWaveNodeStatusSensor(SensorEntity):
         """Initialize a generic Z-Wave device entity."""
         self.config_entry = config_entry
         self.node = node
-        name: str = (
-            self.node.name
-            or self.node.device_config.description
-            or f"Node {self.node.node_id}"
-        )
+
         # Entity class attributes
-        self._attr_name = f"{name}: Node Status"
+        self._attr_name = "Node status"
         self._base_unique_id = get_valueless_base_unique_id(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.node_status"
         # device may not be precreated in main handler yet
         self._attr_device_info = get_device_info(driver, node)
-        self._attr_native_value: str = node.status.name.lower()
 
     async def async_poll_value(self, _: bool) -> None:
         """Poll a value."""
@@ -534,4 +530,5 @@ class ZWaveNodeStatusSensor(SensorEntity):
                 self.async_remove,
             )
         )
+        self._attr_native_value: str = self.node.status.name.lower()
         self.async_write_ha_state()

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -386,13 +386,8 @@ class ZWaveListSensor(ZwaveSensorBase):
             config_entry, driver, info, entity_description, unit_of_measurement
         )
 
-        property_key_name = self.info.primary_value.property_key_name
         # Entity class attributes
-        self._attr_name = self.generate_name(
-            include_value_name=True,
-            alternate_value_name=self.info.primary_value.property_name,
-            additional_info=[property_key_name] if property_key_name else None,
-        )
+        self._attr_name = self.generate_name(include_value_name=True)
 
     @property
     def native_value(self) -> str | None:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -432,7 +432,6 @@ class ZWaveConfigParameterSensor(ZwaveSensorBase):
         property_key_name = self.info.primary_value.property_key_name
         # Entity class attributes
         self._attr_name = self.generate_name(
-            include_value_name=True,
             alternate_value_name=self.info.primary_value.property_name,
             additional_info=[property_key_name] if property_key_name else None,
             name_prefix="Config parameter",

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -1,9 +1,7 @@
 """Provide common test tools for Z-Wave JS."""
 AIR_TEMPERATURE_SENSOR = "sensor.multisensor_6_air_temperature"
 BATTERY_SENSOR = "sensor.multisensor_6_battery_level"
-TAMPER_SENSOR = (
-    "binary_sensor.multisensor_6_home_security_tampering_product_cover_removed"
-)
+TAMPER_SENSOR = "binary_sensor.multisensor_6_tampering_product_cover_removed"
 HUMIDITY_SENSOR = "sensor.multisensor_6_humidity"
 POWER_SENSOR = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
 ENERGY_SENSOR = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_2"
@@ -13,10 +11,8 @@ SWITCH_ENTITY = "switch.smart_plug_with_two_usb_ports"
 LOW_BATTERY_BINARY_SENSOR = "binary_sensor.multisensor_6_low_battery_level"
 ENABLED_LEGACY_BINARY_SENSOR = "binary_sensor.z_wave_door_window_sensor_any"
 DISABLED_LEGACY_BINARY_SENSOR = "binary_sensor.multisensor_6_any"
-NOTIFICATION_MOTION_BINARY_SENSOR = (
-    "binary_sensor.multisensor_6_home_security_motion_detection"
-)
-NOTIFICATION_MOTION_SENSOR = "sensor.multisensor_6_home_security_motion_sensor_status"
+NOTIFICATION_MOTION_BINARY_SENSOR = "binary_sensor.multisensor_6_motion_detection"
+NOTIFICATION_MOTION_SENSOR = "sensor.multisensor_6_motion_sensor_status"
 INDICATOR_SENSOR = "sensor.z_wave_thermostat_indicator_value"
 BASIC_NUMBER_ENTITY = "number.livingroomlight_basic"
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -141,7 +141,7 @@ async def test_notification_off_state(
 
     state = door_states[0]
     assert state
-    assert state.entity_id == "binary_sensor.node_62_access_control_window_door_is_open"
+    assert state.entity_id == "binary_sensor.node_62_window_door_is_open"
 
 
 async def test_property_sensor_door_status(hass, lock_august_pro, integration):

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -347,10 +347,10 @@ async def test_existing_node_not_replaced_when_not_ready(
     assert not device.area_id
     assert device == dev_reg.async_get_device(identifiers={(DOMAIN, device_id_ext)})
 
-    motion_entity = "binary_sensor.4_in_1_sensor_home_security_motion_detection"
+    motion_entity = "binary_sensor.4_in_1_sensor_motion_detection"
     state = hass.states.get(motion_entity)
     assert state
-    assert state.name == "4-in-1 Sensor Home Security - Motion detection"
+    assert state.name == "4-in-1 Sensor Motion detection"
 
     dev_reg.async_update_device(
         device.id, name_by_user="Custom Device Name", area_id=kitchen_area.id
@@ -1179,10 +1179,10 @@ async def test_node_model_change(hass, zp3111, client, integration):
 
     dev_id = device.id
 
-    motion_entity = "binary_sensor.4_in_1_sensor_home_security_motion_detection"
+    motion_entity = "binary_sensor.4_in_1_sensor_motion_detection"
     state = hass.states.get(motion_entity)
     assert state
-    assert state.name == "4-in-1 Sensor Home Security - Motion detection"
+    assert state.name == "4-in-1 Sensor Motion detection"
 
     # Customize device and entity names/ids
     dev_reg.async_update_device(device.id, name_by_user="Custom Device Name")
@@ -1267,7 +1267,7 @@ async def test_disabled_entity_on_value_removed(hass, zp3111, client, integratio
     er_reg = er.async_get(hass)
 
     # re-enable this default-disabled entity
-    sensor_cover_entity = "sensor.4_in_1_sensor_home_security_cover_status"
+    sensor_cover_entity = "sensor.4_in_1_sensor_cover_status"
     er_reg.async_update_entity(entity_id=sensor_cover_entity, disabled_by=None)
     await hass.async_block_till_done()
 
@@ -1285,9 +1285,7 @@ async def test_disabled_entity_on_value_removed(hass, zp3111, client, integratio
     assert state.state != STATE_UNAVAILABLE
 
     # check for expected entities
-    binary_cover_entity = (
-        "binary_sensor.4_in_1_sensor_home_security_tampering_product_cover_removed"
-    )
+    binary_cover_entity = "binary_sensor.4_in_1_sensor_tampering_product_cover_removed"
     state = hass.states.get(binary_cover_entity)
     assert state
     assert state.state != STATE_UNAVAILABLE

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -350,7 +350,7 @@ async def test_existing_node_not_replaced_when_not_ready(
     motion_entity = "binary_sensor.4_in_1_sensor_home_security_motion_detection"
     state = hass.states.get(motion_entity)
     assert state
-    assert state.name == "4-in-1 Sensor: Home Security - Motion detection"
+    assert state.name == "4-in-1 Sensor Home Security - Motion detection"
 
     dev_reg.async_update_device(
         device.id, name_by_user="Custom Device Name", area_id=kitchen_area.id
@@ -1182,7 +1182,7 @@ async def test_node_model_change(hass, zp3111, client, integration):
     motion_entity = "binary_sensor.4_in_1_sensor_home_security_motion_detection"
     state = hass.states.get(motion_entity)
     assert state
-    assert state.name == "4-in-1 Sensor: Home Security - Motion detection"
+    assert state.name == "4-in-1 Sensor Home Security - Motion detection"
 
     # Customize device and entity names/ids
     dev_reg.async_update_device(device.id, name_by_user="Custom Device Name")


### PR DESCRIPTION
## Proposed change
In this PR we use the new entity naming schema. There is a slight deviance as we sometimes compound multiple strings together with an end result of having multiple capitalized words instead of just one. But each piece of the compound follows the expected format (capitalize first word, lowercase everything else).

~~This PR did expose a bug where we create the node status sensor and ping button when a node is added but before it's been registered to the device registry, meaning that they dangle until the next run. This PR fixes that bug along with introducing this change to the naming scheme.~~

Also fixed a bug where we captured the node state before the entity was added to HA.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
