### PR TITLE
Escape media_content_id in media player proxy

### DIFF
--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -7,7 +7,6 @@ from functools import wraps
 import logging
 import re
 from typing import Any, TypeVar
-import urllib.parse
 
 from jsonrpc_base.jsonrpc import ProtocolError, TransportError
 from pykodi import CannotConnectError
@@ -920,7 +919,7 @@ class KodiEntity(MediaPlayerEntity):
 
             return self.get_browse_image_url(
                 media_content_type,
-                urllib.parse.quote_plus(media_content_id),
+                media_content_id,
                 media_image_id,
             )
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1089,6 +1089,8 @@ class MediaPlayerEntity(Entity):
         """Generate an url for a media browser image."""
         url_path = (
             f"/api/media_player_proxy/{self.entity_id}/browse_media"
+            # aiohttp unquotes the path once before matching the paths. Quoting twice
+            # prevents a '/' in the media_content_id from breaking the matching.
             f"/{media_content_type}/{quote(quote(media_content_id,safe=''))}"
         )
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1111,7 +1111,7 @@ class MediaPlayerImageView(HomeAssistantView):
         # Need to modify the default regex for media_content_id as it may
         # include arbitrary characters including '/','{', or '}'
         url
-        + "/browse_media/{media_content_type}/{media_content_id:.*}",
+        + "/browse_media/{media_content_type}/{media_content_id:.+}",
     ]
 
     def __init__(self, component: EntityComponent) -> None:

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -13,7 +13,7 @@ from http import HTTPStatus
 import logging
 import secrets
 from typing import Any, cast, final
-from urllib.parse import quote, unquote, urlparse
+from urllib.parse import quote, urlparse
 
 from aiohttp import web
 from aiohttp.hdrs import CACHE_CONTROL, CONTENT_TYPE
@@ -1089,9 +1089,9 @@ class MediaPlayerEntity(Entity):
         """Generate an url for a media browser image."""
         url_path = (
             f"/api/media_player_proxy/{self.entity_id}/browse_media"
-            # aiohttp unquotes the path once before matching the paths. Quoting twice
-            # prevents a '/' in the media_content_id from breaking the matching.
-            f"/{media_content_type}/{quote(quote(media_content_id,safe=''))}"
+            # quote the media_content_id as it may contain url unsafe characters
+            # aiohttp will unquote the path automatically
+            f"/{media_content_type}/{quote(media_content_id)}"
         )
 
         url_query = {"token": self.access_token}
@@ -1108,7 +1108,10 @@ class MediaPlayerImageView(HomeAssistantView):
     url = "/api/media_player_proxy/{entity_id}"
     name = "api:media_player:image"
     extra_urls = [
-        url + "/browse_media/{media_content_type}/{quoted_media_content_id}",
+        # Need to modify the default regex for media_content_id as it may
+        # include arbitrary characters including '/','{', or '}'
+        url
+        + "/browse_media/{media_content_type}/{media_content_id:.*}",
     ]
 
     def __init__(self, component: EntityComponent) -> None:
@@ -1120,7 +1123,7 @@ class MediaPlayerImageView(HomeAssistantView):
         request: web.Request,
         entity_id: str,
         media_content_type: str | None = None,
-        quoted_media_content_id: str | None = None,
+        media_content_id: str | None = None,
     ) -> web.Response:
         """Start a get request."""
         if (player := self.component.get_entity(entity_id)) is None:
@@ -1140,8 +1143,7 @@ class MediaPlayerImageView(HomeAssistantView):
         if not authenticated:
             return web.Response(status=HTTPStatus.UNAUTHORIZED)
 
-        if media_content_type and quoted_media_content_id:
-            media_content_id = unquote(quoted_media_content_id)
+        if media_content_type and media_content_id:
             media_image_id = request.query.get("media_image_id")
             data, content_type = await player.async_get_browse_image(
                 media_content_type, media_content_id, media_image_id

--- a/homeassistant/components/roku/browse_media.py
+++ b/homeassistant/components/roku/browse_media.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
-from urllib.parse import quote_plus
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import BrowseMedia
@@ -64,7 +63,7 @@ def get_thumbnail_url_full(
 
     return get_browse_image_url(
         media_content_type,
-        quote_plus(media_content_id),
+        media_content_id,
         media_image_id,
     )
 

--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -6,7 +6,6 @@ from contextlib import suppress
 from functools import partial
 import logging
 from typing import cast
-from urllib.parse import quote_plus, unquote
 
 from soco.data_structures import DidlFavorite, DidlObject
 from soco.ms_data_structures import MusicServiceItem
@@ -64,7 +63,7 @@ def get_thumbnail_url_full(
 
     return get_browse_image_url(
         media_content_type,
-        quote_plus(media_content_id),
+        media_content_id,
         media_image_id,
     )
 
@@ -201,7 +200,7 @@ def build_item_response(
 
     if not title:
         try:
-            title = unquote(payload["idstring"].split("/")[1])
+            title = payload["idstring"].split("/")[1]
         except IndexError:
             title = LIBRARY_TITLES_MAPPING[payload["idstring"]]
 

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -280,3 +280,34 @@ async def test_enqueue_alert_exclusive(hass):
             },
             blocking=True,
         )
+
+
+async def test_get_async_get_browse_image_quoting(
+    hass, hass_client_no_auth, hass_ws_client
+):
+    """Test get browse image using media_content_id with special characters.
+
+    async_get_browse_image() should get called with the same string that is
+    passed into get_browse_image_url().
+    """
+    await async_setup_component(
+        hass, "media_player", {"media_player": {"platform": "demo"}}
+    )
+    await hass.async_block_till_done()
+
+    entity_comp = hass.data.get("entity_components", {}).get("media_player")
+    assert entity_comp
+
+    player = entity_comp.get_entity("media_player.bedroom")
+    assert player
+
+    client = await hass_client_no_auth()
+
+    with patch(
+        "homeassistant.components.media_player.MediaPlayerEntity."
+        "async_get_browse_image",
+    ) as mock_browse_image:
+        media_content_id = "a/b c/d+e%2Fg"
+        url = player.get_browse_image_url("album", media_content_id)
+        await client.get(url)
+        mock_browse_image.assert_called_with("album", media_content_id, None)

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -307,7 +307,7 @@ async def test_get_async_get_browse_image_quoting(
         "homeassistant.components.media_player.MediaPlayerEntity."
         "async_get_browse_image",
     ) as mock_browse_image:
-        media_content_id = "a/b c/d+e%2Fg"
+        media_content_id = "a/b c/d+e%2Fg{}"
         url = player.get_browse_image_url("album", media_content_id)
         await client.get(url)
         mock_browse_image.assert_called_with("album", media_content_id, None)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`media_content_id`s may include arbitrary characters including characters which are not URL safe, and these should be escaped. Some media players already use` urllib.parse.quote` to pre-escape their `media_content_id`s before passing them to `MediaPlayer.get_browse_image_url`. It is better to do this in `media_player` itself as it avoids having to do it in each individual component, and it keeps the interface cleaner (i.e., a `media_content_id` is not escaped in one case and not escaped in another).
Note that the aiohttp server does unquoting before matching dynamic paths: https://github.com/aio-libs/aiohttp/blob/64516524f7ba36d7efdd7853fe6414d8466accea/aiohttp/web_urldispatcher.py#L473)
As such, '/', '{', and '}' will cause problems for the path matching even if the `media_content_id` is quoted. To work around this, we can either quote the `media_content_id` twice (and unquote it once on the other end) or change the regex to `.+` instead of the default `[^{}/]+`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74824
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
