### PR TITLE
Add Utility meter price

### DIFF
--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_METER_OFFSET,
     CONF_METER_TYPE,
     CONF_SOURCE_SENSOR,
+    CONF_PRICE_SENSOR,
     CONF_TARIFF,
     CONF_TARIFF_ENTITY,
     CONF_TARIFFS,
@@ -75,6 +76,7 @@ METER_CONFIG_SCHEMA = vol.Schema(
     vol.All(
         {
             vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
+            vol.Optional(CONF_PRICE_SENSOR): cv.entity_id,
             vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
             vol.Optional(CONF_METER_TYPE): vol.In(METER_TYPES),

--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -28,6 +28,7 @@ DATA_TARIFF_SENSORS = "utility_meter_sensors"
 
 CONF_METER = "meter"
 CONF_SOURCE_SENSOR = "source"
+CONF_PRICE_SENSOR = "price"
 CONF_METER_TYPE = "cycle"
 CONF_METER_OFFSET = "offset"
 CONF_METER_DELTA_VALUES = "delta_values"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add an option to the utility meter to calculate utility costs based on the price given by a specified entity.

Some use cases enabled by this change:
- Track the energy costs of individual sensors. Currently, it is possible to track the overall cost of your energy usage in the energy dashboard, based on the price from a given entity. However, sometimes it is useful to break this cost down to individual sensors. This is not possible from the energy dashboard.
- Track the cost of any utility even when it has variable pricing.
- Track the cost of the same utility based on different pricing models (e.g. spot vs. fixed pricing).

The utility meter currently allows breaking the meter into different fixed tariffs. Then it is possible to find the total cost by multiplying the consumption within each tariff by the tariff price. However, this is not suitable in the case where the price changes continuously, such as when based on hourly market prices. This can be worked around by using the the Riemann integration sensor coupled with the total current power usage, see e.g. [this community thread](https://community.home-assistant.io/t/calculate-energy-cost-for-sensor-with-hourly-price-utility-meter/417399). However, this is a convoluted step, and additionally, it won't work for utilities that are only available in their accumulated form (e.g. if you only have total energy consumption and not power).

Furthermore, if the user is mainly interested in the fixed cost, it is very convoluted to set this up using tariffs: it results in different sensors for each tariff, and a selector. Then you need to setup an automation for the selector, and finally a template sensor to sum up all the tariff sensors together at each tariff's price.

With this PR, the above use cases are solved simply by adding `price: <entity_id>` to your utility meter.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This is my first time making a PR for Home Assistant, it's only been tested locally using a custom component. I'd appreciate assistance with any steps needed before it can be accepted. Also, feel free to push changes to this PR.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
