### PR TITLE
Add extra_rooms option to mqtt_rooms

### DIFF
--- a/homeassistant/components/mqtt_room/sensor.py
+++ b/homeassistant/components/mqtt_room/sensor.py
@@ -1,9 +1,10 @@
 """Support for MQTT room presence detection."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import json
 import logging
+from typing import TypedDict
 
 import voluptuous as vol
 
@@ -28,13 +29,17 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_DISTANCE = "distance"
 ATTR_ROOM = "room"
+ATTR_UPDATED = "updated"
+ATTR_EXTRA_ROOMS = "extra_rooms"
 
 CONF_AWAY_TIMEOUT = "away_timeout"
+CONF_EXTRA_ROOMS = "extra_rooms"
 
 DEFAULT_AWAY_TIMEOUT = 0
 DEFAULT_NAME = "Room Sensor"
 DEFAULT_TIMEOUT = 5
 DEFAULT_TOPIC = "room_presence"
+DEFAULT_EXTRA_ROOMS = 0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -42,6 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
         vol.Optional(CONF_AWAY_TIMEOUT, default=DEFAULT_AWAY_TIMEOUT): cv.positive_int,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_EXTRA_ROOMS, default=DEFAULT_EXTRA_ROOMS): cv.positive_int,
     }
 ).extend(mqtt.config.MQTT_RO_SCHEMA.schema)
 
@@ -74,17 +80,27 @@ async def async_setup_platform(
                 config.get(CONF_DEVICE_ID),
                 config.get(CONF_TIMEOUT),
                 config.get(CONF_AWAY_TIMEOUT),
+                config.get(CONF_EXTRA_ROOMS),
             )
         ]
     )
 
 
+class MQTTRoomState(TypedDict):
+    """Hold the state of a room."""
+
+    room: str
+    distance: float
+    updated: datetime
+
+
 class MQTTRoomSensor(SensorEntity):
     """Representation of a room sensor that is updated via MQTT."""
 
-    def __init__(self, name, state_topic, device_id, timeout, consider_home):
+    def __init__(
+        self, name, state_topic, device_id, timeout, consider_home, extra_rooms
+    ):
         """Initialize the sensor."""
-        self._state = STATE_NOT_HOME
         self._name = name
         self._state_topic = f"{state_topic}/+"
         self._device_id = slugify(device_id).upper()
@@ -92,18 +108,23 @@ class MQTTRoomSensor(SensorEntity):
         self._consider_home = (
             timedelta(seconds=consider_home) if consider_home else None
         )
-        self._distance = None
-        self._updated = None
+        self._room_states: list[MQTTRoomState] = [
+            MQTTRoomState(room=STATE_NOT_HOME, distance=None, updated=None),
+        ]
+
+        for _ in range(extra_rooms):
+            self._room_states.append(
+                MQTTRoomState(room=STATE_NOT_HOME, distance=None, updated=None)
+            )
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""
 
         @callback
-        def update_state(device_id, room, distance):
+        def update_state(record, device_id, room, distance):
             """Update the sensor state."""
-            self._state = room
-            self._distance = distance
-            self._updated = dt.utcnow()
+
+            record.update(room=room, distance=distance, updated=dt.utcnow())
 
             self.async_write_ha_state()
 
@@ -118,48 +139,59 @@ class MQTTRoomSensor(SensorEntity):
 
             device = _parse_update_data(msg.topic, data)
             if device.get(CONF_DEVICE_ID) == self._device_id:
-                if self._distance is None or self._updated is None:
-                    update_state(**device)
-                else:
+                for rec in self._room_states:
+                    if rec["distance"] is None or rec["updated"] is None:
+                        update_state(rec, **device)
+                        break
+
                     # update if:
                     # device is in the same room OR
                     # device is closer to another room OR
                     # last update from other room was too long ago
-                    timediff = dt.utcnow() - self._updated
+                    timediff = dt.utcnow() - rec["updated"]
                     if (
-                        device.get(ATTR_ROOM) == self._state
-                        or device.get(ATTR_DISTANCE) < self._distance
+                        device.get(ATTR_ROOM) == rec["room"]
+                        or device.get(ATTR_DISTANCE) < rec["distance"]
                         or timediff.total_seconds() >= self._timeout
                     ):
-                        update_state(**device)
+                        update_state(rec, **device)
+                        break
 
-        return await mqtt.async_subscribe(
-            self.hass, self._state_topic, message_received, 1
-        )
+        await mqtt.async_subscribe(self.hass, self._state_topic, message_received, 1)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        return {ATTR_DISTANCE: self._distance}
+        primary_room_state = self._room_states[0]
+        attributes = {
+            ATTR_DISTANCE: primary_room_state["distance"],
+            ATTR_EXTRA_ROOMS: {},
+        }
+        for rec in self._room_states[1:]:
+            attributes[ATTR_EXTRA_ROOMS][rec["room"]] = rec["distance"]
+        return attributes
 
     @property
-    def native_value(self):
+    def native_value(self) -> str:
         """Return the current room of the entity."""
-        return self._state
+        primary_room_state = self._room_states[0]
+        return primary_room_state["room"]
 
     def update(self) -> None:
         """Update the state for absent devices."""
+        primary_room_state = self._room_states[0]
+        updated = primary_room_state["updated"]
         if (
-            self._updated
+            updated
             and self._consider_home
-            and dt.utcnow() - self._updated > self._consider_home
+            and dt.utcnow() - updated > self._consider_home
         ):
-            self._state = STATE_NOT_HOME
+            primary_room_state["room"] = STATE_NOT_HOME
 
 
 def _parse_update_data(topic, data):


### PR DESCRIPTION
The extra_rooms option allows a user to specify any number of additional rooms/base stations to track as sensor attributes for their beacon. This enables more sophisticated tracking solutions within Home Assistant. e.g. some form of triangulation based on distance to other base stations.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds an (optional) extra_rooms configuration and sensor attribute to mqtt_room. By setting extra_rooms to any non-zero positive integer, one can have it's beacon track the distance to more then just the closest room / base station, but to the next N closest, too. With that additional information it's possible to create significantly more sophisticated tracking within Home Assistant. For example, imagine the following template sensor:

```
template:
  - sensor:
      - name: "My Improved Beacon"
        state: >
           {% set state = states('sensor.my_original_beacon') %}
           {% set distance_threshold = 4 %}
           {% if state == 'ambigious_base_station' and state_attr('sensor.my_original_beacon').extra_rooms['room_on_other_side']|float(0) > distance_threshold %}
               {% set state = 'room_without_actual_base_station' %}
           {% endif %}
           {{ state }}
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24215

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

I've tried setting up the Home Assistant development environment (as described here: https://developers.home-assistant.io/docs/development_environment/), but wasn't able to get it to work properly. The code changes were tested in my local production installation, but I haven't run any tests or formatting with black or anything like that. 

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] 
Not yet, will add if the PR is generally ok.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
