### PR TITLE
Enforce MediaPlayerState in group

### DIFF
--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -396,11 +396,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
                 try:
                     self._attr_state = MediaPlayerState(single_state)
                 except ValueError:
-                    if single_state in off_values:
-                        self._attr_state = MediaPlayerState.OFF
-                    else:
-                        self._attr_state = None
-
+                    self._attr_state = None
             elif any(state for state in states if state not in off_values):
                 self._attr_state = MediaPlayerState.ON
             else:

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -402,7 +402,9 @@ class MediaPlayerGroup(MediaPlayerEntity):
                 try:
                     self._state = MediaPlayerState(states[0])
                 except ValueError:
-                    self._state = None
+                    self._state = (
+                        MediaPlayerState.OFF if states[0] in off_values else None
+                    )
             elif any(state for state in states if state not in off_values):
                 self._state = MediaPlayerState.ON
             else:

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -108,7 +108,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
     def __init__(self, unique_id: str | None, name: str, entities: list[str]) -> None:
         """Initialize a Media Group entity."""
         self._name = name
-        self._state: str | None = None
+        self._state: MediaPlayerState | None = None
         self._attr_unique_id = unique_id
 
         self._entities = entities
@@ -207,7 +207,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
         return self._name
 
     @property
-    def state(self) -> str | None:
+    def state(self) -> MediaPlayerState | None:
         """Return the state of the media group."""
         return self._state
 
@@ -399,7 +399,10 @@ class MediaPlayerGroup(MediaPlayerEntity):
         else:
             off_values = {MediaPlayerState.OFF, STATE_UNAVAILABLE, STATE_UNKNOWN}
             if states.count(states[0]) == len(states):
-                self._state = states[0]
+                try:
+                    self._state = MediaPlayerState(states[0])
+                except ValueError:
+                    self._state = None
             elif any(state for state in states if state not in off_values):
                 self._state = MediaPlayerState.ON
             else:

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -393,8 +393,6 @@ class MediaPlayerGroup(MediaPlayerEntity):
         else:
             off_values = {MediaPlayerState.OFF, STATE_UNAVAILABLE, STATE_UNKNOWN}
             if states.count(single_state := states[0]) == len(states):
-                if single_state in off_values:
-                    self._attr_state = MediaPlayerState.OFF
                 try:
                     self._attr_state = MediaPlayerState(single_state)
                 except ValueError:

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -407,8 +407,9 @@ class MediaPlayerGroup(MediaPlayerEntity):
                         if single_state not in _SEEN_INVALID_STATES:
                             _SEEN_INVALID_STATES.add(single_state)
                             _LOGGER.warning(
-                                "State `%s` is not a valid media player state!",
+                                "State `%s` is not a valid media player state for %s!",
                                 single_state,
+                                self.name,
                             )
 
             elif any(state for state in states if state not in off_values):

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -1,6 +1,7 @@
 """This platform allows several media players to be grouped into one media player."""
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import Any
 
 import voluptuous as vol
@@ -393,10 +394,9 @@ class MediaPlayerGroup(MediaPlayerEntity):
         else:
             off_values = {MediaPlayerState.OFF, STATE_UNAVAILABLE, STATE_UNKNOWN}
             if states.count(single_state := states[0]) == len(states):
-                try:
+                self._attr_state = None
+                with suppress(ValueError):
                     self._attr_state = MediaPlayerState(single_state)
-                except ValueError:
-                    self._attr_state = None
             elif any(state for state in states if state not in off_values):
                 self._attr_state = MediaPlayerState.ON
             else:

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -108,7 +108,6 @@ class MediaPlayerGroup(MediaPlayerEntity):
     def __init__(self, unique_id: str | None, name: str, entities: list[str]) -> None:
         """Initialize a Media Group entity."""
         self._name = name
-        self._state: MediaPlayerState | None = None
         self._attr_unique_id = unique_id
 
         self._entities = entities
@@ -205,11 +204,6 @@ class MediaPlayerGroup(MediaPlayerEntity):
     def name(self) -> str:
         """Return the name of the entity."""
         return self._name
-
-    @property
-    def state(self) -> MediaPlayerState | None:
-        """Return the state of the media group."""
-        return self._state
 
     @property
     def extra_state_attributes(self) -> dict:
@@ -395,20 +389,20 @@ class MediaPlayerGroup(MediaPlayerEntity):
         )
         if not valid_state:
             # Set as unknown if all members are unknown or unavailable
-            self._state = None
+            self._attr_state = None
         else:
             off_values = {MediaPlayerState.OFF, STATE_UNAVAILABLE, STATE_UNKNOWN}
             if states.count(states[0]) == len(states):
                 try:
-                    self._state = MediaPlayerState(states[0])
+                    self._attr_state = MediaPlayerState(states[0])
                 except ValueError:
-                    self._state = (
+                    self._attr_state = (
                         MediaPlayerState.OFF if states[0] in off_values else None
                     )
             elif any(state for state in states if state not in off_values):
-                self._state = MediaPlayerState.ON
+                self._attr_state = MediaPlayerState.ON
             else:
-                self._state = MediaPlayerState.OFF
+                self._attr_state = MediaPlayerState.OFF
 
         supported_features = MediaPlayerEntityFeature(0)
         if self._features[KEY_CLEAR_PLAYLIST]:

--- a/tests/components/group/test_media_player.py
+++ b/tests/components/group/test_media_player.py
@@ -171,6 +171,12 @@ async def test_state_reporting(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
         assert hass.states.get("media_player.media_group").state == STATE_OFF
 
+    # All group members in same invalid state -> unknown
+    hass.states.async_set("media_player.player_1", "invalid_state")
+    hass.states.async_set("media_player.player_2", "invalid_state")
+    await hass.async_block_till_done()
+    assert hass.states.get("media_player.media_group").state == STATE_UNKNOWN
+
     # All group members removed from the state machine -> unavailable
     hass.states.async_remove("media_player.player_1")
     hass.states.async_remove("media_player.player_2")

--- a/tests/components/group/test_media_player.py
+++ b/tests/components/group/test_media_player.py
@@ -1,5 +1,5 @@
 """The tests for the Media group platform."""
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import async_timeout
 import pytest
@@ -43,6 +43,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -57,7 +58,7 @@ def media_player_media_seek_fixture():
         yield seek
 
 
-async def test_default_state(hass):
+async def test_default_state(hass: HomeAssistant) -> None:
     """Test media group default state."""
     hass.states.async_set("media_player.player_1", "on")
     await async_setup_component(
@@ -91,7 +92,7 @@ async def test_default_state(hass):
     assert entry.unique_id == "unique_identifier"
 
 
-async def test_state_reporting(hass):
+async def test_state_reporting(hass: HomeAssistant) -> None:
     """Test the state reporting.
 
     The group state is unavailable if all group members are unavailable.
@@ -177,7 +178,7 @@ async def test_state_reporting(hass):
     assert hass.states.get("media_player.media_group").state == STATE_UNAVAILABLE
 
 
-async def test_supported_features(hass):
+async def test_supported_features(hass: HomeAssistant) -> None:
     """Test supported features reporting."""
     pause_play_stop = (
         MediaPlayerEntityFeature.PAUSE
@@ -241,7 +242,7 @@ async def test_supported_features(hass):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == pause_play_stop | play_media
 
 
-async def test_service_calls(hass, mock_media_seek):
+async def test_service_calls(hass: HomeAssistant, mock_media_seek: Mock) -> None:
     """Test service calls."""
     await async_setup_component(
         hass,
@@ -533,7 +534,7 @@ async def test_service_calls(hass, mock_media_seek):
     assert hass.states.get("media_player.living_room").state == STATE_OFF
 
 
-async def test_nested_group(hass):
+async def test_nested_group(hass: HomeAssistant) -> None:
     """Test nested media group."""
     await async_setup_component(
         hass,


### PR DESCRIPTION
## Breaking change
Media player groups containing players in an invalid state will now report as state Unknown.
The list of valid states is available in https://developers.home-assistant.io/docs/core/entity/media-player/#states

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enforce MediaPlayerState in group

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
