### PR TITLE
Add set chime duration service to unifiprotect

### DIFF
--- a/homeassistant/components/unifiprotect/services.yaml
+++ b/homeassistant/components/unifiprotect/services.yaml
@@ -84,6 +84,28 @@ set_doorbell_message:
           step: 1
           mode: slider
           unit_of_measurement: minutes
+set_chime_duration:
+  name: Set the chime duration attached to a doorbell
+  description: Set the duration for doorbell chime
+  fields:
+    device_id:
+      name: UniFi Protect Device
+      description: Any device from the UniFi Protect instance you want to change.
+      required: true
+      selector:
+        device:
+          integration: unifiprotect
+    duration:
+      name: Duration
+      description: Number of milliseconds for the chime to ring. 0 means off.
+      example: 300
+      selector:
+        number:
+          min: 1
+          max: 10000
+          step: 100
+          mode: slider
+          unit_of_measurement: ms
 set_chime_paired_doorbells:
   name: Set Chime Paired Doorbells
   description: >

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -8,10 +8,15 @@ import pytest
 from pyunifiprotect.data import Camera, Chime, Light, ModelType
 from pyunifiprotect.exceptions import BadRequest
 
-from homeassistant.components.unifiprotect.const import ATTR_MESSAGE, DOMAIN
+from homeassistant.components.unifiprotect.const import (
+    ATTR_DURATION,
+    ATTR_MESSAGE,
+    DOMAIN,
+)
 from homeassistant.components.unifiprotect.services import (
     SERVICE_ADD_DOORBELL_TEXT,
     SERVICE_REMOVE_DOORBELL_TEXT,
+    SERVICE_SET_CHIME_DURATION,
     SERVICE_SET_CHIME_PAIRED,
     SERVICE_SET_DEFAULT_DOORBELL_TEXT,
 )
@@ -133,6 +138,24 @@ async def test_set_default_doorbell_text(
         blocking=True,
     )
     nvr.set_default_doorbell_message.assert_called_once_with("Test Message")
+
+
+async def test_set_chime_duration(
+    hass: HomeAssistant, device: dr.DeviceEntry, ufp: MockUFPFixture
+):
+    """Test set_chime_duration service."""
+
+    nvr = ufp.api.bootstrap.nvr
+    nvr.__fields__["set_chime_duration"] = Mock(final=False)
+    nvr.set_chime_duration = AsyncMock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CHIME_DURATION,
+        {ATTR_DEVICE_ID: device.id, ATTR_DURATION: 500},
+        blocking=True,
+    )
+    nvr.set_chime_duration.assert_called_once_with(500)
 
 
 async def test_set_chime_paired_doorbells(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the ability to change the chime duration for unifi protect devices.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- https://github.com/home-assistant/home-assistant.io/pull/24048

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
