### PR TITLE
Simplify zwave_js update entity

### DIFF
--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -118,7 +118,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         # If we have an available firmware update that is a higher version than what's
         # on the node, we should advertise it, otherwise we are on the latest version
         if (firmware := self._latest_version_firmware) and AwesomeVersion(
-            self._latest_version_firmware.version
+            firmware.version
         ) > AwesomeVersion(self.node.firmware_version):
             self._attr_latest_version = firmware.version
         else:

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -67,7 +67,6 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         """Initialize a Z-Wave device firmware update entity."""
         self.driver = driver
         self.node = node
-        self.available_firmware_updates: list[FirmwareUpdateInfo] = []
         self._latest_version_firmware: FirmwareUpdateInfo | None = None
         self._status_unsub: Callable[[], None] | None = None
 
@@ -98,12 +97,16 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             if not self._status_unsub:
                 self._status_unsub = self.node.once("wake up", self._update_on_wake_up)
             return
-        self.available_firmware_updates = (
+        if available_firmware_updates := (
             await self.driver.controller.async_get_available_firmware_updates(
                 self.node, API_KEY_FIRMWARE_UPDATE_SERVICE
             )
-        )
-        self._async_process_available_updates(write_state)
+        ):
+            self._latest_version_firmware = max(
+                available_firmware_updates,
+                key=lambda x: AwesomeVersion(x.version),
+            )
+            self._async_process_available_updates(write_state)
 
     @callback
     def _async_process_available_updates(self, write_state: bool = True) -> None:
@@ -114,18 +117,11 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         """
         # If we have an available firmware update that is a higher version than what's
         # on the node, we should advertise it, otherwise we are on the latest version
-        if self.available_firmware_updates and AwesomeVersion(
-            (
-                firmware := max(
-                    self.available_firmware_updates,
-                    key=lambda x: AwesomeVersion(x.version),
-                )
-            ).version
+        if (firmware := self._latest_version_firmware) and AwesomeVersion(
+            self._latest_version_firmware.version
         ) > AwesomeVersion(self.node.firmware_version):
-            self._latest_version_firmware = firmware
             self._attr_latest_version = firmware.version
         else:
-            self._latest_version_firmware = None
             self._attr_latest_version = self._attr_installed_version
         if write_state:
             self.async_write_ha_state()
@@ -153,7 +149,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             raise HomeAssistantError(err) from err
         else:
             self._attr_installed_version = firmware.version
-            self.available_firmware_updates.remove(firmware)
+            self._latest_version_firmware = None
             self._async_process_available_updates()
         finally:
             self._attr_in_progress = False


### PR DESCRIPTION
## Proposed change
Follow up since we no longer need to store all possible updates


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
