### PR TITLE
Fix shopping_list service calls not notifying event bus

### DIFF
--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.util.json import load_json, save_json
 
 from .const import (
     DOMAIN,
+    EVENT_SHOPPING_LIST_UPDATED,
     SERVICE_ADD_ITEM,
     SERVICE_CLEAR_COMPLETED_ITEMS,
     SERVICE_COMPLETE_ALL,
@@ -29,7 +30,6 @@ ATTR_COMPLETE = "complete"
 
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({DOMAIN: {}}, extra=vol.ALLOW_EXTRA)
-EVENT = "shopping_list_updated"
 ITEM_UPDATE_SCHEMA = vol.Schema({ATTR_COMPLETE: bool, ATTR_NAME: str})
 PERSISTENCE = ".shopping_list.json"
 
@@ -204,14 +204,19 @@ class ShoppingData:
         self.hass = hass
         self.items = []
 
-    async def async_add(self, name):
+    async def async_add(self, name, context=None):
         """Add a shopping list item."""
         item = {"name": name, "id": uuid.uuid4().hex, "complete": False}
         self.items.append(item)
         await self.hass.async_add_executor_job(self.save)
+        self.hass.bus.async_fire(
+            EVENT_SHOPPING_LIST_UPDATED,
+            {"action": "add", "item": item},
+            context=context,
+        )
         return item
 
-    async def async_update(self, item_id, info):
+    async def async_update(self, item_id, info, context=None):
         """Update a shopping list item."""
         item = next((itm for itm in self.items if itm["id"] == item_id), None)
 
@@ -221,22 +226,37 @@ class ShoppingData:
         info = ITEM_UPDATE_SCHEMA(info)
         item.update(info)
         await self.hass.async_add_executor_job(self.save)
+        self.hass.bus.async_fire(
+            EVENT_SHOPPING_LIST_UPDATED,
+            {"action": "update", "item": item},
+            context=context,
+        )
         return item
 
-    async def async_clear_completed(self):
+    async def async_clear_completed(self, context=None):
         """Clear completed items."""
         self.items = [itm for itm in self.items if not itm["complete"]]
         await self.hass.async_add_executor_job(self.save)
+        self.hass.bus.async_fire(
+            EVENT_SHOPPING_LIST_UPDATED,
+            {"action": "clear"},
+            context=context,
+        )
 
-    async def async_update_list(self, info):
+    async def async_update_list(self, info, context=None):
         """Update all items in the list."""
         for item in self.items:
             item.update(info)
         await self.hass.async_add_executor_job(self.save)
+        self.hass.bus.async_fire(
+            EVENT_SHOPPING_LIST_UPDATED,
+            {"action": "update_list"},
+            context=context,
+        )
         return self.items
 
     @callback
-    def async_reorder(self, item_ids):
+    def async_reorder(self, item_ids, context=None):
         """Reorder items."""
         # The array for sorted items.
         new_items = []
@@ -259,6 +279,11 @@ class ShoppingData:
             new_items.append(all_items_mapping[key])
         self.items = new_items
         self.hass.async_add_executor_job(self.save)
+        self.hass.bus.async_fire(
+            EVENT_SHOPPING_LIST_UPDATED,
+            {"action": "reorder"},
+            context=context,
+        )
 
     async def async_load(self):
         """Load items."""
@@ -298,7 +323,6 @@ class UpdateShoppingListItemView(http.HomeAssistantView):
 
         try:
             item = await request.app["hass"].data[DOMAIN].async_update(item_id, data)
-            request.app["hass"].bus.async_fire(EVENT)
             return self.json(item)
         except KeyError:
             return self.json_message("Item not found", HTTPStatus.NOT_FOUND)
@@ -316,7 +340,6 @@ class CreateShoppingListItemView(http.HomeAssistantView):
     async def post(self, request, data):
         """Create a new shopping list item."""
         item = await request.app["hass"].data[DOMAIN].async_add(data["name"])
-        request.app["hass"].bus.async_fire(EVENT)
         return self.json(item)
 
 
@@ -330,7 +353,6 @@ class ClearCompletedItemsView(http.HomeAssistantView):
         """Retrieve if API is running."""
         hass = request.app["hass"]
         await hass.data[DOMAIN].async_clear_completed()
-        hass.bus.async_fire(EVENT)
         return self.json_message("Cleared completed items.")
 
 
@@ -353,10 +375,7 @@ async def websocket_handle_add(
     msg: dict,
 ) -> None:
     """Handle add item to shopping_list."""
-    item = await hass.data[DOMAIN].async_add(msg["name"])
-    hass.bus.async_fire(
-        EVENT, {"action": "add", "item": item}, context=connection.context(msg)
-    )
+    item = await hass.data[DOMAIN].async_add(msg["name"], connection.context(msg))
     connection.send_message(websocket_api.result_message(msg["id"], item))
 
 
@@ -373,9 +392,8 @@ async def websocket_handle_update(
     data = msg
 
     try:
-        item = await hass.data[DOMAIN].async_update(item_id, data)
-        hass.bus.async_fire(
-            EVENT, {"action": "update", "item": item}, context=connection.context(msg)
+        item = await hass.data[DOMAIN].async_update(
+            item_id, data, connection.context(msg)
         )
         connection.send_message(websocket_api.result_message(msg_id, item))
     except KeyError:
@@ -391,8 +409,7 @@ async def websocket_handle_clear(
     msg: dict,
 ) -> None:
     """Handle clearing shopping_list items."""
-    await hass.data[DOMAIN].async_clear_completed()
-    hass.bus.async_fire(EVENT, {"action": "clear"}, context=connection.context(msg))
+    await hass.data[DOMAIN].async_clear_completed(connection.context(msg))
     connection.send_message(websocket_api.result_message(msg["id"]))
 
 
@@ -410,10 +427,7 @@ def websocket_handle_reorder(
     """Handle reordering shopping_list items."""
     msg_id = msg.pop("id")
     try:
-        hass.data[DOMAIN].async_reorder(msg.pop("item_ids"))
-        hass.bus.async_fire(
-            EVENT, {"action": "reorder"}, context=connection.context(msg)
-        )
+        hass.data[DOMAIN].async_reorder(msg.pop("item_ids"), connection.context(msg))
         connection.send_result(msg_id)
     except KeyError:
         connection.send_error(

--- a/homeassistant/components/shopping_list/const.py
+++ b/homeassistant/components/shopping_list/const.py
@@ -1,5 +1,6 @@
 """All constants related to the shopping list component."""
 DOMAIN = "shopping_list"
+EVENT_SHOPPING_LIST_UPDATED = "shopping_list_updated"
 
 SERVICE_ADD_ITEM = "add_item"
 SERVICE_COMPLETE_ITEM = "complete_item"

--- a/homeassistant/components/shopping_list/intent.py
+++ b/homeassistant/components/shopping_list/intent.py
@@ -2,7 +2,7 @@
 from homeassistant.helpers import intent
 import homeassistant.helpers.config_validation as cv
 
-from . import DOMAIN, EVENT
+from . import DOMAIN, EVENT_SHOPPING_LIST_UPDATED
 
 INTENT_ADD_ITEM = "HassShoppingListAddItem"
 INTENT_LAST_ITEMS = "HassShoppingListLastItems"
@@ -28,7 +28,7 @@ class AddItemIntent(intent.IntentHandler):
 
         response = intent_obj.create_response()
         response.async_set_speech(f"I've added {item} to your shopping list")
-        intent_obj.hass.bus.async_fire(EVENT)
+        intent_obj.hass.bus.async_fire(EVENT_SHOPPING_LIST_UPDATED)
         return response
 
 

--- a/homeassistant/components/websocket_api/permissions.py
+++ b/homeassistant/components/websocket_api/permissions.py
@@ -11,7 +11,7 @@ from homeassistant.components.lovelace.const import EVENT_LOVELACE_UPDATED
 from homeassistant.components.persistent_notification import (
     EVENT_PERSISTENT_NOTIFICATIONS_UPDATED,
 )
-from homeassistant.components.shopping_list import EVENT as EVENT_SHOPPING_LIST_UPDATED
+from homeassistant.components.shopping_list import EVENT_SHOPPING_LIST_UPDATED
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
     EVENT_CORE_CONFIG_UPDATE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When using the shopping_list services the frontend won't update automatically. This is because no change event is fired by the backend in this case. Firing the "shopping_list_updated" event after service calls, just like they are fired after any other modification, fixes this issue.

I also added test ensuring that the change event is only fired once per service call.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #76698
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
