### PR TITLE
Convert life360 to aiohttp

### DIFF
--- a/homeassistant/components/life360/config_flow.py
+++ b/homeassistant/components/life360/config_flow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, cast
 
-from aiohttp import ClientTimeout
 from life360 import Life360, Life360Error, LoginError
 import voluptuous as vol
 
@@ -13,7 +12,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
@@ -69,9 +68,7 @@ class Life360ConfigFlow(ConfigFlow, domain=DOMAIN):
         """Attempt to authorize the provided credentials."""
         if not self._api:
             self._api = Life360(
-                session=async_create_clientsession(
-                    self.hass, timeout=ClientTimeout(total=COMM_TIMEOUT)
-                ),
+                session=async_get_clientsession(self.hass), timeout=COMM_TIMEOUT
             )
         errors: dict[str, str] = {}
         try:

--- a/homeassistant/components/life360/const.py
+++ b/homeassistant/components/life360/const.py
@@ -7,7 +7,6 @@ DOMAIN = "life360"
 LOGGER = logging.getLogger(__package__)
 
 ATTRIBUTION = "Data provided by life360.com"
-COMM_MAX_RETRIES = 2
 COMM_TIMEOUT = 3.05
 SPEED_FACTOR_MPH = 2.25
 SPEED_DIGITS = 1

--- a/homeassistant/components/life360/coordinator.py
+++ b/homeassistant/components/life360/coordinator.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
+from aiohttp import ClientTimeout
 from life360 import Life360, Life360Error, LoginError
 
 from homeassistant.config_entries import ConfigEntry
@@ -19,12 +20,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 from .const import (
-    COMM_MAX_RETRIES,
     COMM_TIMEOUT,
     CONF_AUTHORIZATION,
     DOMAIN,
@@ -106,8 +107,9 @@ class Life360DataUpdateCoordinator(DataUpdateCoordinator[Life360Data]):
         )
         self._hass = hass
         self._api = Life360(
-            timeout=COMM_TIMEOUT,
-            max_retries=COMM_MAX_RETRIES,
+            session=async_create_clientsession(
+                hass, timeout=ClientTimeout(total=COMM_TIMEOUT)
+            ),
             authorization=entry.data[CONF_AUTHORIZATION],
         )
         self._missing_loc_reason = hass.data[DOMAIN].missing_loc_reason
@@ -115,9 +117,7 @@ class Life360DataUpdateCoordinator(DataUpdateCoordinator[Life360Data]):
     async def _retrieve_data(self, func: str, *args: Any) -> list[dict[str, Any]]:
         """Get data from Life360."""
         try:
-            return await self._hass.async_add_executor_job(
-                getattr(self._api, func), *args
-            )
+            return await getattr(self._api, func)(*args)
         except LoginError as exc:
             LOGGER.debug("Login error: %s", exc)
             raise ConfigEntryAuthFailed from exc

--- a/homeassistant/components/life360/coordinator.py
+++ b/homeassistant/components/life360/coordinator.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from aiohttp import ClientTimeout
 from life360 import Life360, Life360Error, LoginError
 
 from homeassistant.config_entries import ConfigEntry
@@ -20,7 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
@@ -107,9 +106,8 @@ class Life360DataUpdateCoordinator(DataUpdateCoordinator[Life360Data]):
         )
         self._hass = hass
         self._api = Life360(
-            session=async_create_clientsession(
-                hass, timeout=ClientTimeout(total=COMM_TIMEOUT)
-            ),
+            session=async_get_clientsession(hass),
+            timeout=COMM_TIMEOUT,
             authorization=entry.data[CONF_AUTHORIZATION],
         )
         self._missing_loc_reason = hass.data[DOMAIN].missing_loc_reason

--- a/homeassistant/components/life360/manifest.json
+++ b/homeassistant/components/life360/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/life360",
   "codeowners": ["@pnbruckner"],
-  "requirements": ["life360==5.0.0"],
+  "requirements": ["life360==5.1.0"],
   "iot_class": "cloud_polling",
   "loggers": ["life360"]
 }

--- a/homeassistant/components/life360/manifest.json
+++ b/homeassistant/components/life360/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/life360",
   "codeowners": ["@pnbruckner"],
-  "requirements": ["life360==4.1.1"],
+  "requirements": ["life360==5.0.0"],
   "iot_class": "cloud_polling",
   "loggers": ["life360"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -980,7 +980,7 @@ librouteros==3.2.0
 libsoundtouch==0.8
 
 # homeassistant.components.life360
-life360==5.0.0
+life360==5.1.0
 
 # homeassistant.components.osramlightify
 lightify==1.0.7.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -980,7 +980,7 @@ librouteros==3.2.0
 libsoundtouch==0.8
 
 # homeassistant.components.life360
-life360==4.1.1
+life360==5.0.0
 
 # homeassistant.components.osramlightify
 lightify==1.0.7.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -715,7 +715,7 @@ librouteros==3.2.0
 libsoundtouch==0.8
 
 # homeassistant.components.life360
-life360==4.1.1
+life360==5.0.0
 
 # homeassistant.components.logi_circle
 logi_circle==0.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -715,7 +715,7 @@ librouteros==3.2.0
 libsoundtouch==0.8
 
 # homeassistant.components.life360
-life360==5.0.0
+life360==5.1.0
 
 # homeassistant.components.logi_circle
 logi_circle==0.2.3

--- a/tests/components/life360/test_config_flow.py
+++ b/tests/components/life360/test_config_flow.py
@@ -76,7 +76,9 @@ def life360_fixture():
 @pytest.fixture
 def life360_api():
     """Mock Life360 api."""
-    with patch("homeassistant.components.life360.config_flow.Life360") as mock:
+    with patch(
+        "homeassistant.components.life360.config_flow.Life360", autospec=True
+    ) as mock:
         yield mock.return_value
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Life360 (the pypi package, and hence, the HA integration as well) has always used the
`requests` package and, so, has had to be run in a separate executor thread. This change
updates to v5.0.0 of the life360 package which now uses `aiohttp`, and modifies the
HA integration accordingly.

This does not really improve the speed at which data can be retrieved from the server,
but it should reduce the overhead associated with this network traffic.

Changes to `life360` package:
- https://github.com/pnbruckner/life360/compare/v4.1.1...v5.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
