### PR TITLE
Allow entries with same user_key for Pushover

### DIFF
--- a/homeassistant/components/pushover/__init__.py
+++ b/homeassistant/components/pushover/__init__.py
@@ -25,11 +25,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up pushover from a config entry."""
 
-    # old unique_id is the user_key only
-    if entry.unique_id == entry.data[CONF_USER_KEY]:
-        hass.config_entries.async_update_entry(
-            entry, unique_id=f"{entry.data[CONF_USER_KEY]}-{entry.data[CONF_API_KEY]}"
-        )
+    # remove unique_id for beta users
+    if entry.unique_id is not None:
+        hass.config_entries.async_update_entry(entry, unique_id=None)
 
     pushover_api = PushoverAPI(entry.data[CONF_API_KEY])
     try:

--- a/homeassistant/components/pushover/__init__.py
+++ b/homeassistant/components/pushover/__init__.py
@@ -25,6 +25,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up pushover from a config entry."""
 
+    # old unique_id is the user_key only
+    if entry.unique_id == entry.data[CONF_USER_KEY]:
+        hass.config_entries.async_update_entry(
+            entry, unique_id=f"{entry.data[CONF_USER_KEY]}-{entry.data[CONF_API_KEY]}"
+        )
+
     pushover_api = PushoverAPI(entry.data[CONF_API_KEY])
     try:
         await hass.async_add_executor_job(

--- a/homeassistant/components/pushover/config_flow.py
+++ b/homeassistant/components/pushover/config_flow.py
@@ -62,6 +62,12 @@ class PushBulletConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None and self._reauth_entry:
             user_input = {**self._reauth_entry.data, **user_input}
+            self._async_abort_entries_match(
+                {
+                    CONF_USER_KEY: user_input[CONF_USER_KEY],
+                    CONF_API_KEY: user_input[CONF_API_KEY],
+                }
+            )
             errors = await validate_input(self.hass, user_input)
             if not errors:
                 self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/pushover/config_flow.py
+++ b/homeassistant/components/pushover/config_flow.py
@@ -87,7 +87,9 @@ class PushBulletConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            await self.async_set_unique_id(user_input[CONF_USER_KEY])
+            await self.async_set_unique_id(
+                f"{user_input[CONF_USER_KEY]}-{user_input[CONF_API_KEY]}"
+            )
             self._abort_if_unique_id_configured()
 
             self._async_abort_entries_match({CONF_NAME: user_input[CONF_NAME]})

--- a/homeassistant/components/pushover/config_flow.py
+++ b/homeassistant/components/pushover/config_flow.py
@@ -87,11 +87,13 @@ class PushBulletConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            await self.async_set_unique_id(
-                f"{user_input[CONF_USER_KEY]}-{user_input[CONF_API_KEY]}"
-            )
-            self._abort_if_unique_id_configured()
 
+            self._async_abort_entries_match(
+                {
+                    CONF_USER_KEY: user_input[CONF_USER_KEY],
+                    CONF_API_KEY: user_input[CONF_API_KEY],
+                }
+            )
             self._async_abort_entries_match({CONF_NAME: user_input[CONF_NAME]})
 
             errors = await validate_input(self.hass, user_input)

--- a/tests/components/pushover/test_config_flow.py
+++ b/tests/components/pushover/test_config_flow.py
@@ -170,7 +170,7 @@ async def test_reauth_success(hass: HomeAssistant) -> None:
         data=MOCK_CONFIG,
     )
 
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -180,7 +180,7 @@ async def test_reauth_success(hass: HomeAssistant) -> None:
         },
     )
 
-    assert result2["type"] == "abort"
+    assert result2["type"] == FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
 
 
@@ -212,7 +212,47 @@ async def test_reauth_failed(hass: HomeAssistant, mock_pushover: MagicMock) -> N
         },
     )
 
-    assert result2["type"] == "form"
+    assert result2["type"] == FlowResultType.FORM
     assert result2["errors"] == {
         CONF_API_KEY: "invalid_api_key",
     }
+
+
+async def test_reauth_with_existing_config(hass: HomeAssistant) -> None:
+    """Test reauth fails if the api key entered exists in another entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+    )
+    entry.add_to_hass(hass)
+
+    second_entry = MOCK_CONFIG.copy()
+    second_entry[CONF_API_KEY] = "MYAPIKEY2"
+
+    entry2 = MockConfigEntry(
+        domain=DOMAIN,
+        data=second_entry,
+    )
+    entry2.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+        },
+        data=MOCK_CONFIG,
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_API_KEY: "MYAPIKEY2",
+        },
+    )
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"

--- a/tests/components/pushover/test_config_flow.py
+++ b/tests/components/pushover/test_config_flow.py
@@ -48,12 +48,12 @@ async def test_flow_user(hass: HomeAssistant) -> None:
     assert result["data"] == MOCK_CONFIG
 
 
-async def test_flow_user_key_already_configured(hass: HomeAssistant) -> None:
-    """Test user initialized flow with duplicate user key."""
+async def test_flow_user_key_api_key_exists(hass: HomeAssistant) -> None:
+    """Test user initialized flow with duplicate user key / api key pair."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG,
-        unique_id="MYUSERKEY",
+        unique_id="MYUSERKEY-MYAPIKEY",
     )
 
     entry.add_to_hass(hass)

--- a/tests/components/pushover/test_config_flow.py
+++ b/tests/components/pushover/test_config_flow.py
@@ -53,7 +53,6 @@ async def test_flow_user_key_api_key_exists(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG,
-        unique_id="MYUSERKEY-MYAPIKEY",
     )
 
     entry.add_to_hass(hass)

--- a/tests/components/pushover/test_init.py
+++ b/tests/components/pushover/test_init.py
@@ -68,6 +68,16 @@ async def test_async_setup_entry_success(hass: HomeAssistant) -> None:
     assert entry.state == ConfigEntryState.LOADED
 
 
+async def test_unique_id_updated(hass: HomeAssistant) -> None:
+    """Test updating unique_id to new format."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, unique_id="MYUSERKEY")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state == ConfigEntryState.LOADED
+    assert entry.unique_id == "MYUSERKEY-MYAPIKEY"
+
+
 async def test_async_setup_entry_failed_invalid_api_key(
     hass: HomeAssistant, mock_pushover: MagicMock
 ) -> None:

--- a/tests/components/pushover/test_init.py
+++ b/tests/components/pushover/test_init.py
@@ -75,7 +75,7 @@ async def test_unique_id_updated(hass: HomeAssistant) -> None:
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.state == ConfigEntryState.LOADED
-    assert entry.unique_id == "MYUSERKEY-MYAPIKEY"
+    assert entry.unique_id is None
 
 
 async def test_async_setup_entry_failed_invalid_api_key(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Pushover allows configuring mutiple applications with different api key. These applications will use the same user key.
This PR removes the unique_id so multiple applications (notify services) can be configured.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #77852
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
