### PR TITLE
Add ZHA config flow single instance checks for zeroconf and hardware

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -564,10 +564,6 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
         # Without confirmation, discovery can automatically progress into parts of the
         # config flow logic that interacts with hardware!
         if user_input is not None or not onboarding.async_is_onboarded(self.hass):
-            # One last time, check if ZHA is already configured before touching hardware
-            if self._async_current_entries():
-                return self.async_abort(reason="single_instance_allowed")
-
             # Probe the radio type if we don't have one yet
             if self._radio_type is None and not await self._detect_radio_type():
                 # This path probably will not happen now that we have

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -107,22 +107,31 @@ async def test_zeroconf_discovery_znp(hass):
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
     )
+    assert flow["step_id"] == "confirm"
+
+    # Confirm discovery
     result1 = await hass.config_entries.flow.async_configure(
         flow["flow_id"], user_input={}
     )
+    assert result1["step_id"] == "manual_port_config"
 
-    assert result1["type"] == FlowResultType.MENU
-    assert result1["step_id"] == "choose_formation_strategy"
-
+    # Confirm port settings
     result2 = await hass.config_entries.flow.async_configure(
-        result1["flow_id"],
+        result1["flow_id"], user_input={}
+    )
+
+    assert result2["type"] == FlowResultType.MENU
+    assert result2["step_id"] == "choose_formation_strategy"
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "socket://192.168.1.200:6638"
-    assert result2["data"] == {
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "socket://192.168.1.200:6638"
+    assert result3["data"] == {
         CONF_DEVICE: {
             CONF_BAUDRATE: 115200,
             CONF_FLOWCONTROL: None,
@@ -148,22 +157,31 @@ async def test_zigate_via_zeroconf(setup_entry_mock, hass):
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
     )
+    assert flow["step_id"] == "confirm"
+
+    # Confirm discovery
     result1 = await hass.config_entries.flow.async_configure(
         flow["flow_id"], user_input={}
     )
+    assert result1["step_id"] == "manual_port_config"
 
-    assert result1["type"] == FlowResultType.MENU
-    assert result1["step_id"] == "choose_formation_strategy"
-
+    # Confirm port settings
     result2 = await hass.config_entries.flow.async_configure(
-        result1["flow_id"],
+        result1["flow_id"], user_input={}
+    )
+
+    assert result2["type"] == FlowResultType.MENU
+    assert result2["step_id"] == "choose_formation_strategy"
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "socket://192.168.1.200:1234"
-    assert result2["data"] == {
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "socket://192.168.1.200:1234"
+    assert result3["data"] == {
         CONF_DEVICE: {
             CONF_DEVICE_PATH: "socket://192.168.1.200:1234",
         },
@@ -187,22 +205,31 @@ async def test_efr32_via_zeroconf(hass):
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
     )
+    assert flow["step_id"] == "confirm"
+
+    # Confirm discovery
     result1 = await hass.config_entries.flow.async_configure(
         flow["flow_id"], user_input={}
     )
+    assert result1["step_id"] == "manual_port_config"
 
-    assert result1["type"] == FlowResultType.MENU
-    assert result1["step_id"] == "choose_formation_strategy"
-
+    # Confirm port settings
     result2 = await hass.config_entries.flow.async_configure(
-        result1["flow_id"],
+        result1["flow_id"], user_input={}
+    )
+
+    assert result2["type"] == FlowResultType.MENU
+    assert result2["step_id"] == "choose_formation_strategy"
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "socket://192.168.1.200:6638"
-    assert result2["data"] == {
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "socket://192.168.1.200:6638"
+    assert result3["data"] == {
         CONF_DEVICE: {
             CONF_DEVICE_PATH: "socket://192.168.1.200:6638",
             CONF_BAUDRATE: 115200,
@@ -293,15 +320,16 @@ async def test_discovery_via_usb(hass):
         description="zigbee radio",
         manufacturer="test",
     )
-    result = await hass.config_entries.flow.async_init(
+    result1 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USB}, data=discovery_info
     )
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm"
+
+    assert result1["type"] == FlowResultType.FORM
+    assert result1["step_id"] == "confirm"
 
     result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
+        result1["flow_id"], user_input={}
     )
     await hass.async_block_till_done()
 
@@ -878,17 +906,30 @@ async def test_hardware(onboarded, hass):
             DOMAIN, context={"source": "hardware"}, data=data
         )
 
-    assert result1["type"] == FlowResultType.MENU
-    assert result1["step_id"] == "choose_formation_strategy"
+    if onboarded:
+        # Confirm discovery
+        assert result1["type"] == FlowResultType.FORM
+        assert result1["step_id"] == "confirm"
 
-    result2 = await hass.config_entries.flow.async_configure(
-        result1["flow_id"],
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            user_input={},
+        )
+    else:
+        # No need to confirm
+        result2 = result1
+
+    assert result2["type"] == FlowResultType.MENU
+    assert result2["step_id"] == "choose_formation_strategy"
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result2["title"] == "Yellow"
-    assert result2["data"] == {
+    assert result3["title"] == "Yellow"
+    assert result3["data"] == {
         CONF_DEVICE: {
             CONF_BAUDRATE: 115200,
             CONF_FLOWCONTROL: "hardware",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure all ZHA discovery steps abort with `single_instance` if an existing ZHA entry exists and explicitly confirm setup. This fixes a regression with #77044 for `hardware` where a radio was probed without user input and an existing bug for `zeroconf` that allowed for multiple ZHA config entries to be erroneously created.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
