### PR TITLE
Treat schedule time range as open ended, [FROM, to]

### DIFF
--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -291,17 +291,17 @@ class Schedule(Entity):
         todays_schedule = self._config.get(WEEKDAY_TO_CONF[now.weekday()], [])
 
         # Determine current schedule state
-        self._attr_state = next(
-            (
-                STATE_ON
-                for time_range in todays_schedule
-                if time_range[CONF_FROM] <= now.time()
-                and (
-                    now.time() < time_range[CONF_TO] or time_range[CONF_TO] == time.max
-                )
-            ),
-            STATE_OFF,
-        )
+        for time_range in todays_schedule:
+            # The current time should be greater or equal to CONF_FROM.
+            if now.time() < time_range[CONF_FROM]:
+                continue
+            # The current time should be smaller (and not equal) to CONF_TO.
+            # Note that any time in the day is treated as smaller than time.max.
+            if now.time() < time_range[CONF_TO] or time_range[CONF_TO] == time.max:
+                self._attr_state = STATE_ON
+                break
+        else:
+            self._attr_state = STATE_OFF
 
         # Find next event in the schedule, loop over each day (starting with
         # the current day) until the next event has been found.

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -225,21 +225,10 @@ async def test_events_one_day(
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-11T07:00:00-07:00"
 
 
-@pytest.mark.parametrize(
-    "sun_schedule, mon_schedule",
-    (
-        (
-            {CONF_FROM: "23:00:00", CONF_TO: "24:00:00"},
-            {CONF_FROM: "00:00:00", CONF_TO: "01:00:00"},
-        ),
-    ),
-)
-async def test_adjacent(
+async def test_adjacent_cross_midnight(
     hass: HomeAssistant,
     schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
     caplog: pytest.LogCaptureFixture,
-    sun_schedule: dict[str, str],
-    mon_schedule: dict[str, str],
     freezer,
 ) -> None:
     """Test adjacent events don't toggle on->off->on."""
@@ -251,8 +240,8 @@ async def test_adjacent(
                 "from_yaml": {
                     CONF_NAME: "from yaml",
                     CONF_ICON: "mdi:party-popper",
-                    CONF_SUNDAY: sun_schedule,
-                    CONF_MONDAY: mon_schedule,
+                    CONF_SUNDAY: {CONF_FROM: "23:00:00", CONF_TO: "24:00:00"},
+                    CONF_MONDAY: {CONF_FROM: "00:00:00", CONF_TO: "01:00:00"},
                 }
             }
         },
@@ -289,6 +278,69 @@ async def test_adjacent(
     assert state
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-11T23:00:00-07:00"
+
+    await hass.async_block_till_done()
+    assert len(state_changes) == 3
+    for event in state_changes[:-1]:
+        assert event.data["new_state"].state == STATE_ON
+    assert state_changes[2].data["new_state"].state == STATE_OFF
+
+
+async def test_adjacent_within_day(
+    hass: HomeAssistant,
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+    caplog: pytest.LogCaptureFixture,
+    freezer,
+) -> None:
+    """Test adjacent events don't toggle on->off->on."""
+    freezer.move_to("2022-08-30 13:20:00-07:00")
+
+    assert await schedule_setup(
+        config={
+            DOMAIN: {
+                "from_yaml": {
+                    CONF_NAME: "from yaml",
+                    CONF_ICON: "mdi:party-popper",
+                    CONF_SUNDAY: [
+                        {CONF_FROM: "22:00:00", CONF_TO: "22:30:00"},
+                        {CONF_FROM: "22:30:00", CONF_TO: "23:00:00"},
+                    ],
+                }
+            }
+        },
+        items=[],
+    )
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-04T22:00:00-07:00"
+
+    state_changes = async_capture_events(hass, EVENT_STATE_CHANGED)
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-04T22:30:00-07:00"
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-04T23:00:00-07:00"
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-11T22:00:00-07:00"
 
     await hass.async_block_till_done()
     assert len(state_changes) == 3

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -349,6 +349,78 @@ async def test_adjacent_within_day(
     assert state_changes[2].data["new_state"].state == STATE_OFF
 
 
+async def test_non_adjacent_within_day(
+    hass: HomeAssistant,
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+    caplog: pytest.LogCaptureFixture,
+    freezer,
+) -> None:
+    """Test adjacent events don't toggle on->off->on."""
+    freezer.move_to("2022-08-30 13:20:00-07:00")
+
+    assert await schedule_setup(
+        config={
+            DOMAIN: {
+                "from_yaml": {
+                    CONF_NAME: "from yaml",
+                    CONF_ICON: "mdi:party-popper",
+                    CONF_SUNDAY: [
+                        {CONF_FROM: "22:00:00", CONF_TO: "22:15:00"},
+                        {CONF_FROM: "22:30:00", CONF_TO: "23:00:00"},
+                    ],
+                }
+            }
+        },
+        items=[],
+    )
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-04T22:00:00-07:00"
+
+    state_changes = async_capture_events(hass, EVENT_STATE_CHANGED)
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-04T22:15:00-07:00"
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-04T22:30:00-07:00"
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-04T23:00:00-07:00"
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-11T22:00:00-07:00"
+
+    await hass.async_block_till_done()
+    assert len(state_changes) == 4
+    assert state_changes[0].data["new_state"].state == STATE_ON
+    assert state_changes[1].data["new_state"].state == STATE_OFF
+    assert state_changes[2].data["new_state"].state == STATE_ON
+    assert state_changes[3].data["new_state"].state == STATE_OFF
+
+
 @pytest.mark.parametrize(
     "schedule",
     (

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -221,7 +221,7 @@ async def test_events_one_day(
 
     state = hass.states.get(f"{DOMAIN}.from_yaml")
     assert state
-    assert state.state == STATE_ON
+    assert state.state == STATE_OFF
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-11T07:00:00-07:00"
 
 
@@ -272,17 +272,6 @@ async def test_adjacent(
     state = hass.states.get(f"{DOMAIN}.from_yaml")
     assert state
     assert state.state == STATE_ON
-    assert (
-        state.attributes[ATTR_NEXT_EVENT].isoformat()
-        == "2022-09-04T23:59:59.999999-07:00"
-    )
-
-    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
-    async_fire_time_changed(hass)
-
-    state = hass.states.get(f"{DOMAIN}.from_yaml")
-    assert state
-    assert state.state == STATE_ON
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-05T00:00:00-07:00"
 
     freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
@@ -298,13 +287,14 @@ async def test_adjacent(
 
     state = hass.states.get(f"{DOMAIN}.from_yaml")
     assert state
-    assert state.state == STATE_ON
+    assert state.state == STATE_OFF
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-11T23:00:00-07:00"
 
     await hass.async_block_till_done()
-    assert len(state_changes) == 4
-    for event in state_changes:
+    assert len(state_changes) == 3
+    for event in state_changes[:-1]:
         assert event.data["new_state"].state == STATE_ON
+    assert state_changes[2].data["new_state"].state == STATE_OFF
 
 
 @pytest.mark.parametrize(
@@ -348,17 +338,14 @@ async def test_to_midnight(
     state = hass.states.get(f"{DOMAIN}.from_yaml")
     assert state
     assert state.state == STATE_ON
-    assert (
-        state.attributes[ATTR_NEXT_EVENT].isoformat()
-        == "2022-09-04T23:59:59.999999-07:00"
-    )
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-05T00:00:00-07:00"
 
     freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
     async_fire_time_changed(hass)
 
     state = hass.states.get(f"{DOMAIN}.from_yaml")
     assert state
-    assert state.state == STATE_ON
+    assert state.state == STATE_OFF
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == "2022-09-11T00:00:00-07:00"
 
 
@@ -490,8 +477,8 @@ async def test_ws_delete(
     "to, next_event, saved_to",
     (
         ("23:59:59", "2022-08-10T23:59:59-07:00", "23:59:59"),
-        ("24:00", "2022-08-10T23:59:59.999999-07:00", "24:00:00"),
-        ("24:00:00", "2022-08-10T23:59:59.999999-07:00", "24:00:00"),
+        ("24:00", "2022-08-11T00:00:00-07:00", "24:00:00"),
+        ("24:00:00", "2022-08-11T00:00:00-07:00", "24:00:00"),
     ),
 )
 async def test_update(
@@ -560,8 +547,8 @@ async def test_update(
     "to, next_event, saved_to",
     (
         ("14:00:00", "2022-08-15T14:00:00-07:00", "14:00:00"),
-        ("24:00", "2022-08-15T23:59:59.999999-07:00", "24:00:00"),
-        ("24:00:00", "2022-08-15T23:59:59.999999-07:00", "24:00:00"),
+        ("24:00", "2022-08-16T00:00:00-07:00", "24:00:00"),
+        ("24:00:00", "2022-08-16T00:00:00-07:00", "24:00:00"),
     ),
 )
 async def test_ws_create(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The old implementation treated the time interval as closed, meaning it included both endpoints FROM and TO.
However, the state gets updated only on these timestamps and therefore will never get back to OFF.
So, the 1st changed was to treat the time range as [FROM, TO).
However, this broke the special case of "24:00:00", so there is an additional fix for that as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #77628 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
