### PR TITLE
Add infrared brightness select entity for LIFX Night Vision bulbs

### DIFF
--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = vol.All(
 )
 
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SELECT, Platform.LIGHT]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.LIGHT, Platform.SELECT]
 DISCOVERY_INTERVAL = timedelta(minutes=15)
 MIGRATION_INTERVAL = timedelta(minutes=5)
 

--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = vol.All(
 )
 
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.LIGHT]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SELECT, Platform.LIGHT]
 DISCOVERY_INTERVAL = timedelta(minutes=15)
 MIGRATION_INTERVAL = timedelta(minutes=5)
 

--- a/homeassistant/components/lifx/const.py
+++ b/homeassistant/components/lifx/const.py
@@ -38,7 +38,12 @@ ATTR_ZONES = "zones"
 
 HEV_CYCLE_STATE = "hev_cycle_state"
 INFRARED_BRIGHTNESS = "infrared_brightness"
-
+INFRARED_BRIGHTNESS_VALUES_MAP = {
+    0: "Disabled",
+    16383: "25%",
+    32767: "50%",
+    65535: "100%",
+}
 DATA_LIFX_MANAGER = "lifx_manager"
 
 _LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/lifx/const.py
+++ b/homeassistant/components/lifx/const.py
@@ -37,6 +37,7 @@ ATTR_REMAINING = "remaining"
 ATTR_ZONES = "zones"
 
 HEV_CYCLE_STATE = "hev_cycle_state"
+INFRARED_BRIGHTNESS = "infrared_brightness"
 
 DATA_LIFX_MANAGER = "lifx_manager"
 

--- a/homeassistant/components/lifx/coordinator.py
+++ b/homeassistant/components/lifx/coordinator.py
@@ -22,7 +22,13 @@ from .const import (
     TARGET_ANY,
     UNAVAILABLE_GRACE,
 )
-from .util import async_execute_lifx, get_real_mac_addr, lifx_features
+from .util import (
+    async_execute_lifx,
+    get_real_mac_addr,
+    infrared_brightness_option_to_value,
+    infrared_brightness_value_to_option,
+    lifx_features,
+)
 
 REQUEST_REFRESH_DELAY = 0.35
 LIFX_IDENTIFY_DELAY = 3.0
@@ -207,28 +213,9 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator):
 
     def async_current_infrared_brightness(self) -> str | None:
         """Return the current infrared brightness as a string."""
-        if self.device.infrared_brightness == 0:
-            option = "Disabled"
-        elif self.device.infrared_brightness == 16383:
-            option = "25%"
-        elif self.device.infrared_brightness == 32767:
-            option = "50%"
-        elif self.device.infrared_brightness == 65535:
-            option = "100%"
-        else:
-            option = None
-
-        return option
+        return infrared_brightness_value_to_option(self.device.infrared_brightness)
 
     async def async_set_infrared_brightness(self, option: str) -> None:
         """Set infrared brightness."""
-        if option == "Disabled":
-            infrared_brightness = 0
-        elif option == "25%":
-            infrared_brightness = 16383
-        elif option == "50%":
-            infrared_brightness = 32767
-        elif option == "100%":
-            infrared_brightness = 65535
-
+        infrared_brightness = infrared_brightness_option_to_value(option)
         await async_execute_lifx(partial(self.device.set_infrared, infrared_brightness))

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 import homeassistant.util.color as color_util
 
 from .const import (
+    _LOGGER,
     ATTR_DURATION,
     ATTR_INFRARED,
     ATTR_POWER,
@@ -212,6 +213,9 @@ class LIFXLight(LIFXEntity, LightEntity):
                 return
 
             if ATTR_INFRARED in kwargs:
+                _LOGGER.warning(
+                    "The infrared attribute of the lifx.set_state service is deprecated and will be removed in a future version"
+                )
                 bulb.set_infrared(convert_8_to_16(kwargs[ATTR_INFRARED]))
 
             if ATTR_TRANSITION in kwargs:

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -19,7 +19,7 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
@@ -36,6 +36,7 @@ from .const import (
     ATTR_ZONES,
     DATA_LIFX_MANAGER,
     DOMAIN,
+    INFRARED_BRIGHTNESS,
 )
 from .coordinator import LIFXUpdateCoordinator
 from .entity import LIFXEntity
@@ -213,8 +214,12 @@ class LIFXLight(LIFXEntity, LightEntity):
                 return
 
             if ATTR_INFRARED in kwargs:
+                infrared_entity_id = self.coordinator.async_get_entity_id(
+                    Platform.SELECT, INFRARED_BRIGHTNESS
+                )
                 _LOGGER.warning(
-                    "The infrared attribute of the lifx.set_state service is deprecated and will be removed in a future version"
+                    "The 'infrared' attribute of 'lifx.set_state' is deprecated: call 'select.select_option' targeting '%s' instead",
+                    infrared_entity_id,
                 )
                 bulb.set_infrared(convert_8_to_16(kwargs[ATTR_INFRARED]))
 

--- a/homeassistant/components/lifx/manifest.json
+++ b/homeassistant/components/lifx/manifest.json
@@ -3,7 +3,7 @@
   "name": "LIFX",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/lifx",
-  "requirements": ["aiolifx==0.8.2", "aiolifx_effects==0.2.2"],
+  "requirements": ["aiolifx==0.8.4", "aiolifx_effects==0.2.2"],
   "quality_scale": "platinum",
   "dependencies": ["network"],
   "homekit": {

--- a/homeassistant/components/lifx/select.py
+++ b/homeassistant/components/lifx/select.py
@@ -1,0 +1,67 @@
+"""Select sensor entities for LIFX integration."""
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, INFRARED_BRIGHTNESS
+from .coordinator import LIFXUpdateCoordinator
+from .entity import LIFXEntity
+from .util import lifx_features
+
+INFRARED_BRIGHTNESS_ENTITY = SelectEntityDescription(
+    key=INFRARED_BRIGHTNESS,
+    name="Infrared brightness",
+    entity_category=EntityCategory.CONFIG,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up LIFX from a config entry."""
+    coordinator: LIFXUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    if lifx_features(coordinator.device)["infrared"]:
+        async_add_entities(
+            [
+                LIFXInfraredBrightnessSelectEntity(
+                    coordinator, description=INFRARED_BRIGHTNESS_ENTITY
+                )
+            ]
+        )
+
+
+class LIFXInfraredBrightnessSelectEntity(LIFXEntity, SelectEntity):
+    """LIFX Nightvision infrared brightness configuration entity."""
+
+    _attr_has_entity_name = True
+    _attr_options = ["Disabled", "25%", "50%", "100%"]
+
+    def __init__(
+        self, coordinator: LIFXUpdateCoordinator, description: SelectEntityDescription
+    ) -> None:
+        """Initialise the IR brightness config entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_name = description.name
+        self._attr_unique_id = f"{coordinator.serial_number}_{description.key}"
+        self._attr_current_option = coordinator.async_current_infrared_brightness()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Handle coordinator updates."""
+        self._attr_current_option = self.coordinator.async_current_infrared_brightness()
+
+    async def async_select_option(self, option: str) -> None:
+        """Update the infrared brightness value."""
+        await self.coordinator.async_set_infrared_brightness(option)

--- a/homeassistant/components/lifx/select.py
+++ b/homeassistant/components/lifx/select.py
@@ -51,7 +51,7 @@ class LIFXInfraredBrightnessSelectEntity(LIFXEntity, SelectEntity):
         self.entity_description = description
         self._attr_name = description.name
         self._attr_unique_id = f"{coordinator.serial_number}_{description.key}"
-        self._attr_current_option = coordinator.async_current_infrared_brightness()
+        self._attr_current_option = coordinator.current_infrared_brightness
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -62,7 +62,7 @@ class LIFXInfraredBrightnessSelectEntity(LIFXEntity, SelectEntity):
     @callback
     def _async_update_attrs(self) -> None:
         """Handle coordinator updates."""
-        self._attr_current_option = self.coordinator.async_current_infrared_brightness()
+        self._attr_current_option = self.coordinator.current_infrared_brightness
 
     async def async_select_option(self, option: str) -> None:
         """Update the infrared brightness value."""

--- a/homeassistant/components/lifx/select.py
+++ b/homeassistant/components/lifx/select.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, INFRARED_BRIGHTNESS
+from .const import DOMAIN, INFRARED_BRIGHTNESS, INFRARED_BRIGHTNESS_VALUES_MAP
 from .coordinator import LIFXUpdateCoordinator
 from .entity import LIFXEntity
 from .util import lifx_features
@@ -17,6 +17,8 @@ INFRARED_BRIGHTNESS_ENTITY = SelectEntityDescription(
     name="Infrared brightness",
     entity_category=EntityCategory.CONFIG,
 )
+
+INFRARED_BRIGHTNESS_OPTIONS = list(INFRARED_BRIGHTNESS_VALUES_MAP.values())
 
 
 async def async_setup_entry(
@@ -39,7 +41,7 @@ class LIFXInfraredBrightnessSelectEntity(LIFXEntity, SelectEntity):
     """LIFX Nightvision infrared brightness configuration entity."""
 
     _attr_has_entity_name = True
-    _attr_options = ["Disabled", "25%", "50%", "100%"]
+    _attr_options = INFRARED_BRIGHTNESS_OPTIONS
 
     def __init__(
         self, coordinator: LIFXUpdateCoordinator, description: SelectEntityDescription

--- a/homeassistant/components/lifx/util.py
+++ b/homeassistant/components/lifx/util.py
@@ -25,7 +25,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 import homeassistant.util.color as color_util
 
-from .const import _LOGGER, DOMAIN, OVERALL_TIMEOUT
+from .const import _LOGGER, DOMAIN, INFRARED_BRIGHTNESS_VALUES_MAP, OVERALL_TIMEOUT
 
 FIX_MAC_FW = AwesomeVersion("3.70")
 
@@ -43,6 +43,17 @@ def async_get_legacy_entry(hass: HomeAssistant) -> ConfigEntry | None:
         if async_entry_is_legacy(entry):
             return entry
     return None
+
+
+def infrared_brightness_value_to_option(value: int) -> str | None:
+    """Convert infrared brightness from value to option."""
+    return INFRARED_BRIGHTNESS_VALUES_MAP.get(value, None)
+
+
+def infrared_brightness_option_to_value(option: str) -> int | None:
+    """Convert infrared brightness option to value."""
+    option_values = {v: k for k, v in INFRARED_BRIGHTNESS_VALUES_MAP.items()}
+    return option_values.get(option, None)
 
 
 def convert_8_to_16(value: int) -> int:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -190,7 +190,7 @@ aiokafka==0.7.2
 aiokef==0.2.16
 
 # homeassistant.components.lifx
-aiolifx==0.8.2
+aiolifx==0.8.4
 
 # homeassistant.components.lifx
 aiolifx_effects==0.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -168,7 +168,7 @@ aiohue==4.5.0
 aiokafka==0.7.2
 
 # homeassistant.components.lifx
-aiolifx==0.8.2
+aiolifx==0.8.4
 
 # homeassistant.components.lifx
 aiolifx_effects==0.2.2

--- a/tests/components/lifx/__init__.py
+++ b/tests/components/lifx/__init__.py
@@ -62,6 +62,9 @@ class MockLifxCommand:
         self.bulb = bulb
         self.calls = []
         self.msg_kwargs = kwargs
+        for k, v in kwargs.items():
+            if k != "callb":
+                setattr(self.bulb, k, v)
 
     def __call__(self, *args, **kwargs):
         """Call command."""
@@ -127,6 +130,14 @@ def _mocked_clean_bulb() -> Light:
         "last_power": False,
     }
     bulb.product = 90
+    return bulb
+
+
+def _mocked_infrared_bulb() -> Light:
+    bulb = _mocked_bulb()
+    bulb.product = 29  # LIFX A19 Night Vision
+    bulb.infrared_brightness = 65535
+    bulb.get_infrared = MockLifxCommand(bulb, infrared_brightness=65535)
     return bulb
 
 

--- a/tests/components/lifx/__init__.py
+++ b/tests/components/lifx/__init__.py
@@ -137,6 +137,7 @@ def _mocked_infrared_bulb() -> Light:
     bulb = _mocked_bulb()
     bulb.product = 29  # LIFX A19 Night Vision
     bulb.infrared_brightness = 65535
+    bulb.set_infrared = MockLifxCommand(bulb)
     bulb.get_infrared = MockLifxCommand(bulb, infrared_brightness=65535)
     return bulb
 

--- a/tests/components/lifx/test_select.py
+++ b/tests/components/lifx/test_select.py
@@ -1,0 +1,239 @@
+"""Tests for the lifx integration select entity."""
+from datetime import timedelta
+
+from homeassistant.components import lifx
+from homeassistant.components.lifx.const import DOMAIN
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from . import (
+    DEFAULT_ENTRY_TITLE,
+    IP_ADDRESS,
+    MAC_ADDRESS,
+    SERIAL,
+    MockLifxCommand,
+    _mocked_infrared_bulb,
+    _patch_config_flow_try_connect,
+    _patch_device,
+    _patch_discovery,
+)
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_infrared_brightness(hass: HomeAssistant) -> None:
+    """Test getting and setting infrared brightness."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_ENTRY_TITLE,
+        data={CONF_HOST: IP_ADDRESS},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_infrared_bulb()
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    unique_id = f"{SERIAL}_infrared_brightness"
+    entity_id = "select.my_bulb_infrared_brightness"
+
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    assert not entity.disabled
+    assert entity.unique_id == unique_id
+
+    state = hass.states.get(entity_id)
+    assert state.state == "100%"
+
+
+async def test_set_infrared_brightness_25_percent(hass: HomeAssistant) -> None:
+    """Test getting and setting infrared brightness."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_ENTRY_TITLE,
+        data={CONF_HOST: IP_ADDRESS},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_infrared_bulb()
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "select.my_bulb_infrared_brightness"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        "select_option",
+        {ATTR_ENTITY_ID: entity_id, "option": "25%"},
+        blocking=True,
+    )
+
+    bulb.get_infrared = MockLifxCommand(bulb, infrared_brightness=16383)
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    assert bulb.set_infrared.calls[0][0][0] == 16383
+
+    state = hass.states.get(entity_id)
+    assert state.state == "25%"
+
+    bulb.set_infrared.reset_mock()
+
+
+async def test_set_infrared_brightness_50_percent(hass: HomeAssistant) -> None:
+    """Test getting and setting infrared brightness."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_ENTRY_TITLE,
+        data={CONF_HOST: IP_ADDRESS},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_infrared_bulb()
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "select.my_bulb_infrared_brightness"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        "select_option",
+        {ATTR_ENTITY_ID: entity_id, "option": "50%"},
+        blocking=True,
+    )
+
+    bulb.get_infrared = MockLifxCommand(bulb, infrared_brightness=32767)
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    assert bulb.set_infrared.calls[0][0][0] == 32767
+
+    state = hass.states.get(entity_id)
+    assert state.state == "50%"
+
+    bulb.set_infrared.reset_mock()
+
+
+async def test_set_infrared_brightness_100_percent(hass: HomeAssistant) -> None:
+    """Test getting and setting infrared brightness."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_ENTRY_TITLE,
+        data={CONF_HOST: IP_ADDRESS},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_infrared_bulb()
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "select.my_bulb_infrared_brightness"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        "select_option",
+        {ATTR_ENTITY_ID: entity_id, "option": "100%"},
+        blocking=True,
+    )
+
+    bulb.get_infrared = MockLifxCommand(bulb, infrared_brightness=65535)
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    assert bulb.set_infrared.calls[0][0][0] == 65535
+
+    state = hass.states.get(entity_id)
+    assert state.state == "100%"
+
+    bulb.set_infrared.reset_mock()
+
+
+async def test_disable_infrared(hass: HomeAssistant) -> None:
+    """Test getting and setting infrared brightness."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_ENTRY_TITLE,
+        data={CONF_HOST: IP_ADDRESS},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_infrared_bulb()
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "select.my_bulb_infrared_brightness"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        "select_option",
+        {ATTR_ENTITY_ID: entity_id, "option": "Disabled"},
+        blocking=True,
+    )
+
+    bulb.get_infrared = MockLifxCommand(bulb, infrared_brightness=0)
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    assert bulb.set_infrared.calls[0][0][0] == 0
+
+    state = hass.states.get(entity_id)
+    assert state.state == "Disabled"
+
+    bulb.set_infrared.reset_mock()
+
+
+async def test_invalid_infrared_brightness(hass: HomeAssistant) -> None:
+    """Test getting and setting infrared brightness."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_ENTRY_TITLE,
+        data={CONF_HOST: IP_ADDRESS},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_infrared_bulb()
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "select.my_bulb_infrared_brightness"
+
+    bulb.get_infrared = MockLifxCommand(bulb, infrared_brightness=12345)
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
## Proposed change

Add a select entity that sets the infrared brightness value for LIFX Night Vision bulbs. 

This required an update to the `aiolifx` dependency to v0.8.4.

`aiolifx `release: https://github.com/frawau/aiolifx/releases/tag/0.8.4
`aiolifx `changelog: https://github.com/frawau/aiolifx/compare/0.8.2...0.8.4

Signed-off-by: Avi Miller <me@dje.li>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24028

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
