### PR TITLE
Fix fan speed regression for some xiaomi fans

### DIFF
--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -112,15 +112,6 @@ MODELS_FAN_MIOT = [
     MODEL_FAN_ZA5,
 ]
 
-# number of speed levels each fan has
-SPEEDS_FAN_MIOT = {
-    MODEL_FAN_1C: 3,
-    MODEL_FAN_P10: 4,
-    MODEL_FAN_P11: 4,
-    MODEL_FAN_P9: 4,
-    MODEL_FAN_ZA5: 4,
-}
-
 MODELS_PURIFIER_MIOT = [
     MODEL_AIRPURIFIER_3,
     MODEL_AIRPURIFIER_3C,

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -1089,12 +1089,13 @@ class XiaomiFanMiot(XiaomiGenericFan):
             await self.async_turn_off()
             return
 
-        await self._try_command(
+        result = await self._try_command(
             "Setting fan speed percentage of the miio device failed.",
             self._device.set_speed,
             percentage,
         )
-        self._percentage = percentage
+        if result:
+            self._percentage = percentage
 
         if not self.is_on:
             await self.async_turn_on()

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -1099,7 +1099,7 @@ class XiaomiFanMiot(XiaomiGenericFan):
 
         if not self.is_on:
             await self.async_turn_on()
-        else:
+        elif result:
             self.async_write_ha_state()
 
 

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -85,7 +85,6 @@ from .const import (
     MODELS_PURIFIER_MIOT,
     SERVICE_RESET_FILTER,
     SERVICE_SET_EXTRA_FEATURES,
-    SPEEDS_FAN_MIOT,
 )
 from .device import XiaomiCoordinatedMiioEntity
 
@@ -235,13 +234,11 @@ async def async_setup_entry(
     elif model in MODELS_FAN_MIIO:
         entity = XiaomiFan(device, config_entry, unique_id, coordinator)
     elif model == MODEL_FAN_ZA5:
-        speed_count = SPEEDS_FAN_MIOT[model]
-        entity = XiaomiFanZA5(device, config_entry, unique_id, coordinator, speed_count)
+        entity = XiaomiFanZA5(device, config_entry, unique_id, coordinator)
+    elif model == MODEL_FAN_1C:
+        entity = XiaomiFan1C(device, config_entry, unique_id, coordinator)
     elif model in MODELS_FAN_MIOT:
-        speed_count = SPEEDS_FAN_MIOT[model]
-        entity = XiaomiFanMiot(
-            device, config_entry, unique_id, coordinator, speed_count
-        )
+        entity = XiaomiFanMiot(device, config_entry, unique_id, coordinator)
     else:
         return
 
@@ -1049,11 +1046,6 @@ class XiaomiFanP5(XiaomiGenericFan):
 class XiaomiFanMiot(XiaomiGenericFan):
     """Representation of a Xiaomi Fan Miot."""
 
-    def __init__(self, device, entry, unique_id, coordinator, speed_count):
-        """Initialize MIOT fan with speed count."""
-        super().__init__(device, entry, unique_id, coordinator)
-        self._speed_count = speed_count
-
     @property
     def operation_mode_class(self):
         """Hold operation mode class."""
@@ -1071,9 +1063,7 @@ class XiaomiFanMiot(XiaomiGenericFan):
         self._preset_mode = self.coordinator.data.mode.name
         self._oscillating = self.coordinator.data.oscillate
         if self.coordinator.data.is_on:
-            self._percentage = ranged_value_to_percentage(
-                (1, self._speed_count), self.coordinator.data.speed
-            )
+            self._percentage = self.coordinator.data.speed
         else:
             self._percentage = 0
 
@@ -1090,6 +1080,58 @@ class XiaomiFanMiot(XiaomiGenericFan):
             self.operation_mode_class[preset_mode],
         )
         self._preset_mode = preset_mode
+        self.async_write_ha_state()
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the percentage of the fan."""
+        if percentage == 0:
+            self._percentage = 0
+            await self.async_turn_off()
+            return
+
+        await self._try_command(
+            "Setting fan speed percentage of the miio device failed.",
+            self._device.set_speed,
+            percentage,
+        )
+        self._percentage = percentage
+
+        if not self.is_on:
+            await self.async_turn_on()
+        else:
+            self.async_write_ha_state()
+
+
+class XiaomiFanZA5(XiaomiFanMiot):
+    """Representation of a Xiaomi Fan ZA5."""
+
+    @property
+    def operation_mode_class(self):
+        """Hold operation mode class."""
+        return FanZA5OperationMode
+
+
+class XiaomiFan1C(XiaomiFanMiot):
+    """Representation of a Xiaomi Fan 1C (Standing Fan 2)."""
+
+    def __init__(self, device, entry, unique_id, coordinator):
+        """Initialize MIOT fan with speed count."""
+        super().__init__(device, entry, unique_id, coordinator)
+        self._speed_count = 3
+
+    @callback
+    def _handle_coordinator_update(self):
+        """Fetch state from the device."""
+        self._state = self.coordinator.data.is_on
+        self._preset_mode = self.coordinator.data.mode.name
+        self._oscillating = self.coordinator.data.oscillate
+        if self.coordinator.data.is_on:
+            self._percentage = ranged_value_to_percentage(
+                (1, self._speed_count), self.coordinator.data.speed
+            )
+        else:
+            self._percentage = 0
+
         self.async_write_ha_state()
 
     async def async_set_percentage(self, percentage: int) -> None:
@@ -1116,12 +1158,3 @@ class XiaomiFanMiot(XiaomiGenericFan):
         if result:
             self._percentage = ranged_value_to_percentage((1, self._speed_count), speed)
             self.async_write_ha_state()
-
-
-class XiaomiFanZA5(XiaomiFanMiot):
-    """Representation of a Xiaomi Fan ZA5."""
-
-    @property
-    def operation_mode_class(self):
-        """Hold operation mode class."""
-        return FanZA5OperationMode

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -1113,7 +1113,7 @@ class XiaomiFanZA5(XiaomiFanMiot):
 
 
 class XiaomiFan1C(XiaomiFanMiot):
-    """Representation of a Xiaomi Fan 1C (Standing Fan 2)."""
+    """Representation of a Xiaomi Fan 1C (Standing Fan 2 Lite)."""
 
     def __init__(self, device, entry, unique_id, coordinator):
         """Initialize MIOT fan with speed count."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In my original PR (https://github.com/home-assistant/core/pull/77626) I assumed all miot based fans would have the problem that the speed level is 3-4 values only instead of percentage. However, this holds only true for the 1c fan. So my previous PR fixed the 1c fan but broke the others. 

This PR only handles the 1c fan as an exception and reverts to the previous behavior for the other fans. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #78148
- This PR is related to issue: #75811
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
