### PR TITLE
Warn user if Tasmota devices are configured with invalid MQTT topics

### DIFF
--- a/homeassistant/components/tasmota/discovery.py
+++ b/homeassistant/components/tasmota/discovery.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 import logging
+from typing import TypedDict, cast
 
+from hatasmota import const as tasmota_const
 from hatasmota.discovery import (
     TasmotaDiscovery,
     get_device_config as tasmota_get_device_config,
@@ -17,11 +19,16 @@ from hatasmota.entity import TasmotaEntityConfig
 from hatasmota.models import DiscoveryHashType, TasmotaDeviceConfig
 from hatasmota.mqtt import TasmotaMQTTClient
 from hatasmota.sensor import TasmotaBaseSensorConfig
+from hatasmota.utils import get_topic_command, get_topic_stat
 
 from homeassistant.components import sensor
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_registry import async_entries_for_device
 
@@ -30,9 +37,12 @@ from .const import DOMAIN, PLATFORMS
 _LOGGER = logging.getLogger(__name__)
 
 ALREADY_DISCOVERED = "tasmota_discovered_components"
+DISCOVERY_DATA = "tasmota_discovery_data"
 TASMOTA_DISCOVERY_ENTITY_NEW = "tasmota_discovery_entity_new_{}"
 TASMOTA_DISCOVERY_ENTITY_UPDATED = "tasmota_discovery_entity_updated_{}_{}_{}_{}"
 TASMOTA_DISCOVERY_INSTANCE = "tasmota_discovery_instance"
+
+MQTT_TOPIC_URL = "https://tasmota.github.io/docs/Home-Assistant/#tasmota-integration"
 
 SetupDeviceCallback = Callable[[TasmotaDeviceConfig, str], Awaitable[None]]
 
@@ -52,7 +62,64 @@ def set_discovery_hash(hass: HomeAssistant, discovery_hash: DiscoveryHashType) -
     hass.data[ALREADY_DISCOVERED][discovery_hash] = {}
 
 
-async def async_start(
+def warn_if_topic_duplicated(
+    hass: HomeAssistant,
+    command_topic: str,
+    own_mac: str | None,
+    own_device_config: TasmotaDeviceConfig,
+) -> bool:
+    """Log and create repairs issue if several devices share the same topic."""
+    duplicated = False
+    offenders = []
+    for other_mac, other_config in hass.data[DISCOVERY_DATA].items():
+        if own_mac and other_mac == own_mac:
+            continue
+        if command_topic == get_topic_command(other_config):
+            offenders.append((other_mac, tasmota_get_device_config(other_config)))
+    issue_id = f"topic_duplicated_{command_topic}"
+    if offenders:
+        if own_mac:
+            offenders.append((own_mac, own_device_config))
+        offender_strings = [
+            f"'{cfg[tasmota_const.CONF_NAME]}' ({cfg[tasmota_const.CONF_IP]})"
+            for _, cfg in offenders
+        ]
+        _LOGGER.warning(
+            "Multiple Tasmota devices are sharing the same topic '%s'. Offending devices: %s",
+            command_topic,
+            ", ".join(offender_strings),
+        )
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            data={
+                "key": "topic_duplicated",
+                "mac": " ".join([mac for mac, _ in offenders]),
+                "topic": command_topic,
+            },
+            is_fixable=False,
+            learn_more_url=MQTT_TOPIC_URL,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="topic_duplicated",
+            translation_placeholders={
+                "topic": command_topic,
+                "offenders": "\n\n* " + "\n\n* ".join(offender_strings),
+            },
+        )
+        duplicated = True
+    return duplicated
+
+
+class DuplicatedTopicIssueData(TypedDict):
+    """Typed result dict."""
+
+    key: str
+    mac: str
+    topic: str
+
+
+async def async_start(  # noqa: C901
     hass: HomeAssistant,
     discovery_topic: str,
     config_entry: ConfigEntry,
@@ -121,7 +188,70 @@ async def async_start(
         tasmota_device_config = tasmota_get_device_config(payload)
         await setup_device(tasmota_device_config, mac)
 
+        hass.data[DISCOVERY_DATA][mac] = payload
+
+        add_entities = True
+
+        command_topic = get_topic_command(payload) if payload else None
+        state_topic = get_topic_stat(payload) if payload else None
+
+        # Create or clear issue if topic is missing prefix
+        issue_id = f"topic_no_prefix_{mac}"
+        if payload and command_topic == state_topic:
+            _LOGGER.warning(
+                "Tasmota device '%s' with IP %s doesn't set %%prefix%% in its topic",
+                tasmota_device_config[tasmota_const.CONF_NAME],
+                tasmota_device_config[tasmota_const.CONF_IP],
+            )
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                issue_id,
+                data={"key": "topic_no_prefix"},
+                is_fixable=False,
+                learn_more_url=MQTT_TOPIC_URL,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="topic_no_prefix",
+                translation_placeholders={
+                    "name": tasmota_device_config[tasmota_const.CONF_NAME],
+                    "ip": tasmota_device_config[tasmota_const.CONF_IP],
+                },
+            )
+            add_entities = False
+        else:
+            ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+        # Clear previous issues caused by duplicated topic
+        issue_reg = ir.async_get(hass)
+        tasmota_issues = [
+            issue for key, issue in issue_reg.issues.items() if key[0] == DOMAIN
+        ]
+        for issue in tasmota_issues:
+            if issue.data and issue.data["key"] == "topic_duplicated":
+                issue_data: DuplicatedTopicIssueData = cast(
+                    DuplicatedTopicIssueData, issue.data
+                )
+                macs = issue_data["mac"].split()
+                if mac not in macs:
+                    continue
+                if payload and command_topic == issue_data["topic"]:
+                    continue
+                if len(macs) > 2:
+                    # This device is no longer duplicated, update the issue
+                    warn_if_topic_duplicated(hass, issue_data["topic"], None, {})
+                    continue
+                ir.async_delete_issue(hass, DOMAIN, issue.issue_id)
+
         if not payload:
+            return
+
+        # Warn and add issues if there are duplicated topics
+        if warn_if_topic_duplicated(hass, command_topic, mac, tasmota_device_config):
+            add_entities = False
+
+        if not add_entities:
+            # Add the device entry so the user can identify the device, but do not add
+            # entities or triggers
             return
 
         tasmota_triggers = tasmota_get_triggers(payload)
@@ -194,6 +324,7 @@ async def async_start(
                 entity_registry.async_remove(entity_id)
 
     hass.data[ALREADY_DISCOVERED] = {}
+    hass.data[DISCOVERY_DATA] = {}
 
     tasmota_discovery = TasmotaDiscovery(discovery_topic, tasmota_mqtt)
     await tasmota_discovery.start_discovery(

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.6.0"],
+  "requirements": ["hatasmota==0.6.1"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"],

--- a/homeassistant/components/tasmota/strings.json
+++ b/homeassistant/components/tasmota/strings.json
@@ -16,5 +16,15 @@
     "error": {
       "invalid_discovery_topic": "Invalid discovery topic prefix."
     }
+  },
+  "issues": {
+    "topic_duplicated": {
+      "title": "Several Tasmota devices are sharing the same topic",
+      "description": "Several Tasmota devices are sharing the topic {topic}.\n\n Tasmota devices with this problem: {offenders}."
+    },
+    "topic_no_prefix": {
+      "title": "Tasmota device {name} has an invalid MQTT topic",
+      "description": "Tasmota device {name} with IP {ip} does not include `%prefix%` in its fulltopic.\n\nEntities for this devices are disabled until the configuration has been corrected."
+    }
   }
 }

--- a/homeassistant/components/tasmota/translations/en.json
+++ b/homeassistant/components/tasmota/translations/en.json
@@ -16,5 +16,15 @@
                 "description": "Do you want to set up Tasmota?"
             }
         }
+    },
+    "issues": {
+        "topic_duplicated": {
+            "description": "Several Tasmota devices are sharing the topic {topic}.\n\n Tasmota devices with this problem: {offenders}.",
+            "title": "Several Tasmota devices are sharing the same topic"
+        },
+        "topic_no_prefix": {
+            "description": "Tasmota device {name} with IP {ip} does not include `%prefix%` in its fulltopic.\n\nEntities for this devices are disabled until the configuration has been corrected.",
+            "title": "Tasmota device {name} has an invalid MQTT topic"
+        }
     }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -821,7 +821,7 @@ hass-nabucasa==0.55.0
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.6.0
+hatasmota==0.6.1
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -607,7 +607,7 @@ hangups==0.4.18
 hass-nabucasa==0.55.0
 
 # homeassistant.components.tasmota
-hatasmota==0.6.0
+hatasmota==0.6.1
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Warn user if Tasmota devices are configured with invalid MQTT topics:
  - Create repairs issue + log warning if topic is missing %prefix%
  - Create repairs issue + log warning if multiple devices share the same topic
 
Bump hatasmota from 0.6.0 to 0.6.1

Changes:

- 0.6.1 (https://github.com/emontnemery/hatasmota/releases/tag/0.6.1)
   - https://github.com/emontnemery/hatasmota/pull/175

Git compare: https://github.com/emontnemery/hatasmota/compare/0.6.0..0.6.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
