### PR TITLE
Improve unique_id collision checks in entity_platform

### DIFF
--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -438,13 +438,15 @@ async def test_async_remove_with_platform_update_finishes(hass):
 
 
 async def test_not_adding_duplicate_entities_with_unique_id(hass, caplog):
-    """Test for not adding duplicate entities."""
+    """Test for not adding duplicate entities.
+
+    Also test that the entity registry is not updated for duplicates.
+    """
     caplog.set_level(logging.ERROR)
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
-    await component.async_add_entities(
-        [MockEntity(name="test1", unique_id="not_very_unique")]
-    )
+    ent1 = MockEntity(name="test1", unique_id="not_very_unique")
+    await component.async_add_entities([ent1])
 
     assert len(hass.states.async_entity_ids()) == 1
     assert not caplog.text
@@ -465,6 +467,11 @@ async def test_not_adding_duplicate_entities_with_unique_id(hass, caplog):
     assert ent2.hass is None
     assert ent2.platform is None
     assert len(hass.states.async_entity_ids()) == 1
+
+    registry = er.async_get(hass)
+    # test the entity name was not updated
+    entry = registry.async_get_or_create(DOMAIN, DOMAIN, "not_very_unique")
+    assert entry.original_name == "test1"
 
 
 async def test_using_prescribed_entity_id(hass):
@@ -575,6 +582,28 @@ async def test_registry_respect_entity_disabled(hass):
     await platform.async_add_entities([entity])
     assert entity.entity_id == "test_domain.world"
     assert hass.states.async_entity_ids() == []
+
+
+async def test_unique_id_conflict_has_priority_over_disabled_entity(hass, caplog):
+    """Test that an entity that is not unique has priority over a disabled entity."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    entity1 = MockEntity(
+        name="test1", unique_id="not_very_unique", enabled_by_default=False
+    )
+    entity2 = MockEntity(
+        name="test2", unique_id="not_very_unique", enabled_by_default=False
+    )
+    await component.async_add_entities([entity1])
+    await component.async_add_entities([entity2])
+
+    assert len(hass.states.async_entity_ids()) == 1
+    assert "Platform test_domain does not generate unique IDs." in caplog.text
+    assert entity1.registry_entry is not None
+    assert entity2.registry_entry is None
+    registry = er.async_get(hass)
+    # test the entity name was not updated
+    entry = registry.async_get_or_create(DOMAIN, DOMAIN, "not_very_unique")
+    assert entry.original_name == "test1"
 
 
 async def test_entity_registry_updates_name(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve `unique_id` collision checks in `entity_platform`:
- Check for `unique_id` collision before updating the entity registry
- Check for `unique_id` collision before checking if an entity is disabled

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
