### PR TITLE
crownstone-sse: bump to 2.0.4

### DIFF
--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -7,6 +7,7 @@ from homeassistant.const import Platform
 
 # Platforms
 DOMAIN: Final = "crownstone"
+PROJECT_NAME: Final = "home-assistant-core"
 PLATFORMS: Final[list[Platform]] = [Platform.LIGHT]
 
 # Listeners

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_USB_SPHERE,
     DOMAIN,
     PLATFORMS,
+    PROJECT_NAME,
     SSE_LISTENERS,
     UART_LISTENERS,
 )
@@ -84,6 +85,7 @@ class CrownstoneEntryManager:
             password=password,
             access_token=self.cloud.access_token,
             websession=aiohttp_client.async_create_clientsession(self.hass),
+            project_name=PROJECT_NAME,
         )
         # Listen for events in the background, without task tracking
         asyncio.create_task(self.async_process_events(self.sse))

--- a/homeassistant/components/crownstone/manifest.json
+++ b/homeassistant/components/crownstone/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/crownstone",
   "requirements": [
     "crownstone-cloud==1.4.9",
-    "crownstone-sse==2.0.3",
+    "crownstone-sse==2.0.4",
     "crownstone-uart==2.1.0",
     "pyserial==3.5"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -523,7 +523,7 @@ croniter==1.0.6
 crownstone-cloud==1.4.9
 
 # homeassistant.components.crownstone
-crownstone-sse==2.0.3
+crownstone-sse==2.0.4
 
 # homeassistant.components.crownstone
 crownstone-uart==2.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -400,7 +400,7 @@ croniter==1.0.6
 crownstone-cloud==1.4.9
 
 # homeassistant.components.crownstone
-crownstone-sse==2.0.3
+crownstone-sse==2.0.4
 
 # homeassistant.components.crownstone
 crownstone-uart==2.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added handling for invalid tokens and fixed an issue that caused the client to get stuck and block the event loop.
This also provides a project name string to the client, to add context to where possible issues with the client are coming from.

https://github.com/crownstone/crownstone-lib-python-sse/compare/2.0.3...2.0.4


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
