### PR TITLE
Handle multiple files properly in zwave_js update entity

### DIFF
--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -231,7 +231,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         self._progress_unsub = self.node.on(
             "firmware update progress", self._update_progress
         )
-        self._finished_unsub = self.node.once(
+        self._finished_unsub = self.node.on(
             "firmware update finished", self._update_finished
         )
 

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -138,7 +138,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
 
     @callback
     def _unsub_firmware_events_and_reset_progress(
-        self, write_state: bool = False
+        self, write_state: bool = True
     ) -> None:
         """Unsubscribe from firmware events and reset update install progress."""
         if self._progress_unsub:
@@ -224,7 +224,9 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         """Install an update."""
         firmware = self._latest_version_firmware
         assert firmware
-        self._unsub_firmware_events_and_reset_progress(True)
+        self._unsub_firmware_events_and_reset_progress(False)
+        self._attr_in_progress = True
+        self.async_write_ha_state()
 
         self._progress_unsub = self.node.on(
             "firmware update progress", self._update_progress
@@ -319,4 +321,4 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             self._poll_unsub()
             self._poll_unsub = None
 
-        self._unsub_firmware_events_and_reset_progress()
+        self._unsub_firmware_events_and_reset_progress(False)

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -244,6 +244,8 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
 
             # We need to block until we receive the `firmware update finished` event
             await self._finished_event.wait()
+            # Clear the event so that a second firmware update blocks again
+            self._finished_event.clear()
             assert self._finished_status is not None
 
             # If status is not OK, we should throw an error to let the user know
@@ -262,8 +264,12 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             self._attr_in_progress = floor(
                 100 * self._num_files_installed / len(firmware.files)
             )
+
+            # Clear the status so we can get a new one
+            self._finished_status = None
             self.async_write_ha_state()
 
+        # If we get here, all files were installed successfully
         self._attr_installed_version = self._attr_latest_version = firmware.version
         self._latest_version_firmware = None
         self._unsub_firmware_events_and_reset_progress()

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -7,7 +7,7 @@ from zwave_js_server.event import Event
 from zwave_js_server.exceptions import FailedZWaveCommand
 from zwave_js_server.model.firmware import FirmwareUpdateStatus
 
-from homeassistant.components.update.const import (
+from homeassistant.components.update import (
     ATTR_AUTO_UPDATE,
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
@@ -49,6 +49,19 @@ FIRMWARE_UPDATES = {
             "changelog": "blah 3",
             "files": [
                 {"target": 0, "url": "https://example3.com", "integrity": "sha3"}
+            ],
+        },
+    ]
+}
+
+FIRMWARE_UPDATE_MULTIPLE_FILES = {
+    "updates": [
+        {
+            "version": "11.2.4",
+            "changelog": "blah 2",
+            "files": [
+                {"target": 0, "url": "https://example2.com", "integrity": "sha2"},
+                {"target": 1, "url": "https://example4.com", "integrity": "sha4"},
             ],
         },
     ]
@@ -345,6 +358,124 @@ async def test_update_entity_progress(
     assert state
     attrs = state.attributes
     assert attrs[ATTR_IN_PROGRESS] == 5
+
+    event = Event(
+        type="firmware update finished",
+        data={
+            "source": "node",
+            "event": "firmware update finished",
+            "nodeId": node.node_id,
+            "status": FirmwareUpdateStatus.OK_NO_RESTART,
+        },
+    )
+
+    node.receive_event(event)
+    await hass.async_block_till_done()
+
+    # Validate that progress is reset and entity reflects new version
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    attrs = state.attributes
+    assert attrs[ATTR_IN_PROGRESS] is False
+    assert attrs[ATTR_INSTALLED_VERSION] == "11.2.4"
+    assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
+    assert state.state == STATE_OFF
+
+    await install_task
+
+
+async def test_update_entity_progress_multiple(
+    hass,
+    client,
+    climate_radio_thermostat_ct100_plus_different_endpoints,
+    integration,
+):
+    """Test update entity progress with multiple files."""
+    node = climate_radio_thermostat_ct100_plus_different_endpoints
+    client.async_send_command.return_value = FIRMWARE_UPDATE_MULTIPLE_FILES
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    assert state.state == STATE_ON
+    attrs = state.attributes
+    assert attrs[ATTR_INSTALLED_VERSION] == "10.7"
+    assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
+
+    client.async_send_command.reset_mock()
+    client.async_send_command.return_value = None
+
+    # Test successful install call without a version
+    install_task = hass.async_create_task(
+        hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {
+                ATTR_ENTITY_ID: UPDATE_ENTITY,
+            },
+            blocking=True,
+        )
+    )
+
+    # Sleep so that task starts
+    await asyncio.sleep(0.1)
+
+    event = Event(
+        type="firmware update progress",
+        data={
+            "source": "node",
+            "event": "firmware update progress",
+            "nodeId": node.node_id,
+            "sentFragments": 1,
+            "totalFragments": 20,
+        },
+    )
+    node.receive_event(event)
+
+    # Validate that the progress is updated (two files means progress is 50% of 5)
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    attrs = state.attributes
+    assert attrs[ATTR_IN_PROGRESS] == 2
+
+    event = Event(
+        type="firmware update finished",
+        data={
+            "source": "node",
+            "event": "firmware update finished",
+            "nodeId": node.node_id,
+            "status": FirmwareUpdateStatus.OK_NO_RESTART,
+        },
+    )
+
+    node.receive_event(event)
+    await hass.async_block_till_done()
+
+    # One file done, progress should be 50%
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    attrs = state.attributes
+    assert attrs[ATTR_IN_PROGRESS] == 50
+
+    event = Event(
+        type="firmware update progress",
+        data={
+            "source": "node",
+            "event": "firmware update progress",
+            "nodeId": node.node_id,
+            "sentFragments": 1,
+            "totalFragments": 20,
+        },
+    )
+    node.receive_event(event)
+
+    # Validate that the progress is updated (50% + 50% of 5)
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    attrs = state.attributes
+    assert attrs[ATTR_IN_PROGRESS] == 52
 
     event = Event(
         type="firmware update finished",

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -445,6 +445,9 @@ async def test_update_entity_progress_multiple(
         )
     )
 
+    # Block so HA can do its thing
+    await asyncio.sleep(0)
+
     # Validate that the progress is updated (two files means progress is 50% of 5)
     state = hass.states.get(UPDATE_ENTITY)
     assert state
@@ -463,6 +466,7 @@ async def test_update_entity_progress_multiple(
         )
     )
 
+    # Block so HA can do its thing
     await asyncio.sleep(0)
 
     # One file done, progress should be 50%
@@ -484,6 +488,9 @@ async def test_update_entity_progress_multiple(
         )
     )
 
+    # Block so HA can do its thing
+    await asyncio.sleep(0)
+
     # Validate that the progress is updated (50% + 50% of 5)
     state = hass.states.get(UPDATE_ENTITY)
     assert state
@@ -502,6 +509,7 @@ async def test_update_entity_progress_multiple(
         )
     )
 
+    # Block so HA can do its thing
     await asyncio.sleep(0)
 
     # Validate that progress is reset and entity reflects new version

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -341,6 +341,11 @@ async def test_update_entity_progress(
     # Sleep so that task starts
     await asyncio.sleep(0.1)
 
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    attrs = state.attributes
+    assert attrs[ATTR_IN_PROGRESS] is True
+
     event = Event(
         type="firmware update progress",
         data={
@@ -421,6 +426,11 @@ async def test_update_entity_progress_multiple(
 
     # Sleep so that task starts
     await asyncio.sleep(0.1)
+
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    attrs = state.attributes
+    assert attrs[ATTR_IN_PROGRESS] is True
 
     event = Event(
         type="firmware update progress",

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -432,17 +432,18 @@ async def test_update_entity_progress_multiple(
     attrs = state.attributes
     assert attrs[ATTR_IN_PROGRESS] is True
 
-    event = Event(
-        type="firmware update progress",
-        data={
-            "source": "node",
-            "event": "firmware update progress",
-            "nodeId": node.node_id,
-            "sentFragments": 1,
-            "totalFragments": 20,
-        },
+    node.receive_event(
+        Event(
+            type="firmware update progress",
+            data={
+                "source": "node",
+                "event": "firmware update progress",
+                "nodeId": node.node_id,
+                "sentFragments": 1,
+                "totalFragments": 20,
+            },
+        )
     )
-    node.receive_event(event)
 
     # Validate that the progress is updated (two files means progress is 50% of 5)
     state = hass.states.get(UPDATE_ENTITY)
@@ -450,18 +451,19 @@ async def test_update_entity_progress_multiple(
     attrs = state.attributes
     assert attrs[ATTR_IN_PROGRESS] == 2
 
-    event = Event(
-        type="firmware update finished",
-        data={
-            "source": "node",
-            "event": "firmware update finished",
-            "nodeId": node.node_id,
-            "status": FirmwareUpdateStatus.OK_NO_RESTART,
-        },
+    node.receive_event(
+        Event(
+            type="firmware update finished",
+            data={
+                "source": "node",
+                "event": "firmware update finished",
+                "nodeId": node.node_id,
+                "status": FirmwareUpdateStatus.OK_NO_RESTART,
+            },
+        )
     )
 
-    node.receive_event(event)
-    await hass.async_block_till_done()
+    await asyncio.sleep(0)
 
     # One file done, progress should be 50%
     state = hass.states.get(UPDATE_ENTITY)
@@ -469,17 +471,18 @@ async def test_update_entity_progress_multiple(
     attrs = state.attributes
     assert attrs[ATTR_IN_PROGRESS] == 50
 
-    event = Event(
-        type="firmware update progress",
-        data={
-            "source": "node",
-            "event": "firmware update progress",
-            "nodeId": node.node_id,
-            "sentFragments": 1,
-            "totalFragments": 20,
-        },
+    node.receive_event(
+        Event(
+            type="firmware update progress",
+            data={
+                "source": "node",
+                "event": "firmware update progress",
+                "nodeId": node.node_id,
+                "sentFragments": 1,
+                "totalFragments": 20,
+            },
+        )
     )
-    node.receive_event(event)
 
     # Validate that the progress is updated (50% + 50% of 5)
     state = hass.states.get(UPDATE_ENTITY)
@@ -487,18 +490,19 @@ async def test_update_entity_progress_multiple(
     attrs = state.attributes
     assert attrs[ATTR_IN_PROGRESS] == 52
 
-    event = Event(
-        type="firmware update finished",
-        data={
-            "source": "node",
-            "event": "firmware update finished",
-            "nodeId": node.node_id,
-            "status": FirmwareUpdateStatus.OK_NO_RESTART,
-        },
+    node.receive_event(
+        Event(
+            type="firmware update finished",
+            data={
+                "source": "node",
+                "event": "firmware update finished",
+                "nodeId": node.node_id,
+                "status": FirmwareUpdateStatus.OK_NO_RESTART,
+            },
+        )
     )
 
-    node.receive_event(event)
-    await hass.async_block_till_done()
+    await asyncio.sleep(0)
 
     # Validate that progress is reset and entity reflects new version
     state = hass.states.get(UPDATE_ENTITY)

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -376,7 +376,7 @@ async def test_update_entity_progress(
     state = hass.states.get(UPDATE_ENTITY)
     assert state
     attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] is False
+    assert attrs[ATTR_IN_PROGRESS] == 0
     assert attrs[ATTR_INSTALLED_VERSION] == "11.2.4"
     assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
     assert state.state == STATE_OFF
@@ -494,7 +494,7 @@ async def test_update_entity_progress_multiple(
     state = hass.states.get(UPDATE_ENTITY)
     assert state
     attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] is False
+    assert attrs[ATTR_IN_PROGRESS] == 0
     assert attrs[ATTR_INSTALLED_VERSION] == "11.2.4"
     assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
     assert state.state == STATE_OFF
@@ -577,7 +577,7 @@ async def test_update_entity_install_failed(
     state = hass.states.get(UPDATE_ENTITY)
     assert state
     attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] is False
+    assert attrs[ATTR_IN_PROGRESS] == 0
     assert attrs[ATTR_INSTALLED_VERSION] == "10.7"
     assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
     assert state.state == STATE_ON


### PR DESCRIPTION
## Proposed change
Onto PR 7 related to the update entity, continuing to fix bugs 🙂 hopefully 7th times a charm.

Discovered that the asyncio.Event logic does not handle multiple files because we don't reset the event after waiting for it the first time. Resetting the flag should cause the service to block until the second file is done.

For some reason the new test hangs though and I can't figure out where it is blocking. Would appreciate some guidance


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
