### PR TITLE
Fix handling of Template in schema validation for testing a template condition in automation

### DIFF
--- a/homeassistant/components/template/manifest.json
+++ b/homeassistant/components/template/manifest.json
@@ -3,6 +3,7 @@
   "name": "Template",
   "documentation": "https://www.home-assistant.io/integrations/template",
   "codeowners": ["@PhracturedBlue", "@tetienne", "@home-assistant/core"],
+  "requirements": ["voluptuous==0.13.1"],
   "quality_scale": "internal",
   "after_dependencies": ["group"],
   "iot_class": "local_push"

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -595,10 +595,12 @@ def template(value: Any | None) -> template_helper.Template:
     """Validate a jinja2 template."""
     if value is None:
         raise vol.Invalid("template value is None")
-    if isinstance(value, (list, dict, template_helper.Template)):
+    if isinstance(value, (list, dict)):
         raise vol.Invalid("template value should be a string")
-
-    template_value = template_helper.Template(str(value))  # type: ignore[no-untyped-call]
+    if isinstance(value, (template_helper.Template)):
+        template_value = value
+    else:
+        template_value = template_helper.Template(str(value))  # type: ignore[no-untyped-call]
 
     try:
         template_value.ensure_valid()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2466,6 +2466,9 @@ vilfo-api-client==0.3.2
 # homeassistant.components.volkszaehler
 volkszaehler==0.3.2
 
+# homeassistant.components.template
+voluptuous==0.13.1
+
 # homeassistant.components.volvooncall
 volvooncall==0.10.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1691,6 +1691,9 @@ venstarcolortouch==0.18
 # homeassistant.components.vilfo
 vilfo-api-client==0.3.2
 
+# homeassistant.components.template
+voluptuous==0.13.1
+
 # homeassistant.components.volvooncall
 volvooncall==0.10.0
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [#12282](https://github.com/home-assistant/frontend/issues/12282)
- This PR is related to issue: [#12282](https://github.com/home-assistant/frontend/issues/12282)
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
