### PR TITLE
Fix oauth2 in Toon

### DIFF
--- a/homeassistant/components/toon/oauth2.py
+++ b/homeassistant/components/toon/oauth2.py
@@ -33,6 +33,7 @@ def register_oauth2_implementations(
             client_secret=client_secret,
             name="Engie Electrabel Boxx",
             tenant_id="electrabel",
+            issuer="identity.toon.eu",
         ),
     )
     config_flow.ToonFlowHandler.async_register_implementation(


### PR DESCRIPTION
Use the issuer field for Electrabel (Engie) as it is now required

## Proposed change
Add the "issuer" field to the toon oauth2 flow, used when login with Engie. I found this by intercepting the communication of the Boxx app on my phone, I could see they sent that during oauth flow. I tried it locally on my own instance, by overriding the component. With this single change, Toon with Engie is working again.

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #52708, #59596, #66797

## Checklist
- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
