### PR TITLE
Add config flow to Satel Integra

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1022,7 +1022,11 @@ omit =
     homeassistant/components/sabnzbd/__init__.py
     homeassistant/components/sabnzbd/sensor.py
     homeassistant/components/saj/sensor.py
-    homeassistant/components/satel_integra/*
+    homeassistant/components/satel_integra/__init__.py
+    homeassistant/components/satel_integra/alarm_control_panel.py
+    homeassistant/components/satel_integra/binary_sensor.py
+    homeassistant/components/satel_integra/const.py
+    homeassistant/components/satel_integra/switch.py
     homeassistant/components/schluter/*
     homeassistant/components/screenlogic/__init__.py
     homeassistant/components/screenlogic/binary_sensor.py

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -5,10 +5,11 @@ import asyncio
 from collections import OrderedDict
 import logging
 
-from satel_integra.satel_integra import AlarmState
+from satel_integra.satel_integra import AlarmState, AsyncSatel
 
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
@@ -19,31 +20,30 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 
-from . import (
+from .const import (
     CONF_ARM_HOME_MODE,
     CONF_DEVICE_PARTITIONS,
     CONF_ZONE_NAME,
-    DATA_SATEL,
+    DATA_SATEL_CONFIG,
+    DOMAIN,
     SIGNAL_PANEL_MESSAGE,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
+    config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up for Satel Integra alarm panels."""
-    if not discovery_info:
-        return
+    """Set up the Satel alarm panel platform."""
+    controller: AsyncSatel = hass.data[DOMAIN]
+    config: ConfigType = hass.data[DATA_SATEL_CONFIG]
 
-    configured_partitions = discovery_info[CONF_DEVICE_PARTITIONS]
-    controller = hass.data[DATA_SATEL]
+    configured_partitions = config[CONF_DEVICE_PARTITIONS]
 
     devices = []
 

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -1,38 +1,41 @@
 """Support for Satel Integra zone states- represented as binary sensors."""
 from __future__ import annotations
 
+from satel_integra.satel_integra import AsyncSatel
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 
-from . import (
+from .const import (
     CONF_OUTPUTS,
     CONF_ZONE_NAME,
     CONF_ZONE_TYPE,
     CONF_ZONES,
-    DATA_SATEL,
+    DATA_SATEL_CONFIG,
+    DOMAIN,
     SIGNAL_OUTPUTS_UPDATED,
     SIGNAL_ZONES_UPDATED,
 )
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
+    config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the Satel Integra binary sensor devices."""
-    if not discovery_info:
-        return
+    """Set up the Satel binary sensor platform."""
+    controller: AsyncSatel = hass.data[DOMAIN]
+    config: ConfigType = hass.data[DATA_SATEL_CONFIG]
 
-    configured_zones = discovery_info[CONF_ZONES]
-    controller = hass.data[DATA_SATEL]
+    configured_zones = config[CONF_ZONES]
+    configured_outputs = config[CONF_OUTPUTS]
 
     devices = []
 
@@ -43,8 +46,6 @@ async def async_setup_platform(
             controller, zone_num, zone_name, zone_type, SIGNAL_ZONES_UPDATED
         )
         devices.append(device)
-
-    configured_outputs = discovery_info[CONF_OUTPUTS]
 
     for zone_num, device_config_data in configured_outputs.items():
         zone_type = device_config_data[CONF_ZONE_TYPE]

--- a/homeassistant/components/satel_integra/config_flow.py
+++ b/homeassistant/components/satel_integra/config_flow.py
@@ -1,0 +1,70 @@
+"""Config flow for Satel Integra."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from satel_integra.satel_integra import AsyncSatel
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_validation as cv
+
+from .const import CONF_DEVICE_CODE, DEFAULT_PORT, DOMAIN
+
+_LOGGER = logging.getLogger(__package__)
+
+
+class SatelFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a Satel Integra config flow."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            valid = await self.test_connection(
+                user_input[CONF_HOST], user_input.get(CONF_PORT, DEFAULT_PORT)
+            )
+
+            if valid:
+                return self.async_create_entry(
+                    title=user_input[CONF_HOST], data=user_input
+                )
+
+            errors["base"] = "cannot_connect"
+
+        data_schema = {
+            vol.Required(CONF_HOST): str,
+            vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+            vol.Optional(CONF_DEVICE_CODE): cv.string,
+        }
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors
+        )
+
+    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
+        """Import a config entry."""
+
+        user_input = {
+            CONF_HOST: config[CONF_HOST],
+            CONF_PORT: config.get(CONF_PORT, DEFAULT_PORT),
+            CONF_DEVICE_CODE: config.get(CONF_DEVICE_CODE),
+        }
+        return await self.async_step_user(user_input)
+
+    async def test_connection(self, host, port) -> bool:
+        """Test a connection to the Satel alarm."""
+        controller = AsyncSatel(host, port, self.hass.loop)
+
+        result = await controller.connect()
+
+        # Make sure we close the connection again
+        controller.close()
+
+        return result

--- a/homeassistant/components/satel_integra/const.py
+++ b/homeassistant/components/satel_integra/const.py
@@ -1,0 +1,40 @@
+"""Constants for the Satel Integra integration."""
+from typing import Final
+
+from homeassistant.const import Platform
+
+DEFAULT_ALARM_NAME = "satel_integra"
+DEFAULT_PORT = 7094
+DEFAULT_CONF_ARM_HOME_MODE = 1
+DEFAULT_DEVICE_PARTITION = 1
+DEFAULT_ZONE_TYPE = "motion"
+
+DOMAIN = "satel_integra"
+
+DATA_SATEL_CONFIG: Final = "satel_config"
+
+
+CONF_DEVICE_CODE = "code"
+CONF_DEVICE_PARTITIONS = "partitions"
+CONF_ARM_HOME_MODE = "arm_home_mode"
+CONF_ZONE_NAME = "name"
+CONF_ZONE_TYPE = "type"
+CONF_ZONES = "zones"
+CONF_OUTPUTS = "outputs"
+CONF_SWITCHABLE_OUTPUTS = "switchable_outputs"
+
+ZONES = "zones"
+
+SIGNAL_PANEL_MESSAGE = "satel_integra.panel_message"
+SIGNAL_PANEL_ARM_AWAY = "satel_integra.panel_arm_away"
+SIGNAL_PANEL_ARM_HOME = "satel_integra.panel_arm_home"
+SIGNAL_PANEL_DISARM = "satel_integra.panel_disarm"
+
+SIGNAL_ZONES_UPDATED = "satel_integra.zones_updated"
+SIGNAL_OUTPUTS_UPDATED = "satel_integra.outputs_updated"
+
+SUPPORTED_PLATFORMS: Final = [
+    Platform.ALARM_CONTROL_PANEL,
+    Platform.BINARY_SENSOR,
+    Platform.SWITCH,
+]

--- a/homeassistant/components/satel_integra/manifest.json
+++ b/homeassistant/components/satel_integra/manifest.json
@@ -5,5 +5,6 @@
   "requirements": ["satel_integra==0.3.7"],
   "codeowners": [],
   "iot_class": "local_push",
-  "loggers": ["satel_integra"]
+  "loggers": ["satel_integra"],
+  "config_flow": true
 }

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -3,17 +3,21 @@ from __future__ import annotations
 
 import logging
 
+from satel_integra.satel_integra import AsyncSatel
+
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 
-from . import (
+from .const import (
     CONF_DEVICE_CODE,
     CONF_SWITCHABLE_OUTPUTS,
     CONF_ZONE_NAME,
-    DATA_SATEL,
+    DATA_SATEL_CONFIG,
+    DOMAIN,
     SIGNAL_OUTPUTS_UPDATED,
 )
 
@@ -22,18 +26,16 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ["satel_integra"]
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
+    config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the Satel Integra switch devices."""
-    if not discovery_info:
-        return
+    """Set up the Satel switch platform."""
+    controller: AsyncSatel = hass.data[DOMAIN]
+    config: ConfigType = hass.data[DATA_SATEL_CONFIG]
 
-    configured_zones = discovery_info[CONF_SWITCHABLE_OUTPUTS]
-    controller = hass.data[DATA_SATEL]
+    configured_zones = config[CONF_SWITCHABLE_OUTPUTS]
 
     devices = []
 
@@ -41,7 +43,7 @@ async def async_setup_platform(
         zone_name = device_config_data[CONF_ZONE_NAME]
 
         device = SatelIntegraSwitch(
-            controller, zone_num, zone_name, discovery_info[CONF_DEVICE_CODE]
+            controller, zone_num, zone_name, config_entry.data.get(CONF_DEVICE_CODE)
         )
         devices.append(device)
 

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -303,6 +303,7 @@ FLOWS = {
         "ruckus_unleashed",
         "sabnzbd",
         "samsungtv",
+        "satel_integra",
         "screenlogic",
         "season",
         "sense",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1425,6 +1425,9 @@ samsungctl[websocket]==0.7.1
 # homeassistant.components.samsungtv
 samsungtvws[async,encrypted]==2.5.0
 
+# homeassistant.components.satel_integra
+satel_integra==0.3.7
+
 # homeassistant.components.dhcp
 scapy==2.4.5
 

--- a/tests/components/satel_integra/__init__.py
+++ b/tests/components/satel_integra/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Satel Integra component."""

--- a/tests/components/satel_integra/test_config_flow.py
+++ b/tests/components/satel_integra/test_config_flow.py
@@ -1,0 +1,81 @@
+"""Test config flow."""
+
+from unittest.mock import patch
+
+from homeassistant import data_entry_flow
+from homeassistant.components.satel_integra.const import DEFAULT_PORT, DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+DEFAULT_VALUES = {CONF_PORT: DEFAULT_PORT}
+
+
+async def test_user(hass):
+    """Test we can start a config flow."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert not result["errors"]
+
+
+async def test_user_confirm(hass: HomeAssistant):
+    """Test we can finish a config flow."""
+
+    mockdata = {CONF_HOST: "192.168.1.1"}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert not result["errors"]
+
+    with patch(
+        "satel_integra.satel_integra.AsyncSatel.connect", return_value=True
+    ) as mock_connection, patch(
+        "homeassistant.components.satel_integra.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], mockdata
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["title"] == mockdata[CONF_HOST]
+    assert result2["data"] == {**DEFAULT_VALUES, **mockdata}
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_connection.mock_calls) == 1
+
+
+async def test_user_confirm_failed(hass):
+    """Test we can finish a config flow."""
+
+    mockdata = {CONF_HOST: "192.168.1.1"}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert not result["errors"]
+
+    with patch(
+        "satel_integra.satel_integra.AsyncSatel.connect", return_value=False
+    ) as mock_connection:
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], mockdata
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["errors"]["base"] == "cannot_connect"
+
+    assert len(mock_connection.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
(reopened from https://github.com/home-assistant/core/pull/75927)
Adding config flow to the connection phase of the Satel Integra integration. This is the first step towards getting a unique ID to be used by the entities themselves.

Important to note is this only sets up the connection details for the integration, YAML support is still needed to configure the zones and outputs, the dependency does not provide functionality to get all available zones and outputs. The setup process is modeled after the KNX integration (which has similar behavior)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/74699
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23582

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
