### PR TITLE
Remove CalendarEventDevice which was deprecated in 2022.5

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -189,71 +189,6 @@ def is_offset_reached(
     return start + offset_time <= dt.now(start.tzinfo)
 
 
-class CalendarEventDevice(Entity):
-    """Legacy API for calendar event entities."""
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Print deprecation warning."""
-        super().__init_subclass__(**kwargs)
-        _LOGGER.warning(
-            "CalendarEventDevice is deprecated, modify %s to extend CalendarEntity",
-            cls.__name__,
-        )
-
-    @property
-    def event(self) -> dict[str, Any] | None:
-        """Return the next upcoming event."""
-        raise NotImplementedError()
-
-    @final
-    @property
-    def state_attributes(self) -> dict[str, Any] | None:
-        """Return the entity state attributes."""
-
-        if (event := self.event) is None:
-            return None
-
-        event = normalize_event(event)
-        return {
-            "message": event["message"],
-            "all_day": event["all_day"],
-            "start_time": event["start"],
-            "end_time": event["end"],
-            "location": event["location"],
-            "description": event["description"],
-        }
-
-    @final
-    @property
-    def state(self) -> str:
-        """Return the state of the calendar event."""
-        if (event := self.event) is None:
-            return STATE_OFF
-
-        event = normalize_event(event)
-        start = event["dt_start"]
-        end = event["dt_end"]
-
-        if start is None or end is None:
-            return STATE_OFF
-
-        now = dt.now()
-
-        if start <= now < end:
-            return STATE_ON
-
-        return STATE_OFF
-
-    async def async_get_events(
-        self,
-        hass: HomeAssistant,
-        start_date: datetime.datetime,
-        end_date: datetime.datetime,
-    ) -> list[dict[str, Any]]:
-        """Return calendar events within a datetime range."""
-        raise NotImplementedError()
-
-
 class CalendarEntity(Entity):
     """Base class for calendar event entities."""
 
@@ -314,10 +249,14 @@ class CalendarEventView(http.HomeAssistantView):
 
     async def get(self, request: web.Request, entity_id: str) -> web.Response:
         """Return calendar events."""
-        entity = self.component.get_entity(entity_id)
+        if not (entity := self.component.get_entity(entity_id)) or not isinstance(
+            entity, CalendarEntity
+        ):
+            return web.Response(status=HTTPStatus.BAD_REQUEST)
+
         start = request.query.get("start")
         end = request.query.get("end")
-        if start is None or end is None or entity is None:
+        if start is None or end is None:
             return web.Response(status=HTTPStatus.BAD_REQUEST)
         try:
             start_date = dt.parse_datetime(start)
@@ -325,16 +264,6 @@ class CalendarEventView(http.HomeAssistantView):
         except (ValueError, AttributeError):
             return web.Response(status=HTTPStatus.BAD_REQUEST)
         if start_date is None or end_date is None:
-            return web.Response(status=HTTPStatus.BAD_REQUEST)
-
-        # Compatibility shim for old API
-        if isinstance(entity, CalendarEventDevice):
-            event_list = await entity.async_get_events(
-                request.app["hass"], start_date, end_date
-            )
-            return self.json(event_list)
-
-        if not isinstance(entity, CalendarEntity):
             return web.Response(status=HTTPStatus.BAD_REQUEST)
 
         try:

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -1,16 +1,9 @@
 """Demo platform that has two fake binary sensors."""
 from __future__ import annotations
 
-import copy
 import datetime
-from typing import Any
 
-from homeassistant.components.calendar import (
-    CalendarEntity,
-    CalendarEvent,
-    CalendarEventDevice,
-    get_date,
-)
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -28,7 +21,6 @@ def setup_platform(
         [
             DemoCalendar(calendar_data_future(), "Calendar 1"),
             DemoCalendar(calendar_data_current(), "Calendar 2"),
-            LegacyDemoCalendar("Calendar 3"),
         ]
     )
 
@@ -76,41 +68,3 @@ class DemoCalendar(CalendarEntity):
     ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
         return [self._event]
-
-
-class LegacyDemoCalendar(CalendarEventDevice):
-    """Calendar for exercising shim API."""
-
-    def __init__(self, name: str) -> None:
-        """Initialize demo calendar."""
-        self._attr_name = name
-        one_hour_from_now = dt_util.now() + datetime.timedelta(minutes=30)
-        self._event = {
-            "start": {"dateTime": one_hour_from_now.isoformat()},
-            "end": {
-                "dateTime": (
-                    one_hour_from_now + datetime.timedelta(minutes=60)
-                ).isoformat()
-            },
-            "summary": "Future Event",
-            "description": "Future Description",
-            "location": "Future Location",
-        }
-
-    @property
-    def event(self) -> dict[str, Any]:
-        """Return the next upcoming event."""
-        return self._event
-
-    async def async_get_events(
-        self,
-        hass: HomeAssistant,
-        start_date: datetime.datetime,
-        end_date: datetime.datetime,
-    ) -> list[dict[str, Any]]:
-        """Get all events in a specific time frame."""
-        event = copy.copy(self.event)
-        event["title"] = event["summary"]
-        event["start"] = get_date(event["start"]).isoformat()
-        event["end"] = get_date(event["end"]).isoformat()
-        return [event]

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -66,26 +66,4 @@ async def test_calendars_http_api(hass, hass_client):
     assert data == [
         {"entity_id": "calendar.calendar_1", "name": "Calendar 1"},
         {"entity_id": "calendar.calendar_2", "name": "Calendar 2"},
-        {"entity_id": "calendar.calendar_3", "name": "Calendar 3"},
     ]
-
-
-async def test_events_http_api_shim(hass, hass_client):
-    """Test the legacy shim calendar demo view."""
-    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
-    await hass.async_block_till_done()
-    client = await hass_client()
-    response = await client.get("/api/calendars/calendar.calendar_3")
-    assert response.status == HTTPStatus.BAD_REQUEST
-    start = dt_util.now()
-    end = start + timedelta(days=1)
-    response = await client.get(
-        "/api/calendars/calendar.calendar_1?start={}&end={}".format(
-            start.isoformat(), end.isoformat()
-        )
-    )
-    assert response.status == HTTPStatus.OK
-    events = await response.json()
-    assert events[0]["summary"] == "Future Event"
-    assert events[0]["description"] == "Future Description"
-    assert events[0]["location"] == "Future Location"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `CalendarEventDevice` entity which was deprecated in `2022.5` has been removed.  See https://developers.home-assistant.io/blog/2022/04/18/calendar-data-model/ for more details.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove CalendarEventDevice which was deprecated in 2022.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
