### PR TITLE
Add enable and disable config entry services

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -255,7 +255,7 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
         vol.Schema({ATTR_LATITUDE: cv.latitude, ATTR_LONGITUDE: cv.longitude}),
     )
 
-    async def async_get_entries_ids_set(call: ha.ServiceCall) -> set:
+    async def _async_get_entries_ids_set(call: ha.ServiceCall) -> set:
         reload_entries = set()
         if ATTR_ENTRY_ID in call.data:
             reload_entries.add(call.data[ATTR_ENTRY_ID])
@@ -264,7 +264,7 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
 
     async def async_handle_reload_config_entry(call: ha.ServiceCall) -> None:
         """Service handler for reloading a config entry."""
-        reload_entries = await async_get_entries_ids_set(call)
+        reload_entries = await _async_get_entries_ids_set(call)
         if not reload_entries:
             raise ValueError("There were no matching config entries to reload")
         await asyncio.gather(
@@ -284,7 +284,7 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
 
     async def async_handle_enable_config_entry(call: ha.ServiceCall) -> None:
         """Service handler for enabling a config entry."""
-        enable_entries = await async_get_entries_ids_set(call)
+        enable_entries = await _async_get_entries_ids_set(call)
         if not enable_entries:
             raise ValueError("There were no matching config entries to enable")
         await asyncio.gather(
@@ -304,7 +304,7 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
 
     async def async_handle_disable_config_entry(call: ha.ServiceCall) -> None:
         """Service handler for disabling a config entry."""
-        disable_entries = await async_get_entries_ids_set(call)
+        disable_entries = await _async_get_entries_ids_set(call)
         if not disable_entries:
             raise ValueError("There were no matching config entries to disable")
         await asyncio.gather(

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -311,7 +311,7 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
             *(
                 hass.config_entries.async_set_disabled_by(
                     config_entry_id,
-                    ConfigEntryDisabler.USER,
+                    ConfigEntryDisabler.SERVICE,
                 )
                 for config_entry_id in disable_entries
             )

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -75,6 +75,38 @@ reload_config_entry:
       selector:
         text:
 
+enable_config_entry:
+  name: Enable config entry
+  description: Enable a config entry that matches a target.
+  target:
+    entity: {}
+    device: {}
+  fields:
+    entry_id:
+      advanced: true
+      name: Config entry id
+      description: A configuration entry id
+      required: false
+      example: 8955375327824e14ba89e4b29cc3ec9a
+      selector:
+        text:
+
+disable_config_entry:
+  name: Disable config entry
+  description: Disable a config entry that matches a target.
+  target:
+    entity: {}
+    device: {}
+  fields:
+    entry_id:
+      advanced: true
+      name: Config entry id
+      description: A configuration entry id
+      required: false
+      example: 8955375327824e14ba89e4b29cc3ec9a
+      selector:
+        text:
+
 save_persistent_states:
   name: Save Persistent States
   description:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -141,6 +141,7 @@ class ConfigEntryDisabler(StrEnum):
     """What disabled a config entry."""
 
     USER = "user"
+    SERVICE = "service"
 
 
 # DISABLED_* is deprecated, to be removed in 2022.3

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -490,8 +490,8 @@ async def test_disable_config_entry_by_entity_id(hass):
         mock_disable.mock_calls[0][1][0],
         mock_disable.mock_calls[1][1][0],
     } == {entry1.entry_id, entry2.entry_id}
-    assert mock_disable.mock_calls[0][1][1] is ConfigEntryDisabler.USER
-    assert mock_disable.mock_calls[1][1][1] is ConfigEntryDisabler.USER
+    assert mock_disable.mock_calls[0][1][1] is ConfigEntryDisabler.SERVICE
+    assert mock_disable.mock_calls[1][1][1] is ConfigEntryDisabler.SERVICE
 
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -570,7 +570,7 @@ async def test_disable_config_entry_by_entry_id(hass):
     # print(mock_enable_disable.mock_calls[0])
     assert len(mock_disable.mock_calls) == 1
     assert mock_disable.mock_calls[0][1][0] == entry.entry_id
-    assert mock_disable.mock_calls[0][1][1] == ConfigEntryDisabler.USER
+    assert mock_disable.mock_calls[0][1][1] == ConfigEntryDisabler.SERVICE
 
     with pytest.raises(ValueError):
         await hass.services.async_call(

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -516,6 +516,7 @@ async def test_reload_config_entry_by_entry_id(hass):
             {ATTR_ENTRY_ID: "8955375327824e14ba89e4b29cc3ec9a"},
             blocking=True,
         )
+
     assert len(mock_reload.mock_calls) == 1
     assert mock_reload.mock_calls[0][1][0] == "8955375327824e14ba89e4b29cc3ec9a"
 

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -568,7 +568,6 @@ async def test_disable_config_entry_by_entry_id(hass):
             blocking=True,
         )
 
-    # print(mock_enable_disable.mock_calls[0])
     assert len(mock_disable.mock_calls) == 1
     assert mock_disable.mock_calls[0][1][0] == entry.entry_id
     assert mock_disable.mock_calls[0][1][1] == ConfigEntryDisabler.SERVICE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding 2 services to enable and disable integrations/config-entries.

I ran into a situation where I need to use automation to enable and disable (NOT reload) an integration.
I didn't find such services and found some discussions confirming that it's a missing feature:

https://community.home-assistant.io/t/programmatically-disable-enable-integration/322971
https://community.home-assistant.io/t/disabling-enabling-an-integration-automatically/437038


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23927

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/23927

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
