### PR TITLE
Update CalendarEvent to share api and trigger attribute building

### DIFF
--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -108,8 +108,8 @@ class FakeSchedule:
         current_time = dt_util.as_utc(self.freezer())
         if (end - current_time) > datetime.timedelta(minutes=35):
             # Reduce the amount of unnecessary small increments by jumping ahead
-            # closer to the target time. This jump is larger than the trigger
-            # update interval to ensure we still pick up the right sliding set of events
+            # closer to the target time. This is further away than the trigger update
+            # interval to ensure we still pick up the right sliding window of events.
             await self.fire_time(end - datetime.timedelta(minutes=35))
 
         while dt_util.utcnow() < end:

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -62,14 +62,15 @@ class FakeSchedule:
         self,
         start: datetime.timedelta,
         end: datetime.timedelta,
-        description: str = None,
-        location: str = None,
+        summary: str | None = None,
+        description: str | None = None,
+        location: str | None = None,
     ) -> dict[str, Any]:
         """Create a new fake event, used by tests."""
         event = calendar.CalendarEvent(
             start=start,
             end=end,
-            summary=f"Event {secrets.token_hex(16)}",  # Arbitrary unique data
+            summary=summary if summary else f"Event {secrets.token_hex(16)}",
             description=description,
             location=location,
         )
@@ -85,8 +86,13 @@ class FakeSchedule:
         """Get all events in a specific time frame, used by the demo calendar."""
         assert start_date < end_date
         values = []
+        local_start_date = dt_util.as_local(start_date)
+        local_end_date = dt_util.as_local(end_date)
         for event in self.events:
-            if start_date < event.start < end_date or start_date < event.end < end_date:
+            if (
+                event.start_datetime_local < local_end_date
+                and local_start_date < event.end_datetime_local
+            ):
                 values.append(event)
         return values
 
@@ -99,6 +105,13 @@ class FakeSchedule:
 
     async def fire_until(self, end: datetime.timedelta) -> None:
         """Simulate the passage of time by firing alarms until the time is reached."""
+        current_time = dt_util.as_utc(self.freezer())
+        if (end - current_time) > datetime.timedelta(minutes=35):
+            # Reduce the amount of unnecessary small increments by jumping ahead
+            # closer to the target time. This jump is larger than the trigger
+            # update interval to ensure we still pick up the right sliding set of events
+            await self.fire_time(end - datetime.timedelta(minutes=35))
+
         while dt_util.utcnow() < end:
             self.freezer.tick(TEST_TIME_ADVANCE_INTERVAL)
             await self.fire_time(dt_util.utcnow())
@@ -124,6 +137,14 @@ async def setup_calendar(hass: HomeAssistant, fake_schedule: FakeSchedule) -> No
     """Initialize the demo calendar."""
     assert await async_setup_component(hass, calendar.DOMAIN, CONFIG)
     await hass.async_block_till_done()
+
+
+@pytest.fixture
+def set_time_zone(hass):
+    """Set the time zone for the tests."""
+    # Set our timezone to CST/Regina so we can check calculations
+    # This keeps UTC-6 all year round
+    hass.config.set_time_zone("America/Regina")
 
 
 async def create_automation(hass: HomeAssistant, event_type: str, offset=None) -> None:
@@ -534,25 +555,72 @@ async def test_update_missed(hass, calls, fake_schedule):
     ]
 
 
-async def test_event_payload(hass, calls, fake_schedule):
-    """Test the a calendar trigger based on start time."""
-    event_data = fake_schedule.create_event(
-        start=datetime.datetime.fromisoformat("2022-04-19 11:00:00+00:00"),
-        end=datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00"),
-        description="Description",
-        location="Location",
-    )
+@pytest.mark.parametrize(
+    "create_data,fire_time,payload_data",
+    [
+        (
+            {
+                "start": datetime.datetime.fromisoformat("2022-04-19 11:00:00+00:00"),
+                "end": datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00"),
+                "summary": "Summary",
+            },
+            datetime.datetime.fromisoformat("2022-04-19 11:15:00+00:00"),
+            {
+                "summary": "Summary",
+                "start": "2022-04-19T11:00:00+00:00",
+                "end": "2022-04-19T11:30:00+00:00",
+                "all_day": False,
+            },
+        ),
+        (
+            {
+                "start": datetime.datetime.fromisoformat("2022-04-19 11:00:00+00:00"),
+                "end": datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00"),
+                "summary": "Summary",
+                "description": "Description",
+                "location": "Location",
+            },
+            datetime.datetime.fromisoformat("2022-04-19 11:15:00+00:00"),
+            {
+                "summary": "Summary",
+                "start": "2022-04-19T11:00:00+00:00",
+                "end": "2022-04-19T11:30:00+00:00",
+                "all_day": False,
+                "description": "Description",
+                "location": "Location",
+            },
+        ),
+        (
+            {
+                "summary": "Summary",
+                "start": datetime.date.fromisoformat("2022-04-20"),
+                "end": datetime.date.fromisoformat("2022-04-21"),
+            },
+            datetime.datetime.fromisoformat("2022-04-20 00:00:01-06:00"),
+            {
+                "summary": "Summary",
+                "start": "2022-04-20",
+                "end": "2022-04-21",
+                "all_day": True,
+            },
+        ),
+    ],
+    ids=["basic", "more-fields", "all-day"],
+)
+async def test_event_payload(
+    hass, calls, fake_schedule, set_time_zone, create_data, fire_time, payload_data
+):
+    """Test the fields in the calendar event payload are set."""
+    fake_schedule.create_event(**create_data)
     await create_automation(hass, EVENT_START)
     assert len(calls()) == 0
 
-    await fake_schedule.fire_until(
-        datetime.datetime.fromisoformat("2022-04-19 11:15:00+00:00")
-    )
+    await fake_schedule.fire_until(fire_time)
     assert calls() == [
         {
             "platform": "calendar",
             "event": EVENT_START,
-            "calendar_event": event_data,
+            "calendar_event": payload_data,
         }
     ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the logic in calendar for serializing `CalendarEvent` to rest API and trigger payloads using builtin `dataclasses.asdict`. This is in preparation for adding more attributes in the future, to have to update fewer places when new fields are added.

In support of the above there are a few smaller changes:
- Removes dead code `normalize_event` which used to exist for the removed `CalendarEventDevice` entity
- Adds test coverage for more attributes found in trigger payloads
- Fixes test harness to correctly compare all day events

Note: The calendar event attributes are not updated, and will remain separate.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
