### PR TITLE
Refactor MQTT tests to use modern platform schema part 2

### DIFF
--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -234,9 +234,10 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {light.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    light.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[light.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -234,8 +234,8 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {light.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[light.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -2222,8 +2222,8 @@ async def test_discovery_removal_light(hass, mqtt_mock_entry_no_yaml_config, cap
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_discovery_deprecated(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test discovery of mqtt light with deprecated platform option."""
     await mqtt_mock_entry_no_yaml_config()
@@ -3154,8 +3154,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = light.DOMAIN

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -2,169 +2,170 @@
 
 Configuration for RGB Version with brightness:
 
-light:
-  platform: mqtt
-  name: "Office Light RGB"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  brightness_state_topic: "office/rgb1/brightness/status"
-  brightness_command_topic: "office/rgb1/brightness/set"
-  rgb_state_topic: "office/rgb1/rgb/status"
-  rgb_command_topic: "office/rgb1/rgb/set"
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light RGB"
+        state_topic: "office/rgb1/light/status"
+        command_topic: "office/rgb1/light/switch"
+        brightness_state_topic: "office/rgb1/brightness/status"
+        brightness_command_topic: "office/rgb1/brightness/set"
+        rgb_state_topic: "office/rgb1/rgb/status"
+        rgb_command_topic: "office/rgb1/rgb/set"
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 Configuration for XY Version with brightness:
 
-light:
-  platform: mqtt
-  name: "Office Light XY"
-  state_topic: "office/xy1/light/status"
-  command_topic: "office/xy1/light/switch"
-  brightness_state_topic: "office/xy1/brightness/status"
-  brightness_command_topic: "office/xy1/brightness/set"
-  xy_state_topic: "office/xy1/xy/status"
-  xy_command_topic: "office/xy1/xy/set"
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - platform: mqtt
+        name: "Office Light XY"
+        state_topic: "office/xy1/light/status"
+        command_topic: "office/xy1/light/switch"
+        brightness_state_topic: "office/xy1/brightness/status"
+        brightness_command_topic: "office/xy1/brightness/set"
+        xy_state_topic: "office/xy1/xy/status"
+        xy_command_topic: "office/xy1/xy/set"
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 config without RGB:
 
-light:
-  platform: mqtt
-  name: "Office Light"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  brightness_state_topic: "office/rgb1/brightness/status"
-  brightness_command_topic: "office/rgb1/brightness/set"
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light"
+        state_topic: "office/rgb1/light/status"
+        command_topic: "office/rgb1/light/switch"
+        brightness_state_topic: "office/rgb1/brightness/status"
+        brightness_command_topic: "office/rgb1/brightness/set"
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 config without RGB and brightness:
 
-light:
-  platform: mqtt
-  name: "Office Light"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light"
+        state_topic: "office/rgb1/light/status"
+        command_topic: "office/rgb1/light/switch"
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 config for RGB Version with brightness and scale:
 
-light:
-  platform: mqtt
-  name: "Office Light RGB"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  brightness_state_topic: "office/rgb1/brightness/status"
-  brightness_command_topic: "office/rgb1/brightness/set"
-  brightness_scale: 99
-  rgb_state_topic: "office/rgb1/rgb/status"
-  rgb_command_topic: "office/rgb1/rgb/set"
-  rgb_scale: 99
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light RGB"
+        state_topic: "office/rgb1/light/status"
+        command_topic: "office/rgb1/light/switch"
+        brightness_state_topic: "office/rgb1/brightness/status"
+        brightness_command_topic: "office/rgb1/brightness/set"
+        brightness_scale: 99
+        rgb_state_topic: "office/rgb1/rgb/status"
+        rgb_command_topic: "office/rgb1/rgb/set"
+        rgb_scale: 99
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 config with brightness and color temp
 
-light:
-  platform: mqtt
-  name: "Office Light Color Temp"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  brightness_state_topic: "office/rgb1/brightness/status"
-  brightness_command_topic: "office/rgb1/brightness/set"
-  brightness_scale: 99
-  color_temp_state_topic: "office/rgb1/color_temp/status"
-  color_temp_command_topic: "office/rgb1/color_temp/set"
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light Color Temp"
+        state_topic: "office/rgb1/light/status"
+        command_topic: "office/rgb1/light/switch"
+        brightness_state_topic: "office/rgb1/brightness/status"
+        brightness_command_topic: "office/rgb1/brightness/set"
+        brightness_scale: 99
+        color_temp_state_topic: "office/rgb1/color_temp/status"
+        color_temp_command_topic: "office/rgb1/color_temp/set"
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 config with brightness and effect
 
-light:
-  platform: mqtt
-  name: "Office Light Color Temp"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  brightness_state_topic: "office/rgb1/brightness/status"
-  brightness_command_topic: "office/rgb1/brightness/set"
-  brightness_scale: 99
-  effect_state_topic: "office/rgb1/effect/status"
-  effect_command_topic: "office/rgb1/effect/set"
-  effect_list:
-    - rainbow
-    - colorloop
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light Color Temp"
+        state_topic: "office/rgb1/light/status"
+        command_topic: "office/rgb1/light/switch"
+        brightness_state_topic: "office/rgb1/brightness/status"
+        brightness_command_topic: "office/rgb1/brightness/set"
+        brightness_scale: 99
+        effect_state_topic: "office/rgb1/effect/status"
+        effect_command_topic: "office/rgb1/effect/set"
+        effect_list:
+            - rainbow
+            - colorloop
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 config for RGB Version with RGB command template:
 
-light:
-  platform: mqtt
-  name: "Office Light RGB"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  rgb_state_topic: "office/rgb1/rgb/status"
-  rgb_command_topic: "office/rgb1/rgb/set"
-  rgb_command_template: "{{ '#%02x%02x%02x' | format(red, green, blue)}}"
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light RGB"
+        state_topic: "office/rgb1/light/status"
+        command_topic: "office/rgb1/light/switch"
+        rgb_state_topic: "office/rgb1/rgb/status"
+        rgb_command_topic: "office/rgb1/rgb/set"
+        rgb_command_template: "{{ '#%02x%02x%02x' | format(red, green, blue)}}"
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 Configuration for HS Version with brightness:
 
-light:
-  platform: mqtt
-  name: "Office Light HS"
-  state_topic: "office/hs1/light/status"
-  command_topic: "office/hs1/light/switch"
-  brightness_state_topic: "office/hs1/brightness/status"
-  brightness_command_topic: "office/hs1/brightness/set"
-  hs_state_topic: "office/hs1/hs/status"
-  hs_command_topic: "office/hs1/hs/set"
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light HS"
+        state_topic: "office/hs1/light/status"
+        command_topic: "office/hs1/light/switch"
+        brightness_state_topic: "office/hs1/brightness/status"
+        brightness_command_topic: "office/hs1/brightness/set"
+        hs_state_topic: "office/hs1/hs/status"
+        hs_command_topic: "office/hs1/hs/set"
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 Configuration with brightness command template:
 
-light:
-  platform: mqtt
-  name: "Office Light"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  brightness_state_topic: "office/rgb1/brightness/status"
-  brightness_command_topic: "office/rgb1/brightness/set"
-  brightness_command_template: '{ "brightness": "{{ value }}" }'
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light"
+        state_topic: "office/rgb1/light/status"
+        command_topic: "office/rgb1/light/switch"
+        brightness_state_topic: "office/rgb1/brightness/status"
+        brightness_command_topic: "office/rgb1/brightness/set"
+        brightness_command_template: '{ "brightness": "{{ value }}" }'
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 Configuration with effect command template:
 
-light:
-  platform: mqtt
-  name: "Office Light Color Temp"
-  state_topic: "office/rgb1/light/status"
-  command_topic: "office/rgb1/light/switch"
-  effect_state_topic: "office/rgb1/effect/status"
-  effect_command_topic: "office/rgb1/effect/set"
-  effect_command_template: '{ "effect": "{{ value }}" }'
-  effect_list:
-    - rainbow
-    - colorloop
-  qos: 0
-  payload_on: "on"
-  payload_off: "off"
+mqtt:
+    light:
+      - name: "Office Light Color Temp"
+        state_topic: "office/rgb1/light/status"
+        command_topic: "office/rgb1/light/switch"
+        effect_state_topic: "office/rgb1/effect/status"
+        effect_command_topic: "office/rgb1/effect/set"
+        effect_command_template: '{ "effect": "{{ value }}" }'
+        effect_list:
+            - rainbow
+            - colorloop
+        qos: 0
+        payload_on: "on"
+        payload_off: "off"
 
 """
 import copy
@@ -172,7 +173,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from homeassistant.components import light
+from homeassistant.components import light, mqtt
 from homeassistant.components.mqtt.light.schema_basic import (
     CONF_BRIGHTNESS_COMMAND_TOPIC,
     CONF_COLOR_TEMP_COMMAND_TOPIC,
@@ -226,14 +227,14 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
-from tests.common import (
-    assert_setup_component,
-    async_fire_mqtt_message,
-    mock_restore_cache,
-)
+from tests.common import async_fire_mqtt_message, mock_restore_cache
 from tests.components.light import common
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {light.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
+}
+
+DEFAULT_CONFIG_LEGACY = {
     light.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
 
@@ -245,14 +246,15 @@ def light_platform_only():
         yield
 
 
-async def test_fail_setup_if_no_command_topic(hass, mqtt_mock_entry_no_yaml_config):
+async def test_fail_setup_if_no_command_topic(hass, caplog):
     """Test if command fails with command topic."""
-    assert await async_setup_component(
-        hass, light.DOMAIN, {light.DOMAIN: {"platform": "mqtt", "name": "test"}}
+    assert not await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {light.DOMAIN: {"name": "test"}}}
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
-    assert hass.states.get("light.test") is None
+    assert (
+        "Invalid config for [mqtt]: required key not provided @ data['mqtt']['light'][0]['command_topic']. Got None."
+        in caplog.text
+    )
 
 
 async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(
@@ -261,13 +263,14 @@ async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(
     """Test if there is no color and brightness if no topic."""
     assert await async_setup_component(
         hass,
-        light.DOMAIN,
+        mqtt.DOMAIN,
         {
-            light.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test_light_rgb/status",
-                "command_topic": "test_light_rgb/set",
+            mqtt.DOMAIN: {
+                light.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test_light_rgb/status",
+                    "command_topic": "test_light_rgb/set",
+                }
             }
         },
     )
@@ -317,7 +320,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     """Test the controlling of the state via topic."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "state_topic": "test_light_rgb/status",
             "command_topic": "test_light_rgb/set",
@@ -344,7 +346,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     }
     color_modes = ["color_temp", "hs", "rgb", "rgbw", "rgbww", "xy"]
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -437,7 +439,6 @@ async def test_invalid_state_via_topic(hass, mqtt_mock_entry_with_yaml_config, c
     """Test handling of empty data via topic."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "state_topic": "test_light_rgb/status",
             "command_topic": "test_light_rgb/set",
@@ -464,7 +465,7 @@ async def test_invalid_state_via_topic(hass, mqtt_mock_entry_with_yaml_config, c
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -570,13 +571,12 @@ async def test_invalid_state_via_topic(hass, mqtt_mock_entry_with_yaml_config, c
 
 async def test_brightness_controlling_scale(hass, mqtt_mock_entry_with_yaml_config):
     """Test the brightness controlling scale."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "name": "test",
                     "state_topic": "test_scale/status",
                     "command_topic": "test_scale/set",
@@ -587,10 +587,11 @@ async def test_brightness_controlling_scale(hass, mqtt_mock_entry_with_yaml_conf
                     "payload_on": "on",
                     "payload_off": "off",
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -620,13 +621,12 @@ async def test_brightness_from_rgb_controlling_scale(
     hass, mqtt_mock_entry_with_yaml_config
 ):
     """Test the brightness controlling scale."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "name": "test",
                     "state_topic": "test_scale_rgb/status",
                     "command_topic": "test_scale_rgb/set",
@@ -636,10 +636,11 @@ async def test_brightness_from_rgb_controlling_scale(
                     "payload_on": "on",
                     "payload_off": "off",
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -664,7 +665,6 @@ async def test_controlling_state_via_topic_with_templates(
     """Test the setting of the state with a template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "state_topic": "test_light_rgb/status",
             "command_topic": "test_light_rgb/set",
@@ -697,7 +697,7 @@ async def test_controlling_state_via_topic_with_templates(
     }
     color_modes = ["color_temp", "hs", "rgb", "rgbw", "rgbww", "xy"]
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -767,7 +767,6 @@ async def test_sending_mqtt_commands_and_optimistic(
     """Test the sending of command in optimistic mode."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light_rgb/set",
             "brightness_command_topic": "test_light_rgb/brightness/set",
@@ -798,10 +797,9 @@ async def test_sending_mqtt_commands_and_optimistic(
     )
     mock_restore_cache(hass, (fake_state,))
 
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(hass, light.DOMAIN, config)
-        await hass.async_block_till_done()
-        mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
+    await hass.async_block_till_done()
+    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
@@ -958,7 +956,6 @@ async def test_sending_mqtt_rgb_command_with_template(
     """Test the sending of RGB command with template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light_rgb/set",
             "rgb_command_topic": "test_light_rgb/rgb/set",
@@ -970,7 +967,7 @@ async def test_sending_mqtt_rgb_command_with_template(
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -998,7 +995,6 @@ async def test_sending_mqtt_rgbw_command_with_template(
     """Test the sending of RGBW command with template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light_rgb/set",
             "rgbw_command_topic": "test_light_rgb/rgbw/set",
@@ -1010,7 +1006,7 @@ async def test_sending_mqtt_rgbw_command_with_template(
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1038,7 +1034,6 @@ async def test_sending_mqtt_rgbww_command_with_template(
     """Test the sending of RGBWW command with template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light_rgb/set",
             "rgbww_command_topic": "test_light_rgb/rgbww/set",
@@ -1050,7 +1045,7 @@ async def test_sending_mqtt_rgbww_command_with_template(
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1078,7 +1073,6 @@ async def test_sending_mqtt_color_temp_command_with_template(
     """Test the sending of Color Temp command with template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light_color_temp/set",
             "color_temp_command_topic": "test_light_color_temp/color_temp/set",
@@ -1089,7 +1083,7 @@ async def test_sending_mqtt_color_temp_command_with_template(
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1115,7 +1109,6 @@ async def test_on_command_first(hass, mqtt_mock_entry_with_yaml_config):
     """Test on command being sent before brightness."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "brightness_command_topic": "test_light/bright",
@@ -1123,7 +1116,7 @@ async def test_on_command_first(hass, mqtt_mock_entry_with_yaml_config):
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1152,14 +1145,13 @@ async def test_on_command_last(hass, mqtt_mock_entry_with_yaml_config):
     """Test on command being sent after brightness."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "brightness_command_topic": "test_light/bright",
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1188,7 +1180,6 @@ async def test_on_command_brightness(hass, mqtt_mock_entry_with_yaml_config):
     """Test on command being sent as only brightness."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "brightness_command_topic": "test_light/bright",
@@ -1197,7 +1188,7 @@ async def test_on_command_brightness(hass, mqtt_mock_entry_with_yaml_config):
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1244,7 +1235,6 @@ async def test_on_command_brightness_scaled(hass, mqtt_mock_entry_with_yaml_conf
     """Test brightness scale."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "brightness_command_topic": "test_light/bright",
@@ -1254,7 +1244,7 @@ async def test_on_command_brightness_scaled(hass, mqtt_mock_entry_with_yaml_conf
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1315,14 +1305,13 @@ async def test_on_command_rgb(hass, mqtt_mock_entry_with_yaml_config):
     """Test on command in RGB brightness mode."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "rgb_command_topic": "test_light/rgb",
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1406,14 +1395,13 @@ async def test_on_command_rgbw(hass, mqtt_mock_entry_with_yaml_config):
     """Test on command in RGBW brightness mode."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "rgbw_command_topic": "test_light/rgbw",
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1497,14 +1485,13 @@ async def test_on_command_rgbww(hass, mqtt_mock_entry_with_yaml_config):
     """Test on command in RGBWW brightness mode."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "rgbww_command_topic": "test_light/rgbww",
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1588,7 +1575,6 @@ async def test_on_command_rgb_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test on command in RGB brightness mode with RGB template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "rgb_command_topic": "test_light/rgb",
@@ -1596,7 +1582,7 @@ async def test_on_command_rgb_template(hass, mqtt_mock_entry_with_yaml_config):
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1626,7 +1612,6 @@ async def test_on_command_rgbw_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test on command in RGBW brightness mode with RGBW template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "rgbw_command_topic": "test_light/rgbw",
@@ -1634,7 +1619,7 @@ async def test_on_command_rgbw_template(hass, mqtt_mock_entry_with_yaml_config):
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1663,7 +1648,6 @@ async def test_on_command_rgbww_template(hass, mqtt_mock_entry_with_yaml_config)
     """Test on command in RGBWW brightness mode with RGBWW template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "rgbww_command_topic": "test_light/rgbww",
@@ -1671,7 +1655,7 @@ async def test_on_command_rgbww_template(hass, mqtt_mock_entry_with_yaml_config)
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1701,7 +1685,6 @@ async def test_on_command_white(hass, mqtt_mock_entry_with_yaml_config):
     """Test sending commands for RGB + white light."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "tasmota_B94927/cmnd/POWER",
             "state_value_template": "{{ value_json.POWER }}",
@@ -1721,7 +1704,7 @@ async def test_on_command_white(hass, mqtt_mock_entry_with_yaml_config):
     }
     color_modes = ["rgb", "white"]
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -1779,7 +1762,6 @@ async def test_explicit_color_mode(hass, mqtt_mock_entry_with_yaml_config):
     """Test explicit color mode over mqtt."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "state_topic": "test_light_rgb/status",
             "command_topic": "test_light_rgb/set",
@@ -1807,7 +1789,7 @@ async def test_explicit_color_mode(hass, mqtt_mock_entry_with_yaml_config):
     }
     color_modes = ["color_temp", "hs", "rgb", "rgbw", "rgbww", "xy"]
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -1928,7 +1910,6 @@ async def test_explicit_color_mode_templated(hass, mqtt_mock_entry_with_yaml_con
     """Test templated explicit color mode over mqtt."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "state_topic": "test_light_rgb/status",
             "command_topic": "test_light_rgb/set",
@@ -1947,7 +1928,7 @@ async def test_explicit_color_mode_templated(hass, mqtt_mock_entry_with_yaml_con
     }
     color_modes = ["color_temp", "hs"]
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -2010,7 +1991,6 @@ async def test_white_state_update(hass, mqtt_mock_entry_with_yaml_config):
     """Test state updates for RGB + white light."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "state_topic": "tasmota_B94927/tele/STATE",
             "command_topic": "tasmota_B94927/cmnd/POWER",
@@ -2034,7 +2014,7 @@ async def test_white_state_update(hass, mqtt_mock_entry_with_yaml_config):
     }
     color_modes = ["rgb", "white"]
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -2075,7 +2055,6 @@ async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
     """Test effect."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light/set",
             "effect_command_topic": "test_light/effect/set",
@@ -2083,7 +2062,7 @@ async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -2114,28 +2093,28 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -2144,7 +2123,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -2156,7 +2135,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
         light.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_LIGHT_ATTRIBUTES_BLOCKED,
     )
 
@@ -2164,7 +2143,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -2173,7 +2152,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, light.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        light.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -2182,14 +2165,22 @@ async def test_update_with_json_attrs_bad_JSON(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, light.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        light.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, light.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        light.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -2230,6 +2221,8 @@ async def test_discovery_removal_light(hass, mqtt_mock_entry_no_yaml_config, cap
     )
 
 
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
 async def test_discovery_deprecated(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test discovery of mqtt light with deprecated platform option."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2750,42 +2743,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -2795,7 +2788,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         light.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         light.SERVICE_TURN_ON,
     )
 
@@ -2804,7 +2797,6 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting min_mireds and max_mireds."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_max_mireds/set",
             "color_temp_command_topic": "test_max_mireds/color_temp/set",
@@ -2812,7 +2804,7 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -2921,7 +2913,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = light.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
     if topic == "effect_command_topic":
         config["effect_list"] = ["random", "color_loop"]
     elif topic == "white_command_topic":
@@ -2946,7 +2938,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = light.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -2955,7 +2947,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = light.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -3000,7 +2992,7 @@ async def test_encoding_subscribable_topics(
     init_payload,
 ):
     """Test handling of incoming encoded payload."""
-    config = copy.deepcopy(DEFAULT_CONFIG[light.DOMAIN])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[light.DOMAIN])
     config[CONF_EFFECT_COMMAND_TOPIC] = "light/CONF_EFFECT_COMMAND_TOPIC"
     config[CONF_RGB_COMMAND_TOPIC] = "light/CONF_RGB_COMMAND_TOPIC"
     config[CONF_BRIGHTNESS_COMMAND_TOPIC] = "light/CONF_BRIGHTNESS_COMMAND_TOPIC"
@@ -3043,7 +3035,7 @@ async def test_encoding_subscribable_topics_brightness(
     init_payload,
 ):
     """Test handling of incoming encoded payload for a brightness only light."""
-    config = copy.deepcopy(DEFAULT_CONFIG[light.DOMAIN])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[light.DOMAIN])
     config[CONF_BRIGHTNESS_COMMAND_TOPIC] = "light/CONF_BRIGHTNESS_COMMAND_TOPIC"
 
     await help_test_encoding_subscribable_topics(
@@ -3066,7 +3058,6 @@ async def test_sending_mqtt_brightness_command_with_template(
     """Test the sending of Brightness command with template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light_brightness/set",
             "brightness_command_topic": "test_light_brightness/brightness/set",
@@ -3077,7 +3068,7 @@ async def test_sending_mqtt_brightness_command_with_template(
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -3105,7 +3096,6 @@ async def test_sending_mqtt_effect_command_with_template(
     """Test the sending of Effect command with template."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "name": "test",
             "command_topic": "test_light_brightness/set",
             "brightness_command_topic": "test_light_brightness/brightness/set",
@@ -3118,7 +3108,7 @@ async def test_sending_mqtt_effect_command_with_template(
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -3147,7 +3137,7 @@ async def test_sending_mqtt_effect_command_with_template(
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = light.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -3157,7 +3147,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = light.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = light.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -142,8 +142,8 @@ DEFAULT_CONFIG = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[light.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -2252,8 +2252,8 @@ async def test_setup_manual_entity_from_yaml(hass):
     assert hass.states.get(f"{platform}.test") is not None
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = light.DOMAIN

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -2108,7 +2108,6 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting min_mireds and max_mireds."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "schema": "json",
             "name": "test",
             "command_topic": "test_max_mireds/set",
@@ -2117,7 +2116,7 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -142,14 +142,10 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    light.DOMAIN: {
-        "platform": "mqtt",
-        "schema": "json",
-        "name": "test",
-        "command_topic": "test-topic",
-    }
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[light.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -90,16 +90,10 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    light.DOMAIN: {
-        "platform": "mqtt",
-        "schema": "template",
-        "name": "test",
-        "command_topic": "test-topic",
-        "command_on_template": "on,{{ transition }}",
-        "command_off_template": "off,{{ transition|d }}",
-    }
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[light.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -90,8 +90,8 @@ DEFAULT_CONFIG = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[light.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -1235,8 +1235,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = light.DOMAIN

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -2,20 +2,21 @@
 
 Configuration example with all features:
 
-light:
-  platform: mqtt_template
-  name: mqtt_template_light_1
-  state_topic: 'home/rgb1'
-  command_topic: 'home/rgb1/set'
-  command_on_template: >
-    on,{{ brightness|d }},{{ red|d }}-{{ green|d }}-{{ blue|d }}
-  command_off_template: 'off'
-  state_template: '{{ value.split(",")[0] }}'
-  brightness_template: '{{ value.split(",")[1] }}'
-  color_temp_template: '{{ value.split(",")[2] }}'
-  red_template: '{{ value.split(",")[4].split("-")[0] }}'
-  green_template: '{{ value.split(",")[4].split("-")[1] }}'
-  blue_template: '{{ value.split(",")[4].split("-")[2] }}'
+mqtt:
+    light:
+        schema: template
+        name: mqtt_template_light_1
+        state_topic: 'home/rgb1'
+        command_topic: 'home/rgb1/set'
+        command_on_template: >
+            on,{{ brightness|d }},{{ red|d }}-{{ green|d }}-{{ blue|d }}
+        command_off_template: 'off'
+        state_template: '{{ value.split(",")[0] }}'
+        brightness_template: '{{ value.split(",")[1] }}'
+        color_temp_template: '{{ value.split(",")[2] }}'
+        red_template: '{{ value.split(",")[4].split("-")[0] }}'
+        green_template: '{{ value.split(",")[4].split("-")[1] }}'
+        blue_template: '{{ value.split(",")[4].split("-")[2] }}'
 
 If your light doesn't support brightness feature, omit `brightness_template`.
 
@@ -28,7 +29,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import light
+from homeassistant.components import light, mqtt
 from homeassistant.components.mqtt.light.schema_basic import (
     MQTT_LIGHT_ATTRIBUTES_BLOCKED,
 )
@@ -74,14 +75,22 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
-from tests.common import (
-    assert_setup_component,
-    async_fire_mqtt_message,
-    mock_restore_cache,
-)
+from tests.common import async_fire_mqtt_message, mock_restore_cache
 from tests.components.light import common
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {
+        light.DOMAIN: {
+            "schema": "template",
+            "name": "test",
+            "command_topic": "test-topic",
+            "command_on_template": "on,{{ transition }}",
+            "command_off_template": "off,{{ transition|d }}",
+        }
+    }
+}
+
+DEFAULT_CONFIG_LEGACY = {
     light.DOMAIN: {
         "platform": "mqtt",
         "schema": "template",
@@ -103,10 +112,9 @@ def light_platform_only():
 @pytest.mark.parametrize(
     "test_config",
     [
-        ({"platform": "mqtt", "schema": "template", "name": "test"},),
+        ({"schema": "template", "name": "test"},),
         (
             {
-                "platform": "mqtt",
                 "schema": "template",
                 "name": "test",
                 "command_topic": "test_topic",
@@ -114,7 +122,6 @@ def light_platform_only():
         ),
         (
             {
-                "platform": "mqtt",
                 "schema": "template",
                 "name": "test",
                 "command_topic": "test_topic",
@@ -123,7 +130,6 @@ def light_platform_only():
         ),
         (
             {
-                "platform": "mqtt",
                 "schema": "template",
                 "name": "test",
                 "command_topic": "test_topic",
@@ -132,36 +138,33 @@ def light_platform_only():
         ),
     ],
 )
-async def test_setup_fails(hass, mqtt_mock_entry_no_yaml_config, test_config):
+async def test_setup_fails(hass, caplog, test_config):
     """Test that setup fails with missing required configuration items."""
-    with assert_setup_component(0, light.DOMAIN) as setup_config:
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {light.DOMAIN: test_config},
-        )
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_no_yaml_config()
-        assert not setup_config[light.DOMAIN]
-    assert hass.states.get("light.test") is None
+    assert not await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {mqtt.DOMAIN: {light.DOMAIN: test_config}},
+    )
+    assert "Invalid config for [mqtt]" in caplog.text
 
 
 async def test_rgb_light(hass, mqtt_mock_entry_with_yaml_config):
     """Test RGB light flags brightness support."""
     assert await async_setup_component(
         hass,
-        light.DOMAIN,
+        mqtt.DOMAIN,
         {
-            light.DOMAIN: {
-                "platform": "mqtt",
-                "schema": "template",
-                "name": "test",
-                "command_topic": "test_light_rgb/set",
-                "command_on_template": "on",
-                "command_off_template": "off",
-                "red_template": '{{ value.split(",")[4].' 'split("-")[0] }}',
-                "green_template": '{{ value.split(",")[4].' 'split("-")[1] }}',
-                "blue_template": '{{ value.split(",")[4].' 'split("-")[2] }}',
+            mqtt.DOMAIN: {
+                light.DOMAIN: {
+                    "schema": "template",
+                    "name": "test",
+                    "command_topic": "test_light_rgb/set",
+                    "command_on_template": "on",
+                    "command_off_template": "off",
+                    "red_template": '{{ value.split(",")[4].' 'split("-")[0] }}',
+                    "green_template": '{{ value.split(",")[4].' 'split("-")[1] }}',
+                    "blue_template": '{{ value.split(",")[4].' 'split("-")[2] }}',
+                }
             }
         },
     )
@@ -181,13 +184,12 @@ async def test_rgb_light(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_state_change_via_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test state change via topic."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "schema": "template",
                     "name": "test",
                     "state_topic": "test_light_rgb",
@@ -201,10 +203,11 @@ async def test_state_change_via_topic(hass, mqtt_mock_entry_with_yaml_config):
                     "command_off_template": "off",
                     "state_template": '{{ value.split(",")[0] }}',
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -236,13 +239,12 @@ async def test_state_brightness_color_effect_temp_change_via_topic(
     hass, mqtt_mock_entry_with_yaml_config
 ):
     """Test state, bri, color, effect, color temp change."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "schema": "template",
                     "name": "test",
                     "effect_list": ["rainbow", "colorloop"],
@@ -264,10 +266,11 @@ async def test_state_brightness_color_effect_temp_change_via_topic(
                     "blue_template": '{{ value.split(",")[3].' 'split("-")[2] }}',
                     "effect_template": '{{ value.split(",")[4] }}',
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -340,13 +343,12 @@ async def test_sending_mqtt_commands_and_optimistic(
     )
     mock_restore_cache(hass, (fake_state,))
 
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "schema": "template",
                     "name": "test",
                     "command_topic": "test_light_rgb/set",
@@ -369,10 +371,11 @@ async def test_sending_mqtt_commands_and_optimistic(
                     "effect_template": '{{ value.split(",")[4] }}',
                     "qos": 2,
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
@@ -470,13 +473,12 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     hass, mqtt_mock_entry_with_yaml_config
 ):
     """Test the sending of command in optimistic mode."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "schema": "template",
                     "name": "test",
                     "effect_list": ["rainbow", "colorloop"],
@@ -499,10 +501,11 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
                     "blue_template": '{{ value.split(",")[3].' 'split("-")[2] }}',
                     "effect_template": '{{ value.split(",")[4] }}',
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -591,13 +594,12 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
 
 async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
     """Test effect sent over MQTT in optimistic mode."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "schema": "template",
                     "effect_list": ["rainbow", "colorloop"],
                     "name": "test",
@@ -606,10 +608,11 @@ async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
                     "command_off_template": "off",
                     "qos": 0,
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -644,13 +647,12 @@ async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_flash(hass, mqtt_mock_entry_with_yaml_config):
     """Test flash sent over MQTT in optimistic mode."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "schema": "template",
                     "name": "test",
                     "command_topic": "test_light_rgb/set",
@@ -658,10 +660,11 @@ async def test_flash(hass, mqtt_mock_entry_with_yaml_config):
                     "command_off_template": "off",
                     "qos": 0,
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -693,13 +696,12 @@ async def test_flash(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_transition(hass, mqtt_mock_entry_with_yaml_config):
     """Test for transition time being sent when included."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "schema": "template",
                     "name": "test",
                     "command_topic": "test_light_rgb/set",
@@ -707,10 +709,11 @@ async def test_transition(hass, mqtt_mock_entry_with_yaml_config):
                     "command_off_template": "off,{{ transition|int|d }}",
                     "qos": 1,
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -735,13 +738,12 @@ async def test_transition(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
     """Test that invalid values are ignored."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
+    assert await async_setup_component(
+        hass,
+        mqtt.DOMAIN,
+        {
+            mqtt.DOMAIN: {
                 light.DOMAIN: {
-                    "platform": "mqtt",
                     "schema": "template",
                     "name": "test",
                     "effect_list": ["rainbow", "colorloop"],
@@ -763,10 +765,11 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
                     "blue_template": '{{ value.split(",")[3].' 'split("-")[2] }}',
                     "effect_template": '{{ value.split(",")[4] }}',
                 }
-            },
-        )
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_with_yaml_config()
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -827,28 +830,28 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -857,7 +860,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -869,7 +872,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
         light.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_LIGHT_ATTRIBUTES_BLOCKED,
     )
 
@@ -877,7 +880,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -886,7 +889,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, light.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        light.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -895,14 +902,22 @@ async def test_update_with_json_attrs_bad_JSON(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, light.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        light.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, light.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        light.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -1017,42 +1032,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -1082,7 +1097,6 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
     """Test setting min_mireds and max_mireds."""
     config = {
         light.DOMAIN: {
-            "platform": "mqtt",
             "schema": "template",
             "name": "test",
             "command_topic": "test_max_mireds/set",
@@ -1093,7 +1107,7 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
         }
     }
 
-    assert await async_setup_component(hass, light.DOMAIN, config)
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -1139,7 +1153,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = light.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
     if topic == "effect_command_topic":
         config["effect_list"] = ["random", "color_loop"]
 
@@ -1162,7 +1176,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = light.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -1171,7 +1185,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = light.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -1192,7 +1206,7 @@ async def test_encoding_subscribable_topics(
     init_payload,
 ):
     """Test handling of incoming encoded payload."""
-    config = copy.deepcopy(DEFAULT_CONFIG[light.DOMAIN])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[light.DOMAIN])
     config["state_template"] = "{{ value }}"
     await help_test_encoding_subscribable_topics(
         hass,
@@ -1211,7 +1225,7 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = light.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -1221,7 +1235,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = light.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = light.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -4,14 +4,14 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components import lock, mqtt
 from homeassistant.components.lock import (
-    DOMAIN as LOCK_DOMAIN,
     SERVICE_LOCK,
     SERVICE_OPEN,
     SERVICE_UNLOCK,
     STATE_LOCKED,
     STATE_UNLOCKED,
-    SUPPORT_OPEN,
+    LockEntityFeature,
 )
 from homeassistant.components.mqtt.lock import MQTT_LOCK_ATTRIBUTES_BLOCKED
 from homeassistant.const import (
@@ -56,7 +56,11 @@ from .test_common import (
 from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {
-    LOCK_DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
+    mqtt.DOMAIN: {lock.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
+}
+
+DEFAULT_CONFIG_LEGACY = {
+    lock.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
 
 
@@ -71,17 +75,18 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        LOCK_DOMAIN,
+        mqtt.DOMAIN,
         {
-            LOCK_DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_lock": "LOCK",
-                "payload_unlock": "UNLOCK",
-                "state_locked": "LOCKED",
-                "state_unlocked": "UNLOCKED",
+            mqtt.DOMAIN: {
+                lock.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_lock": "LOCK",
+                    "payload_unlock": "UNLOCK",
+                    "state_locked": "LOCKED",
+                    "state_unlocked": "UNLOCKED",
+                }
             }
         },
     )
@@ -110,17 +115,18 @@ async def test_controlling_non_default_state_via_topic(
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        LOCK_DOMAIN,
+        mqtt.DOMAIN,
         {
-            LOCK_DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_lock": "LOCK",
-                "payload_unlock": "UNLOCK",
-                "state_locked": "closed",
-                "state_unlocked": "open",
+            mqtt.DOMAIN: {
+                lock.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_lock": "LOCK",
+                    "payload_unlock": "UNLOCK",
+                    "state_locked": "closed",
+                    "state_unlocked": "open",
+                }
             }
         },
     )
@@ -148,18 +154,19 @@ async def test_controlling_state_via_topic_and_json_message(
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
-        LOCK_DOMAIN,
+        mqtt.DOMAIN,
         {
-            LOCK_DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_lock": "LOCK",
-                "payload_unlock": "UNLOCK",
-                "state_locked": "LOCKED",
-                "state_unlocked": "UNLOCKED",
-                "value_template": "{{ value_json.val }}",
+            mqtt.DOMAIN: {
+                lock.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_lock": "LOCK",
+                    "payload_unlock": "UNLOCK",
+                    "state_locked": "LOCKED",
+                    "state_unlocked": "UNLOCKED",
+                    "value_template": "{{ value_json.val }}",
+                }
             }
         },
     )
@@ -186,18 +193,19 @@ async def test_controlling_non_default_state_via_topic_and_json_message(
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
-        LOCK_DOMAIN,
+        mqtt.DOMAIN,
         {
-            LOCK_DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_lock": "LOCK",
-                "payload_unlock": "UNLOCK",
-                "state_locked": "closed",
-                "state_unlocked": "open",
-                "value_template": "{{ value_json.val }}",
+            mqtt.DOMAIN: {
+                lock.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_lock": "LOCK",
+                    "payload_unlock": "UNLOCK",
+                    "state_locked": "closed",
+                    "state_unlocked": "open",
+                    "value_template": "{{ value_json.val }}",
+                }
             }
         },
     )
@@ -224,16 +232,17 @@ async def test_sending_mqtt_commands_and_optimistic(
     """Test optimistic mode without state topic."""
     assert await async_setup_component(
         hass,
-        LOCK_DOMAIN,
+        mqtt.DOMAIN,
         {
-            LOCK_DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "payload_lock": "LOCK",
-                "payload_unlock": "UNLOCK",
-                "state_locked": "LOCKED",
-                "state_unlocked": "UNLOCKED",
+            mqtt.DOMAIN: {
+                lock.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "payload_lock": "LOCK",
+                    "payload_unlock": "UNLOCK",
+                    "state_locked": "LOCKED",
+                    "state_unlocked": "UNLOCKED",
+                }
             }
         },
     )
@@ -245,7 +254,7 @@ async def test_sending_mqtt_commands_and_optimistic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "LOCK", 0, False)
@@ -255,7 +264,7 @@ async def test_sending_mqtt_commands_and_optimistic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "UNLOCK", 0, False)
@@ -271,18 +280,19 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(
     """Test optimistic mode without state topic."""
     assert await async_setup_component(
         hass,
-        LOCK_DOMAIN,
+        mqtt.DOMAIN,
         {
-            LOCK_DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_lock": "LOCK",
-                "payload_unlock": "UNLOCK",
-                "state_locked": "LOCKED",
-                "state_unlocked": "UNLOCKED",
-                "optimistic": True,
+            mqtt.DOMAIN: {
+                lock.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_lock": "LOCK",
+                    "payload_unlock": "UNLOCK",
+                    "state_locked": "LOCKED",
+                    "state_unlocked": "UNLOCKED",
+                    "optimistic": True,
+                }
             }
         },
     )
@@ -294,7 +304,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "LOCK", 0, False)
@@ -304,7 +314,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "UNLOCK", 0, False)
@@ -320,17 +330,18 @@ async def test_sending_mqtt_commands_support_open_and_optimistic(
     """Test open function of the lock without state topic."""
     assert await async_setup_component(
         hass,
-        LOCK_DOMAIN,
+        mqtt.DOMAIN,
         {
-            LOCK_DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "payload_lock": "LOCK",
-                "payload_unlock": "UNLOCK",
-                "payload_open": "OPEN",
-                "state_locked": "LOCKED",
-                "state_unlocked": "UNLOCKED",
+            mqtt.DOMAIN: {
+                lock.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "payload_lock": "LOCK",
+                    "payload_unlock": "UNLOCK",
+                    "payload_open": "OPEN",
+                    "state_locked": "LOCKED",
+                    "state_unlocked": "UNLOCKED",
+                }
             }
         },
     )
@@ -340,10 +351,10 @@ async def test_sending_mqtt_commands_support_open_and_optimistic(
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
     assert state.attributes.get(ATTR_ASSUMED_STATE)
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == SUPPORT_OPEN
+    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == LockEntityFeature.OPEN
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "LOCK", 0, False)
@@ -353,7 +364,7 @@ async def test_sending_mqtt_commands_support_open_and_optimistic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "UNLOCK", 0, False)
@@ -363,7 +374,7 @@ async def test_sending_mqtt_commands_support_open_and_optimistic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_OPEN, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_OPEN, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "OPEN", 0, False)
@@ -379,19 +390,20 @@ async def test_sending_mqtt_commands_support_open_and_explicit_optimistic(
     """Test open function of the lock without state topic."""
     assert await async_setup_component(
         hass,
-        LOCK_DOMAIN,
+        mqtt.DOMAIN,
         {
-            LOCK_DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_lock": "LOCK",
-                "payload_unlock": "UNLOCK",
-                "payload_open": "OPEN",
-                "state_locked": "LOCKED",
-                "state_unlocked": "UNLOCKED",
-                "optimistic": True,
+            mqtt.DOMAIN: {
+                lock.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_lock": "LOCK",
+                    "payload_unlock": "UNLOCK",
+                    "payload_open": "OPEN",
+                    "state_locked": "LOCKED",
+                    "state_unlocked": "UNLOCKED",
+                    "optimistic": True,
+                }
             }
         },
     )
@@ -401,10 +413,10 @@ async def test_sending_mqtt_commands_support_open_and_explicit_optimistic(
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
     assert state.attributes.get(ATTR_ASSUMED_STATE)
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == SUPPORT_OPEN
+    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == LockEntityFeature.OPEN
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "LOCK", 0, False)
@@ -414,7 +426,7 @@ async def test_sending_mqtt_commands_support_open_and_explicit_optimistic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "UNLOCK", 0, False)
@@ -424,7 +436,7 @@ async def test_sending_mqtt_commands_support_open_and_explicit_optimistic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await hass.services.async_call(
-        LOCK_DOMAIN, SERVICE_OPEN, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
+        lock.DOMAIN, SERVICE_OPEN, {ATTR_ENTITY_ID: "lock.test"}, blocking=True
     )
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "OPEN", 0, False)
@@ -439,28 +451,28 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -469,7 +481,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -480,8 +492,8 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
-        LOCK_DOMAIN,
-        DEFAULT_CONFIG,
+        lock.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_LOCK_ATTRIBUTES_BLOCKED,
     )
 
@@ -489,7 +501,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -498,7 +510,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        lock.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -507,21 +523,25 @@ async def test_update_with_json_attrs_bad_json(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        lock.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, caplog, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     """Test unique id option only creates one lock per unique_id."""
     config = {
-        LOCK_DOMAIN: [
+        lock.DOMAIN: [
             {
                 "platform": "mqtt",
                 "name": "Test 1",
@@ -539,7 +559,7 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
         ]
     }
     await help_test_unique_id(
-        hass, mqtt_mock_entry_with_yaml_config, LOCK_DOMAIN, config
+        hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, config
     )
 
 
@@ -547,7 +567,7 @@ async def test_discovery_removal_lock(hass, mqtt_mock_entry_no_yaml_config, capl
     """Test removal of discovered lock."""
     data = '{ "name": "test",' '  "command_topic": "test_topic" }'
     await help_test_discovery_removal(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, LOCK_DOMAIN, data
+        hass, mqtt_mock_entry_no_yaml_config, caplog, lock.DOMAIN, data
     )
 
 
@@ -566,7 +586,7 @@ async def test_discovery_update_lock(hass, mqtt_mock_entry_no_yaml_config, caplo
         "availability_topic": "availability_topic2",
     }
     await help_test_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, LOCK_DOMAIN, config1, config2
+        hass, mqtt_mock_entry_no_yaml_config, caplog, lock.DOMAIN, config1, config2
     )
 
 
@@ -586,7 +606,7 @@ async def test_discovery_update_unchanged_lock(
             hass,
             mqtt_mock_entry_no_yaml_config,
             caplog,
-            LOCK_DOMAIN,
+            lock.DOMAIN,
             data1,
             discovery_update,
         )
@@ -598,49 +618,49 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     data1 = '{ "name": "Beer" }'
     data2 = '{ "name": "Milk",' '  "command_topic": "test_topic" }'
     await help_test_discovery_broken(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, LOCK_DOMAIN, data1, data2
+        hass, mqtt_mock_entry_no_yaml_config, caplog, lock.DOMAIN, data1, data2
     )
 
 
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT lock device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT lock device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, LOCK_DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -649,8 +669,8 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     await help_test_entity_debug_info_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
-        LOCK_DOMAIN,
-        DEFAULT_CONFIG,
+        lock.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
         SERVICE_LOCK,
         command_payload="LOCK",
     )
@@ -679,8 +699,8 @@ async def test_publishing_with_custom_encoding(
     template,
 ):
     """Test publishing MQTT payload with different encoding."""
-    domain = LOCK_DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    domain = lock.DOMAIN
+    config = DEFAULT_CONFIG_LEGACY[domain]
 
     await help_test_publishing_with_custom_encoding(
         hass,
@@ -698,8 +718,8 @@ async def test_publishing_with_custom_encoding(
 
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
-    domain = LOCK_DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    domain = lock.DOMAIN
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -707,8 +727,8 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
-    domain = LOCK_DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    domain = lock.DOMAIN
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -732,8 +752,8 @@ async def test_encoding_subscribable_topics(
         hass,
         mqtt_mock_entry_with_yaml_config,
         caplog,
-        LOCK_DOMAIN,
-        DEFAULT_CONFIG[LOCK_DOMAIN],
+        lock.DOMAIN,
+        DEFAULT_CONFIG_LEGACY[lock.DOMAIN],
         topic,
         value,
         attribute,
@@ -743,8 +763,8 @@ async def test_encoding_subscribable_topics(
 
 async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
     """Test setup manual configured MQTT entity."""
-    platform = LOCK_DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    platform = lock.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -753,8 +773,21 @@ async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
 
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
-    domain = LOCK_DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    domain = lock.DOMAIN
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = lock.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -59,8 +59,8 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {lock.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[lock.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -781,8 +781,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = lock.DOMAIN

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -59,9 +59,10 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {lock.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    lock.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[lock.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -69,9 +69,10 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {number.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    number.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[number.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -69,8 +69,8 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {number.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[number.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -963,8 +963,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = number.DOMAIN

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -66,6 +66,10 @@ from .test_common import (
 from tests.common import async_fire_mqtt_message, mock_restore_cache_with_extra_data
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {number.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
+}
+
+DEFAULT_CONFIG_LEGACY = {
     number.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
 
@@ -82,16 +86,17 @@ async def test_run_number_setup(hass, mqtt_mock_entry_with_yaml_config):
     topic = "test/number"
     await async_setup_component(
         hass,
-        "number",
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test Number",
-                "device_class": "temperature",
-                "unit_of_measurement": TEMP_FAHRENHEIT,
-                "payload_reset": "reset!",
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test Number",
+                    "device_class": "temperature",
+                    "unit_of_measurement": TEMP_FAHRENHEIT,
+                    "payload_reset": "reset!",
+                }
             }
         },
     )
@@ -131,14 +136,15 @@ async def test_value_template(hass, mqtt_mock_entry_with_yaml_config):
     topic = "test/number"
     await async_setup_component(
         hass,
-        "number",
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test Number",
-                "value_template": "{{ value_json.val }}",
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test Number",
+                    "value_template": "{{ value_json.val }}",
+                }
             }
         },
     )
@@ -184,14 +190,15 @@ async def test_restore_native_value(hass, mqtt_mock_entry_with_yaml_config):
     )
     assert await async_setup_component(
         hass,
-        number.DOMAIN,
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "command_topic": topic,
-                "device_class": "temperature",
-                "unit_of_measurement": TEMP_FAHRENHEIT,
-                "name": "Test Number",
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": topic,
+                    "device_class": "temperature",
+                    "unit_of_measurement": TEMP_FAHRENHEIT,
+                    "name": "Test Number",
+                }
             }
         },
     )
@@ -220,12 +227,13 @@ async def test_run_number_service_optimistic(hass, mqtt_mock_entry_with_yaml_con
     )
     assert await async_setup_component(
         hass,
-        number.DOMAIN,
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "command_topic": topic,
-                "name": "Test Number",
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": topic,
+                    "name": "Test Number",
+                }
             }
         },
     )
@@ -295,13 +303,14 @@ async def test_run_number_service_optimistic_with_command_template(
     )
     assert await async_setup_component(
         hass,
-        number.DOMAIN,
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "command_topic": topic,
-                "name": "Test Number",
-                "command_template": '{"number": {{ value }} }',
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": topic,
+                    "name": "Test Number",
+                    "command_template": '{"number": {{ value }} }',
+                }
             }
         },
     )
@@ -361,13 +370,14 @@ async def test_run_number_service(hass, mqtt_mock_entry_with_yaml_config):
 
     assert await async_setup_component(
         hass,
-        number.DOMAIN,
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "command_topic": cmd_topic,
-                "state_topic": state_topic,
-                "name": "Test Number",
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": cmd_topic,
+                    "state_topic": state_topic,
+                    "name": "Test Number",
+                }
             }
         },
     )
@@ -398,14 +408,15 @@ async def test_run_number_service_with_command_template(
 
     assert await async_setup_component(
         hass,
-        number.DOMAIN,
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "command_topic": cmd_topic,
-                "state_topic": state_topic,
-                "name": "Test Number",
-                "command_template": '{"number": {{ value }} }',
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": cmd_topic,
+                    "state_topic": state_topic,
+                    "name": "Test Number",
+                    "command_template": '{"number": {{ value }} }',
+                }
             }
         },
     )
@@ -434,28 +445,28 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -464,7 +475,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -476,7 +487,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
         number.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_NUMBER_ATTRIBUTES_BLOCKED,
     )
 
@@ -484,7 +495,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -493,7 +504,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, number.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        number.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -502,14 +517,22 @@ async def test_update_with_json_attrs_bad_JSON(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, number.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        number.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, number.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        number.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -540,7 +563,7 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_discovery_removal_number(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test removal of discovered number."""
-    data = json.dumps(DEFAULT_CONFIG[number.DOMAIN])
+    data = json.dumps(DEFAULT_CONFIG_LEGACY[number.DOMAIN])
     await help_test_discovery_removal(
         hass, mqtt_mock_entry_no_yaml_config, caplog, number.DOMAIN, data
     )
@@ -600,42 +623,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT number device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT number device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -645,7 +668,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         number.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         SERVICE_SET_VALUE,
         service_parameters={ATTR_VALUE: 45},
         command_payload="45",
@@ -658,16 +681,17 @@ async def test_min_max_step_attributes(hass, mqtt_mock_entry_with_yaml_config):
     topic = "test/number"
     await async_setup_component(
         hass,
-        "number",
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test Number",
-                "min": 5,
-                "max": 110,
-                "step": 20,
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test Number",
+                    "min": 5,
+                    "max": 110,
+                    "step": 20,
+                }
             }
         },
     )
@@ -680,25 +704,24 @@ async def test_min_max_step_attributes(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_STEP) == 20
 
 
-async def test_invalid_min_max_attributes(hass, caplog, mqtt_mock_entry_no_yaml_config):
+async def test_invalid_min_max_attributes(hass, caplog):
     """Test invalid min/max attributes."""
     topic = "test/number"
-    await async_setup_component(
+    assert not await async_setup_component(
         hass,
-        "number",
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test Number",
-                "min": 35,
-                "max": 10,
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test Number",
+                    "min": 35,
+                    "max": 10,
+                }
             }
         },
     )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_no_yaml_config()
 
     assert f"'{CONF_MAX}' must be > '{CONF_MIN}'" in caplog.text
 
@@ -779,15 +802,16 @@ async def test_mqtt_payload_not_a_number_warning(
 ):
     """Test warning for MQTT payload which is not a number."""
     topic = "test/number"
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "number",
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test Number",
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test Number",
+                }
             }
         },
     )
@@ -808,15 +832,16 @@ async def test_mqtt_payload_out_of_range_error(
     topic = "test/number"
     await async_setup_component(
         hass,
-        "number",
+        mqtt.DOMAIN,
         {
-            "number": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test Number",
-                "min": 5,
-                "max": 110,
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test Number",
+                    "min": 5,
+                    "max": 110,
+                }
             }
         },
     )
@@ -856,7 +881,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = NUMBER_DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
 
     await help_test_publishing_with_custom_encoding(
         hass,
@@ -875,7 +900,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = number.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -884,7 +909,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = number.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -910,7 +935,7 @@ async def test_encoding_subscribable_topics(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         "number",
-        DEFAULT_CONFIG["number"],
+        DEFAULT_CONFIG_LEGACY["number"],
         topic,
         value,
         attribute,
@@ -921,7 +946,7 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = number.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -931,7 +956,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = number.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = number.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_scene.py
+++ b/tests/components/mqtt/test_scene.py
@@ -37,8 +37,8 @@ DEFAULT_CONFIG = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[scene.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -255,8 +255,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = scene.DOMAIN

--- a/tests/components/mqtt/test_scene.py
+++ b/tests/components/mqtt/test_scene.py
@@ -37,14 +37,10 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    scene.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "command_topic": "test-topic",
-        "payload_on": "test-payload-on",
-    }
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[scene.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_scene.py
+++ b/tests/components/mqtt/test_scene.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import scene
+from homeassistant.components import mqtt, scene
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNKNOWN, Platform
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -28,6 +28,16 @@ from .test_common import (
 from tests.common import mock_restore_cache
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {
+        scene.DOMAIN: {
+            "name": "test",
+            "command_topic": "test-topic",
+            "payload_on": "test-payload-on",
+        }
+    }
+}
+
+DEFAULT_CONFIG_LEGACY = {
     scene.DOMAIN: {
         "platform": "mqtt",
         "name": "test",
@@ -51,14 +61,15 @@ async def test_sending_mqtt_commands(hass, mqtt_mock_entry_with_yaml_config):
 
     assert await async_setup_component(
         hass,
-        scene.DOMAIN,
+        mqtt.DOMAIN,
         {
-            scene.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "payload_on": "beer on",
-            },
+            mqtt.DOMAIN: {
+                scene.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "payload_on": "beer on",
+                },
+            }
         },
     )
     await hass.async_block_till_done()
@@ -80,14 +91,14 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, scene.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, scene.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, scene.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, scene.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -168,8 +179,8 @@ async def test_discovery_removal_scene(hass, mqtt_mock_entry_no_yaml_config, cap
 
 async def test_discovery_update_payload(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered scene."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[scene.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[scene.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[scene.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[scene.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
     config1["payload_on"] = "ON"
@@ -216,7 +227,7 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = scene.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -225,14 +236,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = scene.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = scene.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -242,7 +253,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = scene.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = scene.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -65,8 +65,8 @@ DEFAULT_CONFIG = {
     }
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[select.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -719,8 +719,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = select.DOMAIN

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import select
+from homeassistant.components import mqtt, select
 from homeassistant.components.mqtt.select import MQTT_SELECT_ATTRIBUTES_BLOCKED
 from homeassistant.components.select import (
     ATTR_OPTION,
@@ -56,6 +56,16 @@ from .test_common import (
 from tests.common import async_fire_mqtt_message, mock_restore_cache
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {
+        select.DOMAIN: {
+            "name": "test",
+            "command_topic": "test-topic",
+            "options": ["milk", "beer"],
+        }
+    }
+}
+
+DEFAULT_CONFIG_LEGACY = {
     select.DOMAIN: {
         "platform": "mqtt",
         "name": "test",
@@ -77,14 +87,15 @@ async def test_run_select_setup(hass, mqtt_mock_entry_with_yaml_config):
     topic = "test/select"
     await async_setup_component(
         hass,
-        "select",
+        mqtt.DOMAIN,
         {
-            "select": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test Select",
-                "options": ["milk", "beer"],
+            mqtt.DOMAIN: {
+                select.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test Select",
+                    "options": ["milk", "beer"],
+                }
             }
         },
     )
@@ -111,15 +122,16 @@ async def test_value_template(hass, mqtt_mock_entry_with_yaml_config):
     topic = "test/select"
     await async_setup_component(
         hass,
-        "select",
+        mqtt.DOMAIN,
         {
-            "select": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test Select",
-                "options": ["milk", "beer"],
-                "value_template": "{{ value_json.val }}",
+            mqtt.DOMAIN: {
+                select.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test Select",
+                    "options": ["milk", "beer"],
+                    "value_template": "{{ value_json.val }}",
+                }
             }
         },
     )
@@ -157,13 +169,14 @@ async def test_run_select_service_optimistic(hass, mqtt_mock_entry_with_yaml_con
 
     assert await async_setup_component(
         hass,
-        select.DOMAIN,
+        mqtt.DOMAIN,
         {
-            "select": {
-                "platform": "mqtt",
-                "command_topic": topic,
-                "name": "Test Select",
-                "options": ["milk", "beer"],
+            mqtt.DOMAIN: {
+                select.DOMAIN: {
+                    "command_topic": topic,
+                    "name": "Test Select",
+                    "options": ["milk", "beer"],
+                }
             }
         },
     )
@@ -198,14 +211,15 @@ async def test_run_select_service_optimistic_with_command_template(
 
     assert await async_setup_component(
         hass,
-        select.DOMAIN,
+        mqtt.DOMAIN,
         {
-            "select": {
-                "platform": "mqtt",
-                "command_topic": topic,
-                "name": "Test Select",
-                "options": ["milk", "beer"],
-                "command_template": '{"option": "{{ value }}"}',
+            mqtt.DOMAIN: {
+                select.DOMAIN: {
+                    "command_topic": topic,
+                    "name": "Test Select",
+                    "options": ["milk", "beer"],
+                    "command_template": '{"option": "{{ value }}"}',
+                }
             }
         },
     )
@@ -238,14 +252,15 @@ async def test_run_select_service(hass, mqtt_mock_entry_with_yaml_config):
 
     assert await async_setup_component(
         hass,
-        select.DOMAIN,
+        mqtt.DOMAIN,
         {
-            "select": {
-                "platform": "mqtt",
-                "command_topic": cmd_topic,
-                "state_topic": state_topic,
-                "name": "Test Select",
-                "options": ["milk", "beer"],
+            mqtt.DOMAIN: {
+                select.DOMAIN: {
+                    "command_topic": cmd_topic,
+                    "state_topic": state_topic,
+                    "name": "Test Select",
+                    "options": ["milk", "beer"],
+                }
             }
         },
     )
@@ -276,15 +291,16 @@ async def test_run_select_service_with_command_template(
 
     assert await async_setup_component(
         hass,
-        select.DOMAIN,
+        mqtt.DOMAIN,
         {
-            "select": {
-                "platform": "mqtt",
-                "command_topic": cmd_topic,
-                "state_topic": state_topic,
-                "name": "Test Select",
-                "options": ["milk", "beer"],
-                "command_template": '{"option": "{{ value }}"}',
+            mqtt.DOMAIN: {
+                select.DOMAIN: {
+                    "command_topic": cmd_topic,
+                    "state_topic": state_topic,
+                    "name": "Test Select",
+                    "options": ["milk", "beer"],
+                    "command_template": '{"option": "{{ value }}"}',
+                }
             }
         },
     )
@@ -311,28 +327,28 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -341,7 +357,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -353,7 +369,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
         select.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_SELECT_ATTRIBUTES_BLOCKED,
     )
 
@@ -361,7 +377,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -370,7 +386,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, select.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        select.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -379,14 +399,22 @@ async def test_update_with_json_attrs_bad_JSON(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, select.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        select.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, select.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        select.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -419,7 +447,7 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_discovery_removal_select(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test removal of discovered select."""
-    data = json.dumps(DEFAULT_CONFIG[select.DOMAIN])
+    data = json.dumps(DEFAULT_CONFIG_LEGACY[select.DOMAIN])
     await help_test_discovery_removal(
         hass, mqtt_mock_entry_no_yaml_config, caplog, select.DOMAIN, data
     )
@@ -477,42 +505,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT select device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT select device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -522,7 +550,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         select.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         select.SERVICE_SELECT_OPTION,
         service_parameters={ATTR_OPTION: "beer"},
         command_payload="beer",
@@ -536,14 +564,15 @@ async def test_options_attributes(hass, mqtt_mock_entry_with_yaml_config, option
     topic = "test/select"
     await async_setup_component(
         hass,
-        "select",
+        mqtt.DOMAIN,
         {
-            "select": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test select",
-                "options": options,
+            mqtt.DOMAIN: {
+                select.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test select",
+                    "options": options,
+                }
             }
         },
     )
@@ -561,14 +590,15 @@ async def test_mqtt_payload_not_an_option_warning(
     topic = "test/select"
     await async_setup_component(
         hass,
-        "select",
+        mqtt.DOMAIN,
         {
-            "select": {
-                "platform": "mqtt",
-                "state_topic": topic,
-                "command_topic": topic,
-                "name": "Test Select",
-                "options": ["milk", "beer"],
+            mqtt.DOMAIN: {
+                select.DOMAIN: {
+                    "state_topic": topic,
+                    "command_topic": topic,
+                    "name": "Test Select",
+                    "options": ["milk", "beer"],
+                }
             }
         },
     )
@@ -609,7 +639,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = select.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     config["options"] = ["milk", "beer"]
 
     await help_test_publishing_with_custom_encoding(
@@ -629,7 +659,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = select.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -638,7 +668,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = select.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -659,7 +689,7 @@ async def test_encoding_subscribable_topics(
     attribute_value,
 ):
     """Test handling of incoming encoded payload."""
-    config = copy.deepcopy(DEFAULT_CONFIG["select"])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY["select"])
     config["options"] = ["milk", "beer"]
     await help_test_encoding_subscribable_topics(
         hass,
@@ -677,7 +707,7 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = select.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -687,7 +717,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = select.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = select.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -65,14 +65,10 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    select.DOMAIN: {
-        "platform": "mqtt",
-        "name": "test",
-        "command_topic": "test-topic",
-        "options": ["milk", "beer"],
-    }
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[select.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -73,9 +73,10 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {sensor.DOMAIN: {"name": "test", "state_topic": "test-topic"}}
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    sensor.DOMAIN: {"platform": "mqtt", "name": "test", "state_topic": "test-topic"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[sensor.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from homeassistant.components import mqtt, sensor
 from homeassistant.components.mqtt.sensor import MQTT_SENSOR_ATTRIBUTES_BLOCKED
-import homeassistant.components.sensor as sensor
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
     STATE_UNAVAILABLE,
@@ -64,13 +64,16 @@ from .test_common import (
 )
 
 from tests.common import (
-    assert_setup_component,
     async_fire_mqtt_message,
     async_fire_time_changed,
     mock_restore_cache_with_extra_data,
 )
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {sensor.DOMAIN: {"name": "test", "state_topic": "test-topic"}}
+}
+
+DEFAULT_CONFIG_LEGACY = {
     sensor.DOMAIN: {"platform": "mqtt", "name": "test", "state_topic": "test-topic"}
 }
 
@@ -88,13 +91,14 @@ async def test_setting_sensor_value_via_mqtt_message(
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                }
             }
         },
     )
@@ -146,13 +150,14 @@ async def test_setting_sensor_native_value_handling_via_mqtt_message(
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "device_class": device_class,
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "device_class": device_class,
+                }
             }
         },
     )
@@ -173,15 +178,16 @@ async def test_setting_sensor_value_expires_availability_topic(
     """Test the expiration of the value."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "expire_after": 4,
-                "force_update": True,
-                "availability_topic": "availability-topic",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "expire_after": 4,
+                    "force_update": True,
+                    "availability_topic": "availability-topic",
+                }
             }
         },
     )
@@ -206,15 +212,16 @@ async def test_setting_sensor_value_expires(
     """Test the expiration of the value."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "expire_after": "4",
-                "force_update": True,
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                    "expire_after": "4",
+                    "force_update": True,
+                }
             }
         },
     )
@@ -285,14 +292,15 @@ async def test_setting_sensor_value_via_mqtt_json_message(
     """Test the setting of the value via MQTT with JSON payload."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "value_template": "{{ value_json.val }}",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                    "value_template": "{{ value_json.val }}",
+                }
             }
         },
     )
@@ -311,14 +319,15 @@ async def test_setting_sensor_value_via_mqtt_json_message_and_default_current_st
     """Test the setting of the value via MQTT with fall back to current state."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "value_template": "{{ value_json.val | is_defined }}-{{ value_json.par }}",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                    "value_template": "{{ value_json.val | is_defined }}-{{ value_json.par }}",
+                }
             }
         },
     )
@@ -344,15 +353,16 @@ async def test_setting_sensor_last_reset_via_mqtt_message(
     """Test the setting of the last_reset property via MQTT."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_class": "total",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "last_reset_topic": "last-reset-topic",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_class": "total",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                    "last_reset_topic": "last-reset-topic",
+                }
             }
         },
     )
@@ -376,15 +386,16 @@ async def test_setting_sensor_bad_last_reset_via_mqtt_message(
     """Test the setting of the last_reset property via MQTT."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_class": "total",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "last_reset_topic": "last-reset-topic",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_class": "total",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                    "last_reset_topic": "last-reset-topic",
+                }
             }
         },
     )
@@ -403,15 +414,16 @@ async def test_setting_sensor_empty_last_reset_via_mqtt_message(
     """Test the setting of the last_reset property via MQTT."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_class": "total",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "last_reset_topic": "last-reset-topic",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_class": "total",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                    "last_reset_topic": "last-reset-topic",
+                }
             }
         },
     )
@@ -430,16 +442,17 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message(
     """Test the setting of the value via MQTT with JSON payload."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_class": "total",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "last_reset_topic": "last-reset-topic",
-                "last_reset_value_template": "{{ value_json.last_reset }}",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_class": "total",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                    "last_reset_topic": "last-reset-topic",
+                    "last_reset_value_template": "{{ value_json.last_reset }}",
+                }
             }
         },
     )
@@ -460,19 +473,20 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message_2(
     """Test the setting of the value via MQTT with JSON payload."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                **{
-                    "platform": "mqtt",
-                    "name": "test",
-                    "state_class": "total",
-                    "state_topic": "test-topic",
-                    "unit_of_measurement": "kWh",
-                    "value_template": "{{ value_json.value | float / 60000 }}",
-                    "last_reset_value_template": "{{ utcnow().fromtimestamp(value_json.time / 1000, tz=utcnow().tzinfo) }}",
-                },
-                **extra,
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    **{
+                        "name": "test",
+                        "state_class": "total",
+                        "state_topic": "test-topic",
+                        "unit_of_measurement": "kWh",
+                        "value_template": "{{ value_json.value | float / 60000 }}",
+                        "last_reset_value_template": "{{ utcnow().fromtimestamp(value_json.time / 1000, tz=utcnow().tzinfo) }}",
+                    },
+                    **extra,
+                }
             }
         },
     )
@@ -498,13 +512,14 @@ async def test_force_update_disabled(hass, mqtt_mock_entry_with_yaml_config):
     """Test force update option."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                }
             }
         },
     )
@@ -532,14 +547,15 @@ async def test_force_update_enabled(hass, mqtt_mock_entry_with_yaml_config):
     """Test force update option."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "force_update": True,
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                    "force_update": True,
+                }
             }
         },
     )
@@ -568,21 +584,21 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -591,7 +607,7 @@ async def test_default_availability_list_payload(
 ):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_list_payload(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -600,7 +616,7 @@ async def test_default_availability_list_payload_all(
 ):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_list_payload_all(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -609,7 +625,7 @@ async def test_default_availability_list_payload_any(
 ):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_list_payload_any(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -618,21 +634,25 @@ async def test_default_availability_list_single(
 ):
     """Test availability list and availability_topic are mutually exclusive."""
     await help_test_default_availability_list_single(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_discovery_update_availability(hass, mqtt_mock_entry_no_yaml_config):
     """Test availability discovery update."""
     await help_test_discovery_update_availability(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -642,11 +662,12 @@ async def test_invalid_device_class(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         sensor.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "device_class": "foobarnotreal",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "device_class": "foobarnotreal",
+                }
             }
         },
     )
@@ -661,17 +682,18 @@ async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     """Test device_class option with valid values."""
     assert await async_setup_component(
         hass,
-        "sensor",
+        mqtt.DOMAIN,
         {
-            "sensor": [
-                {
-                    "platform": "mqtt",
-                    "name": "Test 1",
-                    "state_topic": "test-topic",
-                    "device_class": "temperature",
-                },
-                {"platform": "mqtt", "name": "Test 2", "state_topic": "test-topic"},
-            ]
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: [
+                    {
+                        "name": "Test 1",
+                        "state_topic": "test-topic",
+                        "device_class": "temperature",
+                    },
+                    {"name": "Test 2", "state_topic": "test-topic"},
+                ]
+            }
         },
     )
     await hass.async_block_till_done()
@@ -689,11 +711,12 @@ async def test_invalid_state_class(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         sensor.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "state_class": "foobarnotreal",
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "state_class": "foobarnotreal",
+                }
             }
         },
     )
@@ -708,17 +731,18 @@ async def test_valid_state_class(hass, mqtt_mock_entry_with_yaml_config):
     """Test state_class option with valid values."""
     assert await async_setup_component(
         hass,
-        "sensor",
+        mqtt.DOMAIN,
         {
-            "sensor": [
-                {
-                    "platform": "mqtt",
-                    "name": "Test 1",
-                    "state_topic": "test-topic",
-                    "state_class": "measurement",
-                },
-                {"platform": "mqtt", "name": "Test 2", "state_topic": "test-topic"},
-            ]
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: [
+                    {
+                        "name": "Test 1",
+                        "state_topic": "test-topic",
+                        "state_class": "measurement",
+                    },
+                    {"name": "Test 2", "state_topic": "test-topic"},
+                ]
+            }
         },
     )
     await hass.async_block_till_done()
@@ -735,7 +759,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -747,7 +771,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
         sensor.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         MQTT_SENSOR_ATTRIBUTES_BLOCKED,
     )
 
@@ -755,7 +779,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -764,7 +788,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -773,14 +801,22 @@ async def test_update_with_json_attrs_bad_JSON(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, sensor.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        sensor.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -914,42 +950,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT sensor device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT sensor device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -967,7 +1003,6 @@ async def test_entity_device_info_with_hub(hass, mqtt_mock_entry_no_yaml_config)
 
     data = json.dumps(
         {
-            "platform": "mqtt",
             "name": "Test 1",
             "state_topic": "test-topic",
             "device": {"identifiers": ["helloworld"], "via_device": "hub-id"},
@@ -985,42 +1020,42 @@ async def test_entity_device_info_with_hub(hass, mqtt_mock_entry_no_yaml_config)
 async def test_entity_debug_info(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT sensor debug info."""
     await help_test_entity_debug_info(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_debug_info_max_messages(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT sensor debug info."""
     await help_test_entity_debug_info_max_messages(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG, None
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY, None
     )
 
 
 async def test_entity_debug_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT sensor debug info."""
     await help_test_entity_debug_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_debug_info_update_entity_id(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT sensor debug info."""
     await help_test_entity_debug_info_update_entity_id(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_disabled_by_default(hass, mqtt_mock_entry_no_yaml_config):
     """Test entity disabled by default."""
     await help_test_entity_disabled_by_default(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -1028,7 +1063,7 @@ async def test_entity_disabled_by_default(hass, mqtt_mock_entry_no_yaml_config):
 async def test_entity_category(hass, mqtt_mock_entry_no_yaml_config):
     """Test entity category."""
     await help_test_entity_category(
-        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -1036,19 +1071,20 @@ async def test_value_template_with_entity_id(hass, mqtt_mock_entry_with_yaml_con
     """Test the access to attributes in value_template via the entity_id."""
     assert await async_setup_component(
         hass,
-        sensor.DOMAIN,
+        mqtt.DOMAIN,
         {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "value_template": '\
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "fav unit",
+                    "value_template": '\
                 {% if state_attr(entity_id, "friendly_name") == "test" %} \
                     {{ value | int + 1 }} \
                 {% else %} \
                     {{ value }} \
                 {% endif %}',
+                }
             }
         },
     )
@@ -1064,7 +1100,7 @@ async def test_value_template_with_entity_id(hass, mqtt_mock_entry_with_yaml_con
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = sensor.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -1073,7 +1109,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = sensor.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -1082,14 +1118,14 @@ async def test_cleanup_triggers_and_restoring_state(
 ):
     """Test cleanup old triggers at reloading and restoring the state."""
     domain = sensor.DOMAIN
-    config1 = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][domain])
     config1["name"] = "test1"
     config1["expire_after"] = 30
     config1["state_topic"] = "test-topic1"
     config1["device_class"] = "temperature"
     config1["unit_of_measurement"] = TEMP_FAHRENHEIT
 
-    config2 = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][domain])
     config2["name"] = "test2"
     config2["expire_after"] = 5
     config2["state_topic"] = "test-topic2"
@@ -1100,8 +1136,8 @@ async def test_cleanup_triggers_and_restoring_state(
 
     assert await async_setup_component(
         hass,
-        domain,
-        {domain: [config1, config2]},
+        mqtt.DOMAIN,
+        {mqtt.DOMAIN: {domain: [config1, config2]}},
     )
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
@@ -1116,7 +1152,7 @@ async def test_cleanup_triggers_and_restoring_state(
     freezer.move_to("2022-02-02 12:01:10+01:00")
 
     await help_test_reload_with_config(
-        hass, caplog, tmp_path, {domain: [config1, config2]}
+        hass, caplog, tmp_path, {mqtt.DOMAIN: {domain: [config1, config2]}}
     )
     await hass.async_block_till_done()
 
@@ -1150,7 +1186,7 @@ async def test_skip_restoring_state_with_over_due_expire_trigger(
 
     freezer.move_to("2022-02-02 12:02:00+01:00")
     domain = sensor.DOMAIN
-    config3 = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config3 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][domain])
     config3["name"] = "test3"
     config3["expire_after"] = 10
     config3["state_topic"] = "test-topic3"
@@ -1163,10 +1199,11 @@ async def test_skip_restoring_state_with_over_due_expire_trigger(
     fake_extra_data = MagicMock()
     mock_restore_cache_with_extra_data(hass, ((fake_state, fake_extra_data),))
 
-    with assert_setup_component(1, domain):
-        assert await async_setup_component(hass, domain, {domain: config3})
-        await hass.async_block_till_done()
-        await mqtt_mock_entry_with_yaml_config()
+    assert await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {domain: config3}}
+    )
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
     assert "Skip state recovery after reload for sensor.test3" in caplog.text
 
 
@@ -1192,7 +1229,7 @@ async def test_encoding_subscribable_topics(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         sensor.DOMAIN,
-        DEFAULT_CONFIG[sensor.DOMAIN],
+        DEFAULT_CONFIG_LEGACY[sensor.DOMAIN],
         topic,
         value,
         attribute,
@@ -1204,7 +1241,7 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = sensor.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -1214,7 +1251,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = sensor.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = sensor.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -73,8 +73,8 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {sensor.DOMAIN: {"name": "test", "state_topic": "test-topic"}}
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[sensor.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -1258,8 +1258,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = sensor.DOMAIN

--- a/tests/components/mqtt/test_siren.py
+++ b/tests/components/mqtt/test_siren.py
@@ -56,9 +56,10 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {siren.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    siren.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[siren.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_siren.py
+++ b/tests/components/mqtt/test_siren.py
@@ -56,8 +56,8 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {siren.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[siren.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -1007,8 +1007,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = siren.DOMAIN

--- a/tests/components/mqtt/test_siren.py
+++ b/tests/components/mqtt/test_siren.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import siren
+from homeassistant.components import mqtt, siren
 from homeassistant.components.siren.const import ATTR_VOLUME_LEVEL
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
@@ -53,6 +53,10 @@ from .test_common import (
 from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {siren.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
+}
+
+DEFAULT_CONFIG_LEGACY = {
     siren.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
 
@@ -83,15 +87,16 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        siren.DOMAIN,
+        mqtt.DOMAIN,
         {
-            siren.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_on": 1,
-                "payload_off": 0,
+            mqtt.DOMAIN: {
+                siren.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_on": 1,
+                    "payload_off": 0,
+                }
             }
         },
     )
@@ -119,15 +124,16 @@ async def test_sending_mqtt_commands_and_optimistic(
     """Test the sending MQTT commands in optimistic mode."""
     assert await async_setup_component(
         hass,
-        siren.DOMAIN,
+        mqtt.DOMAIN,
         {
-            siren.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "payload_on": "beer on",
-                "payload_off": "beer off",
-                "qos": "2",
+            mqtt.DOMAIN: {
+                siren.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "payload_on": "beer on",
+                    "payload_off": "beer off",
+                    "qos": "2",
+                }
             }
         },
     )
@@ -162,16 +168,17 @@ async def test_controlling_state_via_topic_and_json_message(
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
-        siren.DOMAIN,
+        mqtt.DOMAIN,
         {
-            siren.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_on": "beer on",
-                "payload_off": "beer off",
-                "state_value_template": "{{ value_json.val }}",
+            mqtt.DOMAIN: {
+                siren.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_on": "beer on",
+                    "payload_off": "beer off",
+                    "state_value_template": "{{ value_json.val }}",
+                }
             }
         },
     )
@@ -202,16 +209,17 @@ async def test_controlling_state_and_attributes_with_json_message_without_templa
     """Test the controlling state via topic and JSON message without a value template."""
     assert await async_setup_component(
         hass,
-        siren.DOMAIN,
+        mqtt.DOMAIN,
         {
-            siren.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_on": "beer on",
-                "payload_off": "beer off",
-                "available_tones": ["ping", "siren", "bell"],
+            mqtt.DOMAIN: {
+                siren.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_on": "beer on",
+                    "payload_off": "beer off",
+                    "available_tones": ["ping", "siren", "bell"],
+                }
             }
         },
     )
@@ -284,7 +292,6 @@ async def test_filtering_not_supported_attributes_optimistic(
 ):
     """Test setting attributes with support flags optimistic."""
     config = {
-        "platform": "mqtt",
         "command_topic": "command-topic",
         "available_tones": ["ping", "siren", "bell"],
     }
@@ -300,8 +307,8 @@ async def test_filtering_not_supported_attributes_optimistic(
 
     assert await async_setup_component(
         hass,
-        siren.DOMAIN,
-        {siren.DOMAIN: [config1, config2, config3]},
+        mqtt.DOMAIN,
+        {mqtt.DOMAIN: {siren.DOMAIN: [config1, config2, config3]}},
     )
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
@@ -370,7 +377,6 @@ async def test_filtering_not_supported_attributes_via_state(
 ):
     """Test setting attributes with support flags via state."""
     config = {
-        "platform": "mqtt",
         "command_topic": "command-topic",
         "available_tones": ["ping", "siren", "bell"],
     }
@@ -389,8 +395,8 @@ async def test_filtering_not_supported_attributes_via_state(
 
     assert await async_setup_component(
         hass,
-        siren.DOMAIN,
-        {siren.DOMAIN: [config1, config2, config3]},
+        mqtt.DOMAIN,
+        {mqtt.DOMAIN: {siren.DOMAIN: [config1, config2, config3]}},
     )
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
@@ -450,14 +456,14 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -513,17 +519,18 @@ async def test_custom_state_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test the state payload."""
     assert await async_setup_component(
         hass,
-        siren.DOMAIN,
+        mqtt.DOMAIN,
         {
-            siren.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_on": 1,
-                "payload_off": 0,
-                "state_on": "HIGH",
-                "state_off": "LOW",
+            mqtt.DOMAIN: {
+                siren.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_on": 1,
+                    "payload_off": 0,
+                    "state_on": "HIGH",
+                    "state_off": "LOW",
+                }
             }
         },
     )
@@ -550,7 +557,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -559,14 +566,14 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG, {}
+        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY, {}
     )
 
 
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -575,7 +582,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, siren.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        siren.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -584,14 +595,22 @@ async def test_update_with_json_attrs_bad_JSON(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, siren.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        siren.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, siren.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        siren.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -636,8 +655,8 @@ async def test_discovery_update_siren_topic_template(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered siren."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[siren.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[siren.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[siren.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[siren.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
     config1["state_topic"] = "siren/state1"
@@ -673,8 +692,8 @@ async def test_discovery_update_siren_template(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered siren."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[siren.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[siren.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[siren.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[siren.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
     config1["state_topic"] = "siren/state1"
@@ -706,7 +725,7 @@ async def test_discovery_update_siren_template(
 
 async def test_command_templates(hass, mqtt_mock_entry_with_yaml_config, caplog):
     """Test siren with command templates optimistic."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[siren.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][siren.DOMAIN])
     config1["name"] = "Beer"
     config1["available_tones"] = ["ping", "chimes"]
     config1[
@@ -719,8 +738,8 @@ async def test_command_templates(hass, mqtt_mock_entry_with_yaml_config, caplog)
 
     assert await async_setup_component(
         hass,
-        siren.DOMAIN,
-        {siren.DOMAIN: [config1, config2]},
+        mqtt.DOMAIN,
+        {mqtt.DOMAIN: {siren.DOMAIN: [config1, config2]}},
     )
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
@@ -824,42 +843,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT siren device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT siren device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -869,7 +888,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         siren.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         siren.SERVICE_TURN_ON,
         command_payload='{"state":"ON"}',
     )
@@ -906,7 +925,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with command templates and different encoding."""
     domain = siren.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
     config[siren.ATTR_AVAILABLE_TONES] = ["siren", "xylophone"]
 
     await help_test_publishing_with_custom_encoding(
@@ -926,7 +945,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = siren.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -935,7 +954,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = siren.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -960,7 +979,7 @@ async def test_encoding_subscribable_topics(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         siren.DOMAIN,
-        DEFAULT_CONFIG[siren.DOMAIN],
+        DEFAULT_CONFIG_LEGACY[siren.DOMAIN],
         topic,
         value,
         attribute,
@@ -971,7 +990,7 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = siren.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -981,7 +1000,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = siren.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = siren.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -86,22 +86,14 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    vacuum.DOMAIN: {
-        CONF_PLATFORM: "mqtt",
-        CONF_SCHEMA: "state",
-        CONF_NAME: "mqtttest",
-        CONF_COMMAND_TOPIC: COMMAND_TOPIC,
-        mqttvacuum.CONF_SEND_COMMAND_TOPIC: SEND_COMMAND_TOPIC,
-        CONF_STATE_TOPIC: STATE_TOPIC,
-        mqttvacuum.CONF_SET_FAN_SPEED_TOPIC: "vacuum/set_fan_speed",
-        mqttvacuum.CONF_FAN_SPEED_LIST: ["min", "medium", "high", "max"],
-    }
-}
+DEFAULT_CONFIG_2 = {mqtt.DOMAIN: {vacuum.DOMAIN: {"schema": "state", "name": "test"}}}
 
-DEFAULT_CONFIG_2_LEGACY = {
-    vacuum.DOMAIN: {"platform": "mqtt", "schema": "state", "name": "test"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[vacuum.DOMAIN][CONF_PLATFORM] = mqtt.DOMAIN
+DEFAULT_CONFIG_2_LEGACY = deepcopy(DEFAULT_CONFIG_2[mqtt.DOMAIN])
+DEFAULT_CONFIG_2_LEGACY[vacuum.DOMAIN][CONF_PLATFORM] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import vacuum
+from homeassistant.components import mqtt, vacuum
 from homeassistant.components.mqtt.const import CONF_COMMAND_TOPIC, CONF_STATE_TOPIC
 from homeassistant.components.mqtt.vacuum import CONF_SCHEMA, schema_state as mqttvacuum
 from homeassistant.components.mqtt.vacuum.const import MQTT_VACUUM_ATTRIBUTES_BLOCKED
@@ -73,17 +73,33 @@ SEND_COMMAND_TOPIC = "vacuum/send_command"
 STATE_TOPIC = "vacuum/state"
 
 DEFAULT_CONFIG = {
-    CONF_PLATFORM: "mqtt",
-    CONF_SCHEMA: "state",
-    CONF_NAME: "mqtttest",
-    CONF_COMMAND_TOPIC: COMMAND_TOPIC,
-    mqttvacuum.CONF_SEND_COMMAND_TOPIC: SEND_COMMAND_TOPIC,
-    CONF_STATE_TOPIC: STATE_TOPIC,
-    mqttvacuum.CONF_SET_FAN_SPEED_TOPIC: "vacuum/set_fan_speed",
-    mqttvacuum.CONF_FAN_SPEED_LIST: ["min", "medium", "high", "max"],
+    mqtt.DOMAIN: {
+        vacuum.DOMAIN: {
+            CONF_SCHEMA: "state",
+            CONF_NAME: "mqtttest",
+            CONF_COMMAND_TOPIC: COMMAND_TOPIC,
+            mqttvacuum.CONF_SEND_COMMAND_TOPIC: SEND_COMMAND_TOPIC,
+            CONF_STATE_TOPIC: STATE_TOPIC,
+            mqttvacuum.CONF_SET_FAN_SPEED_TOPIC: "vacuum/set_fan_speed",
+            mqttvacuum.CONF_FAN_SPEED_LIST: ["min", "medium", "high", "max"],
+        }
+    }
 }
 
-DEFAULT_CONFIG_2 = {
+DEFAULT_CONFIG_LEGACY = {
+    vacuum.DOMAIN: {
+        CONF_PLATFORM: "mqtt",
+        CONF_SCHEMA: "state",
+        CONF_NAME: "mqtttest",
+        CONF_COMMAND_TOPIC: COMMAND_TOPIC,
+        mqttvacuum.CONF_SEND_COMMAND_TOPIC: SEND_COMMAND_TOPIC,
+        CONF_STATE_TOPIC: STATE_TOPIC,
+        mqttvacuum.CONF_SET_FAN_SPEED_TOPIC: "vacuum/set_fan_speed",
+        mqttvacuum.CONF_FAN_SPEED_LIST: ["min", "medium", "high", "max"],
+    }
+}
+
+DEFAULT_CONFIG_2_LEGACY = {
     vacuum.DOMAIN: {"platform": "mqtt", "schema": "state", "name": "test"}
 }
 
@@ -97,9 +113,7 @@ def vacuum_platform_only():
 
 async def test_default_supported_features(hass, mqtt_mock_entry_with_yaml_config):
     """Test that the correct supported features."""
-    assert await async_setup_component(
-        hass, vacuum.DOMAIN, {vacuum.DOMAIN: DEFAULT_CONFIG}
-    )
+    assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
     entity = hass.states.get("vacuum.mqtttest")
@@ -111,12 +125,14 @@ async def test_default_supported_features(hass, mqtt_mock_entry_with_yaml_config
 
 async def test_all_commands(hass, mqtt_mock_entry_with_yaml_config):
     """Test simple commands send to the vacuum."""
-    config = deepcopy(DEFAULT_CONFIG)
+    config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
         mqttvacuum.ALL_SERVICES, SERVICE_TO_STRING
     )
 
-    assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    assert await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {vacuum.DOMAIN: config}}
+    )
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -185,13 +201,15 @@ async def test_commands_without_supported_features(
     hass, mqtt_mock_entry_with_yaml_config
 ):
     """Test commands which are not supported by the vacuum."""
-    config = deepcopy(DEFAULT_CONFIG)
+    config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     services = mqttvacuum.STRING_TO_SERVICE["status"]
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
         services, SERVICE_TO_STRING
     )
 
-    assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    assert await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {vacuum.DOMAIN: config}}
+    )
     await hass.async_block_till_done()
     mqtt_mock = await mqtt_mock_entry_with_yaml_config()
 
@@ -243,12 +261,14 @@ async def test_commands_without_supported_features(
 
 async def test_status(hass, mqtt_mock_entry_with_yaml_config):
     """Test status updates from the vacuum."""
-    config = deepcopy(DEFAULT_CONFIG)
+    config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
         mqttvacuum.ALL_SERVICES, SERVICE_TO_STRING
     )
 
-    assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    assert await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {vacuum.DOMAIN: config}}
+    )
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
     state = hass.states.get("vacuum.mqtttest")
@@ -288,13 +308,15 @@ async def test_status(hass, mqtt_mock_entry_with_yaml_config):
 
 async def test_no_fan_vacuum(hass, mqtt_mock_entry_with_yaml_config):
     """Test status updates from the vacuum when fan is not supported."""
-    config = deepcopy(DEFAULT_CONFIG)
+    config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     del config[mqttvacuum.CONF_FAN_SPEED_LIST]
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
         mqttvacuum.DEFAULT_SERVICES, SERVICE_TO_STRING
     )
 
-    assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    assert await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {vacuum.DOMAIN: config}}
+    )
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -340,12 +362,14 @@ async def test_no_fan_vacuum(hass, mqtt_mock_entry_with_yaml_config):
 @pytest.mark.no_fail_on_log_exception
 async def test_status_invalid_json(hass, mqtt_mock_entry_with_yaml_config):
     """Test to make sure nothing breaks if the vacuum sends bad JSON."""
-    config = deepcopy(DEFAULT_CONFIG)
+    config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
         mqttvacuum.ALL_SERVICES, SERVICE_TO_STRING
     )
 
-    assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    assert await async_setup_component(
+        hass, mqtt.DOMAIN, {mqtt.DOMAIN: {vacuum.DOMAIN: config}}
+    )
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
 
@@ -359,28 +383,28 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
 async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
 async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
-        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
@@ -389,7 +413,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
@@ -401,7 +425,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
         mqtt_mock_entry_no_yaml_config,
         vacuum.DOMAIN,
-        DEFAULT_CONFIG_2,
+        DEFAULT_CONFIG_2_LEGACY,
         MQTT_VACUUM_ATTRIBUTES_BLOCKED,
     )
 
@@ -409,7 +433,7 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
@@ -418,7 +442,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        vacuum.DOMAIN,
+        DEFAULT_CONFIG_2_LEGACY,
     )
 
 
@@ -427,14 +455,22 @@ async def test_update_with_json_attrs_bad_json(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        vacuum.DOMAIN,
+        DEFAULT_CONFIG_2_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        vacuum.DOMAIN,
+        DEFAULT_CONFIG_2_LEGACY,
     )
 
 
@@ -511,42 +547,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT vacuum device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT vacuum device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
+        hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2_LEGACY
     )
 
 
@@ -556,7 +592,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         vacuum.DOMAIN,
-        DEFAULT_CONFIG_2,
+        DEFAULT_CONFIG_2_LEGACY,
         vacuum.SERVICE_START,
         command_payload="start",
         state_payload="{}",
@@ -615,7 +651,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = vacuum.DOMAIN
-    config = deepcopy(DEFAULT_CONFIG)
+    config = deepcopy(DEFAULT_CONFIG_LEGACY[domain])
     config["supported_features"] = [
         "battery",
         "clean_spot",
@@ -646,7 +682,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = vacuum.DOMAIN
-    config = DEFAULT_CONFIG
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -655,7 +691,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = vacuum.DOMAIN
-    config = DEFAULT_CONFIG
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -691,7 +727,7 @@ async def test_encoding_subscribable_topics(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         vacuum.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY[vacuum.DOMAIN],
         topic,
         value,
         attribute,
@@ -703,8 +739,21 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = vacuum.DOMAIN
-    config = deepcopy(DEFAULT_CONFIG)
+    config = deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
     assert hass.states.get(f"{platform}.test") is not None
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = vacuum.DOMAIN
+    config = deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -88,8 +88,8 @@ DEFAULT_CONFIG = {
 
 DEFAULT_CONFIG_2 = {mqtt.DOMAIN: {vacuum.DOMAIN: {"schema": "state", "name": "test"}}}
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[vacuum.DOMAIN][CONF_PLATFORM] = mqtt.DOMAIN
 DEFAULT_CONFIG_2_LEGACY = deepcopy(DEFAULT_CONFIG_2[mqtt.DOMAIN])
@@ -738,8 +738,8 @@ async def test_setup_manual_entity_from_yaml(hass):
     assert hass.states.get(f"{platform}.test") is not None
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = vacuum.DOMAIN

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import switch
+from homeassistant.components import mqtt, switch
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_DEVICE_CLASS,
@@ -51,6 +51,10 @@ from tests.common import async_fire_mqtt_message, mock_restore_cache
 from tests.components.switch import common
 
 DEFAULT_CONFIG = {
+    mqtt.DOMAIN: {switch.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
+}
+
+DEFAULT_CONFIG_LEGACY = {
     switch.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
 
@@ -66,16 +70,17 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
-        switch.DOMAIN,
+        mqtt.DOMAIN,
         {
-            switch.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_on": 1,
-                "payload_off": 0,
-                "device_class": "switch",
+            mqtt.DOMAIN: {
+                switch.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_on": 1,
+                    "payload_off": 0,
+                    "device_class": "switch",
+                }
             }
         },
     )
@@ -112,15 +117,16 @@ async def test_sending_mqtt_commands_and_optimistic(
 
     assert await async_setup_component(
         hass,
-        switch.DOMAIN,
+        mqtt.DOMAIN,
         {
-            switch.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "payload_on": "beer on",
-                "payload_off": "beer off",
-                "qos": "2",
+            mqtt.DOMAIN: {
+                switch.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                    "payload_on": "beer on",
+                    "payload_off": "beer off",
+                    "qos": "2",
+                }
             }
         },
     )
@@ -155,12 +161,13 @@ async def test_sending_inital_state_and_optimistic(
     """Test the initial state in optimistic mode."""
     assert await async_setup_component(
         hass,
-        switch.DOMAIN,
+        mqtt.DOMAIN,
         {
-            switch.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
+            mqtt.DOMAIN: {
+                switch.DOMAIN: {
+                    "name": "test",
+                    "command_topic": "command-topic",
+                }
             }
         },
     )
@@ -178,16 +185,17 @@ async def test_controlling_state_via_topic_and_json_message(
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
-        switch.DOMAIN,
+        mqtt.DOMAIN,
         {
-            switch.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_on": "beer on",
-                "payload_off": "beer off",
-                "value_template": "{{ value_json.val }}",
+            mqtt.DOMAIN: {
+                switch.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_on": "beer on",
+                    "payload_off": "beer off",
+                    "value_template": "{{ value_json.val }}",
+                }
             }
         },
     )
@@ -218,14 +226,14 @@ async def test_availability_when_connection_lost(
 ):
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
-        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
-        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -281,17 +289,18 @@ async def test_custom_state_payload(hass, mqtt_mock_entry_with_yaml_config):
     """Test the state payload."""
     assert await async_setup_component(
         hass,
-        switch.DOMAIN,
+        mqtt.DOMAIN,
         {
-            switch.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "state-topic",
-                "command_topic": "command-topic",
-                "payload_on": 1,
-                "payload_off": 0,
-                "state_on": "HIGH",
-                "state_off": "LOW",
+            mqtt.DOMAIN: {
+                switch.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "payload_on": 1,
+                    "payload_off": 0,
+                    "state_on": "HIGH",
+                    "state_off": "LOW",
+                }
             }
         },
     )
@@ -318,7 +327,7 @@ async def test_setting_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -327,14 +336,14 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 ):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG, {}
+        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY, {}
     )
 
 
 async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
-        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -343,7 +352,11 @@ async def test_update_with_json_attrs_not_dict(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, switch.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        switch.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -352,14 +365,22 @@ async def test_update_with_json_attrs_bad_JSON(
 ):
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_JSON(
-        hass, mqtt_mock_entry_with_yaml_config, caplog, switch.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_with_yaml_config,
+        caplog,
+        switch.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
 async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
-        hass, mqtt_mock_entry_no_yaml_config, caplog, switch.DOMAIN, DEFAULT_CONFIG
+        hass,
+        mqtt_mock_entry_no_yaml_config,
+        caplog,
+        switch.DOMAIN,
+        DEFAULT_CONFIG_LEGACY,
     )
 
 
@@ -404,8 +425,8 @@ async def test_discovery_update_switch_topic_template(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered switch."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[switch.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[switch.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[switch.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[switch.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
     config1["state_topic"] = "switch/state1"
@@ -441,8 +462,8 @@ async def test_discovery_update_switch_template(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
     """Test update of discovered switch."""
-    config1 = copy.deepcopy(DEFAULT_CONFIG[switch.DOMAIN])
-    config2 = copy.deepcopy(DEFAULT_CONFIG[switch.DOMAIN])
+    config1 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[switch.DOMAIN])
+    config2 = copy.deepcopy(DEFAULT_CONFIG_LEGACY[switch.DOMAIN])
     config1["name"] = "Beer"
     config2["name"] = "Milk"
     config1["state_topic"] = "switch/state1"
@@ -512,42 +533,42 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT switch device registry integration."""
     await help_test_entity_device_info_with_connection(
-        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT switch device registry integration."""
     await help_test_entity_device_info_with_identifier(
-        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry update."""
     await help_test_entity_device_info_update(
-        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
-        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
 async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
+        hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG_LEGACY
     )
 
 
@@ -557,7 +578,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
         hass,
         mqtt_mock_entry_no_yaml_config,
         switch.DOMAIN,
-        DEFAULT_CONFIG,
+        DEFAULT_CONFIG_LEGACY,
         switch.SERVICE_TURN_ON,
     )
 
@@ -593,7 +614,7 @@ async def test_publishing_with_custom_encoding(
 ):
     """Test publishing MQTT payload with different encoding."""
     domain = switch.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
 
     await help_test_publishing_with_custom_encoding(
         hass,
@@ -612,7 +633,7 @@ async def test_publishing_with_custom_encoding(
 async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
     """Test reloading the MQTT platform."""
     domain = switch.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable(
         hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, domain, config
     )
@@ -621,7 +642,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 async def test_reloadable_late(hass, mqtt_client_mock, caplog, tmp_path):
     """Test reloading the MQTT platform with late entry setup."""
     domain = switch.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_reloadable_late(hass, caplog, tmp_path, domain, config)
 
 
@@ -646,7 +667,7 @@ async def test_encoding_subscribable_topics(
         mqtt_mock_entry_with_yaml_config,
         caplog,
         switch.DOMAIN,
-        DEFAULT_CONFIG[switch.DOMAIN],
+        DEFAULT_CONFIG_LEGACY[switch.DOMAIN],
         topic,
         value,
         attribute,
@@ -657,7 +678,7 @@ async def test_encoding_subscribable_topics(
 async def test_setup_manual_entity_from_yaml(hass):
     """Test setup manual configured MQTT entity."""
     platform = switch.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[platform])
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[platform])
     config["name"] = "test"
     del config["platform"]
     await help_test_setup_manual_entity_from_yaml(hass, platform, config)
@@ -667,7 +688,20 @@ async def test_setup_manual_entity_from_yaml(hass):
 async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     """Test unloading the config entry."""
     domain = switch.DOMAIN
-    config = DEFAULT_CONFIG[domain]
+    config = DEFAULT_CONFIG_LEGACY[domain]
     await help_test_unload_config_entry_with_platform(
         hass, mqtt_mock_entry_with_yaml_config, tmp_path, domain, config
     )
+
+
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
+    """Test a setup with deprecated yaml platform schema."""
+    domain = switch.DOMAIN
+    config = copy.deepcopy(DEFAULT_CONFIG_LEGACY[domain])
+    config["name"] = "test"
+    assert await async_setup_component(hass, domain, {domain: config})
+    await hass.async_block_till_done()
+    await mqtt_mock_entry_with_yaml_config()
+    assert hass.states.get(f"{domain}.test") is not None

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -54,8 +54,8 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {switch.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
 DEFAULT_CONFIG_LEGACY[switch.DOMAIN]["platform"] = mqtt.DOMAIN
 
@@ -695,8 +695,8 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-# YAML configuration under the platform key is deprecated.
-# Support and will be removed as with HA 2022.12
+# Test deprecated YAML configuration under the platform key
+# Scheduled to be removed in HA core 2022.12
 async def test_setup_with_legacy_schema(hass, mqtt_mock_entry_with_yaml_config):
     """Test a setup with deprecated yaml platform schema."""
     domain = switch.DOMAIN

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -54,9 +54,10 @@ DEFAULT_CONFIG = {
     mqtt.DOMAIN: {switch.DOMAIN: {"name": "test", "command_topic": "test-topic"}}
 }
 
-DEFAULT_CONFIG_LEGACY = {
-    switch.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
-}
+# YAML configuration under the platform key is deprecated.
+# Support and will be removed as with HA 2022.12
+DEFAULT_CONFIG_LEGACY = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
+DEFAULT_CONFIG_LEGACY[switch.DOMAIN]["platform"] = mqtt.DOMAIN
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the legacy schema is going to be removed with HA 2022.12.0 we need to update the tests to use the modern schema.
This PR will be the start of adopting the the modern schema.

The tests for the MQTT integration rely mainly on yaml the deprecated platform schema. For al platform tests a new `DEFAULT_CONFIG` will be defined, a clone without the `platform` attribute.
`DEFAULT_CONFIG_LEGACY` will hold the default config for the deprecated schema.
A new test will be added temporary to still test setup with the deprecated schema: `test_setup_with_legacy_schema`.
So all (common)tests that are not converted yet to the new schema will use `DEFAULT_CONFIG_LEGACY` config until the common code is migrated.
I'll use one commit per platform to begin with. Common tests will be updated later. Finally when the support for config under the platform key is removed all tests referring to the old schema will be labeled with deprecation comment.  

This is a follow up for https://github.com/home-assistant/core/pull/77387

A PR for the common tests can be found here: https://github.com/home-assistant/core/pull/77583


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
