### PR TITLE
Less verbose error logs for bleak connection errors in ActiveBluetoothProcessorCoordinator

### DIFF
--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -113,7 +113,7 @@ class ActiveBluetoothProcessorCoordinator(
             update = await self._async_poll_data(self._last_service_info)
         except BleakError as exc:
             if self.last_poll_successful:
-                self.logger.info(
+                self.logger.error(
                     "%s: Bluetooth error whilst polling: %s", self.address, str(exc)
                 )
                 self.last_poll_successful = False

--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -6,6 +6,8 @@ import logging
 import time
 from typing import Any, Generic, TypeVar
 
+from bleak import BleakError
+
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.debounce import Debouncer
 
@@ -109,6 +111,11 @@ class ActiveBluetoothProcessorCoordinator(
 
         try:
             update = await self._async_poll_data(self._last_service_info)
+        except BleakError as e:
+            if self.last_poll_successful:
+                self.logger.info("%s: Bluetooth error whilst polling: %s", self.address, str(e))
+                self.last_poll_successful = False
+                return
         except Exception:  # pylint: disable=broad-except
             if self.last_poll_successful:
                 self.logger.exception("%s: Failure while polling", self.address)

--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -111,9 +111,11 @@ class ActiveBluetoothProcessorCoordinator(
 
         try:
             update = await self._async_poll_data(self._last_service_info)
-        except BleakError as e:
+        except BleakError as exc:
             if self.last_poll_successful:
-                self.logger.info("%s: Bluetooth error whilst polling: %s", self.address, str(e))
+                self.logger.info(
+                    "%s: Bluetooth error whilst polling: %s", self.address, str(exc)
+                )
                 self.last_poll_successful = False
                 return
         except Exception:  # pylint: disable=broad-except

--- a/tests/components/bluetooth/test_active_update_coordinator.py
+++ b/tests/components/bluetooth/test_active_update_coordinator.py
@@ -164,8 +164,9 @@ async def test_poll_can_be_skipped(hass: HomeAssistant, mock_bleak_scanner_start
     cancel()
 
 
-
-async def test_bleak_error_and_recover(hass: HomeAssistant, mock_bleak_scanner_start, caplog):
+async def test_bleak_error_and_recover(
+    hass: HomeAssistant, mock_bleak_scanner_start, caplog
+):
     """Test bleak error handling and recovery."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -223,7 +224,10 @@ async def test_bleak_error_and_recover(hass: HomeAssistant, mock_bleak_scanner_s
     await hass.async_block_till_done()
     assert async_handle_update.mock_calls[-1] == call({"testdata": None})
 
-    assert "aa:bb:cc:dd:ee:ff: Bluetooth error whilst polling: Connection was aborted" in caplog.text
+    assert (
+        "aa:bb:cc:dd:ee:ff: Bluetooth error whilst polling: Connection was aborted"
+        in caplog.text
+    )
 
     # Second poll works
     flag = False
@@ -232,6 +236,7 @@ async def test_bleak_error_and_recover(hass: HomeAssistant, mock_bleak_scanner_s
     assert async_handle_update.mock_calls[-1] == call({"testdata": False})
 
     cancel()
+
 
 async def test_poll_failure_and_recover(hass: HomeAssistant, mock_bleak_scanner_start):
     """Test error handling and recovery."""

--- a/tests/components/bluetooth/test_active_update_coordinator.py
+++ b/tests/components/bluetooth/test_active_update_coordinator.py
@@ -5,6 +5,8 @@ import asyncio
 import logging
 from unittest.mock import MagicMock, call, patch
 
+from bleak import BleakError
+
 from homeassistant.components.bluetooth import (
     DOMAIN,
     BluetoothChange,
@@ -161,6 +163,75 @@ async def test_poll_can_be_skipped(hass: HomeAssistant, mock_bleak_scanner_start
 
     cancel()
 
+
+
+async def test_bleak_error_and_recover(hass: HomeAssistant, mock_bleak_scanner_start, caplog):
+    """Test bleak error handling and recovery."""
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    flag = True
+
+    def _update_method(service_info: BluetoothServiceInfoBleak):
+        return {"testdata": None}
+
+    def _poll_needed(*args, **kwargs):
+        return True
+
+    async def _poll(*args, **kwargs):
+        nonlocal flag
+        if flag:
+            raise BleakError("Connection was aborted")
+        return {"testdata": flag}
+
+    coordinator = ActiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        address="aa:bb:cc:dd:ee:ff",
+        mode=BluetoothScanningMode.ACTIVE,
+        update_method=_update_method,
+        needs_poll_method=_poll_needed,
+        poll_method=_poll,
+        poll_debouncer=Debouncer(
+            hass,
+            _LOGGER,
+            cooldown=0,
+            immediate=True,
+        ),
+    )
+    assert coordinator.available is False  # no data yet
+    saved_callback = None
+
+    processor = MagicMock()
+    coordinator.async_register_processor(processor)
+    async_handle_update = processor.async_handle_update
+
+    def _async_register_callback(_hass, _callback, _matcher, _mode):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        cancel = coordinator.async_start()
+
+    assert saved_callback is not None
+
+    # First poll fails
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+    assert async_handle_update.mock_calls[-1] == call({"testdata": None})
+
+    assert "aa:bb:cc:dd:ee:ff: Bluetooth error whilst polling: Connection was aborted" in caplog.text
+
+    # Second poll works
+    flag = False
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+    assert async_handle_update.mock_calls[-1] == call({"testdata": False})
+
+    cancel()
 
 async def test_poll_failure_and_recover(hass: HomeAssistant, mock_bleak_scanner_start):
     """Test error handling and recovery."""


### PR DESCRIPTION
## Proposed change

Currently fairly common scenarios like when a bluetooth sensor is in range for passive connections but out of range for active connections can lead to exception logs for xiaomi_ble. These are only shown once and then silenced until the next recovery. However they are big exceptions and look like a Home Assistant bug, when the users plant sensor is just out of range.

A normal data coordinator handles aiohttp errors automatically. To mirror that, it makes sense for this bluetooth coordinator to handle common bluetooth failures.

With this PR, this error:

```
2022-09-05 13:08:59.445 EXCEPTION (MainThread) [homeassistant.components.xiaomi_ble] C4:7C:8D:6A:5C:E6: Failure while polling

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/client.py", line 159, in connect
    reply = await self._bus.call(
  File "/usr/local/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 305, in call
    await future
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/bleak_retry_connector/__init__.py", line 357, in establish_connection
    await client.connect(
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/client.py", line 158, in connect
    async with async_timeout.timeout(timeout):
  File "/usr/local/lib/python3.10/site-packages/async_timeout/__init__.py", line 129, in __aexit__
    self._do_exit(exc_type)
  File "/usr/local/lib/python3.10/site-packages/async_timeout/__init__.py", line 212, in _do_exit
    raise asyncio.TimeoutError
asyncio.exceptions.TimeoutError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/active_update_coordinator.py", line 111, in _async_poll
    update = await self._async_poll_data(self._last_service_info)
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/active_update_coordinator.py", line 104, in _async_poll_data
    return await self._poll_method(last_service_info)
  File "/usr/src/homeassistant/homeassistant/components/xiaomi_ble/__init__.py", line 82, in _async_poll
    return await data.async_poll(connectable_device)
  File "/usr/local/lib/python3.10/site-packages/xiaomi_ble/parser.py", line 1293, in async_poll
    client = await establish_connection(
  File "/usr/local/lib/python3.10/site-packages/bleak_retry_connector/__init__.py", line 370, in establish_connection
    _raise_if_needed(name, description, exc)
  File "/usr/local/lib/python3.10/site-packages/bleak_retry_connector/__init__.py", line 303, in _raise_if_needed
    raise BleakNotFoundError(msg) from exc
bleak_retry_connector.BleakNotFoundError: C4:7C:8D:67:9C:CF - /org/bluez/hci0/dev_C4_7C_8D_67_9C_CF: Failed to connect: 
```

will become something more like:

```
2022-09-05 13:08:59.445 INFO (MainThread) [homeassistant.components.xiaomi_ble] C4:7C:8D:6A:5C:E6: Bluetooth error whilst polling: Reason for failure
```

No more scary traceback.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
