### PR TITLE
Remove use of deprecated SUPPORT_* constants from Template light

### DIFF
--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -9,9 +9,6 @@ from homeassistant.components.light import (
     ATTR_EFFECT,
     ATTR_HS_COLOR,
     ATTR_TRANSITION,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_COLOR_TEMP,
     SUPPORT_TRANSITION,
     ColorMode,
     LightEntityFeature,
@@ -115,7 +112,7 @@ async def setup_light(hass, count, light_config):
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
     "supported_features,supported_color_modes",
-    [(SUPPORT_BRIGHTNESS, [ColorMode.BRIGHTNESS])],
+    [(0, [ColorMode.BRIGHTNESS])],
 )
 @pytest.mark.parametrize(
     "light_config",
@@ -141,10 +138,6 @@ async def test_template_state_invalid(
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_BRIGHTNESS, [ColorMode.BRIGHTNESS])],
-)
-@pytest.mark.parametrize(
     "light_config",
     [
         {
@@ -155,18 +148,16 @@ async def test_template_state_invalid(
         },
     ],
 )
-async def test_template_state_text(
-    hass, supported_features, supported_color_modes, setup_light
-):
+async def test_template_state_text(hass, setup_light):
     """Test the state text of a template."""
     set_state = STATE_ON
     hass.states.async_set("light.test_state", set_state)
     await hass.async_block_till_done()
     state = hass.states.get("light.test_template_light")
     assert state.state == set_state
-    assert state.attributes["color_mode"] == ColorMode.UNKNOWN  # Brightness is None
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
     set_state = STATE_OFF
     hass.states.async_set("light.test_state", set_state)
@@ -174,22 +165,18 @@ async def test_template_state_text(
     state = hass.states.get("light.test_template_light")
     assert state.state == set_state
     assert "color_mode" not in state.attributes
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_BRIGHTNESS, [ColorMode.BRIGHTNESS])],
-)
 @pytest.mark.parametrize(
     "value_template,expected_state,expected_color_mode",
     [
         (
             "{{ 1 == 1 }}",
             STATE_ON,
-            ColorMode.UNKNOWN,
+            ColorMode.BRIGHTNESS,
         ),
         (
             "{{ 1 == 2 }}",
@@ -202,8 +189,6 @@ async def test_templatex_state_boolean(
     hass,
     expected_color_mode,
     expected_state,
-    supported_features,
-    supported_color_modes,
     count,
     value_template,
 ):
@@ -218,8 +203,8 @@ async def test_templatex_state_boolean(
     state = hass.states.get("light.test_template_light")
     assert state.state == expected_state
     assert state.attributes.get("color_mode") == expected_color_mode
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [0])
@@ -280,10 +265,6 @@ async def test_missing_key(hass, count, setup_light):
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_BRIGHTNESS, [ColorMode.BRIGHTNESS])],
-)
-@pytest.mark.parametrize(
     "light_config",
     [
         {
@@ -294,9 +275,7 @@ async def test_missing_key(hass, count, setup_light):
         },
     ],
 )
-async def test_on_action(
-    hass, setup_light, calls, supported_features, supported_color_modes
-):
+async def test_on_action(hass, setup_light, calls):
     """Test on action."""
     hass.states.async_set("light.test_state", STATE_OFF)
     await hass.async_block_till_done()
@@ -304,8 +283,8 @@ async def test_on_action(
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -320,15 +299,11 @@ async def test_on_action(
 
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION, [ColorMode.BRIGHTNESS])],
-)
 @pytest.mark.parametrize(
     "light_config",
     [
@@ -358,9 +333,7 @@ async def test_on_action(
         },
     ],
 )
-async def test_on_action_with_transition(
-    hass, setup_light, calls, supported_features, supported_color_modes
-):
+async def test_on_action_with_transition(hass, setup_light, calls):
     """Test on action with transition."""
     hass.states.async_set("light.test_state", STATE_OFF)
     await hass.async_block_till_done()
@@ -368,8 +341,8 @@ async def test_on_action_with_transition(
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -383,15 +356,11 @@ async def test_on_action_with_transition(
 
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
 
 
 @pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes,expected_color_mode",
-    [(SUPPORT_BRIGHTNESS, [ColorMode.BRIGHTNESS], ColorMode.BRIGHTNESS)],
-)
 @pytest.mark.parametrize(
     "light_config",
     [
@@ -406,9 +375,6 @@ async def test_on_action_optimistic(
     hass,
     setup_light,
     calls,
-    supported_features,
-    supported_color_modes,
-    expected_color_mode,
 ):
     """Test on action with optimistic state."""
     hass.states.async_set("light.test_state", STATE_OFF)
@@ -417,8 +383,8 @@ async def test_on_action_optimistic(
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -432,9 +398,9 @@ async def test_on_action_optimistic(
     assert calls[-1].data["action"] == "turn_on"
     assert calls[-1].data["caller"] == "light.test_template_light"
     assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == ColorMode.UNKNOWN  # Brightness is None
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -449,16 +415,12 @@ async def test_on_action_optimistic(
     assert calls[-1].data["brightness"] == 100
     assert calls[-1].data["caller"] == "light.test_template_light"
     assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == expected_color_mode
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_BRIGHTNESS, [ColorMode.BRIGHTNESS])],
-)
 @pytest.mark.parametrize(
     "light_config",
     [
@@ -470,18 +432,16 @@ async def test_on_action_optimistic(
         },
     ],
 )
-async def test_off_action(
-    hass, setup_light, calls, supported_features, supported_color_modes
-):
+async def test_off_action(hass, setup_light, calls):
     """Test off action."""
     hass.states.async_set("light.test_state", STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == ColorMode.UNKNOWN  # Brightness is None
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -494,16 +454,12 @@ async def test_off_action(
     assert calls[-1].data["action"] == "turn_off"
     assert calls[-1].data["caller"] == "light.test_template_light"
     assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == ColorMode.UNKNOWN  # Brightness is None
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [(1)])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION, [ColorMode.BRIGHTNESS])],
-)
 @pytest.mark.parametrize(
     "light_config",
     [
@@ -533,18 +489,16 @@ async def test_off_action(
         },
     ],
 )
-async def test_off_action_with_transition(
-    hass, setup_light, calls, supported_features, supported_color_modes
-):
+async def test_off_action_with_transition(hass, setup_light, calls):
     """Test off action with transition."""
     hass.states.async_set("light.test_state", STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == ColorMode.UNKNOWN  # Brightness is None
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -556,16 +510,12 @@ async def test_off_action_with_transition(
     assert len(calls) == 1
     assert calls[0].data["transition"] == 2
     assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == ColorMode.UNKNOWN  # Brightness is None
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
 
 
 @pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_BRIGHTNESS, [ColorMode.BRIGHTNESS])],
-)
 @pytest.mark.parametrize(
     "light_config",
     [
@@ -576,15 +526,13 @@ async def test_off_action_with_transition(
         },
     ],
 )
-async def test_off_action_optimistic(
-    hass, setup_light, calls, supported_features, supported_color_modes
-):
+async def test_off_action_optimistic(hass, setup_light, calls):
     """Test off action with optimistic state."""
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -597,15 +545,11 @@ async def test_off_action_optimistic(
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes,expected_color_mode",
-    [(SUPPORT_BRIGHTNESS, [ColorMode.BRIGHTNESS], ColorMode.BRIGHTNESS)],
-)
 @pytest.mark.parametrize(
     "light_config",
     [
@@ -621,9 +565,6 @@ async def test_level_action_no_template(
     hass,
     setup_light,
     calls,
-    supported_features,
-    supported_color_modes,
-    expected_color_mode,
 ):
     """Test setting brightness with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -644,9 +585,9 @@ async def test_level_action_no_template(
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_ON
     assert state.attributes["brightness"] == 124
-    assert state.attributes["color_mode"] == expected_color_mode
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
@@ -654,26 +595,20 @@ async def test_level_action_no_template(
     "expected_level,level_template,expected_color_mode",
     [
         (255, "{{255}}", ColorMode.BRIGHTNESS),
-        (None, "{{256}}", ColorMode.UNKNOWN),
-        (None, "{{x - 12}}", ColorMode.UNKNOWN),
-        (None, "{{ none }}", ColorMode.UNKNOWN),
-        (None, "", ColorMode.UNKNOWN),
+        (None, "{{256}}", ColorMode.BRIGHTNESS),
+        (None, "{{x - 12}}", ColorMode.BRIGHTNESS),
+        (None, "{{ none }}", ColorMode.BRIGHTNESS),
+        (None, "", ColorMode.BRIGHTNESS),
         (
             None,
             "{{ state_attr('light.nolight', 'brightness') }}",
-            ColorMode.UNKNOWN,
+            ColorMode.BRIGHTNESS,
         ),
     ],
-)
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_BRIGHTNESS, [ColorMode.BRIGHTNESS])],
 )
 async def test_level_template(
     hass,
     expected_level,
-    supported_features,
-    supported_color_modes,
     expected_color_mode,
     count,
     level_template,
@@ -691,8 +626,8 @@ async def test_level_template(
     assert state.attributes.get("brightness") == expected_level
     assert state.state == STATE_ON
     assert state.attributes["color_mode"] == expected_color_mode
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
@@ -700,22 +635,16 @@ async def test_level_template(
     "expected_temp,temperature_template,expected_color_mode",
     [
         (500, "{{500}}", ColorMode.COLOR_TEMP),
-        (None, "{{501}}", ColorMode.UNKNOWN),
-        (None, "{{x - 12}}", ColorMode.UNKNOWN),
-        (None, "None", ColorMode.UNKNOWN),
-        (None, "{{ none }}", ColorMode.UNKNOWN),
-        (None, "", ColorMode.UNKNOWN),
+        (None, "{{501}}", ColorMode.COLOR_TEMP),
+        (None, "{{x - 12}}", ColorMode.COLOR_TEMP),
+        (None, "None", ColorMode.COLOR_TEMP),
+        (None, "{{ none }}", ColorMode.COLOR_TEMP),
+        (None, "", ColorMode.COLOR_TEMP),
     ],
-)
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_COLOR_TEMP, [ColorMode.COLOR_TEMP])],
 )
 async def test_temperature_template(
     hass,
     expected_temp,
-    supported_features,
-    supported_color_modes,
     expected_color_mode,
     count,
     temperature_template,
@@ -733,15 +662,11 @@ async def test_temperature_template(
     assert state.attributes.get("color_temp") == expected_temp
     assert state.state == STATE_ON
     assert state.attributes["color_mode"] == expected_color_mode
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.COLOR_TEMP]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes,expected_color_mode",
-    [(SUPPORT_COLOR_TEMP, [ColorMode.COLOR_TEMP], ColorMode.COLOR_TEMP)],
-)
 @pytest.mark.parametrize(
     "light_config",
     [
@@ -757,9 +682,6 @@ async def test_temperature_action_no_template(
     hass,
     setup_light,
     calls,
-    supported_features,
-    supported_color_modes,
-    expected_color_mode,
 ):
     """Test setting temperature with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -781,9 +703,9 @@ async def test_temperature_action_no_template(
     assert state is not None
     assert state.attributes.get("color_temp") == 345
     assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == expected_color_mode
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["color_mode"] == ColorMode.COLOR_TEMP
+    assert state.attributes["supported_color_modes"] == [ColorMode.COLOR_TEMP]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
@@ -868,10 +790,6 @@ async def test_entity_picture_template(hass, setup_light):
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    "supported_features,supported_color_modes, expected_color_mode",
-    [(SUPPORT_COLOR, [ColorMode.HS], ColorMode.HS)],
-)
-@pytest.mark.parametrize(
     "light_config",
     [
         {
@@ -886,9 +804,6 @@ async def test_color_action_no_template(
     hass,
     setup_light,
     calls,
-    supported_features,
-    supported_color_modes,
-    expected_color_mode,
 ):
     """Test setting color with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -909,10 +824,10 @@ async def test_color_action_no_template(
 
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_ON
-    assert state.attributes["color_mode"] == expected_color_mode
+    assert state.attributes["color_mode"] == ColorMode.HS
     assert state.attributes.get("hs_color") == (40, 50)
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.HS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
@@ -921,23 +836,17 @@ async def test_color_action_no_template(
     [
         ((360, 100), "{{(360, 100)}}", ColorMode.HS),
         ((359.9, 99.9), "{{(359.9, 99.9)}}", ColorMode.HS),
-        (None, "{{(361, 100)}}", ColorMode.UNKNOWN),
-        (None, "{{(360, 101)}}", ColorMode.UNKNOWN),
-        (None, "[{{(360)}},{{null}}]", ColorMode.UNKNOWN),
-        (None, "{{x - 12}}", ColorMode.UNKNOWN),
-        (None, "", ColorMode.UNKNOWN),
-        (None, "{{ none }}", ColorMode.UNKNOWN),
+        (None, "{{(361, 100)}}", ColorMode.HS),
+        (None, "{{(360, 101)}}", ColorMode.HS),
+        (None, "[{{(360)}},{{null}}]", ColorMode.HS),
+        (None, "{{x - 12}}", ColorMode.HS),
+        (None, "", ColorMode.HS),
+        (None, "{{ none }}", ColorMode.HS),
     ],
-)
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_COLOR, [ColorMode.HS])],
 )
 async def test_color_template(
     hass,
     expected_hs,
-    supported_features,
-    supported_color_modes,
     expected_color_mode,
     count,
     color_template,
@@ -955,15 +864,11 @@ async def test_color_template(
     assert state.attributes.get("hs_color") == expected_hs
     assert state.state == STATE_ON
     assert state.attributes["color_mode"] == expected_color_mode
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [ColorMode.HS]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])
-@pytest.mark.parametrize(
-    "supported_features,supported_color_modes",
-    [(SUPPORT_COLOR | SUPPORT_COLOR_TEMP, [ColorMode.COLOR_TEMP, ColorMode.HS])],
-)
 @pytest.mark.parametrize(
     "light_config",
     [
@@ -992,9 +897,7 @@ async def test_color_template(
         },
     ],
 )
-async def test_color_and_temperature_actions_no_template(
-    hass, setup_light, calls, supported_features, supported_color_modes
-):
+async def test_color_and_temperature_actions_no_template(hass, setup_light, calls):
     """Test setting color and color temperature with optimistic template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("hs_color") is None
@@ -1015,8 +918,11 @@ async def test_color_and_temperature_actions_no_template(
     assert state.attributes["color_mode"] == ColorMode.HS
     assert "color_temp" not in state.attributes
     assert state.attributes["hs_color"] == (40, 50)
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+    ]
+    assert state.attributes["supported_features"] == 0
 
     # Optimistically set color temp, light should be in color temp mode
     await hass.services.async_call(
@@ -1033,8 +939,11 @@ async def test_color_and_temperature_actions_no_template(
     assert state.attributes["color_mode"] == ColorMode.COLOR_TEMP
     assert state.attributes["color_temp"] == 123
     assert "hs_color" in state.attributes  # Color temp represented as hs_color
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+    ]
+    assert state.attributes["supported_features"] == 0
 
     # Optimistically set color, light should again be in hs_color mode
     await hass.services.async_call(
@@ -1052,8 +961,11 @@ async def test_color_and_temperature_actions_no_template(
     assert state.attributes["color_mode"] == ColorMode.HS
     assert "color_temp" not in state.attributes
     assert state.attributes["hs_color"] == (10, 20)
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+    ]
+    assert state.attributes["supported_features"] == 0
 
     # Optimistically set color temp, light should again be in color temp mode
     await hass.services.async_call(
@@ -1070,8 +982,11 @@ async def test_color_and_temperature_actions_no_template(
     assert state.attributes["color_mode"] == ColorMode.COLOR_TEMP
     assert state.attributes["color_temp"] == 234
     assert "hs_color" in state.attributes  # Color temp represented as hs_color
-    assert state.attributes["supported_color_modes"] == supported_color_modes
-    assert state.attributes["supported_features"] == supported_features
+    assert state.attributes["supported_color_modes"] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+    ]
+    assert state.attributes["supported_features"] == 0
 
 
 @pytest.mark.parametrize("count", [1])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove use of deprecated SUPPORT_* constants from Template light

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
