### PR TITLE
Allow selecting display unit when fetching statistics

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -479,10 +479,16 @@ class Recorder(threading.Thread):
 
     @callback
     def async_adjust_statistics(
-        self, statistic_id: str, start_time: datetime, sum_adjustment: float
+        self,
+        statistic_id: str,
+        start_time: datetime,
+        sum_adjustment: float,
+        display_unit: str,
     ) -> None:
         """Adjust statistics."""
-        self.queue_task(AdjustStatisticsTask(statistic_id, start_time, sum_adjustment))
+        self.queue_task(
+            AdjustStatisticsTask(statistic_id, start_time, sum_adjustment, display_unit)
+        )
 
     @callback
     def async_clear_statistics(self, statistic_ids: list[str]) -> None:

--- a/homeassistant/components/recorder/tasks.py
+++ b/homeassistant/components/recorder/tasks.py
@@ -145,6 +145,7 @@ class AdjustStatisticsTask(RecorderTask):
     statistic_id: str
     start_time: datetime
     sum_adjustment: float
+    display_unit: str
 
     def run(self, instance: Recorder) -> None:
         """Run statistics task."""
@@ -153,12 +154,16 @@ class AdjustStatisticsTask(RecorderTask):
             self.statistic_id,
             self.start_time,
             self.sum_adjustment,
+            self.display_unit,
         ):
             return
         # Schedule a new adjust statistics task if this one didn't finish
         instance.queue_task(
             AdjustStatisticsTask(
-                self.statistic_id, self.start_time, self.sum_adjustment
+                self.statistic_id,
+                self.start_time,
+                self.sum_adjustment,
+                self.display_unit,
             )
         )
 

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -70,6 +70,7 @@ async def test_demo_statistics(hass, recorder_mock):
         "source": "demo",
         "statistic_id": "demo:temperature_outdoor",
         "statistics_unit_of_measurement": "°C",
+        "unit_class": "temperature",
     } in statistic_ids
     assert {
         "display_unit_of_measurement": "kWh",
@@ -79,6 +80,7 @@ async def test_demo_statistics(hass, recorder_mock):
         "source": "demo",
         "statistic_id": "demo:energy_consumption_kwh",
         "statistics_unit_of_measurement": "kWh",
+        "unit_class": "energy",
     } in statistic_ids
 
 

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -532,6 +532,7 @@ async def test_import_statistics(
             "name": "Total imported energy",
             "source": source,
             "statistics_unit_of_measurement": "kWh",
+            "unit_class": "energy",
         }
     ]
     metadata = get_metadata(hass, statistic_ids=(statistic_id,))
@@ -603,7 +604,7 @@ async def test_import_statistics(
         ]
     }
 
-    # Update the previously inserted statistics + rename and change unit
+    # Update the previously inserted statistics + rename and change display unit
     external_statistics = {
         "start": period1,
         "max": 1,
@@ -620,13 +621,14 @@ async def test_import_statistics(
     statistic_ids = list_statistic_ids(hass)
     assert statistic_ids == [
         {
-            "display_unit_of_measurement": "kWh",
+            "display_unit_of_measurement": "MWh",
             "has_mean": False,
             "has_sum": True,
             "statistic_id": statistic_id,
             "name": "Total imported energy renamed",
             "source": source,
             "statistics_unit_of_measurement": "kWh",
+            "unit_class": "energy",
         }
     ]
     metadata = get_metadata(hass, statistic_ids=(statistic_id,))
@@ -651,12 +653,12 @@ async def test_import_statistics(
                 "statistic_id": statistic_id,
                 "start": period1.isoformat(),
                 "end": (period1 + timedelta(hours=1)).isoformat(),
-                "max": approx(1.0),
-                "mean": approx(2.0),
-                "min": approx(3.0),
+                "max": approx(1.0 / 1000),
+                "mean": approx(2.0 / 1000),
+                "min": approx(3.0 / 1000),
                 "last_reset": last_reset_utc_str,
-                "state": approx(4.0),
-                "sum": approx(5.0),
+                "state": approx(4.0 / 1000),
+                "sum": approx(5.0 / 1000),
             },
             {
                 "statistic_id": statistic_id,
@@ -666,8 +668,8 @@ async def test_import_statistics(
                 "mean": None,
                 "min": None,
                 "last_reset": last_reset_utc_str,
-                "state": approx(1.0),
-                "sum": approx(3.0),
+                "state": approx(1.0 / 1000),
+                "sum": approx(3.0 / 1000),
             },
         ]
     }
@@ -680,6 +682,7 @@ async def test_import_statistics(
             "statistic_id": statistic_id,
             "start_time": period2.isoformat(),
             "adjustment": 1000.0,
+            "display_unit": "MWh",
         }
     )
     response = await client.receive_json()
@@ -693,12 +696,12 @@ async def test_import_statistics(
                 "statistic_id": statistic_id,
                 "start": period1.isoformat(),
                 "end": (period1 + timedelta(hours=1)).isoformat(),
-                "max": approx(1.0),
-                "mean": approx(2.0),
-                "min": approx(3.0),
+                "max": approx(1.0 / 1000),
+                "mean": approx(2.0 / 1000),
+                "min": approx(3.0 / 1000),
                 "last_reset": last_reset_utc_str,
-                "state": approx(4.0),
-                "sum": approx(5.0),
+                "state": approx(4.0 / 1000),
+                "sum": approx(5.0 / 1000),
             },
             {
                 "statistic_id": statistic_id,
@@ -708,8 +711,8 @@ async def test_import_statistics(
                 "mean": None,
                 "min": None,
                 "last_reset": last_reset_utc_str,
-                "state": approx(1.0),
-                "sum": approx(1003.0),
+                "state": approx(1.0 / 1000),
+                "sum": approx(1000 + 3.0 / 1000),
             },
         ]
     }

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -50,12 +50,12 @@ TEMPERATURE_SENSOR_F_ATTRIBUTES = {
     "state_class": "measurement",
     "unit_of_measurement": "°F",
 }
-ENERGY_SENSOR_ATTRIBUTES = {
+ENERGY_SENSOR_KWH_ATTRIBUTES = {
     "device_class": "energy",
     "state_class": "total",
     "unit_of_measurement": "kWh",
 }
-GAS_SENSOR_ATTRIBUTES = {
+GAS_SENSOR_M3_ATTRIBUTES = {
     "device_class": "gas",
     "state_class": "total",
     "unit_of_measurement": "m³",
@@ -131,6 +131,241 @@ async def test_statistics_during_period(
             }
         ]
     }
+
+
+@pytest.mark.parametrize(
+    "attributes, state, value, custom_units, converted_value",
+    [
+        (POWER_SENSOR_KW_ATTRIBUTES, 10, 10, {"power": "W"}, 10000),
+        (POWER_SENSOR_KW_ATTRIBUTES, 10, 10, {"power": "kW"}, 10),
+        (PRESSURE_SENSOR_HPA_ATTRIBUTES, 10, 10, {"pressure": "Pa"}, 1000),
+        (PRESSURE_SENSOR_HPA_ATTRIBUTES, 10, 10, {"pressure": "hPa"}, 10),
+        (PRESSURE_SENSOR_HPA_ATTRIBUTES, 10, 10, {"pressure": "psi"}, 1000 / 6894.757),
+        (TEMPERATURE_SENSOR_C_ATTRIBUTES, 10, 10, {"temperature": "°C"}, 10),
+        (TEMPERATURE_SENSOR_C_ATTRIBUTES, 10, 10, {"temperature": "°F"}, 50),
+        (TEMPERATURE_SENSOR_C_ATTRIBUTES, 10, 10, {"temperature": "K"}, 283.15),
+    ],
+)
+async def test_statistics_during_period_unit_conversion(
+    hass,
+    hass_ws_client,
+    recorder_mock,
+    attributes,
+    state,
+    value,
+    custom_units,
+    converted_value,
+):
+    """Test statistics_during_period."""
+    now = dt_util.utcnow()
+
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+    hass.states.async_set("sensor.test", state, attributes=attributes)
+    await async_wait_recording_done(hass)
+
+    do_adhoc_statistics(hass, start=now)
+    await async_wait_recording_done(hass)
+
+    client = await hass_ws_client()
+
+    # Query in state unit
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "statistic_ids": ["sensor.test"],
+            "period": "5minute",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {
+        "sensor.test": [
+            {
+                "statistic_id": "sensor.test",
+                "start": now.isoformat(),
+                "end": (now + timedelta(minutes=5)).isoformat(),
+                "mean": approx(value),
+                "min": approx(value),
+                "max": approx(value),
+                "last_reset": None,
+                "state": None,
+                "sum": None,
+            }
+        ]
+    }
+
+    # Query in custom unit
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "statistic_ids": ["sensor.test"],
+            "period": "5minute",
+            "units": custom_units,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {
+        "sensor.test": [
+            {
+                "statistic_id": "sensor.test",
+                "start": now.isoformat(),
+                "end": (now + timedelta(minutes=5)).isoformat(),
+                "mean": approx(converted_value),
+                "min": approx(converted_value),
+                "max": approx(converted_value),
+                "last_reset": None,
+                "state": None,
+                "sum": None,
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    "attributes, state, value, custom_units, converted_value",
+    [
+        (ENERGY_SENSOR_KWH_ATTRIBUTES, 10, 10, {"energy": "kWh"}, 10),
+        (ENERGY_SENSOR_KWH_ATTRIBUTES, 10, 10, {"energy": "MWh"}, 0.010),
+        (ENERGY_SENSOR_KWH_ATTRIBUTES, 10, 10, {"energy": "Wh"}, 10000),
+        (GAS_SENSOR_M3_ATTRIBUTES, 10, 10, {"volume": "m³"}, 10),
+        (GAS_SENSOR_M3_ATTRIBUTES, 10, 10, {"volume": "ft³"}, 353.147),
+    ],
+)
+async def test_sum_statistics_during_period_unit_conversion(
+    hass,
+    hass_ws_client,
+    recorder_mock,
+    attributes,
+    state,
+    value,
+    custom_units,
+    converted_value,
+):
+    """Test statistics_during_period."""
+    now = dt_util.utcnow()
+
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+    hass.states.async_set("sensor.test", 0, attributes=attributes)
+    hass.states.async_set("sensor.test", state, attributes=attributes)
+    await async_wait_recording_done(hass)
+
+    do_adhoc_statistics(hass, start=now)
+    await async_wait_recording_done(hass)
+
+    client = await hass_ws_client()
+
+    # Query in state unit
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "statistic_ids": ["sensor.test"],
+            "period": "5minute",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {
+        "sensor.test": [
+            {
+                "statistic_id": "sensor.test",
+                "start": now.isoformat(),
+                "end": (now + timedelta(minutes=5)).isoformat(),
+                "mean": None,
+                "min": None,
+                "max": None,
+                "last_reset": None,
+                "state": approx(value),
+                "sum": approx(value),
+            }
+        ]
+    }
+
+    # Query in custom unit
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "statistic_ids": ["sensor.test"],
+            "period": "5minute",
+            "units": custom_units,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {
+        "sensor.test": [
+            {
+                "statistic_id": "sensor.test",
+                "start": now.isoformat(),
+                "end": (now + timedelta(minutes=5)).isoformat(),
+                "mean": None,
+                "min": None,
+                "max": None,
+                "last_reset": None,
+                "state": approx(converted_value),
+                "sum": approx(converted_value),
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    "custom_units",
+    [
+        {"energy": "W"},
+        {"power": "Pa"},
+        {"pressure": "K"},
+        {"temperature": "m³"},
+        {"volume": "kWh"},
+    ],
+)
+async def test_statistics_during_period_invalid_unit_conversion(
+    hass, hass_ws_client, recorder_mock, custom_units
+):
+    """Test statistics_during_period."""
+    now = dt_util.utcnow()
+
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+
+    client = await hass_ws_client()
+
+    # Query in state unit
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "period": "5minute",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {}
+
+    # Query in custom unit
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "period": "5minute",
+            "units": custom_units,
+        }
+    )
+    response = await client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "invalid_format"
 
 
 @pytest.mark.parametrize(
@@ -307,16 +542,16 @@ async def test_statistics_during_period_bad_end_time(
 
 
 @pytest.mark.parametrize(
-    "units, attributes, display_unit, statistics_unit",
+    "units, attributes, display_unit, statistics_unit, unit_class",
     [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, "kW", "W"),
-        (METRIC_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, "kW", "W"),
-        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, "°C", "°C"),
-        (METRIC_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, "°C", "°C"),
-        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_F_ATTRIBUTES, "°F", "°C"),
-        (METRIC_SYSTEM, TEMPERATURE_SENSOR_F_ATTRIBUTES, "°F", "°C"),
-        (IMPERIAL_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, "hPa", "Pa"),
-        (METRIC_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, "hPa", "Pa"),
+        (IMPERIAL_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, "kW", "W", "power"),
+        (METRIC_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, "kW", "W", "power"),
+        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, "°C", "°C", "temperature"),
+        (METRIC_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, "°C", "°C", "temperature"),
+        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_F_ATTRIBUTES, "°F", "°C", "temperature"),
+        (METRIC_SYSTEM, TEMPERATURE_SENSOR_F_ATTRIBUTES, "°F", "°C", "temperature"),
+        (IMPERIAL_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, "hPa", "Pa", "pressure"),
+        (METRIC_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, "hPa", "Pa", "pressure"),
     ],
 )
 async def test_list_statistic_ids(
@@ -327,6 +562,7 @@ async def test_list_statistic_ids(
     attributes,
     display_unit,
     statistics_unit,
+    unit_class,
 ):
     """Test list_statistic_ids."""
     now = dt_util.utcnow()
@@ -356,6 +592,7 @@ async def test_list_statistic_ids(
             "source": "recorder",
             "display_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
 
@@ -377,6 +614,7 @@ async def test_list_statistic_ids(
             "source": "recorder",
             "display_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
 
@@ -400,6 +638,7 @@ async def test_list_statistic_ids(
             "source": "recorder",
             "display_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
 
@@ -590,6 +829,7 @@ async def test_update_statistics_metadata(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "W",
+            "unit_class": "power",
         }
     ]
 
@@ -617,6 +857,7 @@ async def test_update_statistics_metadata(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": new_unit,
+            "unit_class": None,
         }
     ]
 
@@ -802,14 +1043,14 @@ async def test_backup_end_without_start(
 
 
 @pytest.mark.parametrize(
-    "units, attributes, unit",
+    "units, attributes, unit, unit_class",
     [
-        (METRIC_SYSTEM, GAS_SENSOR_ATTRIBUTES, "m³"),
-        (METRIC_SYSTEM, ENERGY_SENSOR_ATTRIBUTES, "kWh"),
+        (METRIC_SYSTEM, GAS_SENSOR_M3_ATTRIBUTES, "m³", "volume"),
+        (METRIC_SYSTEM, ENERGY_SENSOR_KWH_ATTRIBUTES, "kWh", "energy"),
     ],
 )
 async def test_get_statistics_metadata(
-    hass, hass_ws_client, recorder_mock, units, attributes, unit
+    hass, hass_ws_client, recorder_mock, units, attributes, unit, unit_class
 ):
     """Test get_statistics_metadata."""
     now = dt_util.utcnow()
@@ -891,6 +1132,7 @@ async def test_get_statistics_metadata(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": unit,
+            "unit_class": unit_class,
         }
     ]
 
@@ -918,6 +1160,7 @@ async def test_get_statistics_metadata(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": unit,
+            "unit_class": unit_class,
         }
     ]
 
@@ -960,6 +1203,7 @@ async def test_import_statistics(
         "has_sum": True,
         "name": "Total imported energy",
         "source": source,
+        "state_unit_of_measurement": "kWh",
         "statistic_id": statistic_id,
         "unit_of_measurement": "kWh",
     }
@@ -1014,6 +1258,7 @@ async def test_import_statistics(
             "name": "Total imported energy",
             "source": source,
             "statistics_unit_of_measurement": "kWh",
+            "unit_class": "energy",
         }
     ]
     metadata = get_metadata(hass, statistic_ids=(statistic_id,))
@@ -1149,6 +1394,120 @@ async def test_import_statistics(
         ]
     }
 
+
+@pytest.mark.parametrize(
+    "source, statistic_id",
+    (
+        ("test", "test:total_energy_import"),
+        ("recorder", "sensor.total_energy_import"),
+    ),
+)
+async def test_adjust_sum_statistics_energy(
+    hass, hass_ws_client, recorder_mock, caplog, source, statistic_id
+):
+    """Test adjusting statistics."""
+    client = await hass_ws_client()
+
+    assert "Compiling statistics for" not in caplog.text
+    assert "Statistics already compiled" not in caplog.text
+
+    zero = dt_util.utcnow()
+    period1 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    period2 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=2)
+
+    external_statistics1 = {
+        "start": period1.isoformat(),
+        "last_reset": None,
+        "state": 0,
+        "sum": 2,
+    }
+    external_statistics2 = {
+        "start": period2.isoformat(),
+        "last_reset": None,
+        "state": 1,
+        "sum": 3,
+    }
+
+    external_metadata = {
+        "has_mean": False,
+        "has_sum": True,
+        "name": "Total imported energy",
+        "source": source,
+        "state_unit_of_measurement": "kWh",
+        "statistic_id": statistic_id,
+        "unit_of_measurement": "kWh",
+    }
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "recorder/import_statistics",
+            "metadata": external_metadata,
+            "stats": [external_statistics1, external_statistics2],
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] is None
+
+    await async_wait_recording_done(hass)
+    stats = statistics_during_period(hass, zero, period="hour")
+    assert stats == {
+        statistic_id: [
+            {
+                "statistic_id": statistic_id,
+                "start": period1.isoformat(),
+                "end": (period1 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(0.0),
+                "sum": approx(2.0),
+            },
+            {
+                "statistic_id": statistic_id,
+                "start": period2.isoformat(),
+                "end": (period2 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(1.0),
+                "sum": approx(3.0),
+            },
+        ]
+    }
+    statistic_ids = list_statistic_ids(hass)  # TODO
+    assert statistic_ids == [
+        {
+            "display_unit_of_measurement": "kWh",
+            "has_mean": False,
+            "has_sum": True,
+            "statistic_id": statistic_id,
+            "name": "Total imported energy",
+            "source": source,
+            "statistics_unit_of_measurement": "kWh",
+            "unit_class": "energy",
+        }
+    ]
+    metadata = get_metadata(hass, statistic_ids=(statistic_id,))
+    assert metadata == {
+        statistic_id: (
+            1,
+            {
+                "has_mean": False,
+                "has_sum": True,
+                "name": "Total imported energy",
+                "source": source,
+                "state_unit_of_measurement": "kWh",
+                "statistic_id": statistic_id,
+                "unit_of_measurement": "kWh",
+            },
+        )
+    }
+
+    # Adjust previously inserted statistics in kWh
     await client.send_json(
         {
             "id": 4,
@@ -1156,6 +1515,7 @@ async def test_import_statistics(
             "statistic_id": statistic_id,
             "start_time": period2.isoformat(),
             "adjustment": 1000.0,
+            "display_unit": "kWh",
         }
     )
     response = await client.receive_json()
@@ -1169,12 +1529,12 @@ async def test_import_statistics(
                 "statistic_id": statistic_id,
                 "start": period1.isoformat(),
                 "end": (period1 + timedelta(hours=1)).isoformat(),
-                "max": approx(1.0),
-                "mean": approx(2.0),
-                "min": approx(3.0),
+                "max": approx(None),
+                "mean": approx(None),
+                "min": approx(None),
                 "last_reset": None,
-                "state": approx(4.0),
-                "sum": approx(5.0),
+                "state": approx(0.0),
+                "sum": approx(2.0),
             },
             {
                 "statistic_id": statistic_id,
@@ -1189,3 +1549,450 @@ async def test_import_statistics(
             },
         ]
     }
+
+    # Adjust previously inserted statistics in MWh
+    await client.send_json(
+        {
+            "id": 5,
+            "type": "recorder/adjust_sum_statistics",
+            "statistic_id": statistic_id,
+            "start_time": period2.isoformat(),
+            "adjustment": 2.0,
+            "display_unit": "MWh",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await async_wait_recording_done(hass)
+    stats = statistics_during_period(hass, zero, period="hour")
+    assert stats == {
+        statistic_id: [
+            {
+                "statistic_id": statistic_id,
+                "start": period1.isoformat(),
+                "end": (period1 + timedelta(hours=1)).isoformat(),
+                "max": approx(None),
+                "mean": approx(None),
+                "min": approx(None),
+                "last_reset": None,
+                "state": approx(0.0),
+                "sum": approx(2.0),
+            },
+            {
+                "statistic_id": statistic_id,
+                "start": period2.isoformat(),
+                "end": (period2 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(1.0),
+                "sum": approx(3003.0),
+            },
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    "source, statistic_id",
+    (
+        ("test", "test:total_gas"),
+        ("recorder", "sensor.total_gas"),
+    ),
+)
+async def test_adjust_sum_statistics_gas(
+    hass, hass_ws_client, recorder_mock, caplog, source, statistic_id
+):
+    """Test adjusting statistics."""
+    client = await hass_ws_client()
+
+    assert "Compiling statistics for" not in caplog.text
+    assert "Statistics already compiled" not in caplog.text
+
+    zero = dt_util.utcnow()
+    period1 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    period2 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=2)
+
+    external_statistics1 = {
+        "start": period1.isoformat(),
+        "last_reset": None,
+        "state": 0,
+        "sum": 2,
+    }
+    external_statistics2 = {
+        "start": period2.isoformat(),
+        "last_reset": None,
+        "state": 1,
+        "sum": 3,
+    }
+
+    external_metadata = {
+        "has_mean": False,
+        "has_sum": True,
+        "name": "Total imported energy",
+        "source": source,
+        "state_unit_of_measurement": "m³",
+        "statistic_id": statistic_id,
+        "unit_of_measurement": "m³",
+    }
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "recorder/import_statistics",
+            "metadata": external_metadata,
+            "stats": [external_statistics1, external_statistics2],
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] is None
+
+    await async_wait_recording_done(hass)
+    stats = statistics_during_period(hass, zero, period="hour")
+    assert stats == {
+        statistic_id: [
+            {
+                "statistic_id": statistic_id,
+                "start": period1.isoformat(),
+                "end": (period1 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(0.0),
+                "sum": approx(2.0),
+            },
+            {
+                "statistic_id": statistic_id,
+                "start": period2.isoformat(),
+                "end": (period2 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(1.0),
+                "sum": approx(3.0),
+            },
+        ]
+    }
+    statistic_ids = list_statistic_ids(hass)  # TODO
+    assert statistic_ids == [
+        {
+            "display_unit_of_measurement": "m³",
+            "has_mean": False,
+            "has_sum": True,
+            "statistic_id": statistic_id,
+            "name": "Total imported energy",
+            "source": source,
+            "statistics_unit_of_measurement": "m³",
+            "unit_class": "volume",
+        }
+    ]
+    metadata = get_metadata(hass, statistic_ids=(statistic_id,))
+    assert metadata == {
+        statistic_id: (
+            1,
+            {
+                "has_mean": False,
+                "has_sum": True,
+                "name": "Total imported energy",
+                "source": source,
+                "state_unit_of_measurement": "m³",
+                "statistic_id": statistic_id,
+                "unit_of_measurement": "m³",
+            },
+        )
+    }
+
+    # Adjust previously inserted statistics in m³
+    await client.send_json(
+        {
+            "id": 4,
+            "type": "recorder/adjust_sum_statistics",
+            "statistic_id": statistic_id,
+            "start_time": period2.isoformat(),
+            "adjustment": 1000.0,
+            "display_unit": "m³",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await async_wait_recording_done(hass)
+    stats = statistics_during_period(hass, zero, period="hour")
+    assert stats == {
+        statistic_id: [
+            {
+                "statistic_id": statistic_id,
+                "start": period1.isoformat(),
+                "end": (period1 + timedelta(hours=1)).isoformat(),
+                "max": approx(None),
+                "mean": approx(None),
+                "min": approx(None),
+                "last_reset": None,
+                "state": approx(0.0),
+                "sum": approx(2.0),
+            },
+            {
+                "statistic_id": statistic_id,
+                "start": period2.isoformat(),
+                "end": (period2 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(1.0),
+                "sum": approx(1003.0),
+            },
+        ]
+    }
+
+    # Adjust previously inserted statistics in ft³
+    await client.send_json(
+        {
+            "id": 5,
+            "type": "recorder/adjust_sum_statistics",
+            "statistic_id": statistic_id,
+            "start_time": period2.isoformat(),
+            "adjustment": 35.3147,  # ~1 m³
+            "display_unit": "ft³",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await async_wait_recording_done(hass)
+    stats = statistics_during_period(hass, zero, period="hour")
+    assert stats == {
+        statistic_id: [
+            {
+                "statistic_id": statistic_id,
+                "start": period1.isoformat(),
+                "end": (period1 + timedelta(hours=1)).isoformat(),
+                "max": approx(None),
+                "mean": approx(None),
+                "min": approx(None),
+                "last_reset": None,
+                "state": approx(0.0),
+                "sum": approx(2.0),
+            },
+            {
+                "statistic_id": statistic_id,
+                "start": period2.isoformat(),
+                "end": (period2 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(1.0),
+                "sum": approx(1004),
+            },
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    "state_unit, statistic_unit, unit_class, factor, valid_units, invalid_units",
+    (
+        ("kWh", "kWh", "energy", 1, ("Wh", "kWh", "MWh"), ("ft³", "m³", "cats", None)),
+        (
+            "MWh",
+            "kWh",
+            "energy",
+            0.001,
+            ("Wh", "kWh", "MWh"),
+            ("ft³", "m³", "cats", None),
+        ),
+        ("MWh", "MWh", None, 1, ("MWh",), ("Wh", "kWh", "ft³", "m³", "cats", None)),
+        ("m³", "m³", "volume", 1, ("ft³", "m³"), ("Wh", "kWh", "MWh", "cats", None)),
+        (
+            "ft³",
+            "m³",
+            "volume",
+            35.3147,
+            ("ft³", "m³"),
+            ("Wh", "kWh", "MWh", "cats", None),
+        ),
+        ("ft³", "ft³", None, 1, ("ft³",), ("m³", "Wh", "kWh", "MWh", "cats", None)),
+        ("dogs", "dogs", None, 1, ("dogs",), ("cats", None)),
+        (None, None, None, 1, (None,), ("cats",)),
+    ),
+)
+async def test_adjust_sum_statistics_errors(
+    hass,
+    hass_ws_client,
+    recorder_mock,
+    caplog,
+    state_unit,
+    statistic_unit,
+    unit_class,
+    factor,
+    valid_units,
+    invalid_units,
+):
+    """Test incorrectly adjusting statistics."""
+    statistic_id = "sensor.total_energy_import"
+    source = "recorder"
+    client = await hass_ws_client()
+
+    assert "Compiling statistics for" not in caplog.text
+    assert "Statistics already compiled" not in caplog.text
+
+    zero = dt_util.utcnow()
+    period1 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    period2 = zero.replace(minute=0, second=0, microsecond=0) + timedelta(hours=2)
+
+    external_statistics1 = {
+        "start": period1.isoformat(),
+        "last_reset": None,
+        "state": 0,
+        "sum": 2,
+    }
+    external_statistics2 = {
+        "start": period2.isoformat(),
+        "last_reset": None,
+        "state": 1,
+        "sum": 3,
+    }
+
+    external_metadata = {
+        "has_mean": False,
+        "has_sum": True,
+        "name": "Total imported energy",
+        "source": source,
+        "state_unit_of_measurement": state_unit,
+        "statistic_id": statistic_id,
+        "unit_of_measurement": statistic_unit,
+    }
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "recorder/import_statistics",
+            "metadata": external_metadata,
+            "stats": [external_statistics1, external_statistics2],
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] is None
+
+    await async_wait_recording_done(hass)
+    stats = statistics_during_period(hass, zero, period="hour")
+    assert stats == {
+        statistic_id: [
+            {
+                "statistic_id": statistic_id,
+                "start": period1.isoformat(),
+                "end": (period1 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(0.0 * factor),
+                "sum": approx(2.0 * factor),
+            },
+            {
+                "statistic_id": statistic_id,
+                "start": period2.isoformat(),
+                "end": (period2 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(1.0 * factor),
+                "sum": approx(3.0 * factor),
+            },
+        ]
+    }
+    previous_stats = stats
+    statistic_ids = list_statistic_ids(hass)
+    assert statistic_ids == [
+        {
+            "display_unit_of_measurement": state_unit,
+            "has_mean": False,
+            "has_sum": True,
+            "statistic_id": statistic_id,
+            "name": "Total imported energy",
+            "source": source,
+            "statistics_unit_of_measurement": statistic_unit,
+            "unit_class": unit_class,
+        }
+    ]
+    metadata = get_metadata(hass, statistic_ids=(statistic_id,))
+    assert metadata == {
+        statistic_id: (
+            1,
+            {
+                "has_mean": False,
+                "has_sum": True,
+                "name": "Total imported energy",
+                "source": source,
+                "state_unit_of_measurement": state_unit,
+                "statistic_id": statistic_id,
+                "unit_of_measurement": statistic_unit,
+            },
+        )
+    }
+
+    # Try to adjust statistics
+    msg_id = 2
+    await client.send_json(
+        {
+            "id": msg_id,
+            "type": "recorder/adjust_sum_statistics",
+            "statistic_id": "sensor.does_not_exist",
+            "start_time": period2.isoformat(),
+            "adjustment": 1000.0,
+            "display_unit": statistic_unit,
+        }
+    )
+    response = await client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "unknown_statistic_id"
+
+    await async_wait_recording_done(hass)
+    stats = statistics_during_period(hass, zero, period="hour")
+    assert stats == previous_stats
+
+    for unit in invalid_units:
+        msg_id += 1
+        await client.send_json(
+            {
+                "id": msg_id,
+                "type": "recorder/adjust_sum_statistics",
+                "statistic_id": statistic_id,
+                "start_time": period2.isoformat(),
+                "adjustment": 1000.0,
+                "display_unit": unit,
+            }
+        )
+        response = await client.receive_json()
+        assert not response["success"]
+        assert response["error"]["code"] == "invalid_units"
+
+        await async_wait_recording_done(hass)
+        stats = statistics_during_period(hass, zero, period="hour")
+        assert stats == previous_stats
+
+    for unit in valid_units:
+        msg_id += 1
+        await client.send_json(
+            {
+                "id": msg_id,
+                "type": "recorder/adjust_sum_statistics",
+                "statistic_id": statistic_id,
+                "start_time": period2.isoformat(),
+                "adjustment": 1000.0,
+                "display_unit": unit,
+            }
+        )
+        response = await client.receive_json()
+        assert response["success"]
+
+        await async_wait_recording_done(hass)
+        stats = statistics_during_period(hass, zero, period="hour")
+        assert stats != previous_stats
+        previous_stats = stats

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -1203,7 +1203,6 @@ async def test_import_statistics(
         "has_sum": True,
         "name": "Total imported energy",
         "source": source,
-        "state_unit_of_measurement": "kWh",
         "statistic_id": statistic_id,
         "unit_of_measurement": "kWh",
     }
@@ -1433,7 +1432,6 @@ async def test_adjust_sum_statistics_energy(
         "has_sum": True,
         "name": "Total imported energy",
         "source": source,
-        "state_unit_of_measurement": "kWh",
         "statistic_id": statistic_id,
         "unit_of_measurement": "kWh",
     }
@@ -1632,7 +1630,6 @@ async def test_adjust_sum_statistics_gas(
         "has_sum": True,
         "name": "Total imported energy",
         "source": source,
-        "state_unit_of_measurement": "m³",
         "statistic_id": statistic_id,
         "unit_of_measurement": "m³",
     }
@@ -1797,24 +1794,8 @@ async def test_adjust_sum_statistics_gas(
     "state_unit, statistic_unit, unit_class, factor, valid_units, invalid_units",
     (
         ("kWh", "kWh", "energy", 1, ("Wh", "kWh", "MWh"), ("ft³", "m³", "cats", None)),
-        (
-            "MWh",
-            "kWh",
-            "energy",
-            0.001,
-            ("Wh", "kWh", "MWh"),
-            ("ft³", "m³", "cats", None),
-        ),
         ("MWh", "MWh", None, 1, ("MWh",), ("Wh", "kWh", "ft³", "m³", "cats", None)),
         ("m³", "m³", "volume", 1, ("ft³", "m³"), ("Wh", "kWh", "MWh", "cats", None)),
-        (
-            "ft³",
-            "m³",
-            "volume",
-            35.3147,
-            ("ft³", "m³"),
-            ("Wh", "kWh", "MWh", "cats", None),
-        ),
         ("ft³", "ft³", None, 1, ("ft³",), ("m³", "Wh", "kWh", "MWh", "cats", None)),
         ("dogs", "dogs", None, 1, ("dogs",), ("cats", None)),
         (None, None, None, 1, (None,), ("cats",)),
@@ -1862,7 +1843,6 @@ async def test_adjust_sum_statistics_errors(
         "has_sum": True,
         "name": "Total imported energy",
         "source": source,
-        "state_unit_of_measurement": state_unit,
         "statistic_id": statistic_id,
         "unit_of_measurement": statistic_unit,
     }

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -76,20 +76,20 @@ def set_time_zone():
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,mean,min,max",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, mean, min, max",
     [
-        (None, "%", "%", "%", 13.050847, -10, 30),
-        ("battery", "%", "%", "%", 13.050847, -10, 30),
-        ("battery", None, None, None, 13.050847, -10, 30),
-        ("humidity", "%", "%", "%", 13.050847, -10, 30),
-        ("humidity", None, None, None, 13.050847, -10, 30),
-        ("pressure", "Pa", "Pa", "Pa", 13.050847, -10, 30),
-        ("pressure", "hPa", "hPa", "Pa", 13.050847, -10, 30),
-        ("pressure", "mbar", "mbar", "Pa", 13.050847, -10, 30),
-        ("pressure", "inHg", "inHg", "Pa", 13.050847, -10, 30),
-        ("pressure", "psi", "psi", "Pa", 13.050847, -10, 30),
-        ("temperature", "°C", "°C", "°C", 13.050847, -10, 30),
-        ("temperature", "°F", "°F", "°C", 13.050847, -10, 30),
+        (None, "%", "%", "%", None, 13.050847, -10, 30),
+        ("battery", "%", "%", "%", None, 13.050847, -10, 30),
+        ("battery", None, None, None, None, 13.050847, -10, 30),
+        ("humidity", "%", "%", "%", None, 13.050847, -10, 30),
+        ("humidity", None, None, None, None, 13.050847, -10, 30),
+        ("pressure", "Pa", "Pa", "Pa", "pressure", 13.050847, -10, 30),
+        ("pressure", "hPa", "hPa", "Pa", "pressure", 13.050847, -10, 30),
+        ("pressure", "mbar", "mbar", "Pa", "pressure", 13.050847, -10, 30),
+        ("pressure", "inHg", "inHg", "Pa", "pressure", 13.050847, -10, 30),
+        ("pressure", "psi", "psi", "Pa", "pressure", 13.050847, -10, 30),
+        ("temperature", "°C", "°C", "°C", "temperature", 13.050847, -10, 30),
+        ("temperature", "°F", "°F", "°C", "temperature", 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics(
@@ -99,6 +99,7 @@ def test_compile_hourly_statistics(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     mean,
     min,
     max,
@@ -129,6 +130,7 @@ def test_compile_hourly_statistics(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -151,13 +153,19 @@ def test_compile_hourly_statistics(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class",
     [
-        (None, "%", "%", "%"),
+        (None, "%", "%", "%", None),
     ],
 )
 def test_compile_hourly_statistics_purged_state_changes(
-    hass_recorder, caplog, device_class, state_unit, display_unit, statistics_unit
+    hass_recorder,
+    caplog,
+    device_class,
+    state_unit,
+    display_unit,
+    statistics_unit,
+    unit_class,
 ):
     """Test compiling hourly statistics."""
     zero = dt_util.utcnow()
@@ -197,6 +205,7 @@ def test_compile_hourly_statistics_purged_state_changes(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -266,6 +275,7 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "°C",
+            "unit_class": "temperature",
         },
         {
             "statistic_id": "sensor.test6",
@@ -275,6 +285,7 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "°C",
+            "unit_class": "temperature",
         },
         {
             "statistic_id": "sensor.test7",
@@ -284,6 +295,7 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "°C",
+            "unit_class": "temperature",
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -333,20 +345,20 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
 
 @pytest.mark.parametrize("state_class", ["total"])
 @pytest.mark.parametrize(
-    "units,device_class,state_unit,display_unit,statistics_unit,factor",
+    "units, device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
     [
-        (IMPERIAL_SYSTEM, "energy", "kWh", "kWh", "kWh", 1),
-        (IMPERIAL_SYSTEM, "energy", "Wh", "kWh", "kWh", 1 / 1000),
-        (IMPERIAL_SYSTEM, "monetary", "EUR", "EUR", "EUR", 1),
-        (IMPERIAL_SYSTEM, "monetary", "SEK", "SEK", "SEK", 1),
-        (IMPERIAL_SYSTEM, "gas", "m³", "ft³", "m³", 35.314666711),
-        (IMPERIAL_SYSTEM, "gas", "ft³", "ft³", "m³", 1),
-        (METRIC_SYSTEM, "energy", "kWh", "kWh", "kWh", 1),
-        (METRIC_SYSTEM, "energy", "Wh", "kWh", "kWh", 1 / 1000),
-        (METRIC_SYSTEM, "monetary", "EUR", "EUR", "EUR", 1),
-        (METRIC_SYSTEM, "monetary", "SEK", "SEK", "SEK", 1),
-        (METRIC_SYSTEM, "gas", "m³", "m³", "m³", 1),
-        (METRIC_SYSTEM, "gas", "ft³", "m³", "m³", 0.0283168466),
+        (IMPERIAL_SYSTEM, "energy", "kWh", "kWh", "kWh", "energy", 1),
+        (IMPERIAL_SYSTEM, "energy", "Wh", "Wh", "kWh", "energy", 1),
+        (IMPERIAL_SYSTEM, "monetary", "EUR", "EUR", "EUR", None, 1),
+        (IMPERIAL_SYSTEM, "monetary", "SEK", "SEK", "SEK", None, 1),
+        (IMPERIAL_SYSTEM, "gas", "m³", "m³", "m³", "volume", 1),
+        (IMPERIAL_SYSTEM, "gas", "ft³", "ft³", "m³", "volume", 1),
+        (METRIC_SYSTEM, "energy", "kWh", "kWh", "kWh", "energy", 1),
+        (METRIC_SYSTEM, "energy", "Wh", "Wh", "kWh", "energy", 1),
+        (METRIC_SYSTEM, "monetary", "EUR", "EUR", "EUR", None, 1),
+        (METRIC_SYSTEM, "monetary", "SEK", "SEK", "SEK", None, 1),
+        (METRIC_SYSTEM, "gas", "m³", "m³", "m³", "volume", 1),
+        (METRIC_SYSTEM, "gas", "ft³", "ft³", "m³", "volume", 1),
     ],
 )
 async def test_compile_hourly_sum_statistics_amount(
@@ -360,6 +372,7 @@ async def test_compile_hourly_sum_statistics_amount(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     factor,
 ):
     """Test compiling hourly statistics."""
@@ -405,6 +418,7 @@ async def test_compile_hourly_sum_statistics_amount(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
     stats = statistics_during_period(hass, period0, period="5minute")
@@ -478,6 +492,7 @@ async def test_compile_hourly_sum_statistics_amount(
             "statistic_id": "sensor.test1",
             "start_time": period1.isoformat(),
             "adjustment": 100.0,
+            "display_unit": display_unit,
         }
     )
     response = await client.receive_json()
@@ -497,6 +512,7 @@ async def test_compile_hourly_sum_statistics_amount(
             "statistic_id": "sensor.test1",
             "start_time": period2.isoformat(),
             "adjustment": -400.0,
+            "display_unit": display_unit,
         }
     )
     response = await client.receive_json()
@@ -511,14 +527,14 @@ async def test_compile_hourly_sum_statistics_amount(
 
 @pytest.mark.parametrize("state_class", ["total"])
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,factor",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
     [
-        ("energy", "kWh", "kWh", "kWh", 1),
-        ("energy", "Wh", "kWh", "kWh", 1 / 1000),
-        ("monetary", "EUR", "EUR", "EUR", 1),
-        ("monetary", "SEK", "SEK", "SEK", 1),
-        ("gas", "m³", "m³", "m³", 1),
-        ("gas", "ft³", "m³", "m³", 0.0283168466),
+        ("energy", "kWh", "kWh", "kWh", "energy", 1),
+        ("energy", "Wh", "Wh", "kWh", "energy", 1),
+        ("monetary", "EUR", "EUR", "EUR", None, 1),
+        ("monetary", "SEK", "SEK", "SEK", None, 1),
+        ("gas", "m³", "m³", "m³", "volume", 1),
+        ("gas", "ft³", "ft³", "m³", "volume", 1),
     ],
 )
 def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
@@ -529,6 +545,7 @@ def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     factor,
 ):
     """Test compiling hourly statistics."""
@@ -594,6 +611,7 @@ def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -630,9 +648,9 @@ def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
 
 @pytest.mark.parametrize("state_class", ["total"])
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,factor",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
     [
-        ("energy", "kWh", "kWh", "kWh", 1),
+        ("energy", "kWh", "kWh", "kWh", "energy", 1),
     ],
 )
 def test_compile_hourly_sum_statistics_amount_invalid_last_reset(
@@ -643,6 +661,7 @@ def test_compile_hourly_sum_statistics_amount_invalid_last_reset(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     factor,
 ):
     """Test compiling hourly statistics."""
@@ -693,6 +712,7 @@ def test_compile_hourly_sum_statistics_amount_invalid_last_reset(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -717,9 +737,9 @@ def test_compile_hourly_sum_statistics_amount_invalid_last_reset(
 
 @pytest.mark.parametrize("state_class", ["total"])
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,factor",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
     [
-        ("energy", "kWh", "kWh", "kWh", 1),
+        ("energy", "kWh", "kWh", "kWh", "energy", 1),
     ],
 )
 def test_compile_hourly_sum_statistics_nan_inf_state(
@@ -730,6 +750,7 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     factor,
 ):
     """Test compiling hourly statistics with nan and inf states."""
@@ -776,6 +797,7 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -819,9 +841,9 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
 )
 @pytest.mark.parametrize("state_class", ["total_increasing"])
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,factor",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
     [
-        ("energy", "kWh", "kWh", "kWh", 1),
+        ("energy", "kWh", "kWh", "kWh", "energy", 1),
     ],
 )
 def test_compile_hourly_sum_statistics_negative_state(
@@ -835,6 +857,7 @@ def test_compile_hourly_sum_statistics_negative_state(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     factor,
 ):
     """Test compiling hourly statistics with negative states."""
@@ -889,6 +912,7 @@ def test_compile_hourly_sum_statistics_negative_state(
         "source": "recorder",
         "statistic_id": entity_id,
         "statistics_unit_of_measurement": statistics_unit,
+        "unit_class": unit_class,
     } in statistic_ids
     stats = statistics_during_period(hass, zero, period="5minute")
     assert stats[entity_id] == [
@@ -916,14 +940,14 @@ def test_compile_hourly_sum_statistics_negative_state(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,factor",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
     [
-        ("energy", "kWh", "kWh", "kWh", 1),
-        ("energy", "Wh", "kWh", "kWh", 1 / 1000),
-        ("monetary", "EUR", "EUR", "EUR", 1),
-        ("monetary", "SEK", "SEK", "SEK", 1),
-        ("gas", "m³", "m³", "m³", 1),
-        ("gas", "ft³", "m³", "m³", 0.0283168466),
+        ("energy", "kWh", "kWh", "kWh", "energy", 1),
+        ("energy", "Wh", "Wh", "kWh", "energy", 1),
+        ("monetary", "EUR", "EUR", "EUR", None, 1),
+        ("monetary", "SEK", "SEK", "SEK", None, 1),
+        ("gas", "m³", "m³", "m³", "volume", 1),
+        ("gas", "ft³", "ft³", "m³", "volume", 1),
     ],
 )
 def test_compile_hourly_sum_statistics_total_no_reset(
@@ -933,6 +957,7 @@ def test_compile_hourly_sum_statistics_total_no_reset(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     factor,
 ):
     """Test compiling hourly statistics."""
@@ -975,6 +1000,7 @@ def test_compile_hourly_sum_statistics_total_no_reset(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
     stats = statistics_during_period(hass, period0, period="5minute")
@@ -1019,12 +1045,12 @@ def test_compile_hourly_sum_statistics_total_no_reset(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,factor",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
     [
-        ("energy", "kWh", "kWh", "kWh", 1),
-        ("energy", "Wh", "kWh", "kWh", 1 / 1000),
-        ("gas", "m³", "m³", "m³", 1),
-        ("gas", "ft³", "m³", "m³", 0.0283168466),
+        ("energy", "kWh", "kWh", "kWh", "energy", 1),
+        ("energy", "Wh", "Wh", "kWh", "energy", 1),
+        ("gas", "m³", "m³", "m³", "volume", 1),
+        ("gas", "ft³", "ft³", "m³", "volume", 1),
     ],
 )
 def test_compile_hourly_sum_statistics_total_increasing(
@@ -1034,6 +1060,7 @@ def test_compile_hourly_sum_statistics_total_increasing(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     factor,
 ):
     """Test compiling hourly statistics."""
@@ -1076,6 +1103,7 @@ def test_compile_hourly_sum_statistics_total_increasing(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
     stats = statistics_during_period(hass, period0, period="5minute")
@@ -1123,8 +1151,8 @@ def test_compile_hourly_sum_statistics_total_increasing(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,factor",
-    [("energy", "kWh", "kWh", "kWh", 1)],
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
+    [("energy", "kWh", "kWh", "kWh", "energy", 1)],
 )
 def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     hass_recorder,
@@ -1133,6 +1161,7 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     factor,
 ):
     """Test small dips in sensor readings do not trigger a reset."""
@@ -1188,6 +1217,7 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         }
     ]
     stats = statistics_during_period(hass, period0, period="5minute")
@@ -1282,6 +1312,7 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "kWh",
+            "unit_class": "energy",
         }
     ]
     stats = statistics_during_period(hass, period0, period="5minute")
@@ -1374,6 +1405,7 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "kWh",
+            "unit_class": "energy",
         },
         {
             "statistic_id": "sensor.test2",
@@ -1383,15 +1415,17 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "kWh",
+            "unit_class": "energy",
         },
         {
             "statistic_id": "sensor.test3",
-            "display_unit_of_measurement": "kWh",
+            "display_unit_of_measurement": "Wh",
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "kWh",
+            "unit_class": "energy",
         },
     ]
     stats = statistics_during_period(hass, period0, period="5minute")
@@ -1475,8 +1509,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "mean": None,
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(period0),
-                "state": approx(5.0 / 1000),
-                "sum": approx(5.0 / 1000),
+                "state": approx(5.0),
+                "sum": approx(5.0),
             },
             {
                 "statistic_id": "sensor.test3",
@@ -1486,8 +1520,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "mean": None,
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
-                "state": approx(50.0 / 1000),
-                "sum": approx(60.0 / 1000),
+                "state": approx(50.0),
+                "sum": approx(60.0),
             },
             {
                 "statistic_id": "sensor.test3",
@@ -1497,8 +1531,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "mean": None,
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
-                "state": approx(90.0 / 1000),
-                "sum": approx(100.0 / 1000),
+                "state": approx(90.0),
+                "sum": approx(100.0),
             },
         ],
     }
@@ -1666,31 +1700,31 @@ def test_compile_hourly_statistics_fails(hass_recorder, caplog):
 
 
 @pytest.mark.parametrize(
-    "state_class,device_class,state_unit,display_unit,statistics_unit,statistic_type",
+    "state_class, device_class, state_unit, display_unit, statistics_unit, unit_class, statistic_type",
     [
-        ("measurement", "battery", "%", "%", "%", "mean"),
-        ("measurement", "battery", None, None, None, "mean"),
-        ("total", "energy", "Wh", "kWh", "kWh", "sum"),
-        ("total", "energy", "kWh", "kWh", "kWh", "sum"),
-        ("measurement", "energy", "Wh", "kWh", "kWh", "mean"),
-        ("measurement", "energy", "kWh", "kWh", "kWh", "mean"),
-        ("measurement", "humidity", "%", "%", "%", "mean"),
-        ("measurement", "humidity", None, None, None, "mean"),
-        ("total", "monetary", "USD", "USD", "USD", "sum"),
-        ("total", "monetary", "None", "None", "None", "sum"),
-        ("total", "gas", "m³", "m³", "m³", "sum"),
-        ("total", "gas", "ft³", "m³", "m³", "sum"),
-        ("measurement", "monetary", "USD", "USD", "USD", "mean"),
-        ("measurement", "monetary", "None", "None", "None", "mean"),
-        ("measurement", "gas", "m³", "m³", "m³", "mean"),
-        ("measurement", "gas", "ft³", "m³", "m³", "mean"),
-        ("measurement", "pressure", "Pa", "Pa", "Pa", "mean"),
-        ("measurement", "pressure", "hPa", "hPa", "Pa", "mean"),
-        ("measurement", "pressure", "mbar", "mbar", "Pa", "mean"),
-        ("measurement", "pressure", "inHg", "inHg", "Pa", "mean"),
-        ("measurement", "pressure", "psi", "psi", "Pa", "mean"),
-        ("measurement", "temperature", "°C", "°C", "°C", "mean"),
-        ("measurement", "temperature", "°F", "°F", "°C", "mean"),
+        ("measurement", "battery", "%", "%", "%", None, "mean"),
+        ("measurement", "battery", None, None, None, None, "mean"),
+        ("total", "energy", "Wh", "Wh", "kWh", "energy", "sum"),
+        ("total", "energy", "kWh", "kWh", "kWh", "energy", "sum"),
+        ("measurement", "energy", "Wh", "Wh", "kWh", "energy", "mean"),
+        ("measurement", "energy", "kWh", "kWh", "kWh", "energy", "mean"),
+        ("measurement", "humidity", "%", "%", "%", None, "mean"),
+        ("measurement", "humidity", None, None, None, None, "mean"),
+        ("total", "monetary", "USD", "USD", "USD", None, "sum"),
+        ("total", "monetary", "None", "None", "None", None, "sum"),
+        ("total", "gas", "m³", "m³", "m³", "volume", "sum"),
+        ("total", "gas", "ft³", "ft³", "m³", "volume", "sum"),
+        ("measurement", "monetary", "USD", "USD", "USD", None, "mean"),
+        ("measurement", "monetary", "None", "None", "None", None, "mean"),
+        ("measurement", "gas", "m³", "m³", "m³", "volume", "mean"),
+        ("measurement", "gas", "ft³", "ft³", "m³", "volume", "mean"),
+        ("measurement", "pressure", "Pa", "Pa", "Pa", "pressure", "mean"),
+        ("measurement", "pressure", "hPa", "hPa", "Pa", "pressure", "mean"),
+        ("measurement", "pressure", "mbar", "mbar", "Pa", "pressure", "mean"),
+        ("measurement", "pressure", "inHg", "inHg", "Pa", "pressure", "mean"),
+        ("measurement", "pressure", "psi", "psi", "Pa", "pressure", "mean"),
+        ("measurement", "temperature", "°C", "°C", "°C", "temperature", "mean"),
+        ("measurement", "temperature", "°F", "°F", "°C", "temperature", "mean"),
     ],
 )
 def test_list_statistic_ids(
@@ -1701,6 +1735,7 @@ def test_list_statistic_ids(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     statistic_type,
 ):
     """Test listing future statistic ids."""
@@ -1724,6 +1759,7 @@ def test_list_statistic_ids(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         },
     ]
     for stat_type in ["mean", "sum", "dogs"]:
@@ -1738,6 +1774,7 @@ def test_list_statistic_ids(
                     "name": None,
                     "source": "recorder",
                     "statistics_unit_of_measurement": statistics_unit,
+                    "unit_class": unit_class,
                 },
             ]
         else:
@@ -1772,12 +1809,12 @@ def test_list_statistic_ids_unsupported(hass_recorder, caplog, _attributes):
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,mean,min,max",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, mean, min, max",
     [
-        (None, None, None, None, 13.050847, -10, 30),
-        (None, "%", "%", "%", 13.050847, -10, 30),
-        ("battery", "%", "%", "%", 13.050847, -10, 30),
-        ("battery", None, None, None, 13.050847, -10, 30),
+        (None, None, None, None, None, 13.050847, -10, 30),
+        (None, "%", "%", "%", None, 13.050847, -10, 30),
+        ("battery", "%", "%", "%", None, 13.050847, -10, 30),
+        ("battery", None, None, None, None, 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_units_1(
@@ -1787,6 +1824,7 @@ def test_compile_hourly_statistics_changing_units_1(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     mean,
     min,
     max,
@@ -1827,6 +1865,7 @@ def test_compile_hourly_statistics_changing_units_1(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -1862,6 +1901,7 @@ def test_compile_hourly_statistics_changing_units_1(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -1884,12 +1924,12 @@ def test_compile_hourly_statistics_changing_units_1(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,mean,min,max",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, mean, min, max",
     [
-        (None, None, None, None, 13.050847, -10, 30),
-        (None, "%", "%", "%", 13.050847, -10, 30),
-        ("battery", "%", "%", "%", 13.050847, -10, 30),
-        ("battery", None, None, None, 13.050847, -10, 30),
+        (None, None, None, None, None, 13.050847, -10, 30),
+        (None, "%", "%", "%", None, 13.050847, -10, 30),
+        ("battery", "%", "%", "%", None, 13.050847, -10, 30),
+        ("battery", None, None, None, None, 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_units_2(
@@ -1899,6 +1939,7 @@ def test_compile_hourly_statistics_changing_units_2(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     mean,
     min,
     max,
@@ -1936,6 +1977,7 @@ def test_compile_hourly_statistics_changing_units_2(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "cats",
+            "unit_class": unit_class,
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -1945,12 +1987,12 @@ def test_compile_hourly_statistics_changing_units_2(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,mean,min,max",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, mean, min, max",
     [
-        (None, None, None, None, 13.050847, -10, 30),
-        (None, "%", "%", "%", 13.050847, -10, 30),
-        ("battery", "%", "%", "%", 13.050847, -10, 30),
-        ("battery", None, None, None, 13.050847, -10, 30),
+        (None, None, None, None, None, 13.050847, -10, 30),
+        (None, "%", "%", "%", None, 13.050847, -10, 30),
+        ("battery", "%", "%", "%", None, 13.050847, -10, 30),
+        ("battery", None, None, None, None, 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_units_3(
@@ -1960,6 +2002,7 @@ def test_compile_hourly_statistics_changing_units_3(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     mean,
     min,
     max,
@@ -2000,6 +2043,7 @@ def test_compile_hourly_statistics_changing_units_3(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -2035,6 +2079,7 @@ def test_compile_hourly_statistics_changing_units_3(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistics_unit,
+            "unit_class": unit_class,
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -2057,13 +2102,21 @@ def test_compile_hourly_statistics_changing_units_3(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,statistic_unit,mean,min,max",
+    "device_class, state_unit, statistic_unit, unit_class, mean, min, max",
     [
-        ("power", "kW", "W", 13.050847, -10, 30),
+        ("power", "kW", "W", None, 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_device_class_1(
-    hass_recorder, caplog, device_class, state_unit, statistic_unit, mean, min, max
+    hass_recorder,
+    caplog,
+    device_class,
+    state_unit,
+    statistic_unit,
+    unit_class,
+    mean,
+    min,
+    max,
 ):
     """Test compiling hourly statistics where device class changes from one hour to the next."""
     zero = dt_util.utcnow()
@@ -2091,6 +2144,7 @@ def test_compile_hourly_statistics_changing_device_class_1(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": state_unit,
+            "unit_class": unit_class,
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -2140,6 +2194,7 @@ def test_compile_hourly_statistics_changing_device_class_1(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": state_unit,
+            "unit_class": unit_class,
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -2162,9 +2217,9 @@ def test_compile_hourly_statistics_changing_device_class_1(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistic_unit,mean,min,max",
+    "device_class, state_unit, display_unit, statistic_unit, unit_class, mean, min, max",
     [
-        ("power", "kW", "kW", "W", 13.050847, -10, 30),
+        ("power", "kW", "kW", "W", "power", 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_device_class_2(
@@ -2174,6 +2229,7 @@ def test_compile_hourly_statistics_changing_device_class_2(
     state_unit,
     display_unit,
     statistic_unit,
+    unit_class,
     mean,
     min,
     max,
@@ -2205,6 +2261,7 @@ def test_compile_hourly_statistics_changing_device_class_2(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistic_unit,
+            "unit_class": unit_class,
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -2254,6 +2311,7 @@ def test_compile_hourly_statistics_changing_device_class_2(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": statistic_unit,
+            "unit_class": unit_class,
         },
     ]
     stats = statistics_during_period(hass, zero, period="5minute")
@@ -2276,9 +2334,9 @@ def test_compile_hourly_statistics_changing_device_class_2(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,display_unit,statistics_unit,mean,min,max",
+    "device_class, state_unit, display_unit, statistics_unit, unit_class, mean, min, max",
     [
-        (None, None, None, None, 13.050847, -10, 30),
+        (None, None, None, None, None, 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_statistics(
@@ -2288,6 +2346,7 @@ def test_compile_hourly_statistics_changing_statistics(
     state_unit,
     display_unit,
     statistics_unit,
+    unit_class,
     mean,
     min,
     max,
@@ -2322,6 +2381,7 @@ def test_compile_hourly_statistics_changing_statistics(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": None,
+            "unit_class": None,
         },
     ]
     metadata = get_metadata(hass, statistic_ids=("sensor.test1",))
@@ -2358,6 +2418,7 @@ def test_compile_hourly_statistics_changing_statistics(
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": None,
+            "unit_class": None,
         },
     ]
     metadata = get_metadata(hass, statistic_ids=("sensor.test1",))
@@ -2552,6 +2613,7 @@ def test_compile_statistics_hourly_daily_monthly_summary(hass_recorder, caplog):
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "%",
+            "unit_class": None,
         },
         {
             "statistic_id": "sensor.test2",
@@ -2561,6 +2623,7 @@ def test_compile_statistics_hourly_daily_monthly_summary(hass_recorder, caplog):
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "%",
+            "unit_class": None,
         },
         {
             "statistic_id": "sensor.test3",
@@ -2570,6 +2633,7 @@ def test_compile_statistics_hourly_daily_monthly_summary(hass_recorder, caplog):
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "%",
+            "unit_class": None,
         },
         {
             "statistic_id": "sensor.test4",
@@ -2579,6 +2643,7 @@ def test_compile_statistics_hourly_daily_monthly_summary(hass_recorder, caplog):
             "name": None,
             "source": "recorder",
             "statistics_unit_of_measurement": "EUR",
+            "unit_class": None,
         },
     ]
 
@@ -2588,7 +2653,7 @@ def test_compile_statistics_hourly_daily_monthly_summary(hass_recorder, caplog):
     for i in range(13, 24):
         expected_sums["sensor.test4"][i] += sum_adjustment
     instance.async_adjust_statistics(
-        "sensor.test4", sum_adjustement_start, sum_adjustment
+        "sensor.test4", sum_adjustement_start, sum_adjustment, "EUR"
     )
     wait_recording_done(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow selecting display unit when fetching statistics, and drop the special handling of energy and gas statistics
Also, it is now mandatory to specify the unit when adjusting energy or gas statistics

Frontend PR: https://github.com/home-assistant/frontend/pull/13779

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
