### PR TITLE
Add BTHome binary sensors

### DIFF
--- a/homeassistant/components/bthome/__init__.py
+++ b/homeassistant/components/bthome/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 
 from typing import Optional
 
-from bthome_ble import (
-    BTHOME_BINARY_SENSORS,
-    HOME_ASSISTANT_BINARY_SENSOR_DEVICE_CLASSES,
-    SensorUpdate,
-)
+from bthome_ble import BTHOME_BINARY_SENSORS, SensorUpdate
 
 from homeassistant import config_entries
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -30,15 +27,14 @@ BINARY_SENSOR_DESCRIPTIONS = {}
 for key in BTHOME_BINARY_SENSORS:
     # Not all BTHome device classes are available in Home Assistant
     DEV_CLASS = None
-    if key in HOME_ASSISTANT_BINARY_SENSOR_DEVICE_CLASSES:
+    try:
+        BinarySensorDeviceClass(key)
         DEV_CLASS = key
-    BINARY_SENSOR_DESCRIPTIONS.update(
-        {
-            key: BinarySensorEntityDescription(
-                key=key,
-                device_class=DEV_CLASS,
-            )
-        }
+    except ValueError:
+        DEV_CLASS = None
+    BINARY_SENSOR_DESCRIPTIONS[key] = BinarySensorEntityDescription(
+        key=key,
+        device_class=DEV_CLASS,
     )
 
 

--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -26,10 +26,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
 
-DEV_CLASS = None
 BINARY_SENSOR_DESCRIPTIONS = {}
 for key in BTHOME_BINARY_SENSORS:
     # Not all BTHome device classes are available in Home Assistant
+    DEV_CLASS = None
     if key in HOME_ASSISTANT_BINARY_SENSOR_DEVICE_CLASSES:
         DEV_CLASS = key
     BINARY_SENSOR_DESCRIPTIONS.update(

--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -26,10 +26,9 @@ from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_ha
 BINARY_SENSOR_DESCRIPTIONS = {}
 for key in BTHOME_BINARY_SENSORS:
     # Not all BTHome device classes are available in Home Assistant
-    DEV_CLASS = None
+    DEV_CLASS: str | None = key
     try:
         BinarySensorDeviceClass(key)
-        DEV_CLASS = key
     except ValueError:
         DEV_CLASS = None
     BINARY_SENSOR_DESCRIPTIONS[key] = BinarySensorEntityDescription(

--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -1,0 +1,98 @@
+"""Support for BTHome binary sensors."""
+from __future__ import annotations
+
+from typing import Optional
+
+from bthome_ble import (
+    BTHOME_BINARY_SENSORS,
+    HOME_ASSISTANT_BINARY_SENSOR_DEVICE_CLASSES,
+    SensorUpdate,
+)
+
+from homeassistant import config_entries
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.components.bluetooth.passive_update_processor import (
+    PassiveBluetoothDataProcessor,
+    PassiveBluetoothDataUpdate,
+    PassiveBluetoothProcessorCoordinator,
+    PassiveBluetoothProcessorEntity,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+
+DEV_CLASS = None
+BINARY_SENSOR_DESCRIPTIONS = {}
+for key in BTHOME_BINARY_SENSORS:
+    # Not all BTHome device classes are available in Home Assistant
+    if key in HOME_ASSISTANT_BINARY_SENSOR_DEVICE_CLASSES:
+        DEV_CLASS = key
+    BINARY_SENSOR_DESCRIPTIONS.update(
+        {
+            key: BinarySensorEntityDescription(
+                key=key,
+                device_class=DEV_CLASS,
+            )
+        }
+    )
+
+
+def sensor_update_to_bluetooth_data_update(
+    sensor_update: SensorUpdate,
+) -> PassiveBluetoothDataUpdate:
+    """Convert a binary sensor update to a bluetooth data update."""
+    return PassiveBluetoothDataUpdate(
+        devices={
+            device_id: sensor_device_info_to_hass(device_info)
+            for device_id, device_info in sensor_update.devices.items()
+        },
+        entity_descriptions={
+            device_key_to_bluetooth_entity_key(device_key): BINARY_SENSOR_DESCRIPTIONS[
+                description.device_key.key
+            ]
+            for device_key, description in sensor_update.binary_entity_descriptions.items()
+        },
+        entity_data={
+            device_key_to_bluetooth_entity_key(device_key): sensor_values.native_value
+            for device_key, sensor_values in sensor_update.binary_entity_values.items()
+        },
+        entity_names={
+            device_key_to_bluetooth_entity_key(device_key): sensor_values.name
+            for device_key, sensor_values in sensor_update.binary_entity_values.items()
+        },
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the BTHome BLE binary sensors."""
+    coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
+        entry.entry_id
+    ]
+    processor = PassiveBluetoothDataProcessor(sensor_update_to_bluetooth_data_update)
+    entry.async_on_unload(
+        processor.async_add_entities_listener(
+            BTHomeBluetoothBinarySensorEntity, async_add_entities
+        )
+    )
+    entry.async_on_unload(coordinator.async_register_processor(processor))
+
+
+class BTHomeBluetoothBinarySensorEntity(
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[Optional[bool]]],
+    BinarySensorEntity,
+):
+    """Representation of a BTHome binary sensor."""
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the native value."""
+        return self.processor.entity_data.get(self.entity_key)

--- a/homeassistant/components/bthome/manifest.json
+++ b/homeassistant/components/bthome/manifest.json
@@ -13,7 +13,7 @@
       "service_data_uuid": "0000181e-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["bthome-ble==1.0.0"],
+  "requirements": ["bthome-ble==1.2.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/bthome/sensor.py
+++ b/homeassistant/components/bthome/sensor.py
@@ -148,9 +148,9 @@ SENSOR_DESCRIPTIONS = {
         state_class=SensorStateClass.MEASUREMENT,
     ),
     # Used for moisture sensor
-    (None, Units.PERCENTAGE,): SensorEntityDescription(
+    (DeviceClass.MOISTURE, Units.PERCENTAGE): SensorEntityDescription(
         key=f"{DeviceClass.MOISTURE}_{Units.PERCENTAGE}",
-        device_class=None,
+        device_class=SensorDeviceClass.MOISTURE,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -464,7 +464,7 @@ bsblan==0.5.0
 bt_proximity==0.2.1
 
 # homeassistant.components.bthome
-bthome-ble==1.0.0
+bthome-ble==1.2.0
 
 # homeassistant.components.bt_home_hub_5
 bthomehub5-devicelist==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -365,7 +365,7 @@ brunt==1.2.0
 bsblan==0.5.0
 
 # homeassistant.components.bthome
-bthome-ble==1.0.0
+bthome-ble==1.2.0
 
 # homeassistant.components.buienradar
 buienradar==1.0.5

--- a/tests/components/bthome/test_binary_sensor.py
+++ b/tests/components/bthome/test_binary_sensor.py
@@ -1,0 +1,113 @@
+"""Test BTHome binary sensors."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.bluetooth import BluetoothChange
+from homeassistant.components.bthome.const import DOMAIN
+from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_OFF, STATE_ON
+
+from . import make_advertisement
+
+from tests.common import MockConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "mac_address, advertisement, bind_key, result",
+    [
+        (
+            "A4:C1:38:8D:18:B2",
+            make_advertisement(
+                "A4:C1:38:8D:18:B2",
+                b"\x02\x10\x01",
+            ),
+            None,
+            [
+                {
+                    "binary_sensor_entity": "binary_sensor.test_device_18b2_power",
+                    "friendly_name": "Test Device 18B2 Power",
+                    "expected_state": STATE_ON,
+                },
+            ],
+        ),
+        (
+            "A4:C1:38:8D:18:B2",
+            make_advertisement(
+                "A4:C1:38:8D:18:B2",
+                b"\x02\x11\x00",
+            ),
+            None,
+            [
+                {
+                    "binary_sensor_entity": "binary_sensor.test_device_18b2_opening",
+                    "friendly_name": "Test Device 18B2 Opening",
+                    "expected_state": STATE_OFF,
+                },
+            ],
+        ),
+        (
+            "A4:C1:38:8D:18:B2",
+            make_advertisement(
+                "A4:C1:38:8D:18:B2",
+                b"\x02\x0F\x01",
+            ),
+            None,
+            [
+                {
+                    "binary_sensor_entity": "binary_sensor.test_device_18b2_generic",
+                    "friendly_name": "Test Device 18B2 Generic",
+                    "expected_state": STATE_ON,
+                },
+            ],
+        ),
+    ],
+)
+async def test_binary_sensors(
+    hass,
+    mac_address,
+    advertisement,
+    bind_key,
+    result,
+):
+    """Test the different binary sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=mac_address,
+        data={"bindkey": bind_key},
+    )
+    entry.add_to_hass(hass)
+
+    saved_callback = None
+
+    def _async_register_callback(_hass, _callback, _matcher, _mode):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+
+    saved_callback(
+        advertisement,
+        BluetoothChange.ADVERTISEMENT,
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == len(result)
+    for meas in result:
+        binary_sensor = hass.states.get(meas["binary_sensor_entity"])
+        binary_sensor_attr = binary_sensor.attributes
+        assert binary_sensor.state == meas["expected_state"]
+        assert binary_sensor_attr[ATTR_FRIENDLY_NAME] == meas["friendly_name"]
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR has the following changes

- Adding support for Binary Sensors for BTHome. 
- Using the new Device Class `MOISTURE` for moisture sensors. 

bthome-ble has been updated for these changes. 
https://github.com/Bluetooth-Devices/bthome-ble/releases/tag/v1.2.0
https://github.com/Bluetooth-Devices/bthome-ble/releases/tag/v1.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24072

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
