### PR TITLE
Binary sensor description for BTHome

### DIFF
--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -130,10 +130,6 @@ BINARY_SENSOR_DESCRIPTIONS = {
         key=BTHomeBinarySensorDeviceClass.TAMPER,
         device_class=BinarySensorDeviceClass.TAMPER,
     ),
-    BTHomeBinarySensorDeviceClass.UPDATE: BinarySensorEntityDescription(
-        key=BTHomeBinarySensorDeviceClass.UPDATE,
-        device_class=BinarySensorDeviceClass.UPDATE,
-    ),
     BTHomeBinarySensorDeviceClass.VIBRATION: BinarySensorEntityDescription(
         key=BTHomeBinarySensorDeviceClass.VIBRATION,
         device_class=BinarySensorDeviceClass.VIBRATION,

--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 from typing import Optional
 
-from bthome_ble import BTHOME_BINARY_SENSORS, SensorUpdate
+from bthome_ble import (
+    BinarySensorDeviceClass as BTHomeBinarySensorDeviceClass,
+    SensorUpdate,
+)
 
 from homeassistant import config_entries
 from homeassistant.components.binary_sensor import (
@@ -23,18 +26,124 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
 
-BINARY_SENSOR_DESCRIPTIONS = {}
-for key in BTHOME_BINARY_SENSORS:
-    # Not all BTHome device classes are available in Home Assistant
-    DEV_CLASS: str | None = key
-    try:
-        BinarySensorDeviceClass(key)
-    except ValueError:
-        DEV_CLASS = None
-    BINARY_SENSOR_DESCRIPTIONS[key] = BinarySensorEntityDescription(
-        key=key,
-        device_class=DEV_CLASS,
-    )
+BINARY_SENSOR_DESCRIPTIONS = {
+    BTHomeBinarySensorDeviceClass.BATTERY: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.BATTERY,
+        device_class=BinarySensorDeviceClass.BATTERY,
+    ),
+    BTHomeBinarySensorDeviceClass.BATTERY_CHARGING: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.BATTERY_CHARGING,
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+    ),
+    BTHomeBinarySensorDeviceClass.CO: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.CO,
+        device_class=BinarySensorDeviceClass.CO,
+    ),
+    BTHomeBinarySensorDeviceClass.COLD: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.COLD,
+        device_class=BinarySensorDeviceClass.COLD,
+    ),
+    BTHomeBinarySensorDeviceClass.CONNECTIVITY: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.CONNECTIVITY,
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+    ),
+    BTHomeBinarySensorDeviceClass.DOOR: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.DOOR,
+        device_class=BinarySensorDeviceClass.DOOR,
+    ),
+    BTHomeBinarySensorDeviceClass.HEAT: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.HEAT,
+        device_class=BinarySensorDeviceClass.HEAT,
+    ),
+    BTHomeBinarySensorDeviceClass.GARAGE_DOOR: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.GARAGE_DOOR,
+        device_class=BinarySensorDeviceClass.GARAGE_DOOR,
+    ),
+    BTHomeBinarySensorDeviceClass.GAS: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.GAS,
+        device_class=BinarySensorDeviceClass.GAS,
+    ),
+    BTHomeBinarySensorDeviceClass.GENERIC: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.GENERIC,
+        device_class=None,
+    ),
+    BTHomeBinarySensorDeviceClass.LIGHT: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.LIGHT,
+        device_class=BinarySensorDeviceClass.LIGHT,
+    ),
+    BTHomeBinarySensorDeviceClass.LOCK: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.LOCK,
+        device_class=BinarySensorDeviceClass.LOCK,
+    ),
+    BTHomeBinarySensorDeviceClass.MOISTURE: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.MOISTURE,
+        device_class=BinarySensorDeviceClass.MOISTURE,
+    ),
+    BTHomeBinarySensorDeviceClass.MOTION: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.MOTION,
+        device_class=BinarySensorDeviceClass.MOTION,
+    ),
+    BTHomeBinarySensorDeviceClass.MOVING: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.MOVING,
+        device_class=BinarySensorDeviceClass.MOVING,
+    ),
+    BTHomeBinarySensorDeviceClass.OCCUPANCY: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.OCCUPANCY,
+        device_class=BinarySensorDeviceClass.OCCUPANCY,
+    ),
+    BTHomeBinarySensorDeviceClass.OPENING: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.OPENING,
+        device_class=BinarySensorDeviceClass.OPENING,
+    ),
+    BTHomeBinarySensorDeviceClass.PLUG: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.PLUG,
+        device_class=BinarySensorDeviceClass.PLUG,
+    ),
+    BTHomeBinarySensorDeviceClass.POWER: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.POWER,
+        device_class=BinarySensorDeviceClass.POWER,
+    ),
+    BTHomeBinarySensorDeviceClass.PRESENCE: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.PRESENCE,
+        device_class=BinarySensorDeviceClass.PRESENCE,
+    ),
+    BTHomeBinarySensorDeviceClass.PROBLEM: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.PROBLEM,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    BTHomeBinarySensorDeviceClass.RUNNING: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.RUNNING,
+        device_class=BinarySensorDeviceClass.RUNNING,
+    ),
+    BTHomeBinarySensorDeviceClass.SAFETY: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.SAFETY,
+        device_class=BinarySensorDeviceClass.SAFETY,
+    ),
+    BTHomeBinarySensorDeviceClass.SMOKE: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.SMOKE,
+        device_class=BinarySensorDeviceClass.SMOKE,
+    ),
+    BTHomeBinarySensorDeviceClass.SOUND: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.SOUND,
+        device_class=BinarySensorDeviceClass.SOUND,
+    ),
+    BTHomeBinarySensorDeviceClass.TAMPER: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.TAMPER,
+        device_class=BinarySensorDeviceClass.TAMPER,
+    ),
+    BTHomeBinarySensorDeviceClass.UPDATE: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.UPDATE,
+        device_class=BinarySensorDeviceClass.UPDATE,
+    ),
+    BTHomeBinarySensorDeviceClass.VIBRATION: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.VIBRATION,
+        device_class=BinarySensorDeviceClass.VIBRATION,
+    ),
+    BTHomeBinarySensorDeviceClass.WINDOW: BinarySensorEntityDescription(
+        key=BTHomeBinarySensorDeviceClass.WINDOW,
+        device_class=BinarySensorDeviceClass.WINDOW,
+    ),
+}
 
 
 def sensor_update_to_bluetooth_data_update(
@@ -48,9 +157,10 @@ def sensor_update_to_bluetooth_data_update(
         },
         entity_descriptions={
             device_key_to_bluetooth_entity_key(device_key): BINARY_SENSOR_DESCRIPTIONS[
-                description.device_key.key
+                description.device_class
             ]
             for device_key, description in sensor_update.binary_entity_descriptions.items()
+            if description.device_class
         },
         entity_data={
             device_key_to_bluetooth_entity_key(device_key): sensor_values.native_value

--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -65,7 +65,6 @@ BINARY_SENSOR_DESCRIPTIONS = {
     ),
     BTHomeBinarySensorDeviceClass.GENERIC: BinarySensorEntityDescription(
         key=BTHomeBinarySensorDeviceClass.GENERIC,
-        device_class=None,
     ),
     BTHomeBinarySensorDeviceClass.LIGHT: BinarySensorEntityDescription(
         key=BTHomeBinarySensorDeviceClass.LIGHT,

--- a/homeassistant/components/bthome/manifest.json
+++ b/homeassistant/components/bthome/manifest.json
@@ -13,7 +13,7 @@
       "service_data_uuid": "0000181e-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["bthome-ble==1.2.0"],
+  "requirements": ["bthome-ble==1.2.1"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/bthome/manifest.json
+++ b/homeassistant/components/bthome/manifest.json
@@ -13,7 +13,7 @@
       "service_data_uuid": "0000181e-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["bthome-ble==1.2.1"],
+  "requirements": ["bthome-ble==1.2.2"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/bthome/sensor.py
+++ b/homeassistant/components/bthome/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from bthome_ble import DeviceClass, SensorUpdate, Units
+from bthome_ble import SensorDeviceClass as BTHomeSensorDeviceClass, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -40,93 +40,102 @@ from .const import DOMAIN
 from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
 
 SENSOR_DESCRIPTIONS = {
-    (DeviceClass.TEMPERATURE, Units.TEMP_CELSIUS): SensorEntityDescription(
-        key=f"{DeviceClass.TEMPERATURE}_{Units.TEMP_CELSIUS}",
+    (BTHomeSensorDeviceClass.TEMPERATURE, Units.TEMP_CELSIUS): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.TEMPERATURE}_{Units.TEMP_CELSIUS}",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (DeviceClass.HUMIDITY, Units.PERCENTAGE): SensorEntityDescription(
-        key=f"{DeviceClass.HUMIDITY}_{Units.PERCENTAGE}",
+    (BTHomeSensorDeviceClass.HUMIDITY, Units.PERCENTAGE): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.HUMIDITY}_{Units.PERCENTAGE}",
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (DeviceClass.ILLUMINANCE, Units.LIGHT_LUX): SensorEntityDescription(
-        key=f"{DeviceClass.ILLUMINANCE}_{Units.LIGHT_LUX}",
+    (BTHomeSensorDeviceClass.ILLUMINANCE, Units.LIGHT_LUX): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.ILLUMINANCE}_{Units.LIGHT_LUX}",
         device_class=SensorDeviceClass.ILLUMINANCE,
         native_unit_of_measurement=LIGHT_LUX,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (DeviceClass.PRESSURE, Units.PRESSURE_MBAR): SensorEntityDescription(
-        key=f"{DeviceClass.PRESSURE}_{Units.PRESSURE_MBAR}",
+    (BTHomeSensorDeviceClass.PRESSURE, Units.PRESSURE_MBAR): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.PRESSURE}_{Units.PRESSURE_MBAR}",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=PRESSURE_MBAR,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (DeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
-        key=f"{DeviceClass.BATTERY}_{Units.PERCENTAGE}",
+    (BTHomeSensorDeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.BATTERY}_{Units.PERCENTAGE}",
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    (DeviceClass.VOLTAGE, Units.ELECTRIC_POTENTIAL_VOLT): SensorEntityDescription(
-        key=str(Units.ELECTRIC_POTENTIAL_VOLT),
+    (
+        BTHomeSensorDeviceClass.VOLTAGE,
+        Units.ELECTRIC_POTENTIAL_VOLT,
+    ): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.VOLTAGE}_{Units.ELECTRIC_POTENTIAL_VOLT}",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (DeviceClass.ENERGY, Units.ENERGY_KILO_WATT_HOUR): SensorEntityDescription(
-        key=str(Units.ENERGY_KILO_WATT_HOUR),
+    (
+        BTHomeSensorDeviceClass.ENERGY,
+        Units.ENERGY_KILO_WATT_HOUR,
+    ): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.ENERGY}_{Units.ENERGY_KILO_WATT_HOUR}",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    (DeviceClass.POWER, Units.POWER_WATT): SensorEntityDescription(
-        key=str(Units.POWER_WATT),
+    (BTHomeSensorDeviceClass.POWER, Units.POWER_WATT): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.POWER}_{Units.POWER_WATT}",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=POWER_WATT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     (
-        DeviceClass.PM10,
+        BTHomeSensorDeviceClass.PM10,
         Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     ): SensorEntityDescription(
-        key=f"{DeviceClass.PM10}_{Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER}",
+        key=f"{BTHomeSensorDeviceClass.PM10}_{Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER}",
         device_class=SensorDeviceClass.PM10,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     (
-        DeviceClass.PM25,
+        BTHomeSensorDeviceClass.PM25,
         Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     ): SensorEntityDescription(
-        key=f"{DeviceClass.PM25}_{Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER}",
+        key=f"{BTHomeSensorDeviceClass.PM25}_{Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER}",
         device_class=SensorDeviceClass.PM25,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (DeviceClass.CO2, Units.CONCENTRATION_PARTS_PER_MILLION,): SensorEntityDescription(
-        key=f"{DeviceClass.CO2}_{Units.CONCENTRATION_PARTS_PER_MILLION}",
+    (
+        BTHomeSensorDeviceClass.CO2,
+        Units.CONCENTRATION_PARTS_PER_MILLION,
+    ): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.CO2}_{Units.CONCENTRATION_PARTS_PER_MILLION}",
         device_class=SensorDeviceClass.CO2,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     (
-        DeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+        BTHomeSensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
         Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     ): SensorEntityDescription(
-        key=f"{DeviceClass.VOLATILE_ORGANIC_COMPOUNDS}_{Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER}",
+        key=f"{BTHomeSensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS}_{Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER}",
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     (
-        DeviceClass.SIGNAL_STRENGTH,
+        BTHomeSensorDeviceClass.SIGNAL_STRENGTH,
         Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     ): SensorEntityDescription(
-        key=f"{DeviceClass.SIGNAL_STRENGTH}_{Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT}",
+        key=f"{BTHomeSensorDeviceClass.SIGNAL_STRENGTH}_{Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT}",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -134,36 +143,36 @@ SENSOR_DESCRIPTIONS = {
         entity_registry_enabled_default=False,
     ),
     # Used for mass sensor with kg unit
-    (None, Units.MASS_KILOGRAMS): SensorEntityDescription(
-        key=f"{DeviceClass.MASS}_{Units.MASS_KILOGRAMS}",
+    (BTHomeSensorDeviceClass.MASS, Units.MASS_KILOGRAMS): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.MASS}_{Units.MASS_KILOGRAMS}",
         device_class=None,
         native_unit_of_measurement=MASS_KILOGRAMS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     # Used for mass sensor with lb unit
-    (None, Units.MASS_POUNDS): SensorEntityDescription(
-        key=f"{DeviceClass.MASS}_{Units.MASS_POUNDS}",
+    (BTHomeSensorDeviceClass.MASS, Units.MASS_POUNDS): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.MASS}_{Units.MASS_POUNDS}",
         device_class=None,
         native_unit_of_measurement=MASS_POUNDS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     # Used for moisture sensor
-    (DeviceClass.MOISTURE, Units.PERCENTAGE): SensorEntityDescription(
-        key=f"{DeviceClass.MOISTURE}_{Units.PERCENTAGE}",
+    (BTHomeSensorDeviceClass.MOISTURE, Units.PERCENTAGE): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.MOISTURE}_{Units.PERCENTAGE}",
         device_class=SensorDeviceClass.MOISTURE,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     # Used for dew point sensor
-    (None, Units.TEMP_CELSIUS): SensorEntityDescription(
-        key=f"{DeviceClass.DEW_POINT}_{Units.TEMP_CELSIUS}",
+    (BTHomeSensorDeviceClass.DEW_POINT, Units.TEMP_CELSIUS): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.DEW_POINT}_{Units.TEMP_CELSIUS}",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     # Used for count sensor
-    (None, None): SensorEntityDescription(
-        key=f"{DeviceClass.COUNT}",
+    (BTHomeSensorDeviceClass.COUNT, None): SensorEntityDescription(
+        key=f"{BTHomeSensorDeviceClass.COUNT}",
         device_class=None,
         native_unit_of_measurement=None,
         state_class=SensorStateClass.MEASUREMENT,
@@ -185,6 +194,7 @@ def sensor_update_to_bluetooth_data_update(
                 (description.device_class, description.native_unit_of_measurement)
             ]
             for device_key, description in sensor_update.entity_descriptions.items()
+            if description.device_class
         },
         entity_data={
             device_key_to_bluetooth_entity_key(device_key): sensor_values.native_value

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -467,7 +467,7 @@ bsblan==0.5.0
 bt_proximity==0.2.1
 
 # homeassistant.components.bthome
-bthome-ble==1.2.0
+bthome-ble==1.2.1
 
 # homeassistant.components.bt_home_hub_5
 bthomehub5-devicelist==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -467,7 +467,7 @@ bsblan==0.5.0
 bt_proximity==0.2.1
 
 # homeassistant.components.bthome
-bthome-ble==1.2.1
+bthome-ble==1.2.2
 
 # homeassistant.components.bt_home_hub_5
 bthomehub5-devicelist==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -368,7 +368,7 @@ brunt==1.2.0
 bsblan==0.5.0
 
 # homeassistant.components.bthome
-bthome-ble==1.2.0
+bthome-ble==1.2.1
 
 # homeassistant.components.buienradar
 buienradar==1.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -368,7 +368,7 @@ brunt==1.2.0
 bsblan==0.5.0
 
 # homeassistant.components.bthome
-bthome-ble==1.2.1
+bthome-ble==1.2.2
 
 # homeassistant.components.buienradar
 buienradar==1.0.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR resolves the comment of @MartinHjelmare in https://github.com/home-assistant/core/pull/78151#discussion_r969564616

> Please list the descriptions explicitly instead. We want to see what kind of entities are created here in the integration code.

Bumped bthome-ble to 1.2.2. 
- Release notes https://github.com/Bluetooth-Devices/bthome-ble/releases/tag/v1.2.1
- Release notes https://github.com/Bluetooth-Devices/bthome-ble/releases/tag/v1.2.2

bthome-ble will now always give an device class as output, even if it doesn't exist in HA. The BTHome integration will now map is to a `device_class None` if it isn't a Home Assistant device class. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
