### PR TITLE
Fix zwave_js update entity

### DIFF
--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -216,12 +216,14 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         firmware = self._latest_version_firmware
         assert firmware
         self._unsub_firmware_events_and_reset_progress(True)
+
         self._progress_unsub = self.node.on(
             "firmware update progress", self._update_progress
         )
         self._finished_unsub = self.node.once(
             "firmware update finished", self._update_finished
         )
+
         for file in firmware.files:
             try:
                 await self.driver.controller.async_begin_ota_firmware_update(

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -141,6 +141,11 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         if self._progress_unsub:
             self._progress_unsub()
             self._progress_unsub = None
+
+        if self._finished_unsub:
+            self._finished_unsub()
+            self._finished_unsub = None
+
         self._finished_status = None
         self._num_files_installed = 0
         self._attr_in_progress = 0
@@ -286,10 +291,4 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             self._poll_unsub()
             self._poll_unsub = None
 
-        if self._progress_unsub:
-            self._progress_unsub()
-            self._progress_unsub = None
-
-        if self._finished_unsub:
-            self._finished_unsub()
-            self._finished_unsub = None
+        self._reset_progress()

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -200,7 +200,9 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             return None
         return self._latest_version_firmware.changelog
 
-    async def async_install(self, *_: Any, **__: Any) -> None:
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
         """Install an update."""
         firmware = self._latest_version_firmware
         assert firmware

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -209,7 +209,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             "firmware update progress", self._update_progress
         )
         self._finished_unsub = self.node.once(
-            "firmware update finished", self._update_progress
+            "firmware update finished", self._update_finished
         )
         for file in firmware.files:
             try:

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -11,7 +11,6 @@ from awesomeversion import AwesomeVersion
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import NodeStatus
 from zwave_js_server.exceptions import BaseZwaveJSServerError, FailedZWaveCommand
-from zwave_js_server.model.controller import Controller
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.firmware import (
     FirmwareUpdateFinished,
@@ -84,7 +83,6 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         self.driver = driver
         self.node = node
         self.semaphore = semaphore
-        self.controller: Controller = self.driver.controller
         self._latest_version_firmware: FirmwareUpdateInfo | None = None
         self._status_unsub: Callable[[], None] | None = None
         self._poll_unsub: Callable[[], None] | None = None
@@ -171,7 +169,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         try:
             async with self.semaphore:
                 available_firmware_updates = (
-                    await self.controller.async_get_available_firmware_updates(
+                    await self.driver.controller.async_get_available_firmware_updates(
                         self.node, API_KEY_FIRMWARE_UPDATE_SERVICE
                     )
                 )

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -289,3 +289,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         if self._progress_unsub:
             self._progress_unsub()
             self._progress_unsub = None
+
+        if self._finished_unsub:
+            self._finished_unsub()
+            self._finished_unsub = None

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -147,6 +147,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             self._finished_unsub = None
 
         self._finished_status = None
+        self._finished_event.clear()
         self._num_files_installed = 0
         self._attr_in_progress = 0
         if write_state:

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -11,6 +11,7 @@ from awesomeversion import AwesomeVersion
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import NodeStatus
 from zwave_js_server.exceptions import BaseZwaveJSServerError, FailedZWaveCommand
+from zwave_js_server.model.controller import Controller
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.firmware import FirmwareUpdateInfo, FirmwareUpdateProgress
 from zwave_js_server.model.node import Node as ZwaveNode
@@ -78,6 +79,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         self.driver = driver
         self.node = node
         self.semaphore = semaphore
+        self.controller: Controller = self.driver.controller
         self._latest_version_firmware: FirmwareUpdateInfo | None = None
         self._status_unsub: Callable[[], None] | None = None
         self._poll_unsub: Callable[[], None] | None = None
@@ -145,7 +147,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         try:
             async with self.semaphore:
                 available_firmware_updates = (
-                    await self.driver.controller.async_get_available_firmware_updates(
+                    await self.controller.async_get_available_firmware_updates(
                         self.node, API_KEY_FIRMWARE_UPDATE_SERVICE
                     )
                 )

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -313,7 +313,7 @@ async def test_update_entity_progress(
     client.async_send_command.return_value = None
 
     # Test successful install call without a version
-    hass.async_create_task(
+    install_task = hass.async_create_task(
         hass.services.async_call(
             UPDATE_DOMAIN,
             SERVICE_INSTALL,
@@ -367,6 +367,8 @@ async def test_update_entity_progress(
     assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
     assert state.state == STATE_OFF
 
+    await install_task
+
 
 async def test_update_entity_install_failed(
     hass,
@@ -392,8 +394,7 @@ async def test_update_entity_install_failed(
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = None
 
-    # Test install call - we expect it to raise
-    install_task = hass.async_create_task(
+    async def call_install():
         await hass.services.async_call(
             UPDATE_DOMAIN,
             SERVICE_INSTALL,
@@ -402,7 +403,9 @@ async def test_update_entity_install_failed(
             },
             blocking=True,
         )
-    )
+
+    # Test install call - we expect it to raise
+    install_task = hass.async_create_task(call_install())
 
     # Sleep so that task starts
     await asyncio.sleep(0.1)

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -392,20 +392,17 @@ async def test_update_entity_install_failed(
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = None
 
-    async def call_install():
-        """Call install service."""
-        with pytest.raises(HomeAssistantError):
-            await hass.services.async_call(
-                UPDATE_DOMAIN,
-                SERVICE_INSTALL,
-                {
-                    ATTR_ENTITY_ID: UPDATE_ENTITY,
-                },
-                blocking=True,
-            )
-
-    # Test successful install call without a version
-    hass.async_create_task(call_install())
+    # Test install call - we expect it to raise
+    install_task = hass.async_create_task(
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {
+                ATTR_ENTITY_ID: UPDATE_ENTITY,
+            },
+            blocking=True,
+        )
+    )
 
     # Sleep so that task starts
     await asyncio.sleep(0.1)
@@ -449,3 +446,7 @@ async def test_update_entity_install_failed(
     assert attrs[ATTR_INSTALLED_VERSION] == "10.7"
     assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
     assert state.state == STATE_ON
+
+    # validate that the install task failed
+    with pytest.raises(HomeAssistantError):
+        await install_task


### PR DESCRIPTION
## Proposed change
- We need to block until we receive the `firmware update finished` event - this corrects that behavior
- Adds a test to test progress updates when installing new firmware on a zwave_js device


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
