### PR TITLE
Add serial_number to device registry entries

### DIFF
--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -167,6 +167,7 @@ def _entry_dict(entry):
         "model": entry.model,
         "name_by_user": entry.name_by_user,
         "name": entry.name,
+        "serial_number": entry.serial_number,
         "sw_version": entry.sw_version,
         "via_device_id": entry.via_device_id,
     }

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -34,7 +34,7 @@ DATA_REGISTRY = "device_registry"
 EVENT_DEVICE_REGISTRY_UPDATED = "device_registry_updated"
 STORAGE_KEY = "core.device_registry"
 STORAGE_VERSION_MAJOR = 1
-STORAGE_VERSION_MINOR = 3
+STORAGE_VERSION_MINOR = 4
 SAVE_DELAY = 10
 CLEANUP_DELAY = 10
 
@@ -90,6 +90,7 @@ class DeviceEntry:
     model: str | None = attr.ib(default=None)
     name_by_user: str | None = attr.ib(default=None)
     name: str | None = attr.ib(default=None)
+    serial_number: str | None = attr.ib(default=None)
     suggested_area: str | None = attr.ib(default=None)
     sw_version: str | None = attr.ib(default=None)
     via_device_id: str | None = attr.ib(default=None)
@@ -204,6 +205,10 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                 # Introduced in 2022.2
                 for device in old_data["devices"]:
                     device["hw_version"] = device.get("hw_version")
+            if old_minor_version < 4:
+                # Introduced in 2022.10
+                for device in old_data["devices"]:
+                    device["serial_number"] = device.get("serial_number")
 
         if old_major_version > 1:
             raise NotImplementedError
@@ -323,6 +328,7 @@ class DeviceRegistry:
         manufacturer: str | None | UndefinedType = UNDEFINED,
         model: str | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
+        serial_number: str | None | UndefinedType = UNDEFINED,
         suggested_area: str | None | UndefinedType = UNDEFINED,
         sw_version: str | None | UndefinedType = UNDEFINED,
         via_device: tuple[str, str] | None = None,
@@ -388,6 +394,7 @@ class DeviceRegistry:
             merge_identifiers=identifiers or UNDEFINED,
             model=model,
             name=name,
+            serial_number=serial_number,
             suggested_area=suggested_area,
             sw_version=sw_version,
             via_device_id=via_device_id,
@@ -417,6 +424,7 @@ class DeviceRegistry:
         name: str | None | UndefinedType = UNDEFINED,
         new_identifiers: set[tuple[str, str]] | UndefinedType = UNDEFINED,
         remove_config_entry_id: str | UndefinedType = UNDEFINED,
+        serial_number: str | None | UndefinedType = UNDEFINED,
         suggested_area: str | None | UndefinedType = UNDEFINED,
         sw_version: str | None | UndefinedType = UNDEFINED,
         via_device_id: str | None | UndefinedType = UNDEFINED,
@@ -501,6 +509,7 @@ class DeviceRegistry:
             ("model", model),
             ("name", name),
             ("name_by_user", name_by_user),
+            ("serial_number", serial_number),
             ("suggested_area", suggested_area),
             ("sw_version", sw_version),
             ("via_device_id", via_device_id),
@@ -591,6 +600,7 @@ class DeviceRegistry:
                     model=device["model"],
                     name_by_user=device["name_by_user"],
                     name=device["name"],
+                    serial_number=device["serial_number"],
                     sw_version=device["sw_version"],
                     via_device_id=device["via_device_id"],
                 )
@@ -634,6 +644,7 @@ class DeviceRegistry:
                 "model": entry.model,
                 "name_by_user": entry.name_by_user,
                 "name": entry.name,
+                "serial_number": entry.serial_number,
                 "sw_version": entry.sw_version,
                 "via_device_id": entry.via_device_id,
             }

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -64,6 +64,7 @@ async def test_list_devices(hass, client, registry):
             "model": "model",
             "name_by_user": None,
             "name": None,
+            "serial_number": None,
             "sw_version": None,
             "via_device_id": None,
         },
@@ -80,6 +81,7 @@ async def test_list_devices(hass, client, registry):
             "model": "model",
             "name_by_user": None,
             "name": None,
+            "serial_number": None,
             "sw_version": None,
             "via_device_id": dev1,
         },
@@ -106,6 +108,7 @@ async def test_list_devices(hass, client, registry):
             "model": "model",
             "name_by_user": None,
             "name": None,
+            "serial_number": None,
             "sw_version": None,
             "via_device_id": None,
         }

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -189,6 +189,7 @@ async def test_loading_from_storage(hass, hass_storage):
                     "model": "model",
                     "name_by_user": "Test Friendly Name",
                     "name": "name",
+                    "serial_number": "serial_no",
                     "sw_version": "version",
                     "via_device_id": None,
                 }
@@ -231,6 +232,7 @@ async def test_loading_from_storage(hass, hass_storage):
         model="model",
         name_by_user="Test Friendly Name",
         name="name",
+        serial_number="serial_no",
         suggested_area=None,  # Not stored
         sw_version="version",
     )
@@ -261,8 +263,8 @@ async def test_loading_from_storage(hass, hass_storage):
 
 
 @pytest.mark.parametrize("load_registries", [False])
-async def test_migration_1_1_to_1_3(hass, hass_storage):
-    """Test migration from version 1.1 to 1.3."""
+async def test_migration_1_1_to_1_4(hass, hass_storage):
+    """Test migration from version 1.1 to 1.4."""
     hass_storage[device_registry.STORAGE_KEY] = {
         "version": 1,
         "minor_version": 1,
@@ -350,6 +352,7 @@ async def test_migration_1_1_to_1_3(hass, hass_storage):
                     "model": "model",
                     "name": "name",
                     "name_by_user": None,
+                    "serial_number": None,
                     "sw_version": "new_version",
                     "via_device_id": None,
                 },
@@ -367,6 +370,7 @@ async def test_migration_1_1_to_1_3(hass, hass_storage):
                     "model": None,
                     "name_by_user": None,
                     "name": None,
+                    "serial_number": None,
                     "sw_version": None,
                     "via_device_id": None,
                 },
@@ -385,8 +389,8 @@ async def test_migration_1_1_to_1_3(hass, hass_storage):
 
 
 @pytest.mark.parametrize("load_registries", [False])
-async def test_migration_1_2_to_1_3(hass, hass_storage):
-    """Test migration from version 1.2 to 1.3."""
+async def test_migration_1_2_to_1_4(hass, hass_storage):
+    """Test migration from version 1.2 to 1.4."""
     hass_storage[device_registry.STORAGE_KEY] = {
         "version": 1,
         "minor_version": 2,
@@ -473,6 +477,7 @@ async def test_migration_1_2_to_1_3(hass, hass_storage):
                     "model": "model",
                     "name": "name",
                     "name_by_user": None,
+                    "serial_number": None,
                     "sw_version": "new_version",
                     "via_device_id": None,
                 },
@@ -490,6 +495,126 @@ async def test_migration_1_2_to_1_3(hass, hass_storage):
                     "model": None,
                     "name_by_user": None,
                     "name": None,
+                    "serial_number": None,
+                    "sw_version": None,
+                    "via_device_id": None,
+                },
+            ],
+            "deleted_devices": [],
+        },
+    }
+
+
+@pytest.mark.parametrize("load_registries", [False])
+async def test_migration_1_3_to_1_4(hass, hass_storage):
+    """Test migration from version 1.3 to 1.4."""
+    hass_storage[device_registry.STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 3,
+        "key": device_registry.STORAGE_KEY,
+        "data": {
+            "devices": [
+                {
+                    "area_id": None,
+                    "config_entries": ["1234"],
+                    "configuration_url": None,
+                    "connections": [["Zigbee", "01.23.45.67.89"]],
+                    "disabled_by": None,
+                    "entry_type": "service",
+                    "hw_version": "hw_version",
+                    "id": "abcdefghijklm",
+                    "identifiers": [["serial", "12:34:56:AB:CD:EF"]],
+                    "manufacturer": "manufacturer",
+                    "model": "model",
+                    "name": "name",
+                    "name_by_user": None,
+                    "sw_version": "version",
+                    "via_device_id": None,
+                },
+                {
+                    "area_id": None,
+                    "config_entries": [None],
+                    "configuration_url": None,
+                    "connections": [],
+                    "disabled_by": None,
+                    "entry_type": None,
+                    "hw_version": None,
+                    "id": "invalid-entry-type",
+                    "identifiers": [["serial", "mock-id-invalid-entry"]],
+                    "manufacturer": None,
+                    "model": None,
+                    "name_by_user": None,
+                    "name": None,
+                    "sw_version": None,
+                    "via_device_id": None,
+                },
+            ],
+            "deleted_devices": [],
+        },
+    }
+
+    await device_registry.async_load(hass)
+    registry = device_registry.async_get(hass)
+
+    # Test data was loaded
+    entry = registry.async_get_or_create(
+        config_entry_id="1234",
+        connections={("Zigbee", "01.23.45.67.89")},
+        identifiers={("serial", "12:34:56:AB:CD:EF")},
+    )
+    assert entry.id == "abcdefghijklm"
+
+    # Update to trigger a store
+    entry = registry.async_get_or_create(
+        config_entry_id="1234",
+        connections={("Zigbee", "01.23.45.67.89")},
+        identifiers={("serial", "12:34:56:AB:CD:EF")},
+        sw_version="new_version",
+    )
+    assert entry.id == "abcdefghijklm"
+
+    # Check we store migrated data
+    await flush_store(registry._store)
+
+    assert hass_storage[device_registry.STORAGE_KEY] == {
+        "version": device_registry.STORAGE_VERSION_MAJOR,
+        "minor_version": device_registry.STORAGE_VERSION_MINOR,
+        "key": device_registry.STORAGE_KEY,
+        "data": {
+            "devices": [
+                {
+                    "area_id": None,
+                    "config_entries": ["1234"],
+                    "configuration_url": None,
+                    "connections": [["Zigbee", "01.23.45.67.89"]],
+                    "disabled_by": None,
+                    "entry_type": "service",
+                    "hw_version": "hw_version",
+                    "id": "abcdefghijklm",
+                    "identifiers": [["serial", "12:34:56:AB:CD:EF"]],
+                    "manufacturer": "manufacturer",
+                    "model": "model",
+                    "name": "name",
+                    "name_by_user": None,
+                    "serial_number": None,
+                    "sw_version": "new_version",
+                    "via_device_id": None,
+                },
+                {
+                    "area_id": None,
+                    "config_entries": [None],
+                    "configuration_url": None,
+                    "connections": [],
+                    "disabled_by": None,
+                    "entry_type": None,
+                    "hw_version": None,
+                    "id": "invalid-entry-type",
+                    "identifiers": [["serial", "mock-id-invalid-entry"]],
+                    "manufacturer": None,
+                    "model": None,
+                    "name_by_user": None,
+                    "name": None,
+                    "serial_number": None,
                     "sw_version": None,
                     "via_device_id": None,
                 },
@@ -948,6 +1073,7 @@ async def test_update(hass, registry, update_events):
             name_by_user="Test Friendly Name",
             name="name",
             new_identifiers=new_identifiers,
+            serial_number="serial_no",
             suggested_area="suggested_area",
             sw_version="version",
             via_device_id="98765B",
@@ -969,6 +1095,7 @@ async def test_update(hass, registry, update_events):
         model="Test Model",
         name_by_user="Test Friendly Name",
         name="name",
+        serial_number="serial_no",
         suggested_area="suggested_area",
         sw_version="version",
         via_device_id="98765B",
@@ -1008,6 +1135,7 @@ async def test_update(hass, registry, update_events):
         "model": None,
         "name": None,
         "name_by_user": None,
+        "serial_number": None,
         "suggested_area": None,
         "sw_version": None,
         "via_device_id": None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `serial_number` to device registry entries

The serial number can be displayed in the device card in frontend

The "identifiers" set which is part of device registry entries can't be used for this purpose because:
- they are globally unique
- we have no idea what they are, it could be a serial number, but it could also be anything else used by the backing integration

Developer documentation: https://github.com/home-assistant/developers.home-assistant/pull/1477

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
