### PR TITLE
Bump pyfritzhome to 0.6.7

### DIFF
--- a/homeassistant/components/fritzbox/manifest.json
+++ b/homeassistant/components/fritzbox/manifest.json
@@ -2,7 +2,7 @@
   "domain": "fritzbox",
   "name": "AVM FRITZ!SmartHome",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox",
-  "requirements": ["pyfritzhome==0.6.5"],
+  "requirements": ["pyfritzhome==0.6.7"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:fritzbox:1"

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -87,7 +87,9 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suitable=lambda device: device.has_powermeter,  # type: ignore[no-any-return]
-        native_value=lambda device: device.power / 1000 if device.power else 0.0,
+        native_value=lambda device: round(device.power / 1000, 3)
+        if device.power
+        else 0.0,
     ),
     FritzSensorEntityDescription(
         key="voltage",
@@ -96,7 +98,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suitable=lambda device: device.has_powermeter,  # type: ignore[no-any-return]
-        native_value=lambda device: device.voltage
+        native_value=lambda device: round(device.voltage / 1000, 2)
         if getattr(device, "voltage", None)
         else 0.0,
     ),
@@ -107,7 +109,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suitable=lambda device: device.has_powermeter,  # type: ignore[no-any-return]
-        native_value=lambda device: device.power / device.voltage / 1000
+        native_value=lambda device: round(device.power / device.voltage, 3)
         if device.power and getattr(device, "voltage", None)
         else 0.0,
     ),

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -87,9 +87,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suitable=lambda device: device.has_powermeter,  # type: ignore[no-any-return]
-        native_value=lambda device: round(device.power / 1000, 3)
-        if device.power
-        else 0.0,
+        native_value=lambda device: round(device.power or 0.0 / 1000, 3),
     ),
     FritzSensorEntityDescription(
         key="voltage",
@@ -98,9 +96,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suitable=lambda device: device.has_powermeter,  # type: ignore[no-any-return]
-        native_value=lambda device: round(device.voltage / 1000, 2)
-        if getattr(device, "voltage", None)
-        else 0.0,
+        native_value=lambda device: round(device.voltage or 0.0 / 1000, 2),
     ),
     FritzSensorEntityDescription(
         key="electric_current",
@@ -120,7 +116,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suitable=lambda device: device.has_powermeter,  # type: ignore[no-any-return]
-        native_value=lambda device: device.energy / 1000 if device.energy else 0.0,
+        native_value=lambda device: device.energy or 0.0 / 1000,
     ),
     # Thermostat Sensors
     FritzSensorEntityDescription(

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -87,7 +87,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suitable=lambda device: device.has_powermeter,  # type: ignore[no-any-return]
-        native_value=lambda device: round(device.power or 0.0 / 1000, 3),
+        native_value=lambda device: round((device.power or 0.0) / 1000, 3),
     ),
     FritzSensorEntityDescription(
         key="voltage",
@@ -96,7 +96,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suitable=lambda device: device.has_powermeter,  # type: ignore[no-any-return]
-        native_value=lambda device: round(device.voltage or 0.0 / 1000, 2),
+        native_value=lambda device: round((device.voltage or 0.0) / 1000, 2),
     ),
     FritzSensorEntityDescription(
         key="electric_current",
@@ -116,7 +116,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suitable=lambda device: device.has_powermeter,  # type: ignore[no-any-return]
-        native_value=lambda device: device.energy or 0.0 / 1000,
+        native_value=lambda device: (device.energy or 0.0) / 1000,
     ),
     # Thermostat Sensors
     FritzSensorEntityDescription(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1563,7 +1563,7 @@ pyforked-daapd==0.1.11
 pyfreedompro==1.1.0
 
 # homeassistant.components.fritzbox
-pyfritzhome==0.6.5
+pyfritzhome==0.6.7
 
 # homeassistant.components.fronius
 pyfronius==0.7.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1091,7 +1091,7 @@ pyforked-daapd==0.1.11
 pyfreedompro==1.1.0
 
 # homeassistant.components.fritzbox
-pyfritzhome==0.6.5
+pyfritzhome==0.6.7
 
 # homeassistant.components.fronius
 pyfronius==0.7.1

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -121,7 +121,7 @@ class FritzDeviceSwitchMock(FritzDeviceBaseMock):
     battery_level = None
     device_lock = "fake_locked_device"
     energy = 1234
-    voltage = 230
+    voltage = 230000
     fw_version = "1.2.3"
     has_alarm = False
     has_powermeter = True

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -77,14 +77,14 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
         ],
         [
             f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_voltage",
-            "230",
+            "230.0",
             f"{CONF_FAKE_NAME} Voltage",
             ELECTRIC_POTENTIAL_VOLT,
             SensorStateClass.MEASUREMENT,
         ],
         [
             f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_electric_current",
-            "0.0246869565217391",
+            "0.025",
             f"{CONF_FAKE_NAME} Electric Current",
             ELECTRIC_CURRENT_AMPERE,
             SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will bump `pyfritzhome` from 0.6.5 to 0.6.7.
Further the workaround from #73608 will be reverted, since hthiery/python-fritzhome/pull/64 is shipped with 0.6.7 and measurement values will be rounded to avoid unreasonable state changes.

Diff: https://github.com/hthiery/python-fritzhome/compare/0.6.5...0.6.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
