### PR TITLE
Add wemo brightness number entity

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -30,7 +30,7 @@ MAX_CONCURRENCY = 3
 WEMO_MODEL_DISPATCH = {
     "Bridge": [Platform.LIGHT],
     "CoffeeMaker": [Platform.SWITCH],
-    "Dimmer": [Platform.LIGHT],
+    "Dimmer": [Platform.LIGHT, Platform.NUMBER],
     "Humidifier": [Platform.FAN],
     "Insight": [Platform.BINARY_SENSOR, Platform.SWITCH],
     "LightSwitch": [Platform.SWITCH],

--- a/homeassistant/components/wemo/number.py
+++ b/homeassistant/components/wemo/number.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN as WEMO_DOMAIN
+from .const import DOMAIN
 from .entity import WemoEntity
 from .wemo_device import DeviceCoordinator
 
@@ -30,13 +30,13 @@ async def async_setup_entry(
         async_add_entities([DimmerBrightness(coordinator)])
 
     config_entry.async_on_unload(
-        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.number", _discovered_wemo)
+        async_dispatcher_connect(hass, f"{DOMAIN}.number", _discovered_wemo)
     )
 
     await asyncio.gather(
         *(
             _discovered_wemo(coordinator)
-            for coordinator in hass.data[WEMO_DOMAIN]["pending"].pop("number")
+            for coordinator in hass.data[DOMAIN]["pending"].pop("number")
         )
     )
 

--- a/homeassistant/components/wemo/number.py
+++ b/homeassistant/components/wemo/number.py
@@ -1,0 +1,70 @@
+"""Number platform support for WeMo."""
+from __future__ import annotations
+
+import asyncio
+import math
+
+from pywemo import Dimmer
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN as WEMO_DOMAIN
+from .entity import WemoEntity
+from .wemo_device import DeviceCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up number entry."""
+
+    async def _discovered_wemo(coordinator: DeviceCoordinator) -> None:
+        """Handle a discovered Wemo device."""
+        async_add_entities([DimmerBrightness(coordinator)])
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.number", _discovered_wemo)
+    )
+
+    await asyncio.gather(
+        *(
+            _discovered_wemo(coordinator)
+            for coordinator in hass.data[WEMO_DOMAIN]["pending"].pop("number")
+        )
+    )
+
+
+class DimmerBrightness(WemoEntity, NumberEntity):
+    """WeMo Dimmer brightness entity.
+
+    WeMo allows controlling the brightness even when the device is off. Home
+    Assistant provides no other way to adjust the brightness level when the
+    light is off, so we add this separate Number entity to control the
+    brightness independent of the on/off binary state.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_max_value = 255
+    _attr_native_min_value = 1
+    _attr_number_mode = NumberMode.SLIDER
+    _name_suffix = "Brightness"
+    wemo: Dimmer
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the brightness of this light."""
+        wemo_brightness: int = self.wemo.get_brightness()
+        return float(round((wemo_brightness * 255) / 100))
+
+    def set_native_value(self, value: float) -> None:
+        """Set the brightness of the light."""
+        with self._wemo_call_wrapper("set brightness"):
+            brightness = math.ceil((value / 255) * 100)
+            self.wemo.basicevent.SetBinaryState(brightness=brightness)

--- a/tests/components/wemo/test_number.py
+++ b/tests/components/wemo/test_number.py
@@ -1,0 +1,57 @@
+"""Tests for the Wemo number entity."""
+
+import unittest.mock as mock
+
+import pytest
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.components.wemo.number import DimmerBrightness
+from homeassistant.const import ATTR_ENTITY_ID
+
+
+@pytest.fixture
+def pywemo_model():
+    """Pywemo Dimmer number platform."""
+    return "Dimmer"
+
+
+@pytest.fixture
+def wemo_entity_suffix():
+    """Select the DimmerBrightness entity."""
+    return DimmerBrightness._name_suffix.lower()
+
+
+async def test_registry_state_callback(
+    hass, pywemo_registry, pywemo_device, wemo_entity
+):
+    """Verify that the number receives state updates from the registry."""
+    pywemo_device.get_brightness.return_value = 80
+    pywemo_registry.callbacks[pywemo_device.name](pywemo_device, "", "")
+    await hass.async_block_till_done()
+    assert hass.states.get(wemo_entity.entity_id).state == "204.0"
+
+
+async def test_set_brightness(hass, pywemo_device, wemo_entity):
+    """Verify setting the number updates the brightness correctly."""
+    device_brightness = 0
+
+    def set_brightness(brightness):
+        nonlocal device_brightness
+        device_brightness = brightness
+
+    pywemo_device.get_brightness.side_effect = lambda: device_brightness
+    pywemo_device.basicevent = mock.Mock()
+    pywemo_device.basicevent.SetBinaryState.side_effect = set_brightness
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: [wemo_entity.entity_id], ATTR_VALUE: 204},
+        blocking=True,
+    )
+    assert hass.states.get(wemo_entity.entity_id).state == "204.0"
+    pywemo_device.basicevent.SetBinaryState.assert_called_once_with(brightness=80)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a Number entity to WeMo lights that controls the brightness slider. This allows for setting the brightness of the dimmer independently from needing to turn the light on. 

In the evening, I'd like to pre-set the brightness of the dimmer without turning the light on. That way the light comes on at the appropriate brightness when I control it from the device itself. Having a slider to control the brightness avoids needing to use the `turn_on` service, which would do what I'm trying to avoid and turn the light on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
