### PR TITLE
Make LimitedSizeDict a generic

### DIFF
--- a/homeassistant/components/trace/utils.py
+++ b/homeassistant/components/trace/utils.py
@@ -1,22 +1,26 @@
 """Helpers for script and automation tracing and debugging."""
 from collections import OrderedDict
+from typing import Any, TypeVar
+
+_KT = TypeVar("_KT")  # key type
+_VT = TypeVar("_VT")  # value type
 
 
-class LimitedSizeDict(OrderedDict):
+class LimitedSizeDict(OrderedDict[_KT, _VT]):
     """OrderedDict limited in size."""
 
-    def __init__(self, *args, **kwds):
+    def __init__(self, *args: Any, **kwds: Any) -> None:
         """Initialize OrderedDict limited in size."""
         self.size_limit = kwds.pop("size_limit", None)
-        OrderedDict.__init__(self, *args, **kwds)
+        OrderedDict.__init__(self, *args, **kwds)  # type: ignore[arg-type]
         self._check_size_limit()
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: _KT, value: _VT) -> None:
         """Set item and check dict size."""
-        OrderedDict.__setitem__(self, key, value)
+        OrderedDict.__setitem__(self, key, value)  # type: ignore[assignment,index]
         self._check_size_limit()
 
-    def _check_size_limit(self):
+    def _check_size_limit(self) -> None:
         """Check dict size and evict items in FIFO order if needed."""
         if self.size_limit is not None:
             while len(self) > self.size_limit:

--- a/homeassistant/components/trace/utils.py
+++ b/homeassistant/components/trace/utils.py
@@ -14,7 +14,7 @@ class LimitedSizeDict(OrderedDict[_KT, _VT]):
     def __init__(self, *args: Any, **kwds: Any) -> None:
         """Initialize OrderedDict limited in size."""
         self.size_limit = kwds.pop("size_limit", None)
-        super().__init__(self, *args, **kwds)
+        super().__init__(*args, **kwds)
         self._check_size_limit()
 
     def __setitem__(self, key: _KT, value: _VT) -> None:

--- a/homeassistant/components/trace/utils.py
+++ b/homeassistant/components/trace/utils.py
@@ -2,8 +2,8 @@
 from collections import OrderedDict
 from typing import Any, TypeVar
 
-_KT = TypeVar("_KT")  # key type
-_VT = TypeVar("_VT")  # value type
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
 
 
 class LimitedSizeDict(OrderedDict[_KT, _VT]):

--- a/homeassistant/components/trace/utils.py
+++ b/homeassistant/components/trace/utils.py
@@ -1,4 +1,6 @@
 """Helpers for script and automation tracing and debugging."""
+from __future__ import annotations
+
 from collections import OrderedDict
 from typing import Any, TypeVar
 
@@ -12,12 +14,12 @@ class LimitedSizeDict(OrderedDict[_KT, _VT]):
     def __init__(self, *args: Any, **kwds: Any) -> None:
         """Initialize OrderedDict limited in size."""
         self.size_limit = kwds.pop("size_limit", None)
-        OrderedDict.__init__(self, *args, **kwds)  # type: ignore[arg-type]
+        super().__init__(self, *args, **kwds)
         self._check_size_limit()
 
     def __setitem__(self, key: _KT, value: _VT) -> None:
         """Set item and check dict size."""
-        OrderedDict.__setitem__(self, key, value)  # type: ignore[assignment,index]
+        super().__setitem__(key, value)
         self._check_size_limit()
 
     def _check_size_limit(self) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make LimitedSizeDict a generic
Needed for #78441

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
