### PR TITLE
Add Utility Cost helper component

### DIFF
--- a/homeassistant/components/utility_cost/__init__.py
+++ b/homeassistant/components/utility_cost/__init__.py
@@ -1,0 +1,23 @@
+"""The Utility Cost integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Utility Cost from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, (Platform.SENSOR,))
+    entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
+    return True
+
+
+async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update listener, called when the config entry options are changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, (Platform.SENSOR,))

--- a/homeassistant/components/utility_cost/config_flow.py
+++ b/homeassistant/components/utility_cost/config_flow.py
@@ -1,0 +1,50 @@
+"""Config flow for Utility Cost integration."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import selector
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaConfigFlowHandler,
+    SchemaFlowFormStep,
+    SchemaFlowMenuStep,
+)
+
+from .const import CONF_PRICE_SOURCE_SENSOR, CONF_UTILITY_SOURCE_SENSOR, DOMAIN
+
+OPTIONS_SCHEMA = vol.Schema({})
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): selector.TextSelector(),
+        vol.Required(CONF_UTILITY_SOURCE_SENSOR): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain="sensor")
+        ),
+        vol.Required(CONF_PRICE_SOURCE_SENSOR): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain="sensor")
+        ),
+    }
+)
+
+CONFIG_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
+    "user": SchemaFlowFormStep(CONFIG_SCHEMA)
+}
+
+OPTIONS_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
+    "init": SchemaFlowFormStep(OPTIONS_SCHEMA)
+}
+
+
+class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config or options flow for Utility Cost."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return cast(str, options["name"])

--- a/homeassistant/components/utility_cost/const.py
+++ b/homeassistant/components/utility_cost/const.py
@@ -1,0 +1,8 @@
+"""Constants for the Utility Cost integration."""
+
+DOMAIN = "utility_cost"
+
+CONF_UTILITY_SOURCE_SENSOR = "utility_source"
+CONF_PRICE_SOURCE_SENSOR = "price_source"
+
+ATTR_VALUE = "value"

--- a/homeassistant/components/utility_cost/manifest.json
+++ b/homeassistant/components/utility_cost/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "utility_cost",
+  "integration_type": "helper",
+  "name": "Utility Cost",
+  "documentation": "https://www.home-assistant.io/integrations/utility_cost",
+  "codeowners": [],
+  "quality_scale": "internal",
+  "iot_class": "local_push",
+  "loggers": ["croniter"],
+  "config_flow": true
+}

--- a/homeassistant/components/utility_cost/sensor.py
+++ b/homeassistant/components/utility_cost/sensor.py
@@ -48,6 +48,7 @@ SUPPORTED_STATE_CLASSES = [
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Required(CONF_UTILITY_SOURCE_SENSOR): cv.entity_id,
         vol.Required(CONF_PRICE_SOURCE_SENSOR): cv.entity_id,
     }

--- a/homeassistant/components/utility_cost/sensor.py
+++ b/homeassistant/components/utility_cost/sensor.py
@@ -1,0 +1,304 @@
+"""Accumulated cost given a utility meter and a price sensor."""
+from __future__ import annotations
+
+from decimal import Decimal, DecimalException
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import (
+    ATTR_LAST_RESET,
+    ATTR_STATE_CLASS,
+    PLATFORM_SCHEMA,
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.components.sensor.recorder import reset_detected
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+import homeassistant.util.dt as dt_util
+
+from .const import CONF_PRICE_SOURCE_SENSOR, CONF_UTILITY_SOURCE_SENSOR
+
+# mypy: allow-untyped-defs, no-check-untyped-defs
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_UTILITY_SOURCE_ID = "utility_source"
+ATTR_PRICE_SOURCE_ID = "price_source"
+ATTR_LAST_PERIOD = "last_period"
+
+SUPPORTED_STATE_CLASSES = [
+    SensorStateClass.MEASUREMENT,
+    SensorStateClass.TOTAL,
+    SensorStateClass.TOTAL_INCREASING,
+]
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Required(CONF_UTILITY_SOURCE_SENSOR): cv.entity_id,
+        vol.Required(CONF_PRICE_SOURCE_SENSOR): cv.entity_id,
+    }
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize Utility Cost config entry."""
+    registry = er.async_get(hass)
+    # Validate + resolve entity registry id to entity_id
+    utility_source_entity_id = er.async_validate_entity_id(
+        registry, config_entry.options[CONF_UTILITY_SOURCE_SENSOR]
+    )
+    price_source_entity_id = er.async_validate_entity_id(
+        registry, config_entry.options[CONF_PRICE_SOURCE_SENSOR]
+    )
+
+    utility_cost_sensor = UtilityCostSensor(
+        name=config_entry.title,
+        utility_source_entity=utility_source_entity_id,
+        price_source_entity=price_source_entity_id,
+        unique_id=config_entry.entry_id,
+    )
+
+    async_add_entities([utility_cost_sensor])
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the Utility Cost sensor."""
+    utility_cost_sensor = UtilityCostSensor(
+        name=config.get(CONF_NAME),
+        utility_source_entity=config[CONF_UTILITY_SOURCE_SENSOR],
+        price_source_entity=config[CONF_PRICE_SOURCE_SENSOR],
+        unique_id=config.get(CONF_UNIQUE_ID),
+    )
+
+    async_add_entities([utility_cost_sensor])
+
+
+class UtilityCostSensor(RestoreEntity, SensorEntity):
+    """Representation of a Utility Cost sensor."""
+
+    _wrong_state_class_reported = False
+
+    def __init__(
+        self,
+        *,
+        name: str | None,
+        utility_source_entity: str,
+        price_source_entity: str,
+        unique_id: str | None,
+    ) -> None:
+        """Initialize the Utility Cost sensor."""
+        self._attr_unique_id = unique_id
+        self._utility_sensor_source_id = utility_source_entity
+        self._price_sensor_source_id = price_source_entity
+        self._state: Decimal | None = None
+        self._unit_of_measurement: str | None = None
+        self._last_period = Decimal("0")
+
+        self._attr_name = name
+        self._attr_should_poll = False
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
+
+    def _combine_units(self, utility_unit, price_unit):
+        """Combine the price and utility units and return the currency unit.
+
+        Assumes price unit given in <currency>/<utility> and returns <currency>,
+        e.g. "EUR/kWh" returns "EUR".
+        """
+        if not utility_unit:
+            _LOGGER.warning("Invalid utility unit (none)")
+            return None
+        if not price_unit:
+            _LOGGER.warning("Invalid price unit (none)")
+            return None
+
+        currency, _, per_utility_unit = price_unit.partition("/")
+        if not currency:
+            _LOGGER.warning("Invalid price unit %s", price_unit)
+            return None
+        if per_utility_unit == utility_unit:
+            return currency
+
+        _LOGGER.warning(
+            "Incompatible units, utility %s, price %s, expected price unit %s/%s",
+            utility_unit,
+            price_unit,
+            currency,
+            per_utility_unit,
+        )
+        return None
+
+    def _reset(self) -> None:
+        """Reset the cost sensor."""
+        _LOGGER.debug("Resetting cost sensor")
+        self._last_period = self._state if self._state is not None else Decimal("0")
+        self._state = Decimal("0")
+        self._attr_last_reset = dt_util.utcnow()
+
+    @callback
+    def _update_cost(self, event):
+        """Handle the sensor state changes."""
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+
+        _LOGGER.debug(
+            "Update cost %s (%s -> %s)",
+            self._attr_name,
+            old_state.state if old_state is not None else "None",
+            new_state.state if new_state is not None else "None",
+        )
+
+        invalid_states = [
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        ]
+
+        state_class = new_state.attributes.get(ATTR_STATE_CLASS)
+        if state_class not in SUPPORTED_STATE_CLASSES:
+            if not self._wrong_state_class_reported:
+                self._wrong_state_class_reported = True
+                _LOGGER.warning(
+                    "Found unexpected state_class %s for %s",
+                    state_class,
+                    new_state.entity_id,
+                )
+            return
+
+        if new_state is None or new_state.state in invalid_states:
+            _LOGGER.debug("Invalid new state")
+            return
+
+        price_state = self.hass.states.get(self._price_sensor_source_id)
+        if price_state is None or price_state.state in invalid_states:
+            _LOGGER.debug("Invalid price state")
+            return
+
+        new_unit = self._combine_units(
+            new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT),
+            price_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT),
+        )
+        if new_unit is None:
+            return
+        self._unit_of_measurement = new_unit
+
+        if self._state is None:
+            # This is the first valid update
+            self._reset()
+
+        if old_state is None or old_state.state in invalid_states:
+            # Write state in case we reset or updated the unit of measurement
+            self.async_write_ha_state()
+            return
+
+        if (
+            state_class != SensorStateClass.TOTAL_INCREASING
+            and new_state.attributes.get(ATTR_LAST_RESET)
+            != old_state.attributes.get(ATTR_LAST_RESET)
+        ) or (
+            state_class == SensorStateClass.TOTAL_INCREASING
+            and reset_detected(
+                self.hass,
+                self._utility_sensor_source_id,
+                float(new_state.state),
+                float(old_state.state),
+                new_state,
+            )
+        ):
+            # Utility meter was reset, reset cost sensor too
+            self._reset()
+            self.async_write_ha_state()
+            return
+
+        try:
+            price = Decimal(price_state.state)
+
+            utility_increment = Decimal(new_state.state) - Decimal(old_state.state)
+            cost_increment = utility_increment * price
+
+            self._state += cost_increment
+            _LOGGER.debug("Cost increment success")
+
+        except DecimalException as err:
+            _LOGGER.warning(
+                "Invalid cost update (utility %s to %s, price %s): %s",
+                old_state.state,
+                new_state.state,
+                price_state.state,
+                err,
+            )
+
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        if state := await self.async_get_last_state():
+            try:
+                self._state = Decimal(state.state)
+            except (DecimalException, ValueError) as err:
+                _LOGGER.warning(
+                    "%s could not restore last state %s: %s",
+                    self.entity_id,
+                    state.state,
+                    err,
+                )
+            else:
+                if self._unit_of_measurement is None:
+                    self._unit_of_measurement = state.attributes.get(
+                        ATTR_UNIT_OF_MEASUREMENT
+                    )
+                self._last_period = (
+                    Decimal(state.attributes[ATTR_LAST_PERIOD])
+                    if state.attributes.get(ATTR_LAST_PERIOD)
+                    else Decimal("0")
+                )
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [self._utility_sensor_source_id], self._update_cost
+            )
+        )
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def native_unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return {
+            ATTR_UTILITY_SOURCE_ID: self._utility_sensor_source_id,
+            ATTR_PRICE_SOURCE_ID: self._price_sensor_source_id,
+            ATTR_LAST_PERIOD: str(self._last_period),
+        }

--- a/homeassistant/components/utility_cost/sensor.py
+++ b/homeassistant/components/utility_cost/sensor.py
@@ -37,8 +37,6 @@ from .const import CONF_PRICE_SOURCE_SENSOR, CONF_UTILITY_SOURCE_SENSOR
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_UTILITY_SOURCE_ID = "utility_source"
-ATTR_PRICE_SOURCE_ID = "price_source"
 ATTR_LAST_PERIOD = "last_period"
 
 SUPPORTED_STATE_CLASSES = [
@@ -297,8 +295,4 @@ class UtilityCostSensor(RestoreEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
-        return {
-            ATTR_UTILITY_SOURCE_ID: self._utility_sensor_source_id,
-            ATTR_PRICE_SOURCE_ID: self._price_sensor_source_id,
-            ATTR_LAST_PERIOD: str(self._last_period),
-        }
+        return {ATTR_LAST_PERIOD: str(self._last_period)}

--- a/homeassistant/components/utility_cost/strings.json
+++ b/homeassistant/components/utility_cost/strings.json
@@ -1,0 +1,36 @@
+{
+  "title": "Utility Cost",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Add Utility Cost",
+        "description": "Create a sensor which tracks the accumulated cost given a utility meter and a price sensor.",
+        "data": {
+          "method": "Integration method",
+          "name": "Name",
+          "round": "Precision",
+          "source": "Input sensor",
+          "unit_prefix": "Metric prefix",
+          "unit_time": "Time unit"
+        },
+        "data_description": {
+          "round": "Controls the number of decimal digits in the output.",
+          "unit_prefix": "The output will be scaled according to the selected metric prefix.",
+          "unit_time": "The output will be scaled according to the selected time unit."
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "round": "[%key:component::integration::config::step::user::data::round%]"
+        },
+        "data_description": {
+          "round": "[%key:component::integration::config::step::user::data_description::round%]"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/utility_cost/translations/en.json
+++ b/homeassistant/components/utility_cost/translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "data": {
+                    "name": "Name",
+                    "utility_source": "Utility source",
+                    "price_source": "Price source"
+                },
+                "data_description": {
+                    "utility_source": "Utility sensor which provides the cumulative consumption of a given utility, e.g. energy (kWh).",
+                    "price_source": "Price sensor which gives the current price per unit of the given utility, e.g. price per unit of energy (EUR/kWh)."
+                },
+                "description": "Create a sensor which calculates the cumulative cost of a utility, based on the price given by another sensor.",
+                "title": "Add Utility Cost sensor"
+            }
+        }
+    },
+    "options": {},
+    "title": "Utility Cost"
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -12,6 +12,7 @@ FLOWS = {
         "switch_as_x",
         "threshold",
         "tod",
+        "utility_cost",
         "utility_meter",
     ],
     "integration": [

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6458,6 +6458,11 @@
       "config_flow": true,
       "iot_class": "local_push"
     },
+    "utility_cost": {
+      "integration_type": "helper",
+      "config_flow": true,
+      "iot_class": "local_push"
+    },
     "utility_meter": {
       "integration_type": "helper",
       "config_flow": true,
@@ -6502,6 +6507,7 @@
     "threshold",
     "tod",
     "uptime",
+    "utility_cost",
     "utility_meter",
     "waze_travel_time"
   ]

--- a/tests/components/utility_cost/__init__.py
+++ b/tests/components/utility_cost/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Utility Cost component."""

--- a/tests/components/utility_cost/test_config_flow.py
+++ b/tests/components/utility_cost/test_config_flow.py
@@ -1,0 +1,55 @@
+"""Test the Utility Cost config flow."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.utility_cost.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+@pytest.mark.parametrize("platform", ("sensor",))
+async def test_config_flow(hass: HomeAssistant, platform) -> None:
+    """Test the config flow."""
+    utility_input_sensor_entity_id = "sensor.utility_input"
+    price_input_sensor_entity_id = "sensor.price_input"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.utility_cost.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "name": "My utility cost",
+                "utility_source": utility_input_sensor_entity_id,
+                "price_source": price_input_sensor_entity_id,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My utility cost"
+    assert result["data"] == {}
+    assert result["options"] == {
+        "name": "My utility cost",
+        "utility_source": "sensor.utility_input",
+        "price_source": "sensor.price_input",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        "name": "My utility cost",
+        "utility_source": "sensor.utility_input",
+        "price_source": "sensor.price_input",
+    }
+    assert config_entry.title == "My utility cost"

--- a/tests/components/utility_cost/test_init.py
+++ b/tests/components/utility_cost/test_init.py
@@ -41,8 +41,6 @@ async def test_setup_and_remove_config_entry(
     state = hass.states.get(utility_cost_entity_id)
     assert state.state == "unknown"
     assert "unit_of_measurement" not in state.attributes
-    assert state.attributes["utility_source"] == "sensor.utility_input"
-    assert state.attributes["price_source"] == "sensor.price_input"
 
     hass.states.async_set(
         price_input_sensor_entity_id, 20, {"unit_of_measurement": "EUR/cat"}

--- a/tests/components/utility_cost/test_init.py
+++ b/tests/components/utility_cost/test_init.py
@@ -1,0 +1,74 @@
+"""Test the Utility Cost integration."""
+import pytest
+
+from homeassistant.components.utility_cost.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize("platform", ("sensor",))
+async def test_setup_and_remove_config_entry(
+    hass: HomeAssistant,
+    platform: str,
+) -> None:
+    """Test setting up and removing a config entry."""
+    utility_input_sensor_entity_id = "sensor.utility_input"
+    price_input_sensor_entity_id = "sensor.price_input"
+    registry = er.async_get(hass)
+    utility_cost_entity_id = f"{platform}.my_utility_cost"
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My utility cost",
+            "utility_source": "sensor.utility_input",
+            "price_source": "sensor.price_input",
+        },
+        title="My utility cost",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the entity is registered in the entity registry
+    assert registry.async_get(utility_cost_entity_id) is not None
+
+    # Check the platform is setup correctly
+    state = hass.states.get(utility_cost_entity_id)
+    assert state.state == "unknown"
+    assert "unit_of_measurement" not in state.attributes
+    assert state.attributes["utility_source"] == "sensor.utility_input"
+    assert state.attributes["price_source"] == "sensor.price_input"
+
+    hass.states.async_set(
+        price_input_sensor_entity_id, 20, {"unit_of_measurement": "EUR/cat"}
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set(
+        utility_input_sensor_entity_id,
+        10,
+        {"unit_of_measurement": "cat", "state_class": "total"},
+    )
+    hass.states.async_set(
+        utility_input_sensor_entity_id,
+        11,
+        {"unit_of_measurement": "cat", "state_class": "total"},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(utility_cost_entity_id)
+    assert state.state != "unknown"
+    assert state.attributes["unit_of_measurement"] == "EUR"
+    assert state.attributes["last_period"] == "0"
+
+    # Remove the config entry
+    assert await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry are removed
+    assert hass.states.get(utility_cost_entity_id) is None
+    assert registry.async_get(utility_cost_entity_id) is None

--- a/tests/components/utility_cost/test_sensor.py
+++ b/tests/components/utility_cost/test_sensor.py
@@ -1,0 +1,451 @@
+"""The tests for the utility_cost sensor platform."""
+from typing import NamedTuple, Optional
+
+import pytest
+
+from homeassistant.components.sensor import (
+    ATTR_LAST_RESET,
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    ENERGY_KILO_WATT_HOUR,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, State
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from tests.common import mock_restore_cache
+
+
+async def test_state(hass) -> None:
+    """Test utility cost sensor state."""
+
+    utility_entity_id = "sensor.utility"
+    price_entity_id = "sensor.price"
+    config = {
+        "sensor": {
+            "platform": "utility_cost",
+            "name": "utility_cost",
+            "utility_source": utility_entity_id,
+            "price_source": price_entity_id,
+        }
+    }
+    utility_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+    }
+    price_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: "EUR/kWh",
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    hass.states.async_set(utility_entity_id, 2, utility_attributes)
+    hass.states.async_set(price_entity_id, 10, price_attributes)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+    assert state.attributes.get("unit_of_measurement") is None
+    assert state.attributes.get("device_class") == SensorDeviceClass.MONETARY
+    assert state.attributes.get("state_class") is SensorStateClass.TOTAL
+
+    hass.states.async_set(utility_entity_id, 3, utility_attributes, force_update=True)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+
+    # Testing 1 kWh energy consumption (from 2 to 3 kWh) at 10 EUR/kWh which should give 10 EUR
+    assert round(float(state.state), 2) == 10.0
+
+    assert state.attributes.get("unit_of_measurement") == "EUR"
+    assert state.attributes.get("device_class") == SensorDeviceClass.MONETARY
+    assert state.attributes.get("state_class") is SensorStateClass.TOTAL
+
+
+async def test_restore_state(hass: HomeAssistant) -> None:
+    """Test utility cost sensor state is restored correctly."""
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "sensor.utility_cost",
+                "100.0",
+                {
+                    "last_period": "2.0",
+                    "unit_of_measurement": "EUR",
+                },
+            ),
+        ),
+    )
+
+    config = {
+        "sensor": {
+            "platform": "utility_cost",
+            "name": "utility_cost",
+            "utility_source": "sensor.utility",
+            "price_source": "sensor.price",
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state
+    assert state.state == "100.0"
+    assert state.attributes.get("unit_of_measurement") == "EUR"
+    assert state.attributes.get("last_period") == "2.0"
+
+
+async def test_restore_state_failed(hass: HomeAssistant) -> None:
+    """Test utility cost sensor state is restored correctly."""
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "sensor.utility_cost",
+                "INVALID",
+                {
+                    "last_reset": "2019-10-06T21:00:00.000000",
+                },
+            ),
+        ),
+    )
+
+    config = {
+        "sensor": {
+            "platform": "utility_cost",
+            "name": "utility_cost",
+            "utility_source": "sensor.utility",
+            "price_source": "sensor.price",
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("unit_of_measurement") is None
+    assert state.attributes.get("state_class") is SensorStateClass.TOTAL
+    assert state.attributes.get("device_class") == SensorDeviceClass.MONETARY
+    assert state.attributes.get("last_period") == "0"
+
+
+async def test_update_monotonic(hass):
+    """Test Utility cost sensor state."""
+
+    utility_entity_id = "sensor.utility"
+    price_entity_id = "sensor.price"
+    config = {
+        "sensor": {
+            "platform": "utility_cost",
+            "name": "utility_cost",
+            "utility_source": utility_entity_id,
+            "price_source": price_entity_id,
+        }
+    }
+    utility_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+    }
+    price_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: "EUR/kWh",
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    hass.states.async_set(price_entity_id, 0, price_attributes)
+    hass.states.async_set(utility_entity_id, 1, utility_attributes)
+    await hass.async_block_till_done()
+
+    # Testing a monotonically increasing energy sensor with varying price
+    for energy, price in (2, 1), (5, 20), (22, 6):
+        hass.states.async_set(price_entity_id, price, price_attributes)
+        hass.states.async_set(utility_entity_id, energy, utility_attributes)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+
+    assert float(state.state) == (2 - 1) * 1 + (5 - 2) * 20 + (22 - 5) * 6
+
+
+async def test_update_with_reset(hass):
+    """Test Utility cost sensor state."""
+
+    utility_entity_id = "sensor.utility"
+    price_entity_id = "sensor.price"
+    config = {
+        "sensor": {
+            "platform": "utility_cost",
+            "name": "utility_cost",
+            "utility_source": utility_entity_id,
+            "price_source": price_entity_id,
+        }
+    }
+    utility_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
+    }
+    price_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: "EUR/kWh",
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    hass.states.async_set(price_entity_id, 0, price_attributes)
+    hass.states.async_set(utility_entity_id, 1, utility_attributes)
+    await hass.async_block_till_done()
+
+    # Testing an energy sensor with varying price and a reset in the middle
+    for energy, price in (5, 2), (0, 20), (10, 5):
+        hass.states.async_set(price_entity_id, price, price_attributes)
+        hass.states.async_set(utility_entity_id, energy, utility_attributes)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+
+    assert float(state.state) == 10 * 5
+    assert float(state.attributes.get("last_period")) == (5 - 1) * 2
+
+
+async def test_update_with_last_reset(hass):
+    """Test Utility Cost sensor state."""
+
+    utility_entity_id = "sensor.utility"
+    price_entity_id = "sensor.price"
+    config = {
+        "sensor": {
+            "platform": "utility_cost",
+            "name": "utility_cost",
+            "utility_source": utility_entity_id,
+            "price_source": price_entity_id,
+        }
+    }
+    old_reset = dt_util.utc_from_timestamp(0).isoformat()
+    new_reset = dt_util.utcnow().isoformat()
+    utility_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+        ATTR_LAST_RESET: old_reset,
+    }
+    price_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: "EUR/kWh",
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    hass.states.async_set(price_entity_id, 0, price_attributes)
+    hass.states.async_set(utility_entity_id, 1, utility_attributes)
+    await hass.async_block_till_done()
+
+    # Testing an energy sensor with varying price and a reset in the middle
+    for energy, price, reset in (5, 2, False), (2, 20, True), (10, 5, False):
+        if reset:
+            utility_attributes[ATTR_LAST_RESET] = new_reset
+        hass.states.async_set(price_entity_id, price, price_attributes)
+        hass.states.async_set(utility_entity_id, energy, utility_attributes)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+
+    assert float(state.state) == (10 - 2) * 5
+    assert float(state.attributes.get("last_period")) == (5 - 1) * 2
+
+
+async def test_utility_initialization(hass):
+    """Test Utility Cost sensor initialization using an energy source."""
+    utility_entity_id = "sensor.utility"
+    price_entity_id = "sensor.price"
+    config = {
+        "sensor": {
+            "platform": "utility_cost",
+            "name": "utility_cost",
+            "utility_source": utility_entity_id,
+            "price_source": price_entity_id,
+        }
+    }
+    utility_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: None,
+        ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+    }
+    price_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: "EUR/kWh",
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    hass.states.async_set(price_entity_id, 2, price_attributes)
+    await hass.async_block_till_done()
+
+    # This replicates the current sequence when HA starts up in a real runtime
+    # by updating the base sensor state before the base sensor's units
+    # or state have been correctly populated.  Those interim updates
+    # include states of None and Unknown
+    hass.states.async_set(utility_entity_id, 100, utility_attributes)
+    await hass.async_block_till_done()
+    hass.states.async_set(utility_entity_id, 200, utility_attributes)
+    await hass.async_block_till_done()
+
+    utility_attributes[ATTR_UNIT_OF_MEASUREMENT] = ENERGY_KILO_WATT_HOUR
+    hass.states.async_set(utility_entity_id, 300, utility_attributes)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+
+    # Testing the sensor ignored the source sensor's units until
+    # they became valid
+    assert state.attributes.get("unit_of_measurement") == "EUR"
+
+    # When source state goes to None / Unknown, expect an early exit without
+    # changes to the state or unit_of_measurement
+    hass.states.async_set(utility_entity_id, STATE_UNAVAILABLE, None)
+    await hass.async_block_till_done()
+
+    new_state = hass.states.get("sensor.utility_cost")
+    assert state == new_state
+    assert state.attributes.get("unit_of_measurement") == "EUR"
+
+
+async def test_price_initialization(hass):
+    """Test Utility Cost sensor initialization using an energy source."""
+    utility_entity_id = "sensor.utility"
+    price_entity_id = "sensor.price"
+    config = {
+        "sensor": {
+            "platform": "utility_cost",
+            "name": "utility_cost",
+            "utility_source": utility_entity_id,
+            "price_source": price_entity_id,
+        }
+    }
+    utility_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+    }
+    price_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: None,
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    # This tests the sensor initialization when the price is not yet
+    # ready due to a missing unit
+    hass.states.async_set(price_entity_id, 2, price_attributes)
+    await hass.async_block_till_done()
+
+    # Any readings from the energy sensor should be ignored
+    hass.states.async_set(utility_entity_id, 100, utility_attributes)
+    await hass.async_block_till_done()
+    hass.states.async_set(utility_entity_id, 200, utility_attributes)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get("unit_of_measurement") is None
+
+    # Now make the price available and submit another energy reading
+    price_attributes[ATTR_UNIT_OF_MEASUREMENT] = "EUR/kWh"
+    hass.states.async_set(price_entity_id, 3, price_attributes)
+    await hass.async_block_till_done()
+
+    hass.states.async_set(utility_entity_id, 300, utility_attributes)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+    assert float(state.state) == (300 - 200) * 3
+    assert state.attributes.get("unit_of_measurement") == "EUR"
+
+    # When price state goes to None / Unknown, expect an early exit without
+    # changes to the state or unit_of_measurement
+    hass.states.async_set(price_entity_id, STATE_UNAVAILABLE, None)
+    await hass.async_block_till_done()
+    hass.states.async_set(utility_entity_id, 400, utility_attributes)
+    await hass.async_block_till_done()
+
+    new_state = hass.states.get("sensor.utility_cost")
+    assert state == new_state
+    assert state.attributes.get("unit_of_measurement") == "EUR"
+
+
+class CurrencyUnitTest(NamedTuple):
+    """Data for resulting currency unit tests."""
+
+    price_unit: Optional[str]
+    utility_unit: Optional[str]
+    expected_currency: Optional[str]
+
+
+@pytest.mark.parametrize(
+    "test",
+    [
+        # Valid units
+        CurrencyUnitTest("EUR/kWh", "kWh", "EUR"),
+        CurrencyUnitTest("EUR/Wh", "Wh", "EUR"),
+        CurrencyUnitTest("NOK/kWh", "kWh", "NOK"),
+        CurrencyUnitTest("USD/MB", "MB", "USD"),
+        CurrencyUnitTest("X/Cat", "Cat", "X"),
+        # Invalid units
+        CurrencyUnitTest("/kWh", "kWh", None),
+        CurrencyUnitTest("EUR/", "kWh", None),
+        CurrencyUnitTest("EUR", "kWh", None),
+        CurrencyUnitTest("", "kWh", None),
+        CurrencyUnitTest("EUR", "", None),
+        CurrencyUnitTest(None, "kWh", None),
+        CurrencyUnitTest("EUR", None, None),
+        # Prefix factor conversions: May want to add support for these later
+        CurrencyUnitTest("EUR/kWh", "Wh", None),
+        CurrencyUnitTest("EUR/Wh", "kWh", None),
+    ],
+)
+async def test_currency_units(hass, test):
+    """Test Utility Cost sensor's resulting currency based on the price and utility units."""
+    utility_entity_id = "sensor.utility"
+    price_entity_id = "sensor.price"
+    config = {
+        "sensor": {
+            "platform": "utility_cost",
+            "name": "utility_cost",
+            "utility_source": utility_entity_id,
+            "price_source": price_entity_id,
+        }
+    }
+    utility_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: test.utility_unit,
+        ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+    }
+    price_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: test.price_unit,
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    hass.states.async_set(price_entity_id, 2, price_attributes)
+    await hass.async_block_till_done()
+
+    # Only price set, our state should not have changed
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+    assert state.attributes.get("unit_of_measurement") is None
+
+    hass.states.async_set(utility_entity_id, 100, utility_attributes)
+    await hass.async_block_till_done()
+
+    # Both price and a utility reading is complete, our unit should be ready now
+    state = hass.states.get("sensor.utility_cost")
+    assert state is not None
+    assert state.attributes.get("unit_of_measurement") == test.expected_currency

--- a/tests/components/utility_cost/test_sensor.py
+++ b/tests/components/utility_cost/test_sensor.py
@@ -11,9 +11,9 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
-    ENERGY_KILO_WATT_HOUR,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    UnitOfEnergy,
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
@@ -36,7 +36,7 @@ async def test_state(hass) -> None:
         }
     }
     utility_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: SensorStateClass.TOTAL,
     }
     price_attributes = {
@@ -154,7 +154,7 @@ async def test_update_monotonic(hass):
         }
     }
     utility_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: SensorStateClass.TOTAL,
     }
     price_attributes = {
@@ -193,7 +193,7 @@ async def test_update_with_reset(hass):
         }
     }
     utility_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
     }
     price_attributes = {
@@ -235,7 +235,7 @@ async def test_update_with_last_reset(hass):
     old_reset = dt_util.utc_from_timestamp(0).isoformat()
     new_reset = dt_util.utcnow().isoformat()
     utility_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: SensorStateClass.TOTAL,
         ATTR_LAST_RESET: old_reset,
     }
@@ -298,7 +298,7 @@ async def test_utility_initialization(hass):
     hass.states.async_set(utility_entity_id, 200, utility_attributes)
     await hass.async_block_till_done()
 
-    utility_attributes[ATTR_UNIT_OF_MEASUREMENT] = ENERGY_KILO_WATT_HOUR
+    utility_attributes[ATTR_UNIT_OF_MEASUREMENT] = UnitOfEnergy.KILO_WATT_HOUR
     hass.states.async_set(utility_entity_id, 300, utility_attributes)
     await hass.async_block_till_done()
 
@@ -332,7 +332,7 @@ async def test_price_initialization(hass):
         }
     }
     utility_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: SensorStateClass.TOTAL,
     }
     price_attributes = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a new helper component which calculates the utility costs based on a utility consumption sensor and a price sensor.

Some use cases enabled by this change:

- Track the energy costs of individual sensors. 
- Track the cost of any utility even when it has variable pricing.
- Track the cost of the same utility based on different pricing models (e.g. spot vs. fixed pricing).

These use cases are not easily solved otherwise:

- Currently, it is possible to track the overall cost of your energy usage in the energy dashboard, based on the price from a given entity. However, sometimes it is useful to break this cost down to individual sensors. This is not possible from the energy dashboard.
-  The utility meter can break consumption into fixed tariffs, but this is not sufficient for continuously varying prices, such as based on hourly market prices. This can be worked around by using the the Riemann integration sensor coupled with the total current power usage, see e.g. [this community thread](https://community.home-assistant.io/t/calculate-energy-cost-for-sensor-with-hourly-price-utility-meter/417399). However, this is a convoluted step, and additionally, it won't work for utilities that are only available in their accumulated form (e.g. if you only have total energy consumption and not power).

Furthermore, this may lead to a simpler setup for people interested in utility costs even when their pricing is divided into tariffs. Previously you would need to set up a utility meter with tariffs which produces different sensors for each tariff, and a selector. Then an automation for the selector would be needed, and finally a template sensor to sum up all the tariff sensors together at each tariff's price. Instead, if you can express your price as a single template sensor then with this feature you would only need that price sensor in addition to your consumption meter.

The helper component can be setup using the frontend (Settings -> Devices & Services -> Helpers -> Create), or by adding a sensor using the yaml configuration:

```yml
sensor:
  - platform: utility_cost
    utility_source: sensor.energy_consumption
    price_source: sensor.energy_price
    name: energy_cost
```

This sensor is made such that it resets any time its `utility_source` resets. Thus, to get the cumulative cost for a given period (e.g. daily, monthly), it can be setup to use the output from a Utility Meter which handles the resets on the given periodicity. Just like the Utility Meter, there is also a `last_period` attribute which records the value before the last reset.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This is a result of the discussion in #77443. While the use cases are equivalent, this PR instead implements this functionality in a separate helper component. This was the desired approach as discussed in the previous PR. Pinging @dgomes and @emontnemery as these were active in the previous discussion.

There was a discussion about re-using `EnergyCostSensor` in `homeassistant/components/energy/sensor.py`, as it implements a lot of the same functionality. However, I decided to make a separate sensor. First, I figured it would be more helpful if we generalized this feature to any utility rather than just dealing with energy. Additionally, I was worried about any potential complexity arising from coupling these components tightly. I think in the future it might make some sense to spawn a utility cost sensor from the energy dashboard instead of the other way around, but I wanted to keep things simple for now.

Please feel free to voice your thoughts on the naming of everything, the component itself, the attributes, and the configuration.

I'm quite new Home Assistant development, I've tried to follow the dev checklist and write tests as best I can. I'd appreciate assistance with any steps needed before it can be accepted. Please feel free to push changes to this PR if you see some potential for improvements.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
