### PR TITLE
Fix lutron_caseta handling of 'None' serials for RA3/QSX zones

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -375,7 +375,7 @@ class LutronCasetaDevice(Entity):
         return self._device["serial"]
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return the unique ID of the device (serial)."""
         return str(self._handle_none_serial(self.serial))
 

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -337,6 +337,7 @@ class LutronCasetaDevice(Entity):
         self._device = device
         self._smartbridge = bridge
         self._bridge_device = bridge_device
+        self._bridge_serial = bridge_device["serial"]
         self._bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
         if "serial" not in self._device:
             return
@@ -366,11 +367,15 @@ class LutronCasetaDevice(Entity):
     @property
     def serial(self):
         """Return the serial number of the device."""
+        if self._device["serial"] is None:
+            return f"{self._bridge_serial}_{self.device_id}"
         return self._device["serial"]
 
     @property
     def unique_id(self):
         """Return the unique ID of the device (serial)."""
+        if self._device["serial"] is None:
+            return f"{self._bridge_unique_id}_{self.device_id}"
         return str(self.serial)
 
     @property
@@ -386,13 +391,6 @@ class LutronCasetaDeviceUpdatableEntity(LutronCasetaDevice):
         """Update when forcing a refresh of the device."""
         self._device = self._smartbridge.get_device_by_id(self.device_id)
         _LOGGER.debug(self._device)
-
-    @property
-    def unique_id(self):
-        """Return a unique identifier if serial number is None."""
-        if self.serial is None:
-            return f"{self._bridge_unique_id}_{self.device_id}"
-        return super().unique_id
 
 
 def _id_to_identifier(lutron_id: str) -> tuple[str, str]:

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -337,14 +337,13 @@ class LutronCasetaDevice(Entity):
         self._device = device
         self._smartbridge = bridge
         self._bridge_device = bridge_device
-        self._bridge_serial = bridge_device["serial"]
         self._bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
         if "serial" not in self._device:
             return
         area, name = _area_and_name_from_name(device["name"])
         self._attr_name = full_name = f"{area} {name}"
         info = DeviceInfo(
-            identifiers={(DOMAIN, self.serial)},
+            identifiers={(DOMAIN, self.unique_id)},
             manufacturer=MANUFACTURER,
             model=f"{device['model']} ({device['type']})",
             name=full_name,
@@ -367,14 +366,14 @@ class LutronCasetaDevice(Entity):
     @property
     def serial(self):
         """Return the serial number of the device."""
-        if self._device["serial"] is None:
-            return f"{self._bridge_serial}_{self.device_id}"
         return self._device["serial"]
 
     @property
     def unique_id(self):
         """Return the unique ID of the device (serial)."""
-        return str(self.serial)
+        if self._device["serial"] is None:
+            return f'{self._bridge_device["serial"]}_{self.device_id}'
+        return str(self._device["serial"])
 
     @property
     def extra_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -374,8 +374,6 @@ class LutronCasetaDevice(Entity):
     @property
     def unique_id(self):
         """Return the unique ID of the device (serial)."""
-        if self._device["serial"] is None:
-            return f"{self._bridge_unique_id}_{self.device_id}"
         return str(self.serial)
 
     @property

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -358,7 +358,7 @@ class LutronCasetaDevice(Entity):
         """Register callbacks."""
         self._smartbridge.add_subscriber(self.device_id, self.async_write_ha_state)
 
-    def _handle_none_serial(self, serial):
+    def _handle_none_serial(self, serial: str | None) -> str | int:
         """Handle None serial returned by RA3 and QSX processors."""
         if serial is None:
             return f"{self._bridge_unique_id}_{self.device_id}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR fixes the handling of 'None' serials present in RA3 and QSX systems for the lutron_caseta component.

Previously the unique_id returned from the LutronCasetaDeviceUpdatableEntity class was handling 'None' serials, but some devices were still not getting set up correctly within HA.  The device setup would fail quietly, causing multiple entities to be listed under the incorrect device, and also causing some binary_sensor entities to not setup at all.

Moving the 'None' serial handling to the LutronCasetaDevice class fixes the problem.  The class has been modified to handle 'None' serials for returning both serial and unique_id.  Device setup now finishes properly for RA3/QSX.

Tested on RA3 Processor and Caseta Pro bridge.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
