### PR TITLE
Handle exception on projector being unavailable

### DIFF
--- a/homeassistant/components/epson/manifest.json
+++ b/homeassistant/components/epson/manifest.json
@@ -3,7 +3,7 @@
   "name": "Epson",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/epson",
-  "requirements": ["epson-projector==0.4.6"],
+  "requirements": ["epson-projector==0.5.0"],
   "codeowners": ["@pszafer"],
   "iot_class": "local_polling",
   "loggers": ["epson_projector"]

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from epson_projector import Projector
+from epson_projector import Projector, ProjectorUnavailableError
 from epson_projector.const import (
     BACK,
     BUSY,
@@ -123,7 +123,11 @@ class EpsonProjectorMediaPlayer(MediaPlayerEntity):
 
     async def async_update(self) -> None:
         """Update state of device."""
-        power_state = await self._projector.get_power()
+        try:
+            power_state = await self._projector.get_power()
+        except ProjectorUnavailableError as ex:
+            self._attr_available = False
+            return
         _LOGGER.debug("Projector status: %s", power_state)
         if not power_state or power_state == EPSON_STATE_UNAVAILABLE:
             self._attr_available = False

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -20,7 +20,6 @@ from epson_projector.const import (
     POWER,
     SOURCE,
     SOURCE_LIST,
-    STATE_UNAVAILABLE as EPSON_STATE_UNAVAILABLE,
     TURN_OFF,
     TURN_ON,
     VOL_DOWN,
@@ -126,12 +125,13 @@ class EpsonProjectorMediaPlayer(MediaPlayerEntity):
         try:
             power_state = await self._projector.get_power()
         except ProjectorUnavailableError as ex:
+            _LOGGER.debug("Projector is unavailable: %s", ex)
+            self._attr_available = False
+            return
+        if not power_state:
             self._attr_available = False
             return
         _LOGGER.debug("Projector status: %s", power_state)
-        if not power_state or power_state == EPSON_STATE_UNAVAILABLE:
-            self._attr_available = False
-            return
         self._attr_available = True
         if power_state == EPSON_CODES[POWER]:
             self._attr_state = STATE_ON

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -630,7 +630,7 @@ envoy_reader==0.20.1
 ephem==4.1.2
 
 # homeassistant.components.epson
-epson-projector==0.4.6
+epson-projector==0.5.0
 
 # homeassistant.components.epsonworkforce
 epsonprinter==0.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -477,7 +477,7 @@ envoy_reader==0.20.1
 ephem==4.1.2
 
 # homeassistant.components.epson
-epson-projector==0.4.6
+epson-projector==0.5.0
 
 # homeassistant.components.faa_delays
 faadelays==0.0.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds support for `epson-projector` library `ProjectorUnavailableError` exception, implemented in https://github.com/pszafer/epson_projector/pull/17.

Using this exception it will now be possible for HA to handle the `unavailable` state properly. Before it was just logging an error from the `epson-projector` every 10 seconds if the device was offline (screenshot under the spoiler below).

<details>
<summary>Screenshot of the problem before these changes</summary>

8280 errors in the log in 23 hours of the projector being offline.

![image](https://user-images.githubusercontent.com/6554415/182876478-70bd029a-f0b4-4486-8a01-0c840a696567.png)
</details>

With this PR, it will be changing state of `media_player` to `unavailable` and we will avoid 1000-message spam in the log, which does not explain anything. After the device is back online, the state will recover to the proper value.

This PR still requires `epson-projector` to release the new version 0.5.0 suggested in https://github.com/pszafer/epson_projector/pull/18 first.

P.S. I am sorry, I am not sure, whether this PR should be marked as a bugfix or a dependency upgrade.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
