### PR TITLE
Fix setting and reading percentage for MIOT based fans

### DIFF
--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -112,6 +112,15 @@ MODELS_FAN_MIOT = [
     MODEL_FAN_ZA5,
 ]
 
+# number of speed levels each fan has
+SPEEDS_FAN_MIOT = {
+    MODEL_FAN_1C: 3,
+    MODEL_FAN_P10: 4,
+    MODEL_FAN_P11: 4,
+    MODEL_FAN_P9: 4,
+    MODEL_FAN_ZA5: 4,
+}
+
 MODELS_PURIFIER_MIOT = [
     MODEL_AIRPURIFIER_3,
     MODEL_AIRPURIFIER_3C,

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -980,7 +980,6 @@ class XiaomiFan(XiaomiGenericFan):
             )
         self._percentage = percentage
 
-        # NOTE: this is broken, is_on is never set
         if not self.is_on:
             await self.async_turn_on()
         else:
@@ -1105,7 +1104,7 @@ class XiaomiFanMiot(XiaomiGenericFan):
         )
 
         # if the fan is not on, we have to turn it on first
-        if not self._state:
+        if not self.is_on:
             await self.async_turn_on()
 
         await self._try_command(

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -1107,13 +1107,15 @@ class XiaomiFanMiot(XiaomiGenericFan):
         if not self.is_on:
             await self.async_turn_on()
 
-        await self._try_command(
+        result = await self._try_command(
             "Setting fan speed percentage of the miio device failed.",
             self._device.set_speed,
             speed,
         )
-        self._percentage = percentage
-        self.async_write_ha_state()
+
+        if result:
+            self._percentage = ranged_value_to_percentage((1, self._speed_count), speed)
+            self.async_write_ha_state()
 
 
 class XiaomiFanZA5(XiaomiFanMiot):

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -334,7 +334,6 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn the device on."""
-        _LOGGER.warning("TRYING TO TURN ON")
         result = await self._try_command(
             "Turning the miio device on failed.", self._device.on
         )
@@ -346,7 +345,6 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
             await self.async_set_preset_mode(preset_mode)
 
         if result:
-            _LOGGER.warning("RESULT WAS OK")
             self._state = True
             self.async_write_ha_state()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
I'm not actually sure if this is considered a breaking change as it's current state is actually broken. 
However, if your automation relied on setting 1% to 4% to set the levels of the fan to the min, mid and max levels, then this will break it as 1% to 4% will now be mapped to level 1 (see below for behavior before and after). 


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Current behavior: 
setting 1, 2, 3 or 4 as percentage value strictly sets the level of miot fans (depending on model 3 or 4 is max). This means if you want to set the fan to the max power, you have to set it to 3% or 4% depending on your model. 
Additionally according to the code, the fan is supposed to turn on when you select a percentage. However, the fan needs to be turned on already to execute speed values (setting the value and then turning it on does not work as it seems). 

New behavior: 
All percentage values are mapped to the corresponding levels (the percentage is split into equal parts according to amount of levels the fan supports). Additionally the fan is turned on first if it was turned off and the speed is set immediately afterwards. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75811
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
