### PR TITLE
Add a helpful message to the config_entries.OperationNotAllowed exception

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1039,7 +1039,10 @@ class ConfigEntries:
             raise UnknownEntry
 
         if entry.state is not ConfigEntryState.NOT_LOADED:
-            raise OperationNotAllowed
+            raise OperationNotAllowed(
+                f"The config entry {entry.title} ({entry.domain}) with entry_id {entry.entry_id}"
+                f" cannot be setup because is already loaded in the {entry.state} state"
+            )
 
         # Setup Component if not set up yet
         if entry.domain in self.hass.config.components:
@@ -1061,7 +1064,10 @@ class ConfigEntries:
             raise UnknownEntry
 
         if not entry.state.recoverable:
-            raise OperationNotAllowed
+            raise OperationNotAllowed(
+                f"The config entry {entry.title} ({entry.domain}) with entry_id "
+                f"{entry.entry_id} cannot be unloaded because it is not in a recoverable state ({entry.state})"
+            )
 
         return await entry.async_unload(self.hass)
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1141,7 +1141,7 @@ async def test_entry_setup_invalid_state(hass, manager, state):
         MockModule("comp", async_setup=mock_setup, async_setup_entry=mock_setup_entry),
     )
 
-    with pytest.raises(config_entries.OperationNotAllowed):
+    with pytest.raises(config_entries.OperationNotAllowed, match=str(state)):
         assert await manager.async_setup(entry.entry_id)
 
     assert len(mock_setup.mock_calls) == 0
@@ -1201,7 +1201,7 @@ async def test_entry_unload_invalid_state(hass, manager, state):
 
     mock_integration(hass, MockModule("comp", async_unload_entry=async_unload_entry))
 
-    with pytest.raises(config_entries.OperationNotAllowed):
+    with pytest.raises(config_entries.OperationNotAllowed, match=str(state)):
         assert await manager.async_unload(entry.entry_id)
 
     assert len(async_unload_entry.mock_calls) == 0
@@ -1296,7 +1296,7 @@ async def test_entry_reload_error(hass, manager, state):
         ),
     )
 
-    with pytest.raises(config_entries.OperationNotAllowed):
+    with pytest.raises(config_entries.OperationNotAllowed, match=str(state)):
         assert await manager.async_reload(entry.entry_id)
 
     assert len(async_unload_entry.mock_calls) == 0
@@ -1370,7 +1370,10 @@ async def test_entry_disable_without_reload_support(hass, manager):
     assert entry.state is config_entries.ConfigEntryState.FAILED_UNLOAD
 
     # Enable
-    with pytest.raises(config_entries.OperationNotAllowed):
+    with pytest.raises(
+        config_entries.OperationNotAllowed,
+        match=str(config_entries.ConfigEntryState.FAILED_UNLOAD),
+    ):
         await manager.async_set_disabled_by(entry.entry_id, None)
     assert len(async_setup.mock_calls) == 0
     assert len(async_setup_entry.mock_calls) == 0
@@ -3270,7 +3273,10 @@ async def test_disallow_entry_reload_with_setup_in_progresss(hass, manager):
     )
     entry.add_to_hass(hass)
 
-    with pytest.raises(config_entries.OperationNotAllowed):
+    with pytest.raises(
+        config_entries.OperationNotAllowed,
+        match=str(config_entries.ConfigEntryState.SETUP_IN_PROGRESS),
+    ):
         assert await manager.async_reload(entry.entry_id)
     assert entry.state is config_entries.ConfigEntryState.SETUP_IN_PROGRESS
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We only expect this exception to be raised as a result of an implementation problem. When it is raised during production it is currently hard to trace down why its happening

See #75835



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
