### PR TITLE
Remove "Awair" from score entity name

### DIFF
--- a/homeassistant/components/awair/const.py
+++ b/homeassistant/components/awair/const.py
@@ -63,6 +63,7 @@ SENSOR_TYPE_SCORE = AwairSensorEntityDescription(
     key=API_SCORE,
     icon="mdi:blur",
     native_unit_of_measurement=PERCENTAGE,
+    name="Score",
     unique_id_tag="score",  # matches legacy format
     state_class=SensorStateClass.MEASUREMENT,
 )

--- a/homeassistant/components/awair/const.py
+++ b/homeassistant/components/awair/const.py
@@ -63,7 +63,6 @@ SENSOR_TYPE_SCORE = AwairSensorEntityDescription(
     key=API_SCORE,
     icon="mdi:blur",
     native_unit_of_measurement=PERCENTAGE,
-    name="Awair score",
     unique_id_tag="score",  # matches legacy format
     state_class=SensorStateClass.MEASUREMENT,
 )

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -72,7 +72,7 @@ async def test_awair_gen1_sensors(hass: HomeAssistant, user, cloud_devices, gen1
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room",
+        "sensor.living_room_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "88",
         {},
@@ -164,7 +164,7 @@ async def test_awair_gen2_sensors(hass: HomeAssistant, user, cloud_devices, gen2
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room",
+        "sensor.living_room_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "97",
         {},
@@ -197,7 +197,7 @@ async def test_local_awair_sensors(hass: HomeAssistant, local_devices, local_dat
     assert_expected_properties(
         hass,
         registry,
-        "sensor.mock_title",
+        "sensor.mock_title_score",
         f"{local_devices['device_uuid']}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "94",
         {},
@@ -214,7 +214,7 @@ async def test_awair_mint_sensors(hass: HomeAssistant, user, cloud_devices, mint
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room",
+        "sensor.living_room_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "98",
         {},
@@ -255,7 +255,7 @@ async def test_awair_glow_sensors(hass: HomeAssistant, user, cloud_devices, glow
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room",
+        "sensor.living_room_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "93",
         {},
@@ -275,7 +275,7 @@ async def test_awair_omni_sensors(hass: HomeAssistant, user, cloud_devices, omni
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room",
+        "sensor.living_room_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "99",
         {},
@@ -315,7 +315,7 @@ async def test_awair_offline(hass: HomeAssistant, user, cloud_devices, awair_off
     # device *should* have if it's online. If we don't see it,
     # then we probably didn't set anything up. Which is correct,
     # in this case.
-    assert hass.states.get("sensor.living_room") is None
+    assert hass.states.get("sensor.living_room_score") is None
 
 
 async def test_awair_unavailable(
@@ -330,18 +330,18 @@ async def test_awair_unavailable(
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room",
+        "sensor.living_room_score",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "88",
         {},
     )
 
     with patch("python_awair.AwairClient.query", side_effect=awair_offline):
-        await async_update_entity(hass, "sensor.living_room")
+        await async_update_entity(hass, "sensor.living_room_score")
         assert_expected_properties(
             hass,
             registry,
-            "sensor.living_room",
+            "sensor.living_room_score",
             f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
             STATE_UNAVAILABLE,
             {},

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -72,7 +72,7 @@ async def test_awair_gen1_sensors(hass: HomeAssistant, user, cloud_devices, gen1
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room_awair_score",
+        "sensor.living_room",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "88",
         {},
@@ -164,7 +164,7 @@ async def test_awair_gen2_sensors(hass: HomeAssistant, user, cloud_devices, gen2
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room_awair_score",
+        "sensor.living_room",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "97",
         {},
@@ -197,7 +197,7 @@ async def test_local_awair_sensors(hass: HomeAssistant, local_devices, local_dat
     assert_expected_properties(
         hass,
         registry,
-        "sensor.mock_title_awair_score",
+        "sensor.mock_title",
         f"{local_devices['device_uuid']}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "94",
         {},
@@ -214,7 +214,7 @@ async def test_awair_mint_sensors(hass: HomeAssistant, user, cloud_devices, mint
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room_awair_score",
+        "sensor.living_room",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "98",
         {},
@@ -255,7 +255,7 @@ async def test_awair_glow_sensors(hass: HomeAssistant, user, cloud_devices, glow
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room_awair_score",
+        "sensor.living_room",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "93",
         {},
@@ -275,7 +275,7 @@ async def test_awair_omni_sensors(hass: HomeAssistant, user, cloud_devices, omni
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room_awair_score",
+        "sensor.living_room",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "99",
         {},
@@ -315,7 +315,7 @@ async def test_awair_offline(hass: HomeAssistant, user, cloud_devices, awair_off
     # device *should* have if it's online. If we don't see it,
     # then we probably didn't set anything up. Which is correct,
     # in this case.
-    assert hass.states.get("sensor.living_room_awair_score") is None
+    assert hass.states.get("sensor.living_room") is None
 
 
 async def test_awair_unavailable(
@@ -330,18 +330,18 @@ async def test_awair_unavailable(
     assert_expected_properties(
         hass,
         registry,
-        "sensor.living_room_awair_score",
+        "sensor.living_room",
         f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
         "88",
         {},
     )
 
     with patch("python_awair.AwairClient.query", side_effect=awair_offline):
-        await async_update_entity(hass, "sensor.living_room_awair_score")
+        await async_update_entity(hass, "sensor.living_room")
         assert_expected_properties(
             hass,
             registry,
-            "sensor.living_room_awair_score",
+            "sensor.living_room",
             f"{AWAIR_UUID}_{SENSOR_TYPES_MAP[API_SCORE].unique_id_tag}",
             STATE_UNAVAILABLE,
             {},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Using entity naming, we can give a name of `None` to indicate that the entity has to be named after the device. This updates Awair to set their score to be assigned to just the device name.

Before:

![image](https://user-images.githubusercontent.com/1444314/187329909-c3121250-2458-4caf-a4c3-418694764f63.png)

After:

![image](https://user-images.githubusercontent.com/1444314/187329976-c8983b03-a133-4ab4-80b6-682b1b39fa67.png)

@ahayworth @zachberger what do you think?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
