### PR TITLE
Bump melnor-bluetooth to v0.0.20

### DIFF
--- a/homeassistant/components/melnor/manifest.json
+++ b/homeassistant/components/melnor/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://www.home-assistant.io/integrations/melnor",
   "iot_class": "local_polling",
   "name": "Melnor Bluetooth",
-  "requirements": ["melnor-bluetooth==0.0.15"]
+  "requirements": ["melnor-bluetooth==0.0.19"]
 }

--- a/homeassistant/components/melnor/manifest.json
+++ b/homeassistant/components/melnor/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://www.home-assistant.io/integrations/melnor",
   "iot_class": "local_polling",
   "name": "Melnor Bluetooth",
-  "requirements": ["melnor-bluetooth==0.0.19"]
+  "requirements": ["melnor-bluetooth==0.0.20"]
 }

--- a/homeassistant/components/melnor/sensor.py
+++ b/homeassistant/components/melnor/sensor.py
@@ -38,38 +38,39 @@ class MelnorSensorEntityDescription(
     """Describes Melnor sensor entity."""
 
 
+sensors = [
+    MelnorSensorEntityDescription(
+        device_class=SensorDeviceClass.BATTERY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        key="battery",
+        name="Battery",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        state_fn=lambda device: device.battery_level,
+    ),
+    MelnorSensorEntityDescription(
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        key="rssi",
+        name="RSSI",
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        state_fn=lambda device: device.rssi,
+    ),
+]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_devices: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
 
     coordinator: MelnorDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    sensors: list[MelnorSensorEntityDescription] = [
-        MelnorSensorEntityDescription(
-            device_class=SensorDeviceClass.BATTERY,
-            entity_category=EntityCategory.DIAGNOSTIC,
-            key="battery",
-            name="Battery",
-            native_unit_of_measurement=PERCENTAGE,
-            state_class=SensorStateClass.MEASUREMENT,
-            state_fn=lambda device: device.battery_level,
-        ),
-        MelnorSensorEntityDescription(
-            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-            entity_category=EntityCategory.DIAGNOSTIC,
-            entity_registry_enabled_default=False,
-            key="rssi",
-            name="RSSI",
-            native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-            state_class=SensorStateClass.MEASUREMENT,
-            state_fn=lambda device: device.rssi,
-        ),
-    ]
-
-    async_add_devices(
+    async_add_entities(
         MelnorSensorEntity(
             coordinator,
             description,

--- a/homeassistant/components/melnor/switch.py
+++ b/homeassistant/components/melnor/switch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
 
@@ -21,16 +21,11 @@ from .const import DOMAIN
 from .models import MelnorDataUpdateCoordinator, MelnorZoneEntity
 
 
-def set_is_watering(valve: Valve, value: bool) -> None:
-    """Set the is_watering state of a valve."""
-    valve.is_watering = value
-
-
 @dataclass
 class MelnorSwitchEntityDescriptionMixin:
     """Mixin for required keys."""
 
-    on_off_fn: Callable[[Valve, bool], Any]
+    on_off_fn: Callable[[Valve, bool], Coroutine[Any, Any, None]]
     state_fn: Callable[[Valve], Any]
 
 
@@ -39,6 +34,18 @@ class MelnorSwitchEntityDescription(
     SwitchEntityDescription, MelnorSwitchEntityDescriptionMixin
 ):
     """Describes Melnor switch entity."""
+
+
+switches = [
+    MelnorSwitchEntityDescription(
+        device_class=SwitchDeviceClass.SWITCH,
+        icon="mdi:sprinkler",
+        key="manual",
+        name="Manual",
+        on_off_fn=lambda valve, bool: valve.set_is_watering(bool),
+        state_fn=lambda valve: valve.is_watering,
+    )
+]
 
 
 async def async_setup_entry(
@@ -56,20 +63,8 @@ async def async_setup_entry(
         valve = coordinator.data[f"zone{i}"]
         if valve is not None:
 
-            entities.append(
-                MelnorZoneSwitch(
-                    coordinator,
-                    valve,
-                    MelnorSwitchEntityDescription(
-                        device_class=SwitchDeviceClass.SWITCH,
-                        icon="mdi:sprinkler",
-                        key="manual",
-                        name="Manual",
-                        on_off_fn=set_is_watering,
-                        state_fn=lambda valve: valve.is_watering,
-                    ),
-                )
-            )
+            for description in switches:
+                entities.append(MelnorZoneSwitch(coordinator, valve, description))
 
     async_add_devices(entities)
 
@@ -98,12 +93,12 @@ class MelnorZoneSwitch(MelnorZoneEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        self.entity_description.on_off_fn(self._valve, True)
+        await self.entity_description.on_off_fn(self._valve, True)
         await self._device.push_state()
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        self.entity_description.on_off_fn(self._valve, False)
+        await self.entity_description.on_off_fn(self._valve, False)
         await self._device.push_state()
         self.async_write_ha_state()

--- a/homeassistant/components/melnor/switch.py
+++ b/homeassistant/components/melnor/switch.py
@@ -94,11 +94,9 @@ class MelnorZoneSwitch(MelnorZoneEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self.entity_description.on_off_fn(self._valve, True)
-        await self._device.push_state()
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.entity_description.on_off_fn(self._valve, False)
-        await self._device.push_state()
         self.async_write_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1046,7 +1046,7 @@ mcstatus==6.0.0
 meater-python==0.0.8
 
 # homeassistant.components.melnor
-melnor-bluetooth==0.0.15
+melnor-bluetooth==0.0.19
 
 # homeassistant.components.message_bird
 messagebird==1.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1046,7 +1046,7 @@ mcstatus==6.0.0
 meater-python==0.0.8
 
 # homeassistant.components.melnor
-melnor-bluetooth==0.0.19
+melnor-bluetooth==0.0.20
 
 # homeassistant.components.message_bird
 messagebird==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -748,7 +748,7 @@ mcstatus==6.0.0
 meater-python==0.0.8
 
 # homeassistant.components.melnor
-melnor-bluetooth==0.0.19
+melnor-bluetooth==0.0.20
 
 # homeassistant.components.meteo_france
 meteofrance-api==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -748,7 +748,7 @@ mcstatus==6.0.0
 meater-python==0.0.8
 
 # homeassistant.components.melnor
-melnor-bluetooth==0.0.15
+melnor-bluetooth==0.0.19
 
 # homeassistant.components.meteo_france
 meteofrance-api==1.0.2

--- a/tests/components/melnor/conftest.py
+++ b/tests/components/melnor/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
-from melnor_bluetooth.device import Device, Valve
+from melnor_bluetooth.device import Device
 
 from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
 from homeassistant.components.melnor.const import DOMAIN
@@ -52,6 +52,34 @@ FAKE_SERVICE_INFO_2 = BluetoothServiceInfoBleak(
 )
 
 
+class MockedValve:
+    """Mocked class for a Valve."""
+
+    _id: int
+    _is_watering: bool
+    _manual_watering_minutes: int
+
+    def __init__(self, identifier: int) -> None:
+        """Initialize a mocked valve."""
+        self._id = identifier
+        self._is_watering = False
+        self._manual_watering_minutes = 0
+
+    @property
+    def id(self) -> int:
+        """Return the valve id."""
+        return self._id
+
+    @property
+    def is_watering(self):
+        """Return true if the valve is currently watering."""
+        return self._is_watering
+
+    async def set_is_watering(self, is_watering: bool):
+        """Set the valve to manual watering."""
+        self._is_watering = is_watering
+
+
 def mock_config_entry(hass: HomeAssistant):
     """Return a mock config entry."""
 
@@ -83,10 +111,10 @@ def mock_melnor_device():
         device.name = "test_melnor"
         device.rssi = -50
 
-        device.zone1 = Valve(0, device)
-        device.zone2 = Valve(1, device)
-        device.zone3 = Valve(2, device)
-        device.zone4 = Valve(3, device)
+        device.zone1 = MockedValve(0)
+        device.zone2 = MockedValve(1)
+        device.zone3 = MockedValve(2)
+        device.zone4 = MockedValve(3)
 
         device.__getitem__.side_effect = lambda key: getattr(device, key)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
While working on additional features there was a code smell coming from the way I was setting attributes that were being pushed to the bluetooth device. In addition to that there was a race condition present where setting a device attribute _and then_ pushing that state to the device might push the old state if an update happened between those 2 operations.

As such the library now has bespoke async `set_SOME_PROP` methods that are wrapped using the same internal lock it was already using for connecting and reading device state. We're now guaranteed a serial order of read/write operations. No more code smell, no more race conditions. Win win.

I moved some entity descriptions around at the request of @MartinHjelmare on an older PR as well (I was touching them anyway)

After this lands I'll start landing the next big set of features for the integration.

https://github.com/vanstinator/melnor-bluetooth/compare/v0.0.16...v0.0.20


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
