### PR TITLE
Fix lifx service call interference

### DIFF
--- a/homeassistant/components/lifx/coordinator.py
+++ b/homeassistant/components/lifx/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
 from .util import async_execute_lifx, get_real_mac_addr, lifx_features
 
 REQUEST_REFRESH_DELAY = 0.35
+LIFX_IDENTIFY_DELAY = 3.0
 
 
 class LIFXUpdateCoordinator(DataUpdateCoordinator):
@@ -92,7 +93,7 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator):
         # Turn the bulb on first, flash for 3 seconds, then turn off
         await self.async_set_power(state=True, duration=1)
         await self.async_set_waveform_optional(value=IDENTIFY_WAVEFORM)
-        await asyncio.sleep(3)
+        await asyncio.sleep(LIFX_IDENTIFY_DELAY)
         await self.async_set_power(state=False, duration=1)
 
     async def _async_update_data(self) -> None:

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -231,6 +231,9 @@ class LIFXLight(LIFXEntity, LightEntity):
                 if power_off:
                     await self.set_power(False, duration=fade)
 
+            # Avoid state ping-pong by holding off updates as the state settles
+            await asyncio.sleep(0.3)
+
         # Update when the transition starts and ends
         await self.update_during_transition(fade)
 

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -39,7 +39,7 @@ from .manager import (
 )
 from .util import convert_8_to_16, convert_16_to_8, find_hsbk, lifx_features, merge_hsbk
 
-COLOR_ZONE_POPULATE_DELAY = 0.3
+LIFX_STATE_SETTLE_DELAY = 0.3
 
 SERVICE_LIFX_SET_STATE = "set_state"
 
@@ -232,7 +232,7 @@ class LIFXLight(LIFXEntity, LightEntity):
                     await self.set_power(False, duration=fade)
 
             # Avoid state ping-pong by holding off updates as the state settles
-            await asyncio.sleep(0.3)
+            await asyncio.sleep(LIFX_STATE_SETTLE_DELAY)
 
         # Update when the transition starts and ends
         await self.update_during_transition(fade)
@@ -341,7 +341,7 @@ class LIFXStrip(LIFXColor):
         # Zone brightness is not reported when powered off
         if not self.is_on and hsbk[HSBK_BRIGHTNESS] is None:
             await self.set_power(True)
-            await asyncio.sleep(COLOR_ZONE_POPULATE_DELAY)
+            await asyncio.sleep(LIFX_STATE_SETTLE_DELAY)
             await self.update_color_zones()
             await self.set_power(False)
 

--- a/tests/components/lifx/conftest.py
+++ b/tests/components/lifx/conftest.py
@@ -1,5 +1,4 @@
 """Tests for the lifx integration."""
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -55,15 +54,3 @@ def device_reg_fixture(hass):
 def entity_reg_fixture(hass):
     """Return an empty, loaded, registry."""
     return mock_registry(hass)
-
-
-@pytest.fixture(autouse=True)
-async def mock_lifx_sleep():
-    """Mock out lifx sleeps."""
-    asyncio_sleep = asyncio.sleep
-
-    async def sleep(duration, loop=None):
-        await asyncio_sleep(0)
-
-    with patch("homeassistant.components.lifx.asyncio.sleep", new=sleep):
-        yield

--- a/tests/components/lifx/conftest.py
+++ b/tests/components/lifx/conftest.py
@@ -1,5 +1,5 @@
 """Tests for the lifx integration."""
-
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -55,3 +55,15 @@ def device_reg_fixture(hass):
 def entity_reg_fixture(hass):
     """Return an empty, loaded, registry."""
     return mock_registry(hass)
+
+
+@pytest.fixture(autouse=True)
+async def mock_lifx_sleep():
+    """Mock out lifx sleeps."""
+    asyncio_sleep = asyncio.sleep
+
+    async def sleep(duration, loop=None):
+        await asyncio_sleep(0)
+
+    with patch("homeassistant.components.lifx.asyncio.sleep", new=sleep):
+        yield

--- a/tests/components/lifx/test_button.py
+++ b/tests/components/lifx/test_button.py
@@ -28,7 +28,7 @@ from tests.common import MockConfigEntry
 @pytest.fixture(autouse=True)
 def mock_lifx_coordinator_sleep():
     """Mock out lifx coordinator sleeps."""
-    with patch("homeassistant.components.lifx.coordinator.asyncio.sleep"):
+    with patch("homeassistant.components.lifx.coordinator.LIFX_IDENTIFY_DELAY", 0):
         yield
 
 

--- a/tests/components/lifx/test_button.py
+++ b/tests/components/lifx/test_button.py
@@ -1,4 +1,8 @@
 """Tests for button platform."""
+from unittest.mock import patch
+
+import pytest
+
 from homeassistant.components import lifx
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.lifx.const import DOMAIN
@@ -19,6 +23,13 @@ from . import (
 )
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def mock_lifx_coordinator_sleep():
+    """Mock out lifx coordinator sleeps."""
+    with patch("homeassistant.components.lifx.coordinator.asyncio.sleep"):
+        yield
 
 
 async def test_button_restart(hass: HomeAssistant) -> None:

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -50,6 +50,13 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+@pytest.fixture(autouse=True)
+def mock_lifx_light_sleep():
+    """Mock out lifx light sleeps."""
+    with patch("homeassistant.components.lifx.light.asyncio.sleep"):
+        yield
+
+
 async def test_light_unique_id(hass: HomeAssistant) -> None:
     """Test a light unique id."""
     already_migrated_config_entry = MockConfigEntry(

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -51,9 +51,9 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture(autouse=True)
-def mock_lifx_light_sleep():
-    """Mock out lifx light sleeps."""
-    with patch("homeassistant.components.lifx.light.asyncio.sleep"):
+def patch_lifx_state_settle_delay():
+    """Set asyncio.sleep for state settles to zero."""
+    with patch("homeassistant.components.lifx.light.LIFX_STATE_SETTLE_DELAY", 0):
         yield
 
 
@@ -105,7 +105,6 @@ async def test_light_unique_id_new_firmware(hass: HomeAssistant) -> None:
     assert device.identifiers == {(DOMAIN, SERIAL)}
 
 
-@patch("homeassistant.components.lifx.light.COLOR_ZONE_POPULATE_DELAY", 0)
 async def test_light_strip(hass: HomeAssistant) -> None:
     """Test a light strip."""
     already_migrated_config_entry = MockConfigEntry(


### PR DESCRIPTION
## Proposed change

Fixes #77735 and probably fixes #77646 by restoring the wait to let HASS's state settle before ending the transition.

Signed-off-by: Avi Miller <me@dje.li>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #77735 
- This PR is related to issue: #77646
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
