### PR TITLE
Support unique_id for Universal Media Player

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -52,6 +52,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_STATE,
     CONF_STATE_TEMPLATE,
+    CONF_UNIQUE_ID,
     EVENT_HOMEASSISTANT_START,
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
@@ -120,6 +121,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ATTRS, default={}): vol.Or(
             cv.ensure_list(ATTRS_SCHEMA), ATTRS_SCHEMA
         ),
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
         vol.Optional(CONF_STATE_TEMPLATE): cv.template,
     },
@@ -142,6 +144,7 @@ async def async_setup_platform(
         config.get(CONF_CHILDREN),
         config.get(CONF_COMMANDS),
         config.get(CONF_ATTRS),
+        config.get(CONF_UNIQUE_ID),
         config.get(CONF_DEVICE_CLASS),
         config.get(CONF_STATE_TEMPLATE),
     )
@@ -161,6 +164,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         children,
         commands,
         attributes,
+        unique_id=None,
         device_class=None,
         state_template=None,
     ):
@@ -179,6 +183,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         self._state_template_result = None
         self._state_template = state_template
         self._device_class = device_class
+        self._unique_id = unique_id
 
     async def async_added_to_hass(self):
         """Subscribe to children and template state changes."""
@@ -298,6 +303,11 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     def name(self):
         """Return the name of universal player."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return the unique id of universal player."""
+        return self._unique_id
 
     @property
     def state(self):

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -183,7 +183,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         self._state_template_result = None
         self._state_template = state_template
         self._device_class = device_class
-        self._unique_id = unique_id
+        self._attr_unique_id = unique_id
 
     async def async_added_to_hass(self):
         """Subscribe to children and template state changes."""
@@ -303,11 +303,6 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     def name(self):
         """Return the name of universal player."""
         return self._name
-
-    @property
-    def unique_id(self):
-        """Return the unique id of universal player."""
-        return self._unique_id
 
     @property
     def state(self):

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import Context, callback
+from homeassistant.helpers import entity_registry
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 
@@ -1086,6 +1087,26 @@ async def test_device_class(hass):
     assert hass.states.get("media_player.tv").attributes["device_class"] == "tv"
 
 
+async def test_unique_id(hass):
+    """Test unique_id property."""
+    hass.states.async_set("sensor.test_sensor", "on")
+
+    await async_setup_component(
+        hass,
+        "media_player",
+        {
+            "media_player": {
+                "platform": "universal",
+                "name": "tv",
+                "unique_id": "universal_master_bed_tv",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    er = entity_registry.async_get(hass)
+    assert er.async_get("media_player.tv").unique_id == "universal_master_bed_tv"
+
+
 async def test_invalid_state_template(hass):
     """Test invalid state template sets state to None."""
     hass.states.async_set("sensor.test_sensor", "on")
@@ -1214,3 +1235,4 @@ async def test_reload(hass):
     assert (
         "device_class" not in hass.states.get("media_player.master_bed_tv").attributes
     )
+    assert "unique_id" not in hass.states.get("media_player.master_bed_tv").attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Universal Media Player Integration currently does not support a `unique_id` property. This results in not being able to edit certain properties in the GUI, most notably Area.

The Universal Media Player integration needs to be set up via yaml, so with this change we expose the `unique_id` property to the yaml entry for the integration entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23925

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
