### PR TITLE
Fix ZHA lighting initial hue/saturation attribute read

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -612,16 +612,18 @@ class Light(BaseLight, ZhaEntity):
                     and self._color_channel.enhanced_current_hue is not None
                 ):
                     curr_hue = self._color_channel.enhanced_current_hue * 65535 / 360
-                else:
+                elif self._color_channel.current_hue is not None:
                     curr_hue = self._color_channel.current_hue * 254 / 360
-                curr_saturation = self._color_channel.current_saturation
-                if curr_hue is not None and curr_saturation is not None:
-                    self._attr_hs_color = (
-                        int(curr_hue),
-                        int(curr_saturation * 2.54),
-                    )
                 else:
-                    self._attr_hs_color = (0, 0)
+                    curr_hue = 0
+
+                if (curr_saturation := self._color_channel.current_saturation) is None:
+                    curr_saturation = 0
+
+                self._attr_hs_color = (
+                    int(curr_hue),
+                    int(curr_saturation * 2.54),
+                )
 
             if self._color_channel.color_loop_supported:
                 self._attr_supported_features |= light.LightEntityFeature.EFFECT

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -2,12 +2,14 @@
 import asyncio
 from datetime import timedelta
 import math
-from unittest.mock import AsyncMock, Mock
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
 
 import zigpy.zcl
 import zigpy.zcl.foundation as zcl_f
 
 import homeassistant.components.zha.core.const as zha_const
+from homeassistant.components.zha.core.helpers import async_get_zha_config_value
 from homeassistant.helpers import entity_registry
 import homeassistant.util.dt as dt_util
 
@@ -243,3 +245,20 @@ async def async_shift_time(hass):
     next_update = dt_util.utcnow() + timedelta(seconds=11)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()
+
+
+def patch_zha_config(component: str, overrides: dict[tuple[str, str], Any]):
+    """Patch the ZHA custom configuration defaults."""
+
+    def new_get_config(config_entry, section, config_key, default):
+        if (section, config_key) in overrides:
+            return overrides[section, config_key]
+        else:
+            return async_get_zha_config_value(
+                config_entry, section, config_key, default
+            )
+
+    return patch(
+        f"homeassistant.components.zha.{component}.async_get_zha_config_value",
+        side_effect=new_get_config,
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fast ZHA initialization can cause startup with unset hue and saturation attributes, throwing an error. This PR fixes the problem by setting defaults.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #76732
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
