### PR TITLE
ZHA Yellow config flow fixes

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -50,6 +50,7 @@ from .core.const import (
     DATA_ZHA,
     DATA_ZHA_GATEWAY,
     DOMAIN,
+    EZSP_OVERWRITE_EUI64,
     GROUP_ID,
     GROUP_IDS,
     GROUP_NAME,
@@ -1140,7 +1141,7 @@ async def websocket_restore_network_backup(
 
     if msg["ezsp_force_write_eui64"]:
         backup.network_info.stack_specific.setdefault("ezsp", {})[
-            "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it"
+            EZSP_OVERWRITE_EUI64
         ] = True
 
     # This can take 30-40s

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -599,9 +599,6 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Confirm a discovery."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is not None or not onboarding.async_is_onboarded(self.hass):
             if not await self._detect_radio_type():
                 # This path probably will not happen now that we have

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -697,20 +697,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
         self._device_path = device_settings.pop(CONF_DEVICE_PATH)
         self._device_settings = device_settings
 
-        self._set_confirm_only()
-        return await self.async_step_confirm_hardware()
-
-    async def async_step_confirm_hardware(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Confirm a hardware discovery."""
-        if user_input is not None or not onboarding.async_is_onboarded(self.hass):
-            return await self._async_create_radio_entity()
-
-        return self.async_show_form(
-            step_id="confirm_hardware",
-            description_placeholders={CONF_NAME: self._title},
-        )
+        return await self.async_step_choose_formation_strategy()
 
 
 class ZhaOptionsFlowHandler(BaseZhaFlow, config_entries.OptionsFlow):

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -35,6 +35,7 @@ from .core.const import (
     DATA_ZHA_CONFIG,
     DEFAULT_DATABASE_NAME,
     DOMAIN,
+    EZSP_OVERWRITE_EUI64,
     RadioType,
 )
 
@@ -91,9 +92,7 @@ def _allow_overwrite_ezsp_ieee(
 ) -> zigpy.backups.NetworkBackup:
     """Return a new backup with the flag to allow overwriting the EZSP EUI64."""
     new_stack_specific = copy.deepcopy(backup.network_info.stack_specific)
-    new_stack_specific.setdefault("ezsp", {})[
-        "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it"
-    ] = True
+    new_stack_specific.setdefault("ezsp", {})[EZSP_OVERWRITE_EUI64] = True
 
     return backup.replace(
         network_info=backup.network_info.replace(stack_specific=new_stack_specific)
@@ -108,9 +107,7 @@ def _prevent_overwrite_ezsp_ieee(
         return backup
 
     new_stack_specific = copy.deepcopy(backup.network_info.stack_specific)
-    new_stack_specific.setdefault("ezsp", {}).pop(
-        "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it", None
-    )
+    new_stack_specific.setdefault("ezsp", {}).pop(EZSP_OVERWRITE_EUI64, None)
 
     return backup.replace(
         network_info=backup.network_info.replace(stack_specific=new_stack_specific)

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -602,6 +602,9 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Confirm a discovery."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
         if user_input is not None or not onboarding.async_is_onboarded(self.hass):
             if not await self._detect_radio_type():
                 # This path probably will not happen now that we have
@@ -664,10 +667,12 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
         """Handle hardware flow."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
+
         if not data:
             return self.async_abort(reason="invalid_hardware_data")
         if data.get("radio_type") != "efr32":
             return self.async_abort(reason="invalid_hardware_data")
+
         self._radio_type = RadioType.ezsp
 
         schema = {

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -694,7 +694,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
             return self.async_abort(reason="invalid_hardware_data")
 
         self._title = data.get("name", data["port"]["path"])
-        self._device_path = device_settings.pop(CONF_DEVICE_PATH)
+        self._device_path = device_settings[CONF_DEVICE_PATH]
         self._device_settings = device_settings
 
         return await self.async_step_choose_formation_strategy()

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -412,3 +412,7 @@ class Strobe(t.enum8):
 
 STARTUP_FAILURE_DELAY_S = 3
 STARTUP_RETRIES = 3
+
+EZSP_OVERWRITE_EUI64 = (
+    "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it"
+)

--- a/tests/components/homeassistant_yellow/conftest.py
+++ b/tests/components/homeassistant_yellow/conftest.py
@@ -1,13 +1,28 @@
 """Test fixtures for the Home Assistant Yellow integration."""
-from unittest.mock import patch
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_zha():
-    """Mock the zha integration."""
+def mock_zha_config_flow_setup() -> Generator[None, None, None]:
+    """Mock the radio connection and probing of the ZHA config flow."""
+
+    def mock_probe(config: dict[str, Any]) -> None:
+        # The radio probing will return the correct baudrate
+        return {**config, "baudrate": 115200}
+
+    mock_connect_app = MagicMock()
+    mock_connect_app.__aenter__.return_value.backups.backups = []
+
     with patch(
+        "bellows.zigbee.application.ControllerApplication.probe", side_effect=mock_probe
+    ), patch(
+        "homeassistant.components.zha.config_flow.BaseZhaFlow._connect_zigpy_app",
+        return_value=mock_connect_app,
+    ), patch(
         "homeassistant.components.zha.async_setup_entry",
         return_value=True,
     ):

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -34,6 +34,7 @@ from homeassistant.components.zha.core.const import (
     CLUSTER_TYPE_IN,
     DATA_ZHA,
     DATA_ZHA_GATEWAY,
+    EZSP_OVERWRITE_EUI64,
     GROUP_ID,
     GROUP_IDS,
     GROUP_NAME,
@@ -709,11 +710,7 @@ async def test_restore_network_backup_force_write_eui64(app_controller, zha_clie
     p.assert_called_once_with(
         backup.replace(
             network_info=backup.network_info.replace(
-                stack_specific={
-                    "ezsp": {
-                        "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it": True
-                    }
-                }
+                stack_specific={"ezsp": {EZSP_OVERWRITE_EUI64: True}}
             )
         )
     )

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -21,6 +21,7 @@ from homeassistant.components.zha.core.const import (
     CONF_FLOWCONTROL,
     CONF_RADIO_TYPE,
     DOMAIN,
+    EZSP_OVERWRITE_EUI64,
     RadioType,
 )
 from homeassistant.config_entries import (
@@ -968,25 +969,18 @@ def test_allow_overwrite_ezsp_ieee():
     new_backup = config_flow._allow_overwrite_ezsp_ieee(backup)
 
     assert backup != new_backup
-    assert (
-        new_backup.network_info.stack_specific["ezsp"][
-            "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it"
-        ]
-        is True
-    )
+    assert new_backup.network_info.stack_specific["ezsp"][EZSP_OVERWRITE_EUI64] is True
 
 
 def test_prevent_overwrite_ezsp_ieee():
     """Test modifying the backup to prevent bellows from overriding the IEEE address."""
     backup = zigpy.backups.NetworkBackup()
-    backup.network_info.stack_specific["ezsp"] = {
-        "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it": True
-    }
+    backup.network_info.stack_specific["ezsp"] = {EZSP_OVERWRITE_EUI64: True}
     new_backup = config_flow._prevent_overwrite_ezsp_ieee(backup)
 
     assert backup != new_backup
     assert not new_backup.network_info.stack_specific.get("ezsp", {}).get(
-        "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it"
+        EZSP_OVERWRITE_EUI64
     )
 
 
@@ -1356,9 +1350,7 @@ async def test_ezsp_restore_without_settings_change_ieee(
     mock_app.state.network_info.network_key.tx_counter += 10000
 
     # Include the overwrite option, just in case someone uploads a backup with it
-    backup.network_info.metadata["ezsp"] = {
-        "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it": True
-    }
+    backup.network_info.metadata["ezsp"] = {EZSP_OVERWRITE_EUI64: True}
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the ZHA config flow's discovery and handling of the Yellow.  It previously bypassed the formation strategy flow entirely.

Unit tests for ZHA, Yellow, and SkyConnect pass locally, as does discovery on the Yellow itself.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
