### PR TITLE
Change Skybell color mode to RGB

### DIFF
--- a/homeassistant/components/skybell/light.py
+++ b/homeassistant/components/skybell/light.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_RGB_COLOR,
     ColorMode,
     LightEntity,
     LightEntityDescription,
@@ -36,12 +35,10 @@ class SkybellLight(SkybellEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
-        if ATTR_RGB_COLOR in kwargs:
-            rgb = kwargs[ATTR_RGB_COLOR]
-            await self._device.async_set_setting(ATTR_RGB_COLOR, rgb)
-        if ATTR_BRIGHTNESS in kwargs:
-            level = int((kwargs.get(ATTR_BRIGHTNESS, 0) * 100) / 255)
-            await self._device.async_set_setting(ATTR_BRIGHTNESS, level)
+        for key, value in kwargs.items():
+            if key == ATTR_BRIGHTNESS:
+                value = int((value * 100) / 255)
+            await self._device.async_set_setting(key, value)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""

--- a/homeassistant/components/skybell/light.py
+++ b/homeassistant/components/skybell/light.py
@@ -31,7 +31,8 @@ async def async_setup_entry(
 class SkybellLight(SkybellEntity, LightEntity):
     """A light implementation for Skybell devices."""
 
-    _attr_supported_color_modes = {ColorMode.BRIGHTNESS, ColorMode.RGB}
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_color_modes = {ColorMode.RGB}
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
@@ -55,3 +56,8 @@ class SkybellLight(SkybellEntity, LightEntity):
     def brightness(self) -> int:
         """Return the brightness of the light."""
         return int((self._device.led_intensity * 255) / 100)
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the rgb color value [int, int, int]."""
+        return self._device.led_rgb

--- a/homeassistant/components/skybell/light.py
+++ b/homeassistant/components/skybell/light.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from aioskybell.helpers.const import BRIGHTNESS, RGB_COLOR
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
     ColorMode,
     LightEntity,
     LightEntityDescription,
@@ -35,10 +38,11 @@ class SkybellLight(SkybellEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
-        for key, value in kwargs.items():
-            if key == ATTR_BRIGHTNESS:
-                value = int(value * 100 / 255)
-            await self._device.async_set_setting(key, value)
+        if ATTR_RGB_COLOR in kwargs:
+            await self._device.async_set_setting(RGB_COLOR, kwargs[ATTR_RGB_COLOR])
+        if ATTR_BRIGHTNESS in kwargs:
+            level = int((kwargs.get(ATTR_BRIGHTNESS, 0) * 100) / 255)
+            await self._device.async_set_setting(BRIGHTNESS, level)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""

--- a/homeassistant/components/skybell/light.py
+++ b/homeassistant/components/skybell/light.py
@@ -37,7 +37,7 @@ class SkybellLight(SkybellEntity, LightEntity):
         """Turn on the light."""
         for key, value in kwargs.items():
             if key == ATTR_BRIGHTNESS:
-                value = int((value * 100) / 255)
+                value = int(value * 100 / 255)
             await self._device.async_set_setting(key, value)
 
     async def async_turn_off(self, **kwargs: Any) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Per the docs, brightness should be the only supported mode if the device supports it. This PR changes that to RGB as Skybell supports it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
