### PR TITLE
Adjust litterrobot platform loading/unloading

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -22,7 +22,7 @@ PLATFORMS_BY_TYPE = {
 }
 
 
-def get_platforms_for_robots(robots: list[Robot]) -> set[str]:
+def get_platforms_for_robots(robots: list[Robot]) -> set[Platform]:
     """Get platforms for robots."""
     return {
         platform

--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -1,7 +1,7 @@
 """The Litter-Robot integration."""
 from __future__ import annotations
 
-from pylitterbot import FeederRobot, LitterRobot, LitterRobot3, LitterRobot4
+from pylitterbot import FeederRobot, LitterRobot, LitterRobot3, Robot
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -10,41 +10,27 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .hub import LitterRobotHub
 
-PLATFORMS = [
-    Platform.BUTTON,
-    Platform.SELECT,
-    Platform.SENSOR,
-    Platform.SWITCH,
-    Platform.VACUUM,
-]
-
 PLATFORMS_BY_TYPE = {
-    LitterRobot: (
-        Platform.SELECT,
-        Platform.SENSOR,
-        Platform.SWITCH,
-        Platform.VACUUM,
-    ),
-    LitterRobot3: (
-        Platform.BUTTON,
-        Platform.SELECT,
-        Platform.SENSOR,
-        Platform.SWITCH,
-        Platform.VACUUM,
-    ),
-    LitterRobot4: (
-        Platform.SELECT,
-        Platform.SENSOR,
-        Platform.SWITCH,
-        Platform.VACUUM,
-    ),
-    FeederRobot: (
-        Platform.BUTTON,
+    Robot: (
         Platform.SELECT,
         Platform.SENSOR,
         Platform.SWITCH,
     ),
+    LitterRobot: (Platform.VACUUM,),
+    LitterRobot3: (Platform.BUTTON,),
+    FeederRobot: (Platform.BUTTON,),
 }
+
+
+def get_platforms_for_robots(robots: list[Robot]) -> set[str]:
+    """Get platforms for robots."""
+    return {
+        platform
+        for robot in robots
+        for robot_type, platforms in PLATFORMS_BY_TYPE.items()
+        if isinstance(robot, robot_type)
+        for platform in platforms
+    }
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -53,21 +39,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hub = hass.data[DOMAIN][entry.entry_id] = LitterRobotHub(hass, entry.data)
     await hub.login(load_robots=True)
 
-    platforms: set[str] = set()
-    for robot in hub.account.robots:
-        platforms.update(PLATFORMS_BY_TYPE[type(robot)])
-    if platforms:
+    if platforms := get_platforms_for_robots(hub.account.robots):
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
     hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
     await hub.account.disconnect()
+
+    platforms = get_platforms_for_robots(hub.account.robots)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, platforms)
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -99,8 +99,8 @@ async def setup_integration(
     with patch(
         "homeassistant.components.litterrobot.hub.Account", return_value=mock_account
     ), patch(
-        "homeassistant.components.litterrobot.PLATFORMS",
-        [platform_domain] if platform_domain else [],
+        "homeassistant.components.litterrobot.PLATFORMS_BY_TYPE",
+        {Robot: (platform_domain,)} if platform_domain else {},
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -52,6 +52,7 @@ async def test_vacuum(hass: HomeAssistant, mock_account: MagicMock) -> None:
     assert ent_reg_entry.unique_id == VACUUM_UNIQUE_ID_OLD
 
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
+    assert len(ent_reg.entities) == 1
     assert hass.services.has_service(DOMAIN, SERVICE_SET_SLEEP_MODE)
 
     vacuum = hass.states.get(VACUUM_ENTITY_ID)
@@ -78,9 +79,15 @@ async def test_no_robots(
     hass: HomeAssistant, mock_account_with_no_robots: MagicMock
 ) -> None:
     """Tests the vacuum entity was set up."""
-    await setup_integration(hass, mock_account_with_no_robots, PLATFORM_DOMAIN)
+    entry = await setup_integration(hass, mock_account_with_no_robots, PLATFORM_DOMAIN)
 
     assert not hass.services.has_service(DOMAIN, SERVICE_SET_SLEEP_MODE)
+
+    ent_reg = er.async_get(hass)
+    assert len(ent_reg.entities) == 0
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
 
 async def test_vacuum_with_error(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust platform loading/unloading to handle accounts with no robots
Also fixes a regression in loading only specific platforms in tests introduced in https://github.com/home-assistant/core/pull/77497

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
