### PR TITLE
Improve reliability of the luci device tracker for openwrt versions 18+

### DIFF
--- a/homeassistant/components/luci/device_tracker.py
+++ b/homeassistant/components/luci/device_tracker.py
@@ -96,7 +96,9 @@ class LuciDeviceScanner(DeviceScanner):
 
     def _update_info(self):
         """Check the Luci router for devices."""
-        result = self.router.get_all_connected_devices(only_reachable=self.only_reachable)
+        result = self.router.get_all_connected_devices(
+            only_reachable=self.only_reachable
+        )
 
         _LOGGER.debug("Luci get_all_connected_devices returned: %s", result)
 

--- a/homeassistant/components/luci/device_tracker.py
+++ b/homeassistant/components/luci/device_tracker.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_SSL,
     CONF_USERNAME,
-    CONF_VERIFY_SSL
+    CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -59,7 +59,7 @@ class LuciDeviceScanner(DeviceScanner):
             config[CONF_USERNAME],
             config[CONF_PASSWORD],
             config[CONF_SSL],
-            config[CONF_VERIFY_SSL]
+            config[CONF_VERIFY_SSL],
         )
 
         self.last_results = {}

--- a/homeassistant/components/luci/manifest.json
+++ b/homeassistant/components/luci/manifest.json
@@ -2,7 +2,7 @@
   "domain": "luci",
   "name": "OpenWrt (luci)",
   "documentation": "https://www.home-assistant.io/integrations/luci",
-  "requirements": ["openwrt-luci-rpc==1.1.11"],
+  "requirements": ["openwrt-luci-rpc==1.1.12"],
   "codeowners": ["@mzdrale"],
   "iot_class": "local_polling",
   "loggers": ["openwrt_luci_rpc"]


### PR DESCRIPTION
## Proposed change
This PR aims to improve the reliability of the luci device tracker for OpenWRT versions 18+ by removing filtering for only reachable devices per default. The used lib suggests this change ([openwrt_luci_rpc](https://github.com/fbradyirl/openwrt-luci-rpc/blob/master/openwrt_luci_rpc/openwrt_luci_rpc.py#L136)) for any OpenWRT v18+. The first v18 of OpenWRT was released [around 4y ago](https://forum.openwrt.org/t/openwrt-18-06-0-release/17955), so I think it's valid to move to updated defaults.

Users using OpenWRT versions below v18, can always switch back to the old behavior by setting the offered "only_reachable" config param to True in their config.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
In my local tests, this drastically improved the reliability of this component.

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24079

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
