### PR TITLE
Support announce and enqueue in forked-daapd

### DIFF
--- a/homeassistant/components/forked_daapd/media_player.py
+++ b/homeassistant/components/forked_daapd/media_player.py
@@ -676,11 +676,14 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         if kwargs.get(ATTR_MEDIA_ANNOUNCE):
             return await self._async_announce(media_id)
 
-        if (
-            enqueue := kwargs.get(ATTR_MEDIA_ENQUEUE, MediaPlayerEnqueue.REPLACE)
-        ) is True:
-            enqueue = MediaPlayerEnqueue.ADD
-        if enqueue in {MediaPlayerEnqueue.ADD, MediaPlayerEnqueue.REPLACE}:
+        # if kwargs[ATTR_MEDIA_ENQUEUE] is None, we assume MediaPlayerEnqueue.REPLACE
+        # if kwargs[ATTR_MEDIA_ENQUEUE] is True, we assume MediaPlayerEnqueue.ADD
+        # kwargs[ATTR_MEDIA_ENQUEUE] is assumed to never be False
+        # See https://github.com/home-assistant/architecture/issues/765
+        enqueue: bool | MediaPlayerEnqueue = kwargs.get(
+            ATTR_MEDIA_ENQUEUE, MediaPlayerEnqueue.REPLACE
+        )
+        if enqueue in {True, MediaPlayerEnqueue.ADD, MediaPlayerEnqueue.REPLACE}:
             return await self._api.add_to_queue(
                 uris=media_id,
                 playback="start",

--- a/homeassistant/components/forked_daapd/media_player.py
+++ b/homeassistant/components/forked_daapd/media_player.py
@@ -12,7 +12,10 @@ from pylibrespot_java import LibrespotJavaAPI
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
+    ATTR_MEDIA_ANNOUNCE,
+    ATTR_MEDIA_ENQUEUE,
     BrowseMedia,
+    MediaPlayerEnqueue,
     MediaPlayerEntity,
     MediaPlayerState,
     MediaType,
@@ -349,11 +352,8 @@ class ForkedDaapdMaster(MediaPlayerEntity):
     @callback
     def _update_queue(self, queue, event):
         self._queue = queue
-        if (
-            self._tts_requested
-            and self._queue["count"] == 1
-            and self._queue["items"][0]["uri"].find("tts_proxy") != -1
-        ):
+        if self._tts_requested:
+            # Assume the change was due to the request
             self._tts_requested = False
             self._tts_queued = True
 
@@ -669,10 +669,45 @@ class ForkedDaapdMaster(MediaPlayerEntity):
 
         if media_type == MediaType.MUSIC:
             media_id = async_process_play_media_url(self.hass, media_id)
+        elif media_type not in CAN_PLAY_TYPE:
+            _LOGGER.warning("Media type '%s' not supported", media_type)
+            return
 
-            await self._async_announce(media_id)
-        else:
-            _LOGGER.debug("Media type '%s' not supported", media_type)
+        if kwargs.get(ATTR_MEDIA_ANNOUNCE):
+            return await self._async_announce(media_id)
+
+        if (
+            enqueue := kwargs.get(ATTR_MEDIA_ENQUEUE, MediaPlayerEnqueue.REPLACE)
+        ) is True:
+            enqueue = MediaPlayerEnqueue.ADD
+        if enqueue in {MediaPlayerEnqueue.ADD, MediaPlayerEnqueue.REPLACE}:
+            return await self._api.add_to_queue(
+                uris=media_id,
+                playback="start",
+                clear=enqueue == MediaPlayerEnqueue.REPLACE,
+            )
+
+        current_position = next(
+            (
+                item["position"]
+                for item in self._queue["items"]
+                if item["id"] == self._player["item_id"]
+            ),
+            0,
+        )
+        if enqueue == MediaPlayerEnqueue.NEXT:
+            return await self._api.add_to_queue(
+                uris=media_id,
+                playback="start",
+                position=current_position + 1,
+            )
+        # enqueue == MediaPlayerEnqueue.PLAY
+        return await self._api.add_to_queue(
+            uris=media_id,
+            playback="start",
+            position=current_position,
+            playback_from_position=current_position,
+        )
 
     async def _async_announce(self, media_id: str) -> None:
         """Play a URI."""

--- a/tests/components/forked_daapd/test_media_player.py
+++ b/tests/components/forked_daapd/test_media_player.py
@@ -22,10 +22,12 @@ from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
     ATTR_MEDIA_ALBUM_ARTIST,
     ATTR_MEDIA_ALBUM_NAME,
+    ATTR_MEDIA_ANNOUNCE,
     ATTR_MEDIA_ARTIST,
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_DURATION,
+    ATTR_MEDIA_ENQUEUE,
     ATTR_MEDIA_POSITION,
     ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_SHUFFLE,
@@ -49,6 +51,7 @@ from homeassistant.components.media_player import (
     SERVICE_TURN_ON,
     SERVICE_VOLUME_MUTE,
     SERVICE_VOLUME_SET,
+    MediaPlayerEnqueue,
     MediaType,
 )
 from homeassistant.config_entries import SOURCE_USER
@@ -110,6 +113,28 @@ SAMPLE_PLAYER_STOPPED = {
     "item_id": 12322,
     "item_length_ms": 50,
     "item_progress_ms": 5,
+}
+
+SAMPLE_QUEUE = {
+    "version": 833,
+    "count": 1,
+    "items": [
+        {
+            "id": 12322,
+            "position": 0,
+            "track_id": 1234,
+            "title": "Some song",
+            "artist": "Some artist",
+            "album": "No album",
+            "album_artist": "The xx",
+            "artwork_url": "http://art",
+            "length_ms": 0,
+            "track_number": 1,
+            "media_kind": "music",
+            "data_kind": "url",
+            "uri": "library:track:5",
+        }
+    ],
 }
 
 SAMPLE_QUEUE_TTS = {
@@ -291,7 +316,7 @@ async def get_request_return_values_fixture():
         "config": SAMPLE_CONFIG,
         "outputs": SAMPLE_OUTPUTS_ON,
         "player": SAMPLE_PLAYER_PAUSED,
-        "queue": SAMPLE_QUEUE_TTS,
+        "queue": SAMPLE_QUEUE,
     }
 
 
@@ -323,13 +348,12 @@ async def mock_api_object_fixture(hass, config_entry, get_request_return_values)
     await hass.async_block_till_done()
 
     async def add_to_queue_side_effect(
-        uris, playback=None, playback_from_position=None, clear=None
+        uris, playback=None, position=None, playback_from_position=None, clear=None
     ):
         await updater_update(["queue", "player"])
 
-    mock_api.return_value.add_to_queue.side_effect = (
-        add_to_queue_side_effect  # for play_media testing
-    )
+    # for play_media testing
+    mock_api.return_value.add_to_queue.side_effect = add_to_queue_side_effect
 
     async def pause_side_effect():
         await updater_update(["player"])
@@ -361,8 +385,8 @@ def test_master_state(hass, mock_api_object):
     assert state.attributes[ATTR_MEDIA_DURATION] == 0.05
     assert state.attributes[ATTR_MEDIA_POSITION] == 0.005
     assert state.attributes[ATTR_MEDIA_TITLE] == "No album"  # reversed for url
-    assert state.attributes[ATTR_MEDIA_ARTIST] == "Google"
-    assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "Short TTS file"  # reversed
+    assert state.attributes[ATTR_MEDIA_ARTIST] == "Some artist"
+    assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "Some song"  # reversed
     assert state.attributes[ATTR_MEDIA_ALBUM_ARTIST] == "The xx"
     assert state.attributes[ATTR_MEDIA_TRACK] == 1
     assert not state.attributes[ATTR_MEDIA_SHUFFLE]
@@ -562,16 +586,18 @@ async def test_async_play_media_from_paused(hass, mock_api_object):
     assert state.last_updated > initial_state.last_updated
 
 
-async def test_async_play_media_from_stopped(
+async def test_async_play_media_announcement_from_stopped(
     hass, get_request_return_values, mock_api_object
 ):
-    """Test async play media from stopped."""
+    """Test async play media announcement (from stopped)."""
     updater_update = mock_api_object.start_websocket_handler.call_args[0][2]
 
     get_request_return_values["player"] = SAMPLE_PLAYER_STOPPED
     await updater_update(["player"])
     await hass.async_block_till_done()
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
+
+    get_request_return_values["queue"] = SAMPLE_QUEUE_TTS
     await _service_call(
         hass,
         TEST_MASTER_ENTITY_NAME,
@@ -579,6 +605,7 @@ async def test_async_play_media_from_stopped(
         {
             ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
             ATTR_MEDIA_CONTENT_ID: "http://example.com/somefile.mp3",
+            ATTR_MEDIA_ANNOUNCE: True,
         },
     )
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -602,8 +629,8 @@ async def test_async_play_media_unsupported(hass, mock_api_object):
     assert state.last_updated == initial_state.last_updated
 
 
-async def test_async_play_media_tts_timeout(hass, mock_api_object):
-    """Test async play media with TTS timeout."""
+async def test_async_play_media_announcement_tts_timeout(hass, mock_api_object):
+    """Test async play media announcement with TTS timeout."""
     mock_api_object.add_to_queue.side_effect = None
     with patch("homeassistant.components.forked_daapd.media_player.TTS_TIMEOUT", 0):
         initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -614,6 +641,7 @@ async def test_async_play_media_tts_timeout(hass, mock_api_object):
             {
                 ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
                 ATTR_MEDIA_CONTENT_ID: "http://example.com/somefile.mp3",
+                ATTR_MEDIA_ANNOUNCE: True,
             },
         )
         state = hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -713,8 +741,8 @@ async def test_librespot_java_stuff(
     assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "some album"
 
 
-async def test_librespot_java_play_media(hass, pipe_control_api_object):
-    """Test play media with librespot-java pipe."""
+async def test_librespot_java_play_announcement(hass, pipe_control_api_object):
+    """Test play announcement with librespot-java pipe."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
         hass,
@@ -723,6 +751,7 @@ async def test_librespot_java_play_media(hass, pipe_control_api_object):
         {
             ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
             ATTR_MEDIA_CONTENT_ID: "http://example.com/somefile.mp3",
+            ATTR_MEDIA_ANNOUNCE: True,
         },
     )
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -783,3 +812,79 @@ async def test_websocket_disconnect(hass, mock_api_object):
     await hass.async_block_till_done()
     assert hass.states.get(TEST_MASTER_ENTITY_NAME).state == STATE_UNAVAILABLE
     assert hass.states.get(TEST_ZONE_ENTITY_NAMES[0]).state == STATE_UNAVAILABLE
+
+
+async def test_async_play_media_enqueue(hass, mock_api_object):
+    """Test async play media with different enqueue options."""
+    initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
+    await _service_call(
+        hass,
+        TEST_MASTER_ENTITY_NAME,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            ATTR_MEDIA_CONTENT_ID: "http://example.com/play.mp3",
+            ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.PLAY,
+        },
+    )
+    state = hass.states.get(TEST_MASTER_ENTITY_NAME)
+    assert state.state == initial_state.state
+    assert state.last_updated > initial_state.last_updated
+    mock_api_object.add_to_queue.assert_called_with(
+        uris="http://example.com/play.mp3",
+        playback="start",
+        position=0,
+        playback_from_position=0,
+    )
+    await _service_call(
+        hass,
+        TEST_MASTER_ENTITY_NAME,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            ATTR_MEDIA_CONTENT_ID: "http://example.com/replace.mp3",
+            ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.REPLACE,
+        },
+    )
+    mock_api_object.add_to_queue.assert_called_with(
+        uris="http://example.com/replace.mp3", playback="start", clear=True
+    )
+    await _service_call(
+        hass,
+        TEST_MASTER_ENTITY_NAME,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            ATTR_MEDIA_CONTENT_ID: "http://example.com/add.mp3",
+            ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.ADD,
+        },
+    )
+    mock_api_object.add_to_queue.assert_called_with(
+        uris="http://example.com/add.mp3", playback="start", clear=False
+    )
+    await _service_call(
+        hass,
+        TEST_MASTER_ENTITY_NAME,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            ATTR_MEDIA_CONTENT_ID: "http://example.com/add.mp3",
+            ATTR_MEDIA_ENQUEUE: True,
+        },
+    )
+    mock_api_object.add_to_queue.assert_called_with(
+        uris="http://example.com/add.mp3", playback="start", clear=False
+    )
+    await _service_call(
+        hass,
+        TEST_MASTER_ENTITY_NAME,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            ATTR_MEDIA_CONTENT_ID: "http://example.com/next.mp3",
+            ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.NEXT,
+        },
+    )
+    mock_api_object.add_to_queue.assert_called_with(
+        uris="http://example.com/next.mp3", playback="start", position=1
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds announce and enqueue support to forked_daapd. This is actually a bug fix because prior to #67564, the `async_play_media` function was only used for TTS (essentially the same as the new announce). After #67564, the media browser calls end up using the same function, but they should not be played like an announcement.
This PR <s>essentially moves the bulk of the previous `async_play_media` method into an `_async_announce` method (the diff looks larger and more confusing than it is because of a difference in indenting)</s> only calls the `_async_announce` method when `ATTR_MEDIA_ANNOUNCE` is True. It also adds support for the enqueue option, queueing the requested media according to the value of `ATTR_MEDIA_ENQUEUE`, and it defaults to `MediaPlayerEnqueue.ENQUEUE` if neither `ATTR_MEDIA_ANNOUNCE` or `ATTR_MEDIA_ENQUEUE` are specified.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
