### PR TITLE
Fix failing unifiprotect unit tests

### DIFF
--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -492,7 +492,7 @@ async def test_camera_enable_motion(
     assert_entity_counts(hass, Platform.CAMERA, 2, 1)
     entity_id = "camera.test_camera_high"
 
-    camera.__fields__["set_motion_detection"] = Mock()
+    camera.__fields__["set_motion_detection"] = Mock(final=False)
     camera.set_motion_detection = AsyncMock()
 
     await hass.services.async_call(
@@ -514,7 +514,7 @@ async def test_camera_disable_motion(
     assert_entity_counts(hass, Platform.CAMERA, 2, 1)
     entity_id = "camera.test_camera_high"
 
-    camera.__fields__["set_motion_detection"] = Mock()
+    camera.__fields__["set_motion_detection"] = Mock(final=False)
     camera.set_motion_detection = AsyncMock()
 
     await hass.services.async_call(

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -96,7 +96,7 @@ async def test_light_turn_on(
     assert_entity_counts(hass, Platform.LIGHT, 1, 1)
 
     entity_id = "light.test_light"
-    light.__fields__["set_light"] = Mock()
+    light.__fields__["set_light"] = Mock(final=False)
     light.set_light = AsyncMock()
 
     await hass.services.async_call(
@@ -118,7 +118,7 @@ async def test_light_turn_off(
     assert_entity_counts(hass, Platform.LIGHT, 1, 1)
 
     entity_id = "light.test_light"
-    light.__fields__["set_light"] = Mock()
+    light.__fields__["set_light"] = Mock(final=False)
     light.set_light = AsyncMock()
 
     await hass.services.async_call(

--- a/tests/components/unifiprotect/test_lock.py
+++ b/tests/components/unifiprotect/test_lock.py
@@ -214,7 +214,7 @@ async def test_lock_do_lock(
     await init_entry(hass, ufp, [doorlock, unadopted_doorlock])
     assert_entity_counts(hass, Platform.LOCK, 1, 1)
 
-    doorlock.__fields__["close_lock"] = Mock()
+    doorlock.__fields__["close_lock"] = Mock(final=False)
     doorlock.close_lock = AsyncMock()
 
     await hass.services.async_call(
@@ -249,7 +249,7 @@ async def test_lock_do_unlock(
     ufp.ws_msg(mock_msg)
     await hass.async_block_till_done()
 
-    new_lock.__fields__["open_lock"] = Mock()
+    new_lock.__fields__["open_lock"] = Mock(final=False)
     new_lock.open_lock = AsyncMock()
 
     await hass.services.async_call(

--- a/tests/components/unifiprotect/test_media_player.py
+++ b/tests/components/unifiprotect/test_media_player.py
@@ -116,7 +116,7 @@ async def test_media_player_set_volume(
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.MEDIA_PLAYER, 1, 1)
 
-    doorbell.__fields__["set_speaker_volume"] = Mock()
+    doorbell.__fields__["set_speaker_volume"] = Mock(final=False)
     doorbell.set_speaker_volume = AsyncMock()
 
     await hass.services.async_call(
@@ -173,9 +173,9 @@ async def test_media_player_play(
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.MEDIA_PLAYER, 1, 1)
 
-    doorbell.__fields__["stop_audio"] = Mock()
-    doorbell.__fields__["play_audio"] = Mock()
-    doorbell.__fields__["wait_until_audio_completes"] = Mock()
+    doorbell.__fields__["stop_audio"] = Mock(final=False)
+    doorbell.__fields__["play_audio"] = Mock(final=False)
+    doorbell.__fields__["wait_until_audio_completes"] = Mock(final=False)
     doorbell.stop_audio = AsyncMock()
     doorbell.play_audio = AsyncMock()
     doorbell.wait_until_audio_completes = AsyncMock()
@@ -208,9 +208,9 @@ async def test_media_player_play_media_source(
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.MEDIA_PLAYER, 1, 1)
 
-    doorbell.__fields__["stop_audio"] = Mock()
-    doorbell.__fields__["play_audio"] = Mock()
-    doorbell.__fields__["wait_until_audio_completes"] = Mock()
+    doorbell.__fields__["stop_audio"] = Mock(final=False)
+    doorbell.__fields__["play_audio"] = Mock(final=False)
+    doorbell.__fields__["wait_until_audio_completes"] = Mock(final=False)
     doorbell.stop_audio = AsyncMock()
     doorbell.play_audio = AsyncMock()
     doorbell.wait_until_audio_completes = AsyncMock()
@@ -247,7 +247,7 @@ async def test_media_player_play_invalid(
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.MEDIA_PLAYER, 1, 1)
 
-    doorbell.__fields__["play_audio"] = Mock()
+    doorbell.__fields__["play_audio"] = Mock(final=False)
     doorbell.play_audio = AsyncMock()
 
     with pytest.raises(HomeAssistantError):
@@ -276,8 +276,8 @@ async def test_media_player_play_error(
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.MEDIA_PLAYER, 1, 1)
 
-    doorbell.__fields__["play_audio"] = Mock()
-    doorbell.__fields__["wait_until_audio_completes"] = Mock()
+    doorbell.__fields__["play_audio"] = Mock(final=False)
+    doorbell.__fields__["wait_until_audio_completes"] = Mock(final=False)
     doorbell.play_audio = AsyncMock(side_effect=StreamError)
     doorbell.wait_until_audio_completes = AsyncMock()
 

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -673,7 +673,7 @@ async def test_browse_media_browse_whole_month(
 ):
     """Test events for a specific day."""
 
-    fixed_now = fixed_now.replace(month=11)
+    fixed_now = fixed_now.replace(month=10)
     last_month = fixed_now.replace(day=1) - timedelta(days=1)
     ufp.api.bootstrap._recording_start = last_month
 

--- a/tests/components/unifiprotect/test_number.py
+++ b/tests/components/unifiprotect/test_number.py
@@ -153,7 +153,7 @@ async def test_number_light_sensitivity(
     description = LIGHT_NUMBERS[0]
     assert description.ufp_set_method is not None
 
-    light.__fields__["set_sensitivity"] = Mock()
+    light.__fields__["set_sensitivity"] = Mock(final=False)
     light.set_sensitivity = AsyncMock()
 
     _, entity_id = ids_from_device_description(Platform.NUMBER, light, description)
@@ -175,7 +175,7 @@ async def test_number_light_duration(
 
     description = LIGHT_NUMBERS[1]
 
-    light.__fields__["set_duration"] = Mock()
+    light.__fields__["set_duration"] = Mock(final=False)
     light.set_duration = AsyncMock()
 
     _, entity_id = ids_from_device_description(Platform.NUMBER, light, description)
@@ -201,7 +201,7 @@ async def test_number_camera_simple(
 
     assert description.ufp_set_method is not None
 
-    camera.__fields__[description.ufp_set_method] = Mock()
+    camera.__fields__[description.ufp_set_method] = Mock(final=False)
     setattr(camera, description.ufp_set_method, AsyncMock())
     set_method = getattr(camera, description.ufp_set_method)
 
@@ -224,7 +224,7 @@ async def test_number_lock_auto_close(
 
     description = DOORLOCK_NUMBERS[0]
 
-    doorlock.__fields__["set_auto_close_time"] = Mock()
+    doorlock.__fields__["set_auto_close_time"] = Mock(final=False)
     doorlock.set_auto_close_time = AsyncMock()
 
     _, entity_id = ids_from_device_description(Platform.NUMBER, doorlock, description)

--- a/tests/components/unifiprotect/test_select.py
+++ b/tests/components/unifiprotect/test_select.py
@@ -255,7 +255,7 @@ async def test_select_update_doorbell_settings(
 
     expected_length += 1
     new_nvr = copy(ufp.api.bootstrap.nvr)
-    new_nvr.__fields__["update_all_messages"] = Mock()
+    new_nvr.__fields__["update_all_messages"] = Mock(final=False)
     new_nvr.update_all_messages = Mock()
 
     new_nvr.doorbell_settings.all_messages = [
@@ -325,7 +325,7 @@ async def test_select_set_option_light_motion(
 
     _, entity_id = ids_from_device_description(Platform.SELECT, light, LIGHT_SELECTS[0])
 
-    light.__fields__["set_light_settings"] = Mock()
+    light.__fields__["set_light_settings"] = Mock(final=False)
     light.set_light_settings = AsyncMock()
 
     await hass.services.async_call(
@@ -350,7 +350,7 @@ async def test_select_set_option_light_camera(
 
     _, entity_id = ids_from_device_description(Platform.SELECT, light, LIGHT_SELECTS[1])
 
-    light.__fields__["set_paired_camera"] = Mock()
+    light.__fields__["set_paired_camera"] = Mock(final=False)
     light.set_paired_camera = AsyncMock()
 
     camera = list(light.api.bootstrap.cameras.values())[0]
@@ -386,7 +386,7 @@ async def test_select_set_option_camera_recording(
         Platform.SELECT, doorbell, CAMERA_SELECTS[0]
     )
 
-    doorbell.__fields__["set_recording_mode"] = Mock()
+    doorbell.__fields__["set_recording_mode"] = Mock(final=False)
     doorbell.set_recording_mode = AsyncMock()
 
     await hass.services.async_call(
@@ -411,7 +411,7 @@ async def test_select_set_option_camera_ir(
         Platform.SELECT, doorbell, CAMERA_SELECTS[1]
     )
 
-    doorbell.__fields__["set_ir_led_model"] = Mock()
+    doorbell.__fields__["set_ir_led_model"] = Mock(final=False)
     doorbell.set_ir_led_model = AsyncMock()
 
     await hass.services.async_call(
@@ -436,7 +436,7 @@ async def test_select_set_option_camera_doorbell_custom(
         Platform.SELECT, doorbell, CAMERA_SELECTS[2]
     )
 
-    doorbell.__fields__["set_lcd_text"] = Mock()
+    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
     doorbell.set_lcd_text = AsyncMock()
 
     await hass.services.async_call(
@@ -463,7 +463,7 @@ async def test_select_set_option_camera_doorbell_unifi(
         Platform.SELECT, doorbell, CAMERA_SELECTS[2]
     )
 
-    doorbell.__fields__["set_lcd_text"] = Mock()
+    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
     doorbell.set_lcd_text = AsyncMock()
 
     await hass.services.async_call(
@@ -505,7 +505,7 @@ async def test_select_set_option_camera_doorbell_default(
         Platform.SELECT, doorbell, CAMERA_SELECTS[2]
     )
 
-    doorbell.__fields__["set_lcd_text"] = Mock()
+    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
     doorbell.set_lcd_text = AsyncMock()
 
     await hass.services.async_call(
@@ -534,7 +534,7 @@ async def test_select_set_option_viewer(
         Platform.SELECT, viewer, VIEWER_SELECTS[0]
     )
 
-    viewer.__fields__["set_liveview"] = Mock()
+    viewer.__fields__["set_liveview"] = Mock(final=False)
     viewer.set_liveview = AsyncMock()
 
     liveview = list(viewer.api.bootstrap.liveviews.values())[0]
@@ -561,7 +561,7 @@ async def test_select_service_doorbell_invalid(
         Platform.SELECT, doorbell, CAMERA_SELECTS[1]
     )
 
-    doorbell.__fields__["set_lcd_text"] = Mock()
+    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
     doorbell.set_lcd_text = AsyncMock()
 
     with pytest.raises(HomeAssistantError):
@@ -587,7 +587,7 @@ async def test_select_service_doorbell_success(
         Platform.SELECT, doorbell, CAMERA_SELECTS[2]
     )
 
-    doorbell.__fields__["set_lcd_text"] = Mock()
+    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
     doorbell.set_lcd_text = AsyncMock()
 
     await hass.services.async_call(
@@ -624,7 +624,7 @@ async def test_select_service_doorbell_with_reset(
     await init_entry(hass, ufp, [doorbell])
     assert_entity_counts(hass, Platform.SELECT, 4, 4)
 
-    doorbell.__fields__["set_lcd_text"] = Mock()
+    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
     doorbell.set_lcd_text = AsyncMock()
 
     await hass.services.async_call(

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -49,7 +49,7 @@ async def test_global_service_bad_device(hass: HomeAssistant, ufp: MockUFPFixtur
     """Test global service, invalid device ID."""
 
     nvr = ufp.api.bootstrap.nvr
-    nvr.__fields__["add_custom_doorbell_message"] = Mock()
+    nvr.__fields__["add_custom_doorbell_message"] = Mock(final=False)
     nvr.add_custom_doorbell_message = AsyncMock()
 
     with pytest.raises(HomeAssistantError):
@@ -68,7 +68,7 @@ async def test_global_service_exception(
     """Test global service, unexpected error."""
 
     nvr = ufp.api.bootstrap.nvr
-    nvr.__fields__["add_custom_doorbell_message"] = Mock()
+    nvr.__fields__["add_custom_doorbell_message"] = Mock(final=False)
     nvr.add_custom_doorbell_message = AsyncMock(side_effect=BadRequest)
 
     with pytest.raises(HomeAssistantError):
@@ -87,7 +87,7 @@ async def test_add_doorbell_text(
     """Test add_doorbell_text service."""
 
     nvr = ufp.api.bootstrap.nvr
-    nvr.__fields__["add_custom_doorbell_message"] = Mock()
+    nvr.__fields__["add_custom_doorbell_message"] = Mock(final=False)
     nvr.add_custom_doorbell_message = AsyncMock()
 
     await hass.services.async_call(
@@ -105,7 +105,7 @@ async def test_remove_doorbell_text(
     """Test remove_doorbell_text service."""
 
     nvr = ufp.api.bootstrap.nvr
-    nvr.__fields__["remove_custom_doorbell_message"] = Mock()
+    nvr.__fields__["remove_custom_doorbell_message"] = Mock(final=False)
     nvr.remove_custom_doorbell_message = AsyncMock()
 
     await hass.services.async_call(
@@ -123,7 +123,7 @@ async def test_set_default_doorbell_text(
     """Test set_default_doorbell_text service."""
 
     nvr = ufp.api.bootstrap.nvr
-    nvr.__fields__["set_default_doorbell_message"] = Mock()
+    nvr.__fields__["set_default_doorbell_message"] = Mock(final=False)
     nvr.set_default_doorbell_message = AsyncMock()
 
     await hass.services.async_call(

--- a/tests/components/unifiprotect/test_switch.py
+++ b/tests/components/unifiprotect/test_switch.py
@@ -78,7 +78,7 @@ async def test_switch_nvr(hass: HomeAssistant, ufp: MockUFPFixture):
     assert_entity_counts(hass, Platform.SWITCH, 2, 2)
 
     nvr = ufp.api.bootstrap.nvr
-    nvr.__fields__["set_insights"] = Mock()
+    nvr.__fields__["set_insights"] = Mock(final=False)
     nvr.set_insights = AsyncMock()
     entity_id = "switch.unifiprotect_insights_enabled"
 
@@ -264,7 +264,7 @@ async def test_switch_light_status(
 
     description = LIGHT_SWITCHES[1]
 
-    light.__fields__["set_status_light"] = Mock()
+    light.__fields__["set_status_light"] = Mock(final=False)
     light.set_status_light = AsyncMock()
 
     _, entity_id = ids_from_device_description(Platform.SWITCH, light, description)
@@ -292,7 +292,7 @@ async def test_switch_camera_ssh(
 
     description = CAMERA_SWITCHES[0]
 
-    doorbell.__fields__["set_ssh"] = Mock()
+    doorbell.__fields__["set_ssh"] = Mock(final=False)
     doorbell.set_ssh = AsyncMock()
 
     _, entity_id = ids_from_device_description(Platform.SWITCH, doorbell, description)
@@ -325,7 +325,7 @@ async def test_switch_camera_simple(
 
     assert description.ufp_set_method is not None
 
-    doorbell.__fields__[description.ufp_set_method] = Mock()
+    doorbell.__fields__[description.ufp_set_method] = Mock(final=False)
     setattr(doorbell, description.ufp_set_method, AsyncMock())
     set_method = getattr(doorbell, description.ufp_set_method)
 
@@ -354,7 +354,7 @@ async def test_switch_camera_highfps(
 
     description = CAMERA_SWITCHES[3]
 
-    doorbell.__fields__["set_video_mode"] = Mock()
+    doorbell.__fields__["set_video_mode"] = Mock(final=False)
     doorbell.set_video_mode = AsyncMock()
 
     _, entity_id = ids_from_device_description(Platform.SWITCH, doorbell, description)
@@ -385,7 +385,7 @@ async def test_switch_camera_privacy(
 
     description = PRIVACY_MODE_SWITCH
 
-    doorbell.__fields__["set_privacy"] = Mock()
+    doorbell.__fields__["set_privacy"] = Mock(final=False)
     doorbell.set_privacy = AsyncMock()
 
     _, entity_id = ids_from_device_description(Platform.SWITCH, doorbell, description)
@@ -437,7 +437,7 @@ async def test_switch_camera_privacy_already_on(
 
     description = PRIVACY_MODE_SWITCH
 
-    doorbell.__fields__["set_privacy"] = Mock()
+    doorbell.__fields__["set_privacy"] = Mock(final=False)
     doorbell.set_privacy = AsyncMock()
 
     _, entity_id = ids_from_device_description(Platform.SWITCH, doorbell, description)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix failing unifiprotect unit tests related to recent pydantic upgrade.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
