### PR TITLE
Add Button platform to Bravia TV

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -139,6 +139,7 @@ omit =
     homeassistant/components/bosch_shc/sensor.py
     homeassistant/components/bosch_shc/switch.py
     homeassistant/components/braviatv/__init__.py
+    homeassistant/components/braviatv/button.py
     homeassistant/components/braviatv/const.py
     homeassistant/components/braviatv/coordinator.py
     homeassistant/components/braviatv/entity.py

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -14,7 +14,11 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from .const import CONF_IGNORED_SOURCES, DOMAIN
 from .coordinator import BraviaTVCoordinator
 
-PLATFORMS: Final[list[Platform]] = [Platform.MEDIA_PLAYER, Platform.REMOTE]
+PLATFORMS: Final[list[Platform]] = [
+    Platform.BUTTON,
+    Platform.MEDIA_PLAYER,
+    Platform.REMOTE,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/homeassistant/components/braviatv/button.py
+++ b/homeassistant/components/braviatv/button.py
@@ -1,7 +1,7 @@
 """Button support for Bravia TV."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 
 from homeassistant.components.button import (
@@ -23,7 +23,7 @@ from .entity import BraviaTVEntity
 class BraviaTVButtonDescriptionMixin:
     """Mixin to describe a Bravia TV Button entity."""
 
-    press_action: Callable
+    press_action: Callable[[BraviaTVCoordinator], Coroutine]
 
 
 @dataclass

--- a/homeassistant/components/braviatv/button.py
+++ b/homeassistant/components/braviatv/button.py
@@ -1,0 +1,89 @@
+"""Button support for Bravia TV."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import BraviaTVCoordinator
+from .entity import BraviaTVEntity
+
+
+@dataclass
+class BraviaTVButtonDescriptionMixin:
+    """Mixin to describe a Bravia TV Button entity."""
+
+    press_action: Callable
+
+
+@dataclass
+class BraviaTVButtonDescription(
+    ButtonEntityDescription, BraviaTVButtonDescriptionMixin
+):
+    """Bravia TV Button description."""
+
+
+BUTTONS: tuple[BraviaTVButtonDescription, ...] = (
+    BraviaTVButtonDescription(
+        key="reboot",
+        name="Reboot",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_category=EntityCategory.CONFIG,
+        press_action=lambda coordinator: coordinator.async_reboot_device(),
+    ),
+    BraviaTVButtonDescription(
+        key="terminate_apps",
+        name="Terminate apps",
+        entity_category=EntityCategory.CONFIG,
+        press_action=lambda coordinator: coordinator.async_terminate_apps(),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Bravia TV Button entities."""
+
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    unique_id = config_entry.unique_id
+    assert unique_id is not None
+
+    async_add_entities(
+        BraviaTVButton(coordinator, unique_id, config_entry.title, description)
+        for description in BUTTONS
+    )
+
+
+class BraviaTVButton(BraviaTVEntity, ButtonEntity):
+    """Representation of a Bravia TV Button."""
+
+    entity_description: BraviaTVButtonDescription
+
+    def __init__(
+        self,
+        coordinator: BraviaTVCoordinator,
+        unique_id: str,
+        model: str,
+        description: BraviaTVButtonDescription,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator, unique_id, model)
+        self._attr_unique_id = f"{unique_id}_{description.key}"
+        self.entity_description = description
+
+    async def async_press(self) -> None:
+        """Trigger the button action."""
+        await self.entity_description.press_action(self.coordinator)

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -282,3 +282,13 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                         cmd,
                         commands_keys,
                     )
+
+    @catch_braviatv_errors
+    async def async_reboot_device(self) -> None:
+        """Send command to reboot the device."""
+        await self.client.reboot()
+
+    @catch_braviatv_errors
+    async def async_terminate_apps(self) -> None:
+        """Send command to terminate all applications."""
+        await self.client.terminate_apps()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR will add the new `button` platform to Bravia TV. The buttons in this integration will allow users to reboot the device and terminate all running apps.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24059

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
