### PR TITLE
Fix zwave_js update entity startup state

### DIFF
--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -204,9 +204,10 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             ):
                 self._latest_version_firmware = latest_firmware
                 self._attr_latest_version = latest_firmware.version
-            else:
+                self.async_write_ha_state()
+            elif self._attr_latest_version != self._attr_installed_version:
                 self._attr_latest_version = self._attr_installed_version
-            self.async_write_ha_state()
+                self.async_write_ha_state()
         finally:
             self._poll_unsub = async_call_later(
                 self.hass, timedelta(days=1), self._async_update

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -100,7 +100,6 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         self._base_unique_id = get_valueless_base_unique_id(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.firmware_update"
         self._attr_installed_version = node.firmware_version
-        self._attr_latest_version = None
         # device may not be precreated in main handler yet
         self._attr_device_info = get_device_info(driver, node)
 

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -66,7 +66,6 @@ async def test_update_entity_states(
 ):
     """Test update entity states."""
     ws_client = await hass_ws_client(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(UPDATE_ENTITY).state == STATE_OFF
 
@@ -464,8 +463,6 @@ async def test_update_entity_reload(
     integration,
 ):
     """Test update entity maintains state after reload."""
-    await hass.async_block_till_done()
-
     assert hass.states.get(UPDATE_ENTITY).state == STATE_OFF
 
     client.async_send_command.return_value = {"updates": []}

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -13,8 +13,10 @@ from homeassistant.components.update.const import (
     ATTR_INSTALLED_VERSION,
     ATTR_LATEST_VERSION,
     ATTR_RELEASE_URL,
+    ATTR_SKIPPED_VERSION,
     DOMAIN as UPDATE_DOMAIN,
     SERVICE_INSTALL,
+    SERVICE_SKIP,
 )
 from homeassistant.components.zwave_js.const import DOMAIN, SERVICE_REFRESH_VALUE
 from homeassistant.components.zwave_js.helpers import get_valueless_base_unique_id
@@ -453,3 +455,65 @@ async def test_update_entity_install_failed(
     # validate that the install task failed
     with pytest.raises(HomeAssistantError):
         await install_task
+
+
+async def test_update_entity_reload(
+    hass,
+    client,
+    climate_radio_thermostat_ct100_plus_different_endpoints,
+    integration,
+):
+    """Test update entity maintains state after reload."""
+    await hass.async_block_till_done()
+
+    assert hass.states.get(UPDATE_ENTITY).state == STATE_OFF
+
+    client.async_send_command.return_value = {"updates": []}
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    assert state.state == STATE_OFF
+
+    client.async_send_command.return_value = FIRMWARE_UPDATES
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=2))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    assert state.state == STATE_ON
+    attrs = state.attributes
+    assert not attrs[ATTR_AUTO_UPDATE]
+    assert attrs[ATTR_INSTALLED_VERSION] == "10.7"
+    assert not attrs[ATTR_IN_PROGRESS]
+    assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
+    assert attrs[ATTR_RELEASE_URL] is None
+
+    await hass.services.async_call(
+        UPDATE_DOMAIN,
+        SERVICE_SKIP,
+        {
+            ATTR_ENTITY_ID: UPDATE_ENTITY,
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_SKIPPED_VERSION] == "11.2.4"
+
+    await hass.config_entries.async_reload(integration.entry_id)
+    await hass.async_block_till_done()
+
+    # Trigger another update and make sure the skipped version is still skipped
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=4))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_SKIPPED_VERSION] == "11.2.4"


### PR DESCRIPTION
## Proposed change
Because we set the latest version to installed version during initialization, the update entity was resetting any skipped updates after a restart. I **think** the correct fix here is to initialize as None and to only set the version to the installed version if there are no available firmware updates that are higher than the installed version.

CC - @frenck for confirmation (ps - hope you enjoyed your vacation!)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
