### PR TITLE
Avoid mutating globals in nina tests

### DIFF
--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Nina config flow."""
 from __future__ import annotations
 
+from copy import deepcopy
 import json
 from typing import Any
 from unittest.mock import patch
@@ -70,7 +71,7 @@ async def test_step_user_connection_error(hass: HomeAssistant) -> None:
     ):
 
         result: dict[str, Any] = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=DUMMY_DATA
+            DOMAIN, context={"source": SOURCE_USER}, data=deepcopy(DUMMY_DATA)
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -85,7 +86,7 @@ async def test_step_user_unexpected_exception(hass: HomeAssistant) -> None:
     ):
 
         result: dict[str, Any] = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=DUMMY_DATA
+            DOMAIN, context={"source": SOURCE_USER}, data=deepcopy(DUMMY_DATA)
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.ABORT
@@ -102,7 +103,7 @@ async def test_step_user(hass: HomeAssistant) -> None:
     ):
 
         result: dict[str, Any] = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=DUMMY_DATA
+            DOMAIN, context={"source": SOURCE_USER}, data=deepcopy(DUMMY_DATA)
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
@@ -132,11 +133,11 @@ async def test_step_user_already_configured(hass: HomeAssistant) -> None:
         wraps=mocked_request_function,
     ):
         result: dict[str, Any] = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=DUMMY_DATA
+            DOMAIN, context={"source": SOURCE_USER}, data=deepcopy(DUMMY_DATA)
         )
 
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=DUMMY_DATA
+            DOMAIN, context={"source": SOURCE_USER}, data=deepcopy(DUMMY_DATA)
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.ABORT
@@ -149,9 +150,9 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         title="NINA",
         data={
-            CONF_FILTER_CORONA: DUMMY_DATA[CONF_FILTER_CORONA],
-            CONF_MESSAGE_SLOTS: DUMMY_DATA[CONF_MESSAGE_SLOTS],
-            CONST_REGION_A_TO_D: DUMMY_DATA[CONST_REGION_A_TO_D],
+            CONF_FILTER_CORONA: deepcopy(DUMMY_DATA[CONF_FILTER_CORONA]),
+            CONF_MESSAGE_SLOTS: deepcopy(DUMMY_DATA[CONF_MESSAGE_SLOTS]),
+            CONST_REGION_A_TO_D: deepcopy(DUMMY_DATA[CONST_REGION_A_TO_D]),
             CONF_REGIONS: {"095760000000": "Aach"},
         },
     )
@@ -187,8 +188,8 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
         assert result["data"] is None
 
         assert dict(config_entry.data) == {
-            CONF_FILTER_CORONA: DUMMY_DATA[CONF_FILTER_CORONA],
-            CONF_MESSAGE_SLOTS: DUMMY_DATA[CONF_MESSAGE_SLOTS],
+            CONF_FILTER_CORONA: deepcopy(DUMMY_DATA[CONF_FILTER_CORONA]),
+            CONF_MESSAGE_SLOTS: deepcopy(DUMMY_DATA[CONF_MESSAGE_SLOTS]),
             CONST_REGION_A_TO_D: ["072350000000_1"],
             CONST_REGION_E_TO_H: [],
             CONST_REGION_I_TO_L: [],
@@ -206,7 +207,7 @@ async def test_options_flow_with_no_selection(hass: HomeAssistant) -> None:
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="NINA",
-        data=DUMMY_DATA,
+        data=deepcopy(DUMMY_DATA),
     )
     config_entry.add_to_hass(hass)
 
@@ -246,7 +247,7 @@ async def test_options_flow_connection_error(hass: HomeAssistant) -> None:
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="NINA",
-        data=DUMMY_DATA,
+        data=deepcopy(DUMMY_DATA),
     )
     config_entry.add_to_hass(hass)
 
@@ -271,7 +272,7 @@ async def test_options_flow_unexpected_exception(hass: HomeAssistant) -> None:
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="NINA",
-        data=DUMMY_DATA,
+        data=deepcopy(DUMMY_DATA),
     )
     config_entry.add_to_hass(hass)
 
@@ -295,7 +296,7 @@ async def test_options_flow_entity_removal(hass: HomeAssistant) -> None:
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="NINA",
-        data=DUMMY_DATA,
+        data=deepcopy(DUMMY_DATA) | {CONF_REGIONS: {"095760000000": "Aach"}},
     )
     config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid mutating globals in nina tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
