### PR TITLE
Reduce overhead to update passive bluetooth devices

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -104,6 +104,16 @@ def async_discovered_service_info(
 
 
 @hass_callback
+def async_last_service_info(
+    hass: HomeAssistant, address: str, connectable: bool = True
+) -> BluetoothServiceInfoBleak | None:
+    """Return the last service info for an address."""
+    if DATA_MANAGER not in hass.data:
+        return None
+    return _get_manager(hass).async_last_service_info(address, connectable)
+
+
+@hass_callback
 def async_ble_device_from_address(
     hass: HomeAssistant, address: str, connectable: bool = True
 ) -> BLEDevice | None:
@@ -173,7 +183,7 @@ async def async_process_advertisements(
 @hass_callback
 def async_track_unavailable(
     hass: HomeAssistant,
-    callback: Callable[[str], None],
+    callback: Callable[[BluetoothServiceInfoBleak], None],
     address: str,
     connectable: bool = True,
 ) -> Callable[[], None]:

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -143,9 +143,11 @@ class BluetoothManager:
         self.hass = hass
         self._integration_matcher = integration_matcher
         self._cancel_unavailable_tracking: list[CALLBACK_TYPE] = []
-        self._unavailable_callbacks: dict[str, list[Callable[[str], None]]] = {}
+        self._unavailable_callbacks: dict[
+            str, list[Callable[[BluetoothServiceInfoBleak], None]]
+        ] = {}
         self._connectable_unavailable_callbacks: dict[
-            str, list[Callable[[str], None]]
+            str, list[Callable[[BluetoothServiceInfoBleak], None]]
         ] = {}
         self._callback_index = BluetoothCallbackMatcherIndex()
         self._bleak_callbacks: list[
@@ -269,12 +271,12 @@ class BluetoothManager:
             }
             disappeared = history_set.difference(active_addresses)
             for address in disappeared:
-                del history[address]
+                service_info = history.pop(address)
                 if not (callbacks := unavailable_callbacks.get(address)):
                     continue
                 for callback in callbacks:
                     try:
-                        callback(address)
+                        callback(service_info)
                     except Exception:  # pylint: disable=broad-except
                         _LOGGER.exception("Error in unavailable callback")
 
@@ -358,7 +360,10 @@ class BluetoothManager:
 
     @hass_callback
     def async_track_unavailable(
-        self, callback: Callable[[str], None], address: str, connectable: bool
+        self,
+        callback: Callable[[BluetoothServiceInfoBleak], None],
+        address: str,
+        connectable: bool,
     ) -> Callable[[], None]:
         """Register a callback."""
         unavailable_callbacks = self._get_unavailable_callbacks_by_type(connectable)
@@ -430,8 +435,15 @@ class BluetoothManager:
     def async_discovered_service_info(
         self, connectable: bool
     ) -> Iterable[BluetoothServiceInfoBleak]:
-        """Return if the address is present."""
+        """Return all the discovered services info."""
         return self._get_history_by_type(connectable).values()
+
+    @hass_callback
+    def async_last_service_info(
+        self, address: str, connectable: bool
+    ) -> BluetoothServiceInfoBleak | None:
+        """Return the last service info for an address."""
+        return self._get_history_by_type(connectable).get(address)
 
     @hass_callback
     def async_rediscover_address(self, address: str) -> None:
@@ -448,7 +460,7 @@ class BluetoothManager:
 
     def _get_unavailable_callbacks_by_type(
         self, connectable: bool
-    ) -> dict[str, list[Callable[[str], None]]]:
+    ) -> dict[str, list[Callable[[BluetoothServiceInfoBleak], None]]]:
         """Return the unavailable callbacks by type."""
         return (
             self._connectable_unavailable_callbacks

--- a/homeassistant/components/bluetooth/passive_update_coordinator.py
+++ b/homeassistant/components/bluetooth/passive_update_coordinator.py
@@ -41,9 +41,11 @@ class PassiveBluetoothDataUpdateCoordinator(BasePassiveBluetoothCoordinator):
             update_callback()
 
     @callback
-    def _async_handle_unavailable(self, address: str) -> None:
+    def _async_handle_unavailable(
+        self, service_info: BluetoothServiceInfoBleak
+    ) -> None:
         """Handle the device going unavailable."""
-        super()._async_handle_unavailable(address)
+        super()._async_handle_unavailable(service_info)
         self.async_update_listeners()
 
     @callback
@@ -73,7 +75,6 @@ class PassiveBluetoothDataUpdateCoordinator(BasePassiveBluetoothCoordinator):
         change: BluetoothChange,
     ) -> None:
         """Handle a Bluetooth event."""
-        super()._async_handle_bluetooth_event(service_info, change)
         self.async_update_listeners()
 
 

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -101,9 +101,11 @@ class PassiveBluetoothProcessorCoordinator(
         return remove_processor
 
     @callback
-    def _async_handle_unavailable(self, address: str) -> None:
+    def _async_handle_unavailable(
+        self, service_info: BluetoothServiceInfoBleak
+    ) -> None:
         """Handle the device going unavailable."""
-        super()._async_handle_unavailable(address)
+        super()._async_handle_unavailable(service_info)
         for processor in self._processors:
             processor.async_handle_unavailable()
 

--- a/homeassistant/components/bluetooth/update_coordinator.py
+++ b/homeassistant/components/bluetooth/update_coordinator.py
@@ -1,8 +1,8 @@
 """Update coordinator for the Bluetooth integration."""
 from __future__ import annotations
 
+from abc import abstractmethod
 import logging
-import time
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 
@@ -11,6 +11,8 @@ from . import (
     BluetoothChange,
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
+    async_address_present,
+    async_last_service_info,
     async_register_callback,
     async_track_unavailable,
 )
@@ -33,14 +35,13 @@ class BasePassiveBluetoothCoordinator:
         """Initialize the coordinator."""
         self.hass = hass
         self.logger = logger
-        self.name: str | None = None
         self.address = address
         self.connectable = connectable
         self._cancel_track_unavailable: CALLBACK_TYPE | None = None
         self._cancel_bluetooth_advertisements: CALLBACK_TYPE | None = None
-        self._present = False
         self.mode = mode
-        self.last_seen = 0.0
+        self._last_unavailable = 0.0
+        self._last_name = address
 
     @callback
     def async_start(self) -> CALLBACK_TYPE:
@@ -53,10 +54,37 @@ class BasePassiveBluetoothCoordinator:
 
         return _async_cancel
 
+    @callback
+    @abstractmethod
+    def _async_handle_bluetooth_event(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Handle a bluetooth event."""
+
+    @property
+    def name(self) -> str:
+        """Return last known name of the device."""
+        if service_info := async_last_service_info(
+            self.hass, self.address, self.connectable
+        ):
+            return service_info.name
+        return self._last_name
+
+    @property
+    def last_seen(self) -> float:
+        """Return the last time the device was seen."""
+        if service_info := async_last_service_info(
+            self.hass, self.address, self.connectable
+        ):
+            return service_info.time
+        return self._last_unavailable
+
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        return self._present
+        return async_address_present(self.hass, self.address, self.connectable)
 
     @callback
     def _async_start(self) -> None:
@@ -84,17 +112,9 @@ class BasePassiveBluetoothCoordinator:
             self._cancel_track_unavailable = None
 
     @callback
-    def _async_handle_unavailable(self, address: str) -> None:
-        """Handle the device going unavailable."""
-        self._present = False
-
-    @callback
-    def _async_handle_bluetooth_event(
-        self,
-        service_info: BluetoothServiceInfoBleak,
-        change: BluetoothChange,
+    def _async_handle_unavailable(
+        self, service_info: BluetoothServiceInfoBleak
     ) -> None:
-        """Handle a Bluetooth event."""
-        self.last_seen = time.monotonic()
-        self.name = service_info.name
-        self._present = True
+        """Handle the device going unavailable."""
+        self._last_unavailable = service_info.time
+        self._last_name = service_info.name

--- a/homeassistant/components/yalexs_ble/entity.py
+++ b/homeassistant/components/yalexs_ble/entity.py
@@ -56,7 +56,9 @@ class YALEXSBLEEntity(Entity):
         self.async_write_ha_state()
 
     @callback
-    def _async_device_unavailable(self, _address: str) -> None:
+    def _async_device_unavailable(
+        self, _service_info: bluetooth.BluetoothServiceInfoBleak
+    ) -> None:
         """Handle device not longer being seen by the bluetooth stack."""
         self._attr_available = False
         self.async_write_ha_state()

--- a/tests/components/bluemaestro/test_sensor.py
+++ b/tests/components/bluemaestro/test_sensor.py
@@ -1,15 +1,14 @@
 """Test the BlueMaestro sensors."""
 
-from unittest.mock import patch
 
 from homeassistant.components.bluemaestro.const import DOMAIN
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 
 from . import BLUEMAESTRO_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass):
@@ -20,22 +19,11 @@ async def test_sensors(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all("sensor")) == 0
-    saved_callback(BLUEMAESTRO_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, BLUEMAESTRO_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all("sensor")) == 4
 

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -80,6 +80,25 @@ def inject_advertisement_with_time_and_source_connectable(
     )
 
 
+def inject_bluetooth_service_info(
+    hass: HomeAssistant, info: models.BluetoothServiceInfo
+) -> None:
+    """Inject a BluetoothServiceInfo into the manager."""
+    advertisement_data = AdvertisementData(  # type: ignore[no-untyped-call]
+        local_name=None if info.name == "" else info.name,
+        manufacturer_data=info.manufacturer_data,
+        service_data=info.service_data,
+        service_uuids=info.service_uuids,
+    )
+    device = BLEDevice(  # type: ignore[no-untyped-call]
+        address=info.address,
+        name=info.name,
+        details={},
+        rssi=info.rssi,
+    )
+    inject_advertisement(hass, device, advertisement_data)
+
+
 def patch_all_discovered_devices(mock_discovered: list[BLEDevice]) -> None:
     """Mock all the discovered devices from all the scanners."""
     return patch.object(

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -26,9 +26,7 @@ __all__ = (
     "inject_advertisement_with_time_and_source_connectable",
     "inject_bluetooth_service_info",
     "patch_all_discovered_devices",
-    "patch_connectable_history",
     "patch_discovered_devices",
-    "patch_history",
 )
 
 
@@ -142,18 +140,6 @@ def patch_all_discovered_devices(mock_discovered: list[BLEDevice]) -> None:
     return patch.object(
         _get_manager(), "async_all_discovered_devices", return_value=mock_discovered
     )
-
-
-def patch_history(mock_history: dict[str, models.BluetoothServiceInfoBleak]) -> None:
-    """Patch the history."""
-    return patch.dict(_get_manager()._history, mock_history)
-
-
-def patch_connectable_history(
-    mock_history: dict[str, models.BluetoothServiceInfoBleak]
-) -> None:
-    """Patch the connectable history."""
-    return patch.dict(_get_manager()._connectable_history, mock_history)
 
 
 def patch_discovered_devices(mock_discovered: list[BLEDevice]) -> None:

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -92,6 +92,32 @@ def inject_advertisement_with_time_and_source_connectable(
     )
 
 
+def inject_bluetooth_service_info_bleak(
+    hass: HomeAssistant, info: models.BluetoothServiceInfoBleak
+) -> None:
+    """Inject an advertisement into the manager with connectable status."""
+    advertisement_data = AdvertisementData(  # type: ignore[no-untyped-call]
+        local_name=None if info.name == "" else info.name,
+        manufacturer_data=info.manufacturer_data,
+        service_data=info.service_data,
+        service_uuids=info.service_uuids,
+    )
+    device = BLEDevice(  # type: ignore[no-untyped-call]
+        address=info.address,
+        name=info.name,
+        details={},
+        rssi=info.rssi,
+    )
+    inject_advertisement_with_time_and_source_connectable(
+        hass,
+        device,
+        advertisement_data,
+        time.monotonic(),
+        SOURCE_LOCAL,
+        connectable=info.connectable,
+    )
+
+
 def inject_bluetooth_service_info(
     hass: HomeAssistant, info: models.BluetoothServiceInfo
 ) -> None:

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -110,7 +110,7 @@ def inject_bluetooth_service_info_bleak(
         hass,
         device,
         advertisement_data,
-        time.monotonic(),
+        info.time,
         SOURCE_LOCAL,
         connectable=info.connectable,
     )

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -19,6 +19,18 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
+__all__ = (
+    "inject_advertisement",
+    "inject_advertisement_with_source",
+    "inject_advertisement_with_time_and_source",
+    "inject_advertisement_with_time_and_source_connectable",
+    "inject_bluetooth_service_info",
+    "patch_all_discovered_devices",
+    "patch_connectable_history",
+    "patch_discovered_devices",
+    "patch_history",
+)
+
 
 def _get_manager() -> BluetoothManager:
     """Return the bluetooth manager."""

--- a/tests/components/bluetooth/test_passive_update_coordinator.py
+++ b/tests/components/bluetooth/test_passive_update_coordinator.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from . import patch_all_discovered_devices, patch_history
+from . import patch_all_discovered_devices
 
 from tests.common import async_fire_time_changed
 from tests.components.bluetooth import inject_bluetooth_service_info
@@ -147,9 +147,7 @@ async def test_unavailable_callbacks_mark_the_coordinator_unavailable(
     inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
     assert coordinator.available is True
 
-    with patch_all_discovered_devices(
-        [MagicMock(address="44:44:33:11:23:45")]
-    ), patch_history({"aa:bb:cc:dd:ee:ff": MagicMock()}):
+    with patch_all_discovered_devices([MagicMock(address="44:44:33:11:23:45")]):
         async_fire_time_changed(
             hass, dt_util.utcnow() + timedelta(seconds=UNAVAILABLE_TRACK_SECONDS)
         )
@@ -159,9 +157,7 @@ async def test_unavailable_callbacks_mark_the_coordinator_unavailable(
     inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
     assert coordinator.available is True
 
-    with patch_all_discovered_devices(
-        [MagicMock(address="44:44:33:11:23:45")]
-    ), patch_history({"aa:bb:cc:dd:ee:ff": MagicMock()}):
+    with patch_all_discovered_devices([MagicMock(address="44:44:33:11:23:45")]):
         async_fire_time_changed(
             hass, dt_util.utcnow() + timedelta(seconds=UNAVAILABLE_TRACK_SECONDS)
         )

--- a/tests/components/bluetooth/test_passive_update_coordinator.py
+++ b/tests/components/bluetooth/test_passive_update_coordinator.py
@@ -23,6 +23,7 @@ from homeassistant.util import dt as dt_util
 from . import patch_all_discovered_devices, patch_history
 
 from tests.common import async_fire_time_changed
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,32 +66,20 @@ async def test_basic_usage(hass, mock_bleak_scanner_start):
         hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
     )
     assert coordinator.available is False  # no data yet
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
 
     mock_listener = MagicMock()
     unregister_listener = coordinator.async_add_listener(mock_listener)
 
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        cancel = coordinator.async_start()
+    cancel = coordinator.async_start()
 
-    assert saved_callback is not None
-
-    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
 
     assert len(mock_listener.mock_calls) == 1
     assert coordinator.data == {"rssi": GENERIC_BLUETOOTH_SERVICE_INFO.rssi}
     assert coordinator.available is True
 
     unregister_listener()
-    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
 
     assert len(mock_listener.mock_calls) == 1
     assert coordinator.data == {"rssi": GENERIC_BLUETOOTH_SERVICE_INFO.rssi}
@@ -107,21 +96,11 @@ async def test_context_compatiblity_with_data_update_coordinator(
         hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.ACTIVE
     )
     assert coordinator.available is False  # no data yet
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
 
     mock_listener = MagicMock()
     coordinator.async_add_listener(mock_listener)
 
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        coordinator.async_start()
+    coordinator.async_start()
 
     assert not set(coordinator.async_contexts())
 
@@ -158,24 +137,14 @@ async def test_unavailable_callbacks_mark_the_coordinator_unavailable(
         hass, _LOGGER, "aa:bb:cc:dd:ee:ff", BluetoothScanningMode.PASSIVE
     )
     assert coordinator.available is False  # no data yet
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
 
     mock_listener = MagicMock()
     coordinator.async_add_listener(mock_listener)
 
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        coordinator.async_start()
+    coordinator.async_start()
 
     assert coordinator.available is False
-    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
     assert coordinator.available is True
 
     with patch_all_discovered_devices(
@@ -187,7 +156,7 @@ async def test_unavailable_callbacks_mark_the_coordinator_unavailable(
         await hass.async_block_till_done()
     assert coordinator.available is False
 
-    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
     assert coordinator.available is True
 
     with patch_all_discovered_devices(
@@ -209,21 +178,10 @@ async def test_passive_bluetooth_coordinator_entity(hass, mock_bleak_scanner_sta
     entity = PassiveBluetoothCoordinatorEntity(coordinator)
     assert entity.available is False
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        coordinator.async_start()
+    coordinator.async_start()
 
     assert coordinator.available is False
-    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
     assert coordinator.available is True
     entity.hass = hass
     await entity.async_update()

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -396,7 +396,7 @@ async def test_bad_data_from_update_method(hass, mock_bleak_scanner_start):
         """Generate mock data."""
         nonlocal run_count
         run_count += 1
-        if run_count == 2:
+        if run_count == 1:
             return "bad_data"
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
@@ -425,7 +425,7 @@ async def test_bad_data_from_update_method(hass, mock_bleak_scanner_start):
 
     processor.async_add_listener(MagicMock())
 
-    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
     assert processor.available is True
 
     # We should go unavailable once we get bad data

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -333,7 +333,7 @@ async def test_exception_from_update_method(hass, caplog, mock_bleak_scanner_sta
         """Generate mock data."""
         nonlocal run_count
         run_count += 1
-        if run_count == 2:
+        if run_count == 1:
             raise Exception("Test exception")
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
@@ -362,7 +362,7 @@ async def test_exception_from_update_method(hass, caplog, mock_bleak_scanner_sta
 
     processor.async_add_listener(MagicMock())
 
-    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
     assert processor.available is True
 
     # We should go unavailable once we get an exception

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -32,7 +32,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from . import patch_all_discovered_devices, patch_connectable_history, patch_history
+from . import patch_all_discovered_devices
 
 from tests.common import MockEntityPlatform, async_fire_time_changed
 from tests.components.bluetooth import inject_bluetooth_service_info
@@ -228,11 +228,7 @@ async def test_unavailable_after_no_data(hass, mock_bleak_scanner_start):
     assert len(mock_add_entities.mock_calls) == 1
     assert coordinator.available is True
     assert processor.available is True
-    with patch_all_discovered_devices(
-        [MagicMock(address="44:44:33:11:23:45")]
-    ), patch_history({"aa:bb:cc:dd:ee:ff": MagicMock()}), patch_connectable_history(
-        {"aa:bb:cc:dd:ee:ff": MagicMock()},
-    ):
+    with patch_all_discovered_devices([MagicMock(address="44:44:33:11:23:45")]):
         async_fire_time_changed(
             hass, dt_util.utcnow() + timedelta(seconds=UNAVAILABLE_TRACK_SECONDS)
         )
@@ -245,11 +241,7 @@ async def test_unavailable_after_no_data(hass, mock_bleak_scanner_start):
     assert coordinator.available is True
     assert processor.available is True
 
-    with patch_all_discovered_devices(
-        [MagicMock(address="44:44:33:11:23:45")]
-    ), patch_history({"aa:bb:cc:dd:ee:ff": MagicMock()}), patch_connectable_history(
-        {"aa:bb:cc:dd:ee:ff": MagicMock()},
-    ):
+    with patch_all_discovered_devices([MagicMock(address="44:44:33:11:23:45")]):
         async_fire_time_changed(
             hass, dt_util.utcnow() + timedelta(seconds=UNAVAILABLE_TRACK_SECONDS)
         )

--- a/tests/components/bthome/test_sensor.py
+++ b/tests/components/bthome/test_sensor.py
@@ -1,10 +1,8 @@
 """Test the BTHome sensors."""
 
-from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.bthome.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -12,6 +10,7 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import make_advertisement, make_encrypted_advertisement
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 @pytest.mark.parametrize(
@@ -340,25 +339,14 @@ async def test_sensors(
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
 
-    saved_callback(
+    inject_bluetooth_service_info(
+        hass,
         advertisement,
-        BluetoothChange.ADVERTISEMENT,
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == len(result)

--- a/tests/components/govee_ble/test_sensor.py
+++ b/tests/components/govee_ble/test_sensor.py
@@ -1,8 +1,6 @@
 """Test the Govee BLE sensors."""
 
-from unittest.mock import patch
 
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.govee_ble.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -10,6 +8,7 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import GVH5075_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass):
@@ -20,22 +19,11 @@ async def test_sensors(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(GVH5075_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, GVH5075_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 3
 

--- a/tests/components/moat/test_sensor.py
+++ b/tests/components/moat/test_sensor.py
@@ -1,8 +1,6 @@
 """Test the Moat sensors."""
 
-from unittest.mock import patch
 
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.moat.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -10,32 +8,22 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import MOAT_S2_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass):
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+        unique_id="aa:bb:cc:dd:ee:ff",
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(MOAT_S2_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, MOAT_S2_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 4
 

--- a/tests/components/qingping/test_binary_sensor.py
+++ b/tests/components/qingping/test_binary_sensor.py
@@ -1,14 +1,13 @@
 """Test the Qingping binary sensors."""
 
-from unittest.mock import patch
 
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.qingping.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
 
 from . import LIGHT_AND_SIGNAL_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_binary_sensors(hass):
@@ -19,22 +18,11 @@ async def test_binary_sensors(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all("binary_sensor")) == 0
-    saved_callback(LIGHT_AND_SIGNAL_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, LIGHT_AND_SIGNAL_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all("binary_sensor")) == 1
 

--- a/tests/components/qingping/test_sensor.py
+++ b/tests/components/qingping/test_sensor.py
@@ -1,8 +1,6 @@
 """Test the Qingping sensors."""
 
-from unittest.mock import patch
 
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.qingping.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -10,6 +8,7 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import LIGHT_AND_SIGNAL_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass):
@@ -20,22 +19,11 @@ async def test_sensors(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all("sensor")) == 0
-    saved_callback(LIGHT_AND_SIGNAL_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, LIGHT_AND_SIGNAL_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all("sensor")) == 1
 

--- a/tests/components/sensorpro/test_sensor.py
+++ b/tests/components/sensorpro/test_sensor.py
@@ -1,8 +1,6 @@
 """Test the SensorPro sensors."""
 
-from unittest.mock import patch
 
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.sensorpro.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -10,6 +8,7 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import SENSORPRO_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass):
@@ -20,22 +19,11 @@ async def test_sensors(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all("sensor")) == 0
-    saved_callback(SENSORPRO_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, SENSORPRO_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all("sensor")) == 4
 

--- a/tests/components/sensorpush/test_sensor.py
+++ b/tests/components/sensorpush/test_sensor.py
@@ -1,8 +1,5 @@
-"""Test the SensorPush config flow."""
+"""Test the SensorPush sensors."""
 
-from unittest.mock import patch
-
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.sensorpush.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -10,6 +7,7 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import HTPWX_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass):
@@ -20,22 +18,11 @@ async def test_sensors(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(HTPWX_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, HTPWX_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 3
 

--- a/tests/components/sensorpush/test_sensor.py
+++ b/tests/components/sensorpush/test_sensor.py
@@ -14,7 +14,7 @@ async def test_sensors(hass):
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+        unique_id="4125DDBA-2774-4851-9889-6AADDD4CAC3D",
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/thermobeacon/test_sensor.py
+++ b/tests/components/thermobeacon/test_sensor.py
@@ -1,8 +1,6 @@
 """Test the ThermoBeacon sensors."""
 
-from unittest.mock import patch
 
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.thermobeacon.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -10,6 +8,7 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import THERMOBEACON_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass):
@@ -20,22 +19,11 @@ async def test_sensors(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all("sensor")) == 0
-    saved_callback(THERMOBEACON_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, THERMOBEACON_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all("sensor")) == 4
 

--- a/tests/components/thermopro/test_sensor.py
+++ b/tests/components/thermopro/test_sensor.py
@@ -1,8 +1,5 @@
 """Test the ThermoPro config flow."""
 
-from unittest.mock import patch
-
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.thermopro.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -10,32 +7,22 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import TP357_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass):
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+        unique_id="4125DDBA-2774-4851-9889-6AADDD4CAC3D",
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(TP357_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, TP357_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 2
 

--- a/tests/components/tilt_ble/test_sensor.py
+++ b/tests/components/tilt_ble/test_sensor.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
-from homeassistant.components.bluetooth import BluetoothCallback, BluetoothChange
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.tilt_ble.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -13,33 +10,22 @@ from homeassistant.core import HomeAssistant
 from . import TILT_GREEN_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass: HomeAssistant):
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+        unique_id="F6:0F:28:F2:1F:CB",
     )
     entry.add_to_hass(hass)
 
-    saved_callback: BluetoothCallback | None = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    assert saved_callback is not None
-    saved_callback(TILT_GREEN_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info(hass, TILT_GREEN_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 2
 

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -1,14 +1,12 @@
 """Test Xiaomi binary sensors."""
 
-from unittest.mock import patch
-
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.xiaomi_ble.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
 
 from . import make_advertisement
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info_bleak
 
 
 async def test_smoke_sensor(hass):
@@ -20,27 +18,16 @@ async def test_smoke_sensor(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "54:EF:44:E3:9C:BC",
             b"XY\x97\tf\xbc\x9c\xe3D\xefT\x01" b"\x08\x12\x05\x00\x00\x00q^\xbe\x90",
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 1
@@ -62,29 +49,18 @@ async def test_moisture(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
 
     # WARNING: This test data is synthetic, rather than captured from a real device
     # obj type is 0x1014, payload len is 0x2 and payload is 0xf400
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A", b"q \x5d\x01iz>j\x8d|\xc4\r\x14\x10\x02\xf4\x00"
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
 
     await hass.async_block_till_done()

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -1,11 +1,6 @@
 """Test the Xiaomi config flow."""
 
-from unittest.mock import patch
 
-from homeassistant.components.bluetooth import (
-    BluetoothChange,
-    async_get_advertisement_callback,
-)
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.xiaomi_ble.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -13,6 +8,7 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import MMC_T201_1_SERVICE_INFO, make_advertisement
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info_bleak
 
 
 async def test_sensors(hass):
@@ -23,22 +19,11 @@ async def test_sensors(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(MMC_T201_1_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    inject_bluetooth_service_info_bleak(hass, MMC_T201_1_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 2
 
@@ -63,29 +48,18 @@ async def test_xiaomi_formaldeyhde(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
 
     # WARNING: This test data is synthetic, rather than captured from a real device
     # obj type is 0x1010, payload len is 0x2 and payload is 0xf400
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A", b"q \x5d\x01iz>j\x8d|\xc4\r\x10\x10\x02\xf4\x00"
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
 
     await hass.async_block_till_done()
@@ -110,29 +84,18 @@ async def test_xiaomi_consumable(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
 
     # WARNING: This test data is synthetic, rather than captured from a real device
     # obj type is 0x1310, payload len is 0x2 and payload is 0x6000
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A", b"q \x5d\x01iz>j\x8d|\xc4\r\x13\x10\x02\x60\x00"
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
 
     await hass.async_block_till_done()
@@ -157,29 +120,16 @@ async def test_xiaomi_battery_voltage(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 0
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     # WARNING: This test data is synthetic, rather than captured from a real device
     # obj type is 0x0a10, payload len is 0x2 and payload is 0x6400
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A", b"q \x5d\x01iz>j\x8d|\xc4\r\x0a\x10\x02\x64\x00"
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
 
     await hass.async_block_till_done()
@@ -211,44 +161,33 @@ async def test_xiaomi_HHCCJCY01(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A", b"q \x98\x00fz>j\x8d|\xc4\r\x07\x10\x03\x00\x00\x00"
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A", b"q \x98\x00hz>j\x8d|\xc4\r\t\x10\x02W\x02"
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A", b"q \x98\x00Gz>j\x8d|\xc4\r\x08\x10\x01@"
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A", b"q \x98\x00iz>j\x8d|\xc4\r\x04\x10\x02\xf4\x00"
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 5
@@ -296,56 +235,45 @@ async def test_xiaomi_HHCCJCY01_not_connectable(hass):
     """This device has multiple advertisements before all sensors are visible but not connectable."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="C4:7C:8D:6A:3E:7B",
+        unique_id="C4:7C:8D:6A:3E:7A",
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A",
             b"q \x98\x00fz>j\x8d|\xc4\r\x07\x10\x03\x00\x00\x00",
             connectable=False,
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A",
             b"q \x98\x00hz>j\x8d|\xc4\r\t\x10\x02W\x02",
             connectable=False,
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A",
             b"q \x98\x00Gz>j\x8d|\xc4\r\x08\x10\x01@",
             connectable=False,
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A",
             b"q \x98\x00iz>j\x8d|\xc4\r\x04\x10\x02\xf4\x00",
             connectable=False,
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 4
@@ -392,34 +320,36 @@ async def test_xiaomi_HHCCJCY01_only_some_sources_connectable(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = async_get_advertisement_callback(hass)
-
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A",
             b"q \x98\x00fz>j\x8d|\xc4\r\x07\x10\x03\x00\x00\x00",
             connectable=True,
         ),
     )
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A",
             b"q \x98\x00hz>j\x8d|\xc4\r\t\x10\x02W\x02",
             connectable=False,
         ),
     )
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A",
             b"q \x98\x00Gz>j\x8d|\xc4\r\x08\x10\x01@",
             connectable=False,
         ),
     )
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "C4:7C:8D:6A:3E:7A",
             b"q \x98\x00iz>j\x8d|\xc4\r\x04\x10\x02\xf4\x00",
@@ -477,27 +407,16 @@ async def test_xiaomi_CGDK2(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
-    saved_callback(
+    inject_bluetooth_service_info_bleak(
+        hass,
         make_advertisement(
             "58:2D:34:12:20:89",
             b"XXo\x06\x07\x89 \x124-X_\x17m\xd5O\x02\x00\x00/\xa4S\xfa",
         ),
-        BluetoothChange.ADVERTISEMENT,
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 1


### PR DESCRIPTION
I'll need to do a blog post on this + update the dev docs. `async_track_unavailable` doesn't look like its heavily used outside the coordinator so the impact should be minimal. https://github.com/home-assistant/developers.home-assistant/pull/1470



<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

In bleak 0.16 there was a [change](https://github.com/hbldh/bleak/pull/964) to always callback RSSI updates which changed everything to get ~4000 callback/min instead of ~30-50 callback/min. This is helpful for the manager but not so useful for integrations as it can overwhelm them as seen in #78094.  This change is needed in preparation for the filtering that will come in the next PR. 

`async_track_unavailable` is now called back with the last `BluetoothServiceInfoBleak` instead of the `address` of the device going unavailable. This allows the subscriber to know when the device was last seen.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1470

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
