### PR TITLE
Add support for Feeder-Robot button

### DIFF
--- a/homeassistant/components/litterrobot/button.py
+++ b/homeassistant/components/litterrobot/button.py
@@ -45,11 +45,15 @@ async def async_setup_entry(
 
 
 @dataclass
-class RobotButtonEntityDescription(ButtonEntityDescription, Generic[_RobotT]):
+class RequiredKeysMixin(Generic[_RobotT]):
+    """A class that describes robot button entity required keys."""
+
+    press_fn: Callable[[_RobotT], Coroutine[Any, Any, bool]]
+
+
+@dataclass
+class RobotButtonEntityDescription(ButtonEntityDescription, RequiredKeysMixin[_RobotT]):
     """A class that describes robot button entities."""
-
-    press_fn: Callable[[_RobotT], Coroutine[Any, Any, bool] | None] = lambda _: None
-
 
 LITTER_ROBOT_BUTTON = RobotButtonEntityDescription[LitterRobot3](
     key="reset_waste_drawer",
@@ -84,6 +88,5 @@ class LitterRobotButtonEntity(LitterRobotEntity[_RobotT], ButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        if action := self.entity_description.press_fn(self.robot):
-            await action
-            self.coordinator.async_set_updated_data(True)
+        await self.entity_description.press_fn(self.robot)
+        self.coordinator.async_set_updated_data(True)

--- a/homeassistant/components/litterrobot/button.py
+++ b/homeassistant/components/litterrobot/button.py
@@ -71,7 +71,7 @@ class FeederRobotButtonEntityDescription(RobotButtonEntityDescription):
 
 LITTER_ROBOT_BUTTON = LitterRobotButtonEntityDescription(
     key="reset_waste_drawer",
-    name="Reset waste drawer",
+    name="Reset Waste Drawer",
     icon="mdi:delete-variant",
     entity_category=EntityCategory.CONFIG,
     press_fn=lambda robot: robot.reset_waste_drawer(),

--- a/homeassistant/components/litterrobot/button.py
+++ b/homeassistant/components/litterrobot/button.py
@@ -1,9 +1,14 @@
 """Support for Litter-Robot button."""
 from __future__ import annotations
 
-from pylitterbot import LitterRobot3
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+import itertools
+from typing import Any
 
-from homeassistant.components.button import ButtonEntity
+from pylitterbot import FeederRobot, LitterRobot3
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
@@ -13,8 +18,6 @@ from .const import DOMAIN
 from .entity import LitterRobotEntity
 from .hub import LitterRobotHub
 
-TYPE_RESET_WASTE_DRAWER = "Reset Waste Drawer"
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -23,22 +26,83 @@ async def async_setup_entry(
 ) -> None:
     """Set up Litter-Robot cleaner using config entry."""
     hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        LitterRobotResetWasteDrawerButton(
-            robot=robot, entity_type=TYPE_RESET_WASTE_DRAWER, hub=hub
-        )
-        for robot in hub.litter_robots()
-        if isinstance(robot, LitterRobot3)
+    entities = itertools.chain(
+        (
+            LitterRobotButtonEntity(
+                robot=robot, hub=hub, description=LITTER_ROBOT_BUTTON
+            )
+            for robot in hub.litter_robots()
+            if isinstance(robot, LitterRobot3)
+        ),
+        (
+            LitterRobotButtonEntity(
+                robot=robot, hub=hub, description=FEEDER_ROBOT_BUTTON
+            )
+            for robot in hub.feeder_robots()
+        ),
     )
+    async_add_entities(entities)
 
 
-class LitterRobotResetWasteDrawerButton(LitterRobotEntity[LitterRobot3], ButtonEntity):
-    """Litter-Robot reset waste drawer button."""
+@dataclass
+class RobotButtonEntityDescription(ButtonEntityDescription):
+    """A class that describes robot button entities."""
 
-    _attr_icon = "mdi:delete-variant"
-    _attr_entity_category = EntityCategory.CONFIG
+    press_fn: Callable[
+        [LitterRobot3 | FeederRobot], Coroutine[Any, Any, bool] | None
+    ] = lambda _: None
+
+
+@dataclass
+class LitterRobotButtonEntityDescription(RobotButtonEntityDescription):
+    """A class that describes Litter-Robot button entities."""
+
+    press_fn: Callable[
+        [LitterRobot3], Coroutine[Any, Any, bool] | None
+    ] = lambda _: None
+
+
+@dataclass
+class FeederRobotButtonEntityDescription(RobotButtonEntityDescription):
+    """A class that describes Feeder-Robot button entities."""
+
+    press_fn: Callable[[FeederRobot], Coroutine[Any, Any, bool] | None] = lambda _: None
+
+
+LITTER_ROBOT_BUTTON = LitterRobotButtonEntityDescription(
+    key="reset_waste_drawer",
+    name="Reset waste drawer",
+    icon="mdi:delete-variant",
+    entity_category=EntityCategory.CONFIG,
+    press_fn=lambda robot: robot.reset_waste_drawer(),
+)
+FEEDER_ROBOT_BUTTON = FeederRobotButtonEntityDescription(
+    key="give_snack",
+    name="Give snack",
+    icon="mdi:candy-outline",
+    press_fn=lambda robot: robot.give_snack(),
+)
+
+
+class LitterRobotButtonEntity(LitterRobotEntity[LitterRobot3], ButtonEntity):
+    """Litter-Robot button entity."""
+
+    entity_description: RobotButtonEntityDescription
+    robot: LitterRobot3 | FeederRobot
+
+    def __init__(
+        self,
+        robot: LitterRobot3 | FeederRobot,
+        hub: LitterRobotHub,
+        description: RobotButtonEntityDescription,
+    ) -> None:
+        """Initialize a Litter-Robot button entity."""
+        assert description.name
+        super().__init__(robot, description.name, hub)
+        self.entity_description = description
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self.robot.reset_waste_drawer()
-        self.coordinator.async_set_updated_data(True)
+        if action := self.entity_description.press_fn(self.robot):
+            await action
+            self.coordinator.async_set_updated_data(True)

--- a/homeassistant/components/litterrobot/button.py
+++ b/homeassistant/components/litterrobot/button.py
@@ -55,6 +55,7 @@ class RequiredKeysMixin(Generic[_RobotT]):
 class RobotButtonEntityDescription(ButtonEntityDescription, RequiredKeysMixin[_RobotT]):
     """A class that describes robot button entities."""
 
+
 LITTER_ROBOT_BUTTON = RobotButtonEntityDescription[LitterRobot3](
     key="reset_waste_drawer",
     name="Reset Waste Drawer",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for Feeder-Robots to give a snack via the button platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23947

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
