### PR TITLE
Move MQTT discovery hass.data globals to dataclass

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -178,7 +178,7 @@ async def async_subscribe(
     | AsyncDeprecatedMessageCallbackType,
     qos: int = DEFAULT_QOS,
     encoding: str | None = DEFAULT_ENCODING,
-):
+) -> Callable[[], None]:
     """Subscribe to an MQTT topic.
 
     Call the return value to unsubscribe.
@@ -357,12 +357,12 @@ class MQTT:
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_mqtt)
         )
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """Clean up listeners."""
         while self._cleanup_on_unload:
             self._cleanup_on_unload.pop()()
 
-    def init_client(self):
+    def init_client(self) -> None:
         """Initialize paho client."""
         self._mqttc = MqttClientSetup(self.conf).client
         self._mqttc.on_connect = self._mqtt_on_connect
@@ -429,10 +429,10 @@ class MQTT:
 
         self._mqttc.loop_start()
 
-    async def async_disconnect(self):
+    async def async_disconnect(self) -> None:
         """Stop the MQTT client."""
 
-        def stop():
+        def stop() -> None:
             """Stop the MQTT client."""
             # Do not disconnect, we want the broker to always publish will
             self._mqttc.loop_stop()

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -27,7 +27,14 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.core import CoreState, Event, HassJob, HomeAssistant, callback
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    CoreState,
+    Event,
+    HassJob,
+    HomeAssistant,
+    callback,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.typing import ConfigType
@@ -178,7 +185,7 @@ async def async_subscribe(
     | AsyncDeprecatedMessageCallbackType,
     qos: int = DEFAULT_QOS,
     encoding: str | None = DEFAULT_ENCODING,
-) -> Callable[[], None]:
+) -> CALLBACK_TYPE:
     """Subscribe to an MQTT topic.
 
     Call the return value to unsubscribe.

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -18,8 +18,9 @@ from homeassistant.const import (
     CONF_PROTOCOL,
     CONF_USERNAME,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.typing import ConfigType
 
 from .client import MqttClientSetup
 from .const import (
@@ -73,7 +74,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             can_connect = await self.hass.async_add_executor_job(
                 try_connection,
-                self.hass,
+                get_mqtt_data(self.hass, True).config or {},
                 user_input[CONF_BROKER],
                 user_input[CONF_PORT],
                 user_input.get(CONF_USERNAME),
@@ -117,7 +118,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data = self._hassio_discovery
             can_connect = await self.hass.async_add_executor_job(
                 try_connection,
-                self.hass,
+                get_mqtt_data(self.hass, True).config or {},
                 data[CONF_HOST],
                 data[CONF_PORT],
                 data.get(CONF_USERNAME),
@@ -164,13 +165,13 @@ class MQTTOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> FlowResult:
         """Manage the MQTT broker configuration."""
         mqtt_data = get_mqtt_data(self.hass, True)
+        yaml_config = mqtt_data.config or {}
         errors = {}
         current_config = self.config_entry.data
-        yaml_config = mqtt_data.config or {}
         if user_input is not None:
             can_connect = await self.hass.async_add_executor_job(
                 try_connection,
-                self.hass,
+                yaml_config,
                 user_input[CONF_BROKER],
                 user_input[CONF_PORT],
                 user_input.get(CONF_USERNAME),
@@ -336,7 +337,7 @@ class MQTTOptionsFlowHandler(config_entries.OptionsFlow):
 
 
 def try_connection(
-    hass: HomeAssistant,
+    yaml_config: ConfigType,
     broker: str,
     port: int,
     username: str | None,
@@ -349,8 +350,6 @@ def try_connection(
     import paho.mqtt.client as mqtt  # pylint: disable=import-outside-toplevel
 
     # Get the config from configuration.yaml
-    mqtt_data = get_mqtt_data(hass, True)
-    yaml_config = mqtt_data.config or {}
     entry_config = {
         CONF_BROKER: broker,
         CONF_PORT: port,

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -62,11 +62,6 @@ SUPPORTED_COMPONENTS = [
     "vacuum",
 ]
 
-ALREADY_DISCOVERED = "mqtt_discovered_components"
-PENDING_DISCOVERED = "mqtt_pending_components"
-DATA_CONFIG_FLOW_LOCK = "mqtt_discovery_config_flow_lock"
-DISCOVERY_UNSUBSCRIBE = "mqtt_discovery_unsubscribe"
-INTEGRATION_UNSUBSCRIBE = "mqtt_integration_discovery_unsubscribe"
 MQTT_DISCOVERY_UPDATED = "mqtt_discovery_updated_{}"
 MQTT_DISCOVERY_NEW = "mqtt_discovery_new_{}_{}"
 MQTT_DISCOVERY_DONE = "mqtt_discovery_done_{}"
@@ -82,12 +77,14 @@ class MQTTConfig(dict):
 
 def clear_discovery_hash(hass: HomeAssistant, discovery_hash: tuple[str, str]) -> None:
     """Clear entry in ALREADY_DISCOVERED list."""
-    del hass.data[ALREADY_DISCOVERED][discovery_hash]
+    mqtt_data = get_mqtt_data(hass)
+    mqtt_data.discovery_already_discovered.remove(discovery_hash)
 
 
 def set_discovery_hash(hass: HomeAssistant, discovery_hash: tuple[str, str]):
     """Clear entry in ALREADY_DISCOVERED list."""
-    hass.data[ALREADY_DISCOVERED][discovery_hash] = {}
+    mqtt_data = get_mqtt_data(hass)
+    mqtt_data.discovery_already_discovered.add(discovery_hash)
 
 
 async def async_start(  # noqa: C901
@@ -175,8 +172,8 @@ async def async_start(  # noqa: C901
 
             payload[CONF_PLATFORM] = "mqtt"
 
-        if discovery_hash in hass.data[PENDING_DISCOVERED]:
-            pending = hass.data[PENDING_DISCOVERED][discovery_hash]["pending"]
+        if discovery_hash in mqtt_data.discovery_pending_discovered:
+            pending = mqtt_data.discovery_pending_discovered[discovery_hash]["pending"]
             pending.appendleft(payload)
             _LOGGER.info(
                 "Component has already been discovered: %s %s, queuing update",
@@ -192,22 +189,24 @@ async def async_start(  # noqa: C901
 
         _LOGGER.debug("Process discovery payload %s", payload)
         discovery_hash = (component, discovery_id)
-        if discovery_hash in hass.data[ALREADY_DISCOVERED] or payload:
+        if discovery_hash in mqtt_data.discovery_already_discovered or payload:
 
             async def discovery_done(_):
-                pending = hass.data[PENDING_DISCOVERED][discovery_hash]["pending"]
+                pending = mqtt_data.discovery_pending_discovered[discovery_hash][
+                    "pending"
+                ]
                 _LOGGER.debug("Pending discovery for %s: %s", discovery_hash, pending)
                 if not pending:
-                    hass.data[PENDING_DISCOVERED][discovery_hash]["unsub"]()
-                    hass.data[PENDING_DISCOVERED].pop(discovery_hash)
+                    mqtt_data.discovery_pending_discovered[discovery_hash]["unsub"]()
+                    mqtt_data.discovery_pending_discovered.pop(discovery_hash)
                 else:
                     payload = pending.pop()
                     await async_process_discovery_payload(
                         component, discovery_id, payload
                     )
 
-            if discovery_hash not in hass.data[PENDING_DISCOVERED]:
-                hass.data[PENDING_DISCOVERED][discovery_hash] = {
+            if discovery_hash not in mqtt_data.discovery_pending_discovered:
+                mqtt_data.discovery_pending_discovered[discovery_hash] = {
                     "unsub": async_dispatcher_connect(
                         hass,
                         MQTT_DISCOVERY_DONE.format(discovery_hash),
@@ -216,7 +215,7 @@ async def async_start(  # noqa: C901
                     "pending": deque([]),
                 }
 
-        if discovery_hash in hass.data[ALREADY_DISCOVERED]:
+        if discovery_hash in mqtt_data.discovery_already_discovered:
             # Dispatch update
             _LOGGER.info(
                 "Component has already been discovered: %s %s, sending update",
@@ -229,7 +228,7 @@ async def async_start(  # noqa: C901
         elif payload:
             # Add component
             _LOGGER.info("Found new component: %s %s", component, discovery_id)
-            hass.data[ALREADY_DISCOVERED][discovery_hash] = None
+            mqtt_data.discovery_already_discovered.add(discovery_hash)
             async_dispatcher_send(
                 hass, MQTT_DISCOVERY_NEW.format(component, "mqtt"), payload
             )
@@ -239,15 +238,16 @@ async def async_start(  # noqa: C901
                 hass, MQTT_DISCOVERY_DONE.format(discovery_hash), None
             )
 
-    hass.data.setdefault(DATA_CONFIG_FLOW_LOCK, asyncio.Lock())
-    hass.data[ALREADY_DISCOVERED] = {}
-    hass.data[PENDING_DISCOVERED] = {}
+    if mqtt_data.data_config_flow_lock is None:
+        mqtt_data.data_config_flow_lock = asyncio.Lock()
+    mqtt_data.discovery_already_discovered = set()
+    mqtt_data.discovery_pending_discovered = {}
 
     discovery_topics = [
         f"{discovery_topic}/+/+/config",
         f"{discovery_topic}/+/+/+/config",
     ]
-    hass.data[DISCOVERY_UNSUBSCRIBE] = await asyncio.gather(
+    mqtt_data.discovery_unsubscribe = await asyncio.gather(
         *(
             mqtt.async_subscribe(hass, topic, async_discovery_message_received, 0)
             for topic in discovery_topics
@@ -257,7 +257,7 @@ async def async_start(  # noqa: C901
     mqtt_data.last_discovery = time.time()
     mqtt_integrations = await async_get_mqtt(hass)
 
-    hass.data[INTEGRATION_UNSUBSCRIBE] = {}
+    mqtt_data.integration_unsubscribe = {}
 
     for (integration, topics) in mqtt_integrations.items():
 
@@ -267,9 +267,9 @@ async def async_start(  # noqa: C901
 
             # Lock to prevent initiating many parallel config flows.
             # Note: The lock is not intended to prevent a race, only for performance
-            async with hass.data[DATA_CONFIG_FLOW_LOCK]:
+            async with mqtt_data.data_config_flow_lock:
                 # Already unsubscribed
-                if key not in hass.data[INTEGRATION_UNSUBSCRIBE]:
+                if key not in mqtt_data.integration_unsubscribe:
                     return
 
                 data = MqttServiceInfo(
@@ -289,14 +289,14 @@ async def async_start(  # noqa: C901
                     and result["reason"]
                     in ("already_configured", "single_instance_allowed")
                 ):
-                    unsub = hass.data[INTEGRATION_UNSUBSCRIBE].pop(key, None)
+                    unsub = mqtt_data.integration_unsubscribe.pop(key, None)
                     if unsub is None:
                         return
                     unsub()
 
         for topic in topics:
             key = f"{integration}_{topic}"
-            hass.data[INTEGRATION_UNSUBSCRIBE][key] = await mqtt.async_subscribe(
+            mqtt_data.integration_unsubscribe[key] = await mqtt.async_subscribe(
                 hass,
                 topic,
                 functools.partial(async_integration_message_received, integration),
@@ -306,11 +306,10 @@ async def async_start(  # noqa: C901
 
 async def async_stop(hass: HomeAssistant) -> None:
     """Stop MQTT Discovery."""
-    if DISCOVERY_UNSUBSCRIBE in hass.data:
-        for unsub in hass.data[DISCOVERY_UNSUBSCRIBE]:
-            unsub()
-        hass.data[DISCOVERY_UNSUBSCRIBE] = []
-    if INTEGRATION_UNSUBSCRIBE in hass.data:
-        for key, unsub in list(hass.data[INTEGRATION_UNSUBSCRIBE].items()):
-            unsub()
-            hass.data[INTEGRATION_UNSUBSCRIBE].pop(key)
+    mqtt_data = get_mqtt_data(hass)
+    for unsub in mqtt_data.discovery_unsubscribe:
+        unsub()
+    mqtt_data.discovery_unsubscribe = []
+    for key, unsub in list(mqtt_data.integration_unsubscribe.items()):
+        unsub()
+        mqtt_data.integration_unsubscribe.pop(key)

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -84,7 +84,7 @@ def clear_discovery_hash(hass: HomeAssistant, discovery_hash: tuple[str, str]) -
 
 
 def set_discovery_hash(hass: HomeAssistant, discovery_hash: tuple[str, str]) -> None:
-    """Add entry tp already discovered list."""
+    """Add entry to already discovered list."""
     get_mqtt_data(hass).discovery_already_discovered.add(discovery_hash)
 
 
@@ -200,10 +200,8 @@ async def async_start(  # noqa: C901
                 ]
                 _LOGGER.debug("Pending discovery for %s: %s", discovery_hash, pending)
                 if not pending:
-                    discovery = mqtt_data.discovery_pending_discovered.pop(
-                        discovery_hash
-                    )
-                    discovery["unsub"]()
+                    mqtt_data.discovery_pending_discovered[discovery_hash]["unsub"]()
+                    mqtt_data.discovery_pending_discovered.pop(discovery_hash)
                 else:
                     payload = pending.pop()
                     await async_process_discovery_payload(

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -1,15 +1,15 @@
 """Models used by multiple MQTT modules."""
 from __future__ import annotations
 
-import asyncio
-import attr
-
 from ast import literal_eval
+import asyncio
 from collections import deque
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 import datetime as dt
 from typing import TYPE_CHECKING, Any, TypedDict, Union
+
+import attr
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -1,14 +1,15 @@
 """Models used by multiple MQTT modules."""
 from __future__ import annotations
 
+import asyncio
+import attr
+
 from ast import literal_eval
 from collections import deque
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 import datetime as dt
 from typing import TYPE_CHECKING, Any, TypedDict, Union
-
-import attr
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
@@ -216,9 +217,16 @@ class MqttData:
         default_factory=dict
     )
     device_triggers: dict[str, Trigger] = field(default_factory=dict)
+    data_config_flow_lock: asyncio.Lock | None = None
+    discovery_already_discovered: set[tuple[str, str]] = field(default_factory=set)
+    discovery_pending_discovered: dict[
+        tuple[str, str], dict[str, CALLBACK_TYPE | deque]
+    ] = field(default_factory=dict)
     discovery_registry_hooks: dict[tuple[str, str], CALLBACK_TYPE] = field(
         default_factory=dict
     )
+    discovery_unsubscribe: list[CALLBACK_TYPE] = field(default_factory=list)
+    integration_unsubscribe: dict[str, CALLBACK_TYPE] = field(default_factory=dict)
     last_discovery: float = 0.0
     reload_dispatchers: list[CALLBACK_TYPE] = field(default_factory=list)
     reload_entry: bool = False

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from .debug_info import TimestampedPublishMessage
     from .device_trigger import Trigger
     from .discovery import MQTTConfig
+    from .tag import MQTTTagScanner
 
 _SENTINEL = object()
 
@@ -243,4 +244,5 @@ class MqttData:
     )
     reload_needed: bool = False
     subscriptions_to_restore: list[Subscription] = field(default_factory=list)
+    tags: dict[str, dict[str, MQTTTagScanner]] = field(default_factory=dict)
     updated_config: ConfigType = field(default_factory=dict)

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from .client import MQTT, Subscription
     from .debug_info import TimestampedPublishMessage
     from .device_trigger import Trigger
+    from .discovery import MQTTConfig
 
 _SENTINEL = object()
 
@@ -76,6 +77,13 @@ class TriggerDebugInfo(TypedDict):
 
     device_id: str
     discovery_data: DiscoveryInfoType
+
+
+class PendingDiscovered(TypedDict):
+    """Pending discovered items."""
+
+    pending: deque[MQTTConfig]
+    unsub: CALLBACK_TYPE
 
 
 class MqttCommandTemplate:
@@ -219,9 +227,9 @@ class MqttData:
     device_triggers: dict[str, Trigger] = field(default_factory=dict)
     data_config_flow_lock: asyncio.Lock | None = None
     discovery_already_discovered: set[tuple[str, str]] = field(default_factory=set)
-    discovery_pending_discovered: dict[
-        tuple[str, str], dict[str, CALLBACK_TYPE | deque]
-    ] = field(default_factory=dict)
+    discovery_pending_discovered: dict[tuple[str, str], PendingDiscovered] = field(
+        default_factory=dict
+    )
     discovery_registry_hooks: dict[tuple[str, str], CALLBACK_TYPE] = field(
         default_factory=dict
     )

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -226,7 +226,7 @@ class MqttData:
         default_factory=dict
     )
     device_triggers: dict[str, Trigger] = field(default_factory=dict)
-    data_config_flow_lock: asyncio.Lock | None = None
+    data_config_flow_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     discovery_already_discovered: set[tuple[str, str]] = field(default_factory=set)
     discovery_pending_discovered: dict[tuple[str, str], PendingDiscovered] = field(
         default_factory=dict

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -23,7 +23,7 @@ from .mixins import (
 )
 from .models import MqttValueTemplate, ReceiveMessage
 from .subscription import EntitySubscription
-from .util import valid_subscribe_topic
+from .util import get_mqtt_data, valid_subscribe_topic
 
 LOG_NAME = "Tag"
 
@@ -59,9 +59,8 @@ async def _async_setup_tag(
     discovery_id = discovery_hash[1]
 
     device_id = update_device(hass, config_entry, config)
-    hass.data.setdefault(TAGS, {})
-    if device_id not in hass.data[TAGS]:
-        hass.data[TAGS][device_id] = {}
+    if device_id is not None and device_id not in (tags := get_mqtt_data(hass).tags):
+        tags[device_id] = {}
 
     tag_scanner = MQTTTagScanner(
         hass,
@@ -74,16 +73,16 @@ async def _async_setup_tag(
     await tag_scanner.subscribe_topics()
 
     if device_id:
-        hass.data[TAGS][device_id][discovery_id] = tag_scanner
+        tags[device_id][discovery_id] = tag_scanner
 
     send_discovery_done(hass, discovery_data)
 
 
 def async_has_tags(hass: HomeAssistant, device_id: str) -> bool:
     """Device has tag scanners."""
-    if TAGS not in hass.data or device_id not in hass.data[TAGS]:
+    if device_id not in (tags := get_mqtt_data(hass).tags):
         return False
-    return hass.data[TAGS][device_id] != {}
+    return tags[device_id] != {}
 
 
 class MQTTTagScanner(MqttDiscoveryDeviceUpdate):
@@ -159,4 +158,4 @@ class MQTTTagScanner(MqttDiscoveryDeviceUpdate):
             self.hass, self._sub_state
         )
         if self.device_id:
-            self.hass.data[TAGS][self.device_id].pop(discovery_id)
+            get_mqtt_data(self.hass).tags[self.device_id].pop(discovery_id)

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -28,7 +28,6 @@ from .util import get_mqtt_data, valid_subscribe_topic
 LOG_NAME = "Tag"
 
 TAG = "tag"
-TAGS = "mqtt_tags"
 
 PLATFORM_SCHEMA = MQTT_BASE_SCHEMA.extend(
     {

--- a/homeassistant/components/mqtt_room/sensor.py
+++ b/homeassistant/components/mqtt_room/sensor.py
@@ -133,9 +133,7 @@ class MQTTRoomSensor(SensorEntity):
                     ):
                         update_state(**device)
 
-        return await mqtt.async_subscribe(
-            self.hass, self._state_topic, message_received, 1
-        )
+        await mqtt.async_subscribe(self.hass, self._state_topic, message_received, 1)
 
     @property
     def name(self):

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -177,7 +177,18 @@ async def test_manual_config_set(
         "discovery": True,
     }
     # Check we tried the connection, with precedence for config entry settings
-    mock_try_connection.assert_called_once_with(hass, "127.0.0.1", 1883, None, None)
+    mock_try_connection.assert_called_once_with(
+        {
+            "broker": "bla",
+            "keepalive": 60,
+            "discovery_prefix": "homeassistant",
+            "protocol": "3.1.1",
+        },
+        "127.0.0.1",
+        1883,
+        None,
+        None,
+    )
     # Check config entry got setup
     assert len(mock_finish_setup.mock_calls) == 1
 

--- a/tests/components/mqtt/test_device_tracker_discovery.py
+++ b/tests/components/mqtt/test_device_tracker_discovery.py
@@ -6,7 +6,6 @@ import pytest
 
 from homeassistant.components import device_tracker, mqtt
 from homeassistant.components.mqtt.const import DOMAIN as MQTT_DOMAIN
-from homeassistant.components.mqtt.discovery import ALREADY_DISCOVERED
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNKNOWN, Platform
 from homeassistant.setup import async_setup_component
 
@@ -60,7 +59,7 @@ async def test_discover_device_tracker(hass, mqtt_mock_entry_no_yaml_config, cap
 
     assert state is not None
     assert state.name == "test"
-    assert ("device_tracker", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("device_tracker", "bla") in hass.data["mqtt"].discovery_already_discovered
 
 
 @pytest.mark.no_fail_on_log_exception

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -13,7 +13,7 @@ from homeassistant.components.mqtt.abbreviations import (
     ABBREVIATIONS,
     DEVICE_ABBREVIATIONS,
 )
-from homeassistant.components.mqtt.discovery import ALREADY_DISCOVERED, async_start
+from homeassistant.components.mqtt.discovery import async_start
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
     STATE_ON,
@@ -152,7 +152,7 @@ async def test_correct_config_discovery(hass, mqtt_mock_entry_no_yaml_config, ca
 
     assert state is not None
     assert state.name == "Beer"
-    assert ("binary_sensor", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("binary_sensor", "bla") in hass.data["mqtt"].discovery_already_discovered
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.FAN])
@@ -170,7 +170,7 @@ async def test_discover_fan(hass, mqtt_mock_entry_no_yaml_config, caplog):
 
     assert state is not None
     assert state.name == "Beer"
-    assert ("fan", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("fan", "bla") in hass.data["mqtt"].discovery_already_discovered
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.CLIMATE])
@@ -190,7 +190,7 @@ async def test_discover_climate(hass, mqtt_mock_entry_no_yaml_config, caplog):
 
     assert state is not None
     assert state.name == "ClimateTest"
-    assert ("climate", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("climate", "bla") in hass.data["mqtt"].discovery_already_discovered
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.ALARM_CONTROL_PANEL])
@@ -212,7 +212,9 @@ async def test_discover_alarm_control_panel(
 
     assert state is not None
     assert state.name == "AlarmControlPanelTest"
-    assert ("alarm_control_panel", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("alarm_control_panel", "bla") in hass.data[
+        "mqtt"
+    ].discovery_already_discovered
 
 
 @pytest.mark.parametrize(
@@ -372,7 +374,7 @@ async def test_discovery_with_object_id(
 
     assert state is not None
     assert state.name == name
-    assert (domain, "object bla") in hass.data[ALREADY_DISCOVERED]
+    assert (domain, "object bla") in hass.data["mqtt"].discovery_already_discovered
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
@@ -390,7 +392,9 @@ async def test_discovery_incl_nodeid(hass, mqtt_mock_entry_no_yaml_config, caplo
 
     assert state is not None
     assert state.name == "Beer"
-    assert ("binary_sensor", "my_node_id bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("binary_sensor", "my_node_id bla") in hass.data[
+        "mqtt"
+    ].discovery_already_discovered
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
@@ -970,7 +974,7 @@ async def test_discovery_expansion(hass, mqtt_mock_entry_no_yaml_config, caplog)
     state = hass.states.get("switch.DiscoveryExpansionTest1")
     assert state is not None
     assert state.name == "DiscoveryExpansionTest1"
-    assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("switch", "bla") in hass.data["mqtt"].discovery_already_discovered
     assert state.state == STATE_UNKNOWN
 
     async_fire_mqtt_message(hass, "test_topic/some/base/topic", "ON")
@@ -1023,7 +1027,7 @@ async def test_discovery_expansion_2(hass, mqtt_mock_entry_no_yaml_config, caplo
     state = hass.states.get("switch.DiscoveryExpansionTest1")
     assert state is not None
     assert state.name == "DiscoveryExpansionTest1"
-    assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("switch", "bla") in hass.data["mqtt"].discovery_already_discovered
     assert state.state == STATE_UNKNOWN
 
 
@@ -1102,7 +1106,7 @@ async def test_discovery_expansion_without_encoding_and_value_template_1(
     state = hass.states.get("switch.DiscoveryExpansionTest1")
     assert state is not None
     assert state.name == "DiscoveryExpansionTest1"
-    assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("switch", "bla") in hass.data["mqtt"].discovery_already_discovered
     assert state.state == STATE_UNKNOWN
 
     async_fire_mqtt_message(hass, "some/base/topic/avail_item1", b"\x00")
@@ -1151,7 +1155,7 @@ async def test_discovery_expansion_without_encoding_and_value_template_2(
     state = hass.states.get("switch.DiscoveryExpansionTest1")
     assert state is not None
     assert state.name == "DiscoveryExpansionTest1"
-    assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("switch", "bla") in hass.data["mqtt"].discovery_already_discovered
     assert state.state == STATE_UNKNOWN
 
     async_fire_mqtt_message(hass, "some/base/topic/avail_item1", b"\x00")
@@ -1236,7 +1240,7 @@ async def test_no_implicit_state_topic_switch(
     state = hass.states.get("switch.Test1")
     assert state is not None
     assert state.name == "Test1"
-    assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
+    assert ("switch", "bla") in hass.data["mqtt"].discovery_already_discovered
     assert state.state == STATE_UNKNOWN
     assert state.attributes["assumed_state"] is True
 
@@ -1280,7 +1284,9 @@ async def test_complex_discovery_topic_prefix(
 
     assert state is not None
     assert state.name == "Beer"
-    assert ("binary_sensor", "node1 object1") in hass.data[ALREADY_DISCOVERED]
+    assert ("binary_sensor", "node1 object1") in hass.data[
+        "mqtt"
+    ].discovery_already_discovered
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move the `hass.data[]` globals `ALREADY_DISCOVERED`, `PENDING_DISCOVERED`, `DATA_CONFIG_FLOW_LOCK`, `DISCOVERY_UNSUBSCRIBE`, `INTEGRATION_UNSUBSCRIBE` and `TAGS` to the `MqttData` class.

This is a follow-up PR on #77972

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
