### PR TITLE
Remove unused humidifier constants

### DIFF
--- a/homeassistant/components/humidifier/const.py
+++ b/homeassistant/components/humidifier/const.py
@@ -2,14 +2,8 @@
 from enum import IntEnum
 
 MODE_NORMAL = "normal"
-MODE_ECO = "eco"
 MODE_AWAY = "away"
-MODE_BOOST = "boost"
-MODE_COMFORT = "comfort"
-MODE_HOME = "home"
-MODE_SLEEP = "sleep"
 MODE_AUTO = "auto"
-MODE_BABY = "baby"
 
 ATTR_AVAILABLE_MODES = "available_modes"
 ATTR_HUMIDITY = "humidity"

--- a/tests/components/humidifier/test_device_action.py
+++ b/tests/components/humidifier/test_device_action.py
@@ -152,7 +152,7 @@ async def test_action(hass):
     hass.states.async_set(
         "humidifier.entity",
         STATE_ON,
-        {const.ATTR_AVAILABLE_MODES: [const.MODE_HOME, const.MODE_AWAY]},
+        {const.ATTR_AVAILABLE_MODES: ["home", const.MODE_AWAY]},
     )
 
     assert await async_setup_component(
@@ -308,7 +308,7 @@ async def test_action(hass):
         ),
         (
             False,
-            {const.ATTR_AVAILABLE_MODES: [const.MODE_HOME, const.MODE_AWAY]},
+            {const.ATTR_AVAILABLE_MODES: ["home", const.MODE_AWAY]},
             {},
             "set_mode",
             [
@@ -350,7 +350,7 @@ async def test_action(hass):
         (
             True,
             {},
-            {const.ATTR_AVAILABLE_MODES: [const.MODE_HOME, const.MODE_AWAY]},
+            {const.ATTR_AVAILABLE_MODES: ["home", const.MODE_AWAY]},
             "set_mode",
             [
                 {

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -248,7 +248,7 @@ async def test_if_state(hass, calls):
     assert len(calls) == 3
     assert calls[2].data["some"] == "is_mode - event - test_event3"
 
-    hass.states.async_set("humidifier.entity", STATE_ON, {ATTR_MODE: const.MODE_HOME})
+    hass.states.async_set("humidifier.entity", STATE_ON, {ATTR_MODE: "home"})
 
     # Should not fire
     hass.bus.async_fire("test_event3")
@@ -275,7 +275,7 @@ async def test_if_state(hass, calls):
         ),
         (
             False,
-            {const.ATTR_AVAILABLE_MODES: [const.MODE_HOME, const.MODE_AWAY]},
+            {const.ATTR_AVAILABLE_MODES: ["home", const.MODE_AWAY]},
             {},
             "is_mode",
             [
@@ -330,7 +330,7 @@ async def test_if_state(hass, calls):
         (
             True,
             {},
-            {const.ATTR_AVAILABLE_MODES: [const.MODE_HOME, const.MODE_AWAY]},
+            {const.ATTR_AVAILABLE_MODES: ["home", const.MODE_AWAY]},
             "is_mode",
             [
                 {

--- a/tests/components/humidifier/test_reproduce_state.py
+++ b/tests/components/humidifier/test_reproduce_state.py
@@ -6,7 +6,6 @@ from homeassistant.components.humidifier.const import (
     ATTR_HUMIDITY,
     DOMAIN,
     MODE_AWAY,
-    MODE_ECO,
     MODE_NORMAL,
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_MODE,
@@ -144,7 +143,7 @@ async def test_multiple_modes(hass):
     await async_reproduce_states(
         hass,
         [
-            State(ENTITY_1, STATE_ON, {ATTR_MODE: MODE_ECO, ATTR_HUMIDITY: 40}),
+            State(ENTITY_1, STATE_ON, {ATTR_MODE: "eco", ATTR_HUMIDITY: 40}),
             State(ENTITY_2, STATE_ON, {ATTR_MODE: MODE_NORMAL, ATTR_HUMIDITY: 50}),
         ],
     )
@@ -156,7 +155,7 @@ async def test_multiple_modes(hass):
     assert len(mode_calls) == 2
     # order is not guaranteed
     assert any(
-        call.data == {"entity_id": ENTITY_1, "mode": MODE_ECO} for call in mode_calls
+        call.data == {"entity_id": ENTITY_1, "mode": "eco"} for call in mode_calls
     )
     assert any(
         call.data == {"entity_id": ENTITY_2, "mode": MODE_NORMAL} for call in mode_calls


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
AFAICT, these constants are unused in the core code.
Linked to this discussion: https://github.com/home-assistant/core/pull/78033#discussion_r967158403

Todo:
- [ ] update docs https://developers.home-assistant.io/docs/core/entity/humidifier#modes
- [ ] check HACS

Ref:
- https://github.com/home-assistant/architecture/issues/310
- https://github.com/home-assistant/developers.home-assistant/pull/356
- https://github.com/home-assistant/core/pull/28693

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
