### PR TITLE
Move twilio to config flow completely

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1165,6 +1165,8 @@ build.json @home-assistant/supervisor
 /tests/components/tuya/ @Tuya @zlinoliver @frenck
 /homeassistant/components/twentemilieu/ @frenck
 /tests/components/twentemilieu/ @frenck
+/homeassistant/components/twilio/ @engrbm87
+/tests/components/twilio/ @engrbm87
 /homeassistant/components/twinkly/ @dr1rrb @Robbie1221
 /tests/components/twinkly/ @dr1rrb @Robbie1221
 /homeassistant/components/ukraine_alarm/ @PaulAnnekov

--- a/homeassistant/components/twilio/__init__.py
+++ b/homeassistant/components/twilio/__init__.py
@@ -1,35 +1,36 @@
-"""Support for Twilio."""
+"""The Twilio integration."""
+from __future__ import annotations
+
 from aiohttp import web
 from twilio.rest import Client
 import voluptuous as vol
 
 from homeassistant.components import webhook
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN
-
-CONF_ACCOUNT_SID = "account_sid"
-CONF_AUTH_TOKEN = "auth_token"
+from .const import CONF_ACCOUNT_SID, CONF_AUTH_TOKEN, DOMAIN, RECEIVED_DATA
 
 DATA_TWILIO = DOMAIN
 
-RECEIVED_DATA = f"{DOMAIN}_data_received"
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        vol.Optional(DOMAIN): vol.Schema(
-            {
-                vol.Required(CONF_ACCOUNT_SID): cv.string,
-                vol.Required(CONF_AUTH_TOKEN): cv.string,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
+CONFIG_SCHEMA = vol.All(
+    cv.deprecated(DOMAIN),
+    vol.Schema(
+        {
+            vol.Optional(DOMAIN): vol.Schema(
+                {
+                    vol.Required(CONF_ACCOUNT_SID): cv.string,
+                    vol.Required(CONF_AUTH_TOKEN): cv.string,
+                }
+            )
+        },
+        extra=vol.ALLOW_EXTRA,
+    ),
 )
 
 
@@ -38,24 +39,42 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if DOMAIN not in config:
         return True
 
-    conf = config[DOMAIN]
-    hass.data[DATA_TWILIO] = Client(
-        conf.get(CONF_ACCOUNT_SID), conf.get(CONF_AUTH_TOKEN)
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "deprecated_yaml",
+        breaks_in_ha_version="2022.12.0",
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
     )
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config[DOMAIN]
+        )
+    )
+
     return True
 
 
-async def handle_webhook(hass, webhook_id, request):
+async def handle_webhook(
+    hass: HomeAssistant, webhook_id: str, request: web.Request
+) -> web.Response:
     """Handle incoming webhook from Twilio for inbound messages and calls."""
     data = dict(await request.post())
     data["webhook_id"] = webhook_id
-    hass.bus.async_fire(RECEIVED_DATA, dict(data))
+    hass.bus.async_fire(RECEIVED_DATA, data)
 
     return web.Response(text="")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Configure based on config entry."""
+
+    hass.data[DOMAIN] = Client(
+        entry.data[CONF_ACCOUNT_SID],
+        entry.data[CONF_AUTH_TOKEN],
+    )
     webhook.async_register(
         hass, DOMAIN, "Twilio", entry.data[CONF_WEBHOOK_ID], handle_webhook
     )
@@ -65,6 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     webhook.async_unregister(hass, entry.data[CONF_WEBHOOK_ID])
+    del hass.data[DOMAIN]
     return True
 
 

--- a/homeassistant/components/twilio/config_flow.py
+++ b/homeassistant/components/twilio/config_flow.py
@@ -1,13 +1,124 @@
-"""Config flow for Twilio."""
-from homeassistant.helpers import config_entry_flow
+"""Config flow for Twilio integration."""
+from __future__ import annotations
 
-from .const import DOMAIN
+from typing import Any
 
-config_entry_flow.register_webhook_flow(
-    DOMAIN,
-    "Twilio Webhook",
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components import cloud, webhook
+from homeassistant.const import CONF_WEBHOOK_ID
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
+
+from .const import CONF_ACCOUNT_SID, CONF_AUTH_TOKEN, CONF_CLOUDHOOK, DOMAIN
+
+USER_DATA_SCHEMA = vol.Schema(
     {
-        "twilio_url": "https://www.twilio.com/docs/glossary/what-is-a-webhook",
-        "docs_url": "https://www.home-assistant.io/integrations/twilio/",
-    },
+        vol.Required(CONF_ACCOUNT_SID): selector.TextSelector(),
+        vol.Required(CONF_AUTH_TOKEN): selector.TextSelector(),
+    }
 )
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Twilio."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is None:
+            return self.async_show_form(step_id="user", data_schema=USER_DATA_SCHEMA)
+
+        try:
+            webhook_id, webhook_url, cloudhook = await self._get_webhook_id()
+        except cloud.CloudNotConnected:
+            return self.async_abort(reason="cloud_not_connected")
+
+        user_input[CONF_WEBHOOK_ID] = webhook_id
+        user_input[CONF_CLOUDHOOK] = cloudhook
+
+        return self.async_create_entry(
+            title="Twilio",
+            data=user_input,
+            description_placeholders={
+                "webhook_url": webhook_url,
+                "twilio_url": "https://www.twilio.com/docs/glossary/what-is-a-webhook",
+                "docs_url": "https://www.home-assistant.io/integrations/twilio/",
+            },
+        )
+
+    async def async_step_import(self, import_config: dict[str, Any]) -> FlowResult:
+        """Import a config entry from configuration.yaml."""
+
+        if self._async_current_entries():
+            # an entry exists for the webhook so just save the
+            # account_sid and auth_token in data
+            entry = self._async_current_entries()[0]
+            data = {
+                **entry.data,
+                CONF_ACCOUNT_SID: import_config[CONF_ACCOUNT_SID],
+                CONF_AUTH_TOKEN: import_config[CONF_AUTH_TOKEN],
+            }
+            self.hass.config_entries.async_update_entry(entry, data=data)
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(entry.entry_id)
+            )
+            return self.async_abort(reason="already_configured")
+
+        return await self.async_step_user(import_config)
+
+    async def _get_webhook_id(self):
+        """Generate webhook ID."""
+        webhook_id = webhook.async_generate_id()
+        if cloud.async_active_subscription(self.hass):
+            webhook_url = await cloud.async_create_cloudhook(self.hass, webhook_id)
+            cloudhook = True
+        else:
+            webhook_url = webhook.async_generate_url(self.hass, webhook_id)
+            cloudhook = False
+
+        return webhook_id, webhook_url, cloudhook
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> TwilioOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return TwilioOptionsFlowHandler(config_entry)
+
+
+class TwilioOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a option flow for Twilio."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+
+        if user_input is not None:
+            return self.async_create_entry(title="", data={})
+
+        webhook_id = self.config_entry.data[CONF_WEBHOOK_ID]
+        webhook_url = webhook.async_generate_url(self.hass, webhook_id)
+
+        return self.async_show_form(
+            step_id="init",
+            description_placeholders={
+                "webhook_url": webhook_url,
+                "twilio_url": "https://www.twilio.com/docs/glossary/what-is-a-webhook",
+                "docs_url": "https://www.home-assistant.io/integrations/twilio/",
+            },
+        )

--- a/homeassistant/components/twilio/const.py
+++ b/homeassistant/components/twilio/const.py
@@ -1,3 +1,11 @@
-"""Const for Twilio."""
+"""Constants for the Twilio integration."""
 
-DOMAIN = "twilio"
+from typing import Final
+
+DOMAIN: Final = "twilio"
+
+CONF_ACCOUNT_SID: Final = "account_sid"
+CONF_AUTH_TOKEN: Final = "auth_token"
+CONF_CLOUDHOOK: Final = "cloudhook"
+
+RECEIVED_DATA: Final = "twilio_data_received"

--- a/homeassistant/components/twilio/manifest.json
+++ b/homeassistant/components/twilio/manifest.json
@@ -4,8 +4,8 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/twilio",
   "requirements": ["twilio==6.32.0"],
-  "dependencies": ["webhook"],
-  "codeowners": [],
+  "dependencies": ["cloud", "webhook"],
+  "codeowners": ["@engrbm87"],
   "iot_class": "cloud_push",
   "loggers": ["twilio"]
 }

--- a/homeassistant/components/twilio/strings.json
+++ b/homeassistant/components/twilio/strings.json
@@ -2,17 +2,28 @@
   "config": {
     "step": {
       "user": {
-        "title": "Set up the Twilio Webhook",
-        "description": "[%key:common::config_flow::description::confirm_setup%]"
+        "data": {
+          "account_sid": "Your Twilio account",
+          "auth_token": "Your Twilio AUTH TOKEN",
+          "use_webhook": "Use webhook"
+        }
       }
     },
     "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [Webhooks with Twilio]({twilio_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "To send events to Home Assistant, you will need to setup [Webhooks with Twilio]({twilio_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."
+      }
     }
   }
 }

--- a/homeassistant/components/twilio/translations/en.json
+++ b/homeassistant/components/twilio/translations/en.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "abort": {
+            "already_configured": "Device is already configured",
             "cloud_not_connected": "Not connected to Home Assistant Cloud.",
             "single_instance_allowed": "Already configured. Only a single configuration possible.",
             "webhook_not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive webhook messages."
@@ -10,8 +11,18 @@
         },
         "step": {
             "user": {
-                "description": "Do you want to start set up?",
-                "title": "Set up the Twilio Webhook"
+                "data": {
+                    "account_sid": "Your Twilio account",
+                    "auth_token": "Your Twilio AUTH TOKEN",
+                    "use_webhook": "Use webhook"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "description": "To send events to Home Assistant, you will need to setup [Webhooks with Twilio]({twilio_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."
             }
         }
     }

--- a/tests/components/twilio/__init__.py
+++ b/tests/components/twilio/__init__.py
@@ -1,1 +1,8 @@
 """Tests for the Twilio component."""
+
+MOCK_CONFIG_DATA = {
+    "account_sid": "12345678",
+    "auth_token": "token",
+    "webhook_id": "ABCD",
+    "cloudhook": True,
+}

--- a/tests/components/twilio/test_config_flow.py
+++ b/tests/components/twilio/test_config_flow.py
@@ -1,0 +1,165 @@
+"""Test the Twilio config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.twilio.const import DOMAIN
+from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
+
+from . import MOCK_CONFIG_DATA
+
+from tests.common import MockConfigEntry
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.twilio.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.cloud.async_active_subscription", return_value=True
+    ), patch(
+        "homeassistant.components.cloud.async_is_logged_in", return_value=True
+    ), patch(
+        "homeassistant.components.cloud.async_is_connected", return_value=True
+    ), patch(
+        "homeassistant.components.cloud.async_create_cloudhook",
+        return_value="https://hooks.nabu.casa/ABCD",
+    ) as fake_create_cloudhook:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "account_sid": "12345678",
+                "auth_token": "token",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert len(mock_setup_entry.mock_calls) == 1
+    fake_create_cloudhook.assert_called_once()
+    assert result2["data"]["cloudhook"]
+    assert result2["description_placeholders"] == {
+        "docs_url": "https://www.home-assistant.io/integrations/twilio/",
+        "twilio_url": "https://www.twilio.com/docs/glossary/what-is-a-webhook",
+        "webhook_url": "https://hooks.nabu.casa/ABCD",
+    }
+
+
+async def test_import_flow_success(hass: HomeAssistant) -> None:
+    """Test a successful import from yaml and update existing entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={"webhook_id": "ABCD", "cloudhook": True}
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.twilio.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.cloud.async_active_subscription", return_value=True
+    ), patch(
+        "homeassistant.components.cloud.async_is_logged_in", return_value=True
+    ), patch(
+        "homeassistant.components.cloud.async_is_connected", return_value=True
+    ), patch(
+        "homeassistant.components.cloud.async_create_cloudhook",
+        return_value="https://hooks.nabu.casa/ABCD",
+    ) as fake_create_cloudhook:
+        result2 = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                "account_sid": "12345678",
+                "auth_token": "token",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    fake_create_cloudhook.assert_not_called()
+
+    assert entry.data["account_sid"] == "12345678"
+    assert entry.data["auth_token"] == "token"
+
+
+async def test_options(hass: HomeAssistant) -> None:
+    """Test showing webhook url through the options menu."""
+    await async_process_ha_core_config(
+        hass,
+        {"internal_url": "http://example.local:8123"},
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA, "webhook_id": "ABCD", "cloudhook": True},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.twilio.async_setup_entry",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["description_placeholders"] == {
+        "docs_url": "https://www.home-assistant.io/integrations/twilio/",
+        "twilio_url": "https://www.twilio.com/docs/glossary/what-is-a-webhook",
+        "webhook_url": "http://example.local:8123/api/webhook/ABCD",
+    }
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_integration_already_configured(hass: HomeAssistant) -> None:
+    """Test aborting if the integration is already configured."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_with_cloud_sub_not_connected(hass):
+    """Test creating a config flow while subscribed."""
+    assert await async_setup_component(hass, "cloud", {})
+
+    with patch(
+        "homeassistant.components.cloud.async_active_subscription", return_value=True
+    ), patch(
+        "homeassistant.components.cloud.async_is_logged_in", return_value=True
+    ), patch(
+        "homeassistant.components.cloud.async_is_connected", return_value=False
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={
+                "account_sid": "12345678",
+                "auth_token": "token",
+            },
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "cloud_not_connected"

--- a/tests/components/twilio/test_init.py
+++ b/tests/components/twilio/test_init.py
@@ -1,24 +1,54 @@
 """Test the init file of Twilio."""
-from homeassistant import config_entries, data_entry_flow
+from collections.abc import Awaitable
+from typing import Callable
+
+import aiohttp
+from aiohttp.test_utils import TestClient
+
 from homeassistant.components import twilio
+from homeassistant.components.twilio.const import DOMAIN
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.setup import async_setup_component
+
+from . import MOCK_CONFIG_DATA
+
+from tests.common import MockConfigEntry
+from tests.components.repairs import get_repairs
 
 
-async def test_config_flow_registers_webhook(hass, hass_client_no_auth):
+async def test_setup(
+    hass: HomeAssistant,
+    hass_ws_client: Callable[
+        [HomeAssistant], Awaitable[aiohttp.ClientWebSocketResponse]
+    ],
+) -> None:
+    """Test integration failed due to an error."""
+    assert await async_setup_component(
+        hass, DOMAIN, {DOMAIN: {"account_sid": "12345678", "auth_token": "token"}}
+    )
+    assert hass.config_entries.async_entries(DOMAIN)
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == 1
+    assert issues[0]["issue_id"] == "deprecated_yaml"
+
+
+async def test_config_flow_registers_webhook(
+    hass: HomeAssistant, hass_client_no_auth: Callable[[], Awaitable[TestClient]]
+):
     """Test setting up Twilio and sending webhook."""
     await async_process_ha_core_config(
         hass,
         {"internal_url": "http://example.local:8123"},
     )
-    result = await hass.config_entries.flow.async_init(
-        "twilio", context={"source": config_entries.SOURCE_USER}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    webhook_id = result["result"].data["webhook_id"]
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     twilio_events = []
 
@@ -30,8 +60,26 @@ async def test_config_flow_registers_webhook(hass, hass_client_no_auth):
     hass.bus.async_listen(twilio.RECEIVED_DATA, handle_event)
 
     client = await hass_client_no_auth()
-    await client.post(f"/api/webhook/{webhook_id}", data={"hello": "twilio"})
+    await client.post("/api/webhook/ABCD", data={"hello": "twilio"})
 
     assert len(twilio_events) == 1
-    assert twilio_events[0].data["webhook_id"] == webhook_id
+    assert twilio_events[0].data["webhook_id"] == "ABCD"
     assert twilio_events[0].data["hello"] == "twilio"
+
+
+async def test_unload_entry(hass: HomeAssistant) -> None:
+    """Test removing integration."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert DOMAIN not in hass.data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Twilio integration migrated completely to configuration via the UI. Configuring Twilio via YAML configuration has been deprecated and will be removed in a future Home Assistant release.

Your existing YAML configuration is automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fully configure Twilio through UI.
- Import Twilio YAML  to config entry.
  - If there is an existing config entry (currently used to create a webhook) the entry data gets updated with the imported account_sid and auth_token.
  - If no config entry is present a new entry is created and a webhook is automatically generated.
  -  If cloud is configured a cloudhook is created and can be viewed from the Home Assistant Cloud setting page. Alternatively the webhook_url can be viewed by clicking the on `CONFIGURE` button and initiating the options menu.

If this gets merged the next step would be to incorporate the `twilio_sms` and `twilio_call` into this integration (if such a move is approved).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
