### PR TITLE
Use attributes in kef media player

### DIFF
--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -219,7 +219,7 @@ class KefMediaPlayer(MediaPlayerEntity):
         self._muted = None
         self._source = None
         self._volume = None
-        self._is_online = None
+        self._attr_available = False
         self._dsp = None
         self._update_dsp_task_remover = None
 
@@ -251,8 +251,8 @@ class KefMediaPlayer(MediaPlayerEntity):
         """Update latest state."""
         _LOGGER.debug("Running async_update")
         try:
-            self._is_online = await self._speaker.is_online()
-            if self._is_online:
+            self._attr_available = await self._speaker.is_online()
+            if self.available:
                 (
                     self._volume,
                     self._muted,
@@ -293,11 +293,6 @@ class KefMediaPlayer(MediaPlayerEntity):
     def source_list(self):
         """List of available input sources."""
         return self._sources
-
-    @property
-    def available(self):
-        """Return if the speaker is reachable online."""
-        return self._is_online
 
     @property
     def unique_id(self):

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -203,7 +203,7 @@ class KefMediaPlayer(MediaPlayerEntity):
     ):
         """Initialize the media player."""
         self._attr_name = name
-        self._sources = sources
+        self._attr_source_list = sources
         self._speaker = AsyncKefSpeaker(
             host,
             port,
@@ -262,11 +262,6 @@ class KefMediaPlayer(MediaPlayerEntity):
             _LOGGER.debug("Error in `update`: %s", err)
             self._attr_state = None
 
-    @property
-    def source_list(self):
-        """List of available input sources."""
-        return self._sources
-
     async def async_turn_off(self) -> None:
         """Turn the media player off."""
         await self._speaker.turn_off()
@@ -298,7 +293,7 @@ class KefMediaPlayer(MediaPlayerEntity):
 
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
-        if source in self.source_list:
+        if self.source_list is not None and source in self.source_list:
             await self._speaker.set_source(source)
         else:
             raise ValueError(f"Unknown input source: {source}.")

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -218,7 +218,6 @@ class KefMediaPlayer(MediaPlayerEntity):
         self._speaker_type = speaker_type
 
         self._muted = None
-        self._volume = None
         self._attr_available = False
         self._dsp = None
         self._update_dsp_task_remover = None
@@ -244,7 +243,7 @@ class KefMediaPlayer(MediaPlayerEntity):
             self._attr_available = await self._speaker.is_online()
             if self.available:
                 (
-                    self._volume,
+                    self._attr_volume_level,
                     self._muted,
                 ) = await self._speaker.get_volume_and_is_muted()
                 state = await self._speaker.get_state()
@@ -258,16 +257,11 @@ class KefMediaPlayer(MediaPlayerEntity):
             else:
                 self._muted = None
                 self._attr_source = None
-                self._volume = None
+                self._attr_volume_level = None
                 self._attr_state = MediaPlayerState.OFF
         except (ConnectionError, TimeoutError) as err:
             _LOGGER.debug("Error in `update`: %s", err)
             self._attr_state = None
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1)."""
-        return self._volume
 
     @property
     def is_volume_muted(self):

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -217,7 +217,6 @@ class KefMediaPlayer(MediaPlayerEntity):
         self._supports_on = supports_on
         self._speaker_type = speaker_type
 
-        self._muted = None
         self._attr_available = False
         self._dsp = None
         self._update_dsp_task_remover = None
@@ -244,7 +243,7 @@ class KefMediaPlayer(MediaPlayerEntity):
             if self.available:
                 (
                     self._attr_volume_level,
-                    self._muted,
+                    self._attr_is_volume_muted,
                 ) = await self._speaker.get_volume_and_is_muted()
                 state = await self._speaker.get_state()
                 self._attr_source = state.source
@@ -255,18 +254,13 @@ class KefMediaPlayer(MediaPlayerEntity):
                     # Only do this when necessary because it is a slow operation
                     await self.update_dsp()
             else:
-                self._muted = None
+                self._attr_is_volume_muted = None
                 self._attr_source = None
                 self._attr_volume_level = None
                 self._attr_state = MediaPlayerState.OFF
         except (ConnectionError, TimeoutError) as err:
             _LOGGER.debug("Error in `update`: %s", err)
             self._attr_state = None
-
-    @property
-    def is_volume_muted(self):
-        """Boolean if volume is currently muted."""
-        return self._muted
 
     @property
     def source_list(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use attr_available in kef media player
As follow-up to #77594

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
