### PR TITLE
Fix bug with 1st gen RainMachine controllers and unknown API calls

### DIFF
--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -175,7 +175,9 @@ class ProvisionSettingsBinarySensor(RainMachineEntity, BinarySensorEntity):
     def update_from_latest_data(self) -> None:
         """Update the state."""
         if self.entity_description.key == TYPE_FLOW_SENSOR:
-            self._attr_is_on = self.coordinator.data.get("system", {}).get("useFlowSensor")
+            self._attr_is_on = self.coordinator.data.get("system", {}).get(
+                "useFlowSensor"
+            )
 
 
 class UniversalRestrictionsBinarySensor(RainMachineEntity, BinarySensorEntity):

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -175,7 +175,7 @@ class ProvisionSettingsBinarySensor(RainMachineEntity, BinarySensorEntity):
     def update_from_latest_data(self) -> None:
         """Update the state."""
         if self.entity_description.key == TYPE_FLOW_SENSOR:
-            self._attr_is_on = self.coordinator.data.get("system").get("useFlowSensor")
+            self._attr_is_on = self.coordinator.data.get("system", {}).get("useFlowSensor")
 
 
 class UniversalRestrictionsBinarySensor(RainMachineEntity, BinarySensorEntity):

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -175,7 +175,7 @@ class ProvisionSettingsBinarySensor(RainMachineEntity, BinarySensorEntity):
     def update_from_latest_data(self) -> None:
         """Update the state."""
         if self.entity_description.key == TYPE_FLOW_SENSOR:
-            self._attr_is_on = self.coordinator.data["system"].get("useFlowSensor")
+            self._attr_is_on = self.coordinator.data.get("system").get("useFlowSensor")
 
 
 class UniversalRestrictionsBinarySensor(RainMachineEntity, BinarySensorEntity):

--- a/homeassistant/components/rainmachine/manifest.json
+++ b/homeassistant/components/rainmachine/manifest.json
@@ -3,7 +3,7 @@
   "name": "RainMachine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rainmachine",
-  "requirements": ["regenmaschine==2022.08.0"],
+  "requirements": ["regenmaschine==2022.09.0"],
   "codeowners": ["@bachya"],
   "iot_class": "local_polling",
   "homekit": {

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -273,12 +273,12 @@ class ProvisionSettingsSensor(RainMachineEntity, SensorEntity):
     def update_from_latest_data(self) -> None:
         """Update the state."""
         if self.entity_description.key == TYPE_FLOW_SENSOR_CLICK_M3:
-            self._attr_native_value = self.coordinator.data["system"].get(
+            self._attr_native_value = self.coordinator.data.get("system").get(
                 "flowSensorClicksPerCubicMeter"
             )
         elif self.entity_description.key == TYPE_FLOW_SENSOR_CONSUMED_LITERS:
-            clicks = self.coordinator.data["system"].get("flowSensorWateringClicks")
-            clicks_per_m3 = self.coordinator.data["system"].get(
+            clicks = self.coordinator.data.get("system").get("flowSensorWateringClicks")
+            clicks_per_m3 = self.coordinator.data.get("system").get(
                 "flowSensorClicksPerCubicMeter"
             )
 
@@ -287,11 +287,11 @@ class ProvisionSettingsSensor(RainMachineEntity, SensorEntity):
             else:
                 self._attr_native_value = None
         elif self.entity_description.key == TYPE_FLOW_SENSOR_START_INDEX:
-            self._attr_native_value = self.coordinator.data["system"].get(
+            self._attr_native_value = self.coordinator.data.get("system").get(
                 "flowSensorStartIndex"
             )
         elif self.entity_description.key == TYPE_FLOW_SENSOR_WATERING_CLICKS:
-            self._attr_native_value = self.coordinator.data["system"].get(
+            self._attr_native_value = self.coordinator.data.get("system").get(
                 "flowSensorWateringClicks"
             )
 

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -273,12 +273,14 @@ class ProvisionSettingsSensor(RainMachineEntity, SensorEntity):
     def update_from_latest_data(self) -> None:
         """Update the state."""
         if self.entity_description.key == TYPE_FLOW_SENSOR_CLICK_M3:
-            self._attr_native_value = self.coordinator.data.get("system").get(
+            self._attr_native_value = self.coordinator.data.get("system", {}).get(
                 "flowSensorClicksPerCubicMeter"
             )
         elif self.entity_description.key == TYPE_FLOW_SENSOR_CONSUMED_LITERS:
-            clicks = self.coordinator.data.get("system").get("flowSensorWateringClicks")
-            clicks_per_m3 = self.coordinator.data.get("system").get(
+            clicks = self.coordinator.data.get("system", {}).get(
+                "flowSensorWateringClicks"
+            )
+            clicks_per_m3 = self.coordinator.data.get("system", {}).get(
                 "flowSensorClicksPerCubicMeter"
             )
 
@@ -287,11 +289,11 @@ class ProvisionSettingsSensor(RainMachineEntity, SensorEntity):
             else:
                 self._attr_native_value = None
         elif self.entity_description.key == TYPE_FLOW_SENSOR_START_INDEX:
-            self._attr_native_value = self.coordinator.data.get("system").get(
+            self._attr_native_value = self.coordinator.data.get("system", {}).get(
                 "flowSensorStartIndex"
             )
         elif self.entity_description.key == TYPE_FLOW_SENSOR_WATERING_CLICKS:
-            self._attr_native_value = self.coordinator.data.get("system").get(
+            self._attr_native_value = self.coordinator.data.get("system", {}).get(
                 "flowSensorWateringClicks"
             )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2121,7 +2121,7 @@ raincloudy==0.0.7
 raspyrfm-client==1.2.8
 
 # homeassistant.components.rainmachine
-regenmaschine==2022.08.0
+regenmaschine==2022.09.0
 
 # homeassistant.components.renault
 renault-api==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1454,7 +1454,7 @@ radios==0.1.1
 radiotherm==2.1.0
 
 # homeassistant.components.rainmachine
-regenmaschine==2022.08.0
+regenmaschine==2022.09.0
 
 # homeassistant.components.renault
 renault-api==0.1.11


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adjusts RainMachine so unknown API calls (which occur with older controller versions) don't prevent the integration from loading.

`regenmaschine` changelog: https://github.com/bachya/regenmaschine/releases/tag/2022.09.0
`regenmaschine` diff: https://github.com/bachya/regenmaschine/compare/2022.08.0...2022.09.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/77982
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
