### PR TITLE
Add calendar status attribute

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -356,6 +356,7 @@ class CalendarEventView(http.HomeAssistantView):
                     "location": event.location,
                     "start": _get_api_date(event.start),
                     "end": _get_api_date(event.end),
+                    "status": event.status,
                 }
                 for event in calendar_event_list
             ]

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -84,6 +84,7 @@ class CalendarEvent:
     summary: str
     description: str | None = None
     location: str | None = None
+    status: str | None = None
 
     @property
     def start_datetime_local(self) -> datetime.datetime:
@@ -112,6 +113,8 @@ class CalendarEvent:
             data["description"] = self.description
         if self.location:
             data["location"] = self.location
+        if self.status:
+            data["status"] = self.status
         return data
 
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -279,6 +279,7 @@ class CalendarEntity(Entity):
             "end_time": event.end_datetime_local.strftime(DATE_STR_FORMAT),
             "location": event.location if event.location else "",
             "description": event.description if event.description else "",
+            "status": event.status if event.status else "",
         }
 
     @final

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -41,6 +41,7 @@ def calendar_data_future() -> CalendarEvent:
         summary="Future Event",
         description="Future Description",
         location="Future Location",
+        status="tentative",
     )
 
 
@@ -99,6 +100,7 @@ class LegacyDemoCalendar(CalendarEventDevice):
             "summary": "Future Event",
             "description": "Future Description",
             "location": "Future Location",
+            "status": "tentative",
         }
 
     @property

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -89,3 +89,4 @@ async def test_events_http_api_shim(hass, hass_client):
     assert events[0]["summary"] == "Future Event"
     assert events[0]["description"] == "Future Description"
     assert events[0]["location"] == "Future Location"
+    assert events[0]["status"] == "tentative"

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -64,6 +64,7 @@ class FakeSchedule:
         end: datetime.timedelta,
         description: str = None,
         location: str = None,
+        status: str = None,
     ) -> dict[str, Any]:
         """Create a new fake event, used by tests."""
         event = calendar.CalendarEvent(
@@ -71,7 +72,7 @@ class FakeSchedule:
             end=end,
             summary=f"Event {secrets.token_hex(16)}",  # Arbitrary unique data
             description=description,
-            location=location,
+            status=status,
         )
         self.events.append(event)
         return event.as_dict()
@@ -541,6 +542,7 @@ async def test_event_payload(hass, calls, fake_schedule):
         end=datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00"),
         description="Description",
         location="Location",
+        status="confirmed",
     )
     await create_automation(hass, EVENT_START)
     assert len(calls()) == 0

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -72,6 +72,7 @@ class FakeSchedule:
             end=end,
             summary=f"Event {secrets.token_hex(16)}",  # Arbitrary unique data
             description=description,
+            location=location,
             status=status,
         )
         self.events.append(event)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding a "status" attribute to the CalendarEvent.  Almost all calendars support various kind of "status" attributes for events.  The most common are "Tentative", "Confirmed" and "Cancelled", but others exist.  

By extending the CalendarEvent class with this field you can now chose to ignore e.g. cancelled events from triggering an automation, or you can list only the confirmed events in your daily schedule.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
