### PR TITLE
Replace archived sucks by py-sucks and bump to 0.9.8 for Ecovacs integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -275,7 +275,7 @@ build.json @home-assistant/supervisor
 /tests/components/ecobee/ @marthoc
 /homeassistant/components/econet/ @vangorra @w1ll1am23
 /tests/components/econet/ @vangorra @w1ll1am23
-/homeassistant/components/ecovacs/ @OverloadUT
+/homeassistant/components/ecovacs/ @OverloadUT @mib1185
 /homeassistant/components/ecowitt/ @pvizeli
 /tests/components/ecowitt/ @pvizeli
 /homeassistant/components/edl21/ @mtdcr

--- a/homeassistant/components/ecovacs/manifest.json
+++ b/homeassistant/components/ecovacs/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovacs",
   "name": "Ecovacs",
   "documentation": "https://www.home-assistant.io/integrations/ecovacs",
-  "requirements": ["sucks==0.9.4"],
+  "requirements": ["py-sucks==0.9.7"],
   "codeowners": ["@OverloadUT"],
   "iot_class": "cloud_push",
   "loggers": ["sleekxmppfs", "sucks"]

--- a/homeassistant/components/ecovacs/manifest.json
+++ b/homeassistant/components/ecovacs/manifest.json
@@ -2,8 +2,8 @@
   "domain": "ecovacs",
   "name": "Ecovacs",
   "documentation": "https://www.home-assistant.io/integrations/ecovacs",
-  "requirements": ["py-sucks==0.9.7"],
-  "codeowners": ["@OverloadUT"],
+  "requirements": ["py-sucks==0.9.8"],
+  "codeowners": ["@OverloadUT", "@mib1185"],
   "iot_class": "cloud_push",
   "loggers": ["sleekxmppfs", "sucks"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1349,7 +1349,7 @@ py-nightscout==1.2.2
 py-schluter==0.1.7
 
 # homeassistant.components.ecovacs
-py-sucks==0.9.7
+py-sucks==0.9.8
 
 # homeassistant.components.synology_dsm
 py-synologydsm-api==1.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1348,6 +1348,9 @@ py-nightscout==1.2.2
 # homeassistant.components.schluter
 py-schluter==0.1.7
 
+# homeassistant.components.ecovacs
+py-sucks==0.9.7
+
 # homeassistant.components.synology_dsm
 py-synologydsm-api==1.0.8
 
@@ -2307,9 +2310,6 @@ stringcase==1.2.0
 
 # homeassistant.components.subaru
 subarulink==0.5.0
-
-# homeassistant.components.ecovacs
-sucks==0.9.4
 
 # homeassistant.components.solarlog
 sunwatcher==0.2.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will replace the archived [sucks](https://github.com/wpietri/sucks) lib by the forked [py-sucks](https://github.com/mib1185/py-sucks) and further bumps the version.
Release-notes:
- https://github.com/mib1185/py-sucks/releases/tag/v0.9.7
- https://github.com/mib1185/py-sucks/releases/tag/v0.9.8

Diff: https://github.com/mib1185/py-sucks/compare/v0.9.4...v0.9.8

most interesting changes
- https://github.com/mib1185/py-sucks/commit/df8b179ad85a69a09280fea26379b5611a16bddc
- https://github.com/mib1185/py-sucks/commit/8df69c675ac5741704d590f8c5bfcd699bda827c

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #74564
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
