### PR TITLE
Add support for Kegtron Smart (Beer) Keg Monitor BLE devices

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -579,6 +579,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/keenetic_ndms2/ @foxel
 /tests/components/keenetic_ndms2/ @foxel
 /homeassistant/components/kef/ @basnijholt
+/homeassistant/components/kegtron/ @Ernst79
+/tests/components/kegtron/ @Ernst79
 /homeassistant/components/keyboard_remote/ @bendavid @lanrat
 /homeassistant/components/kmtronic/ @dgomes
 /tests/components/kmtronic/ @dgomes

--- a/homeassistant/components/kegtron/__init__.py
+++ b/homeassistant/components/kegtron/__init__.py
@@ -1,0 +1,49 @@
+"""The Kegtron integration."""
+from __future__ import annotations
+
+import logging
+
+from kegtron_ble import KegtronBluetoothDeviceData
+
+from homeassistant.components.bluetooth import BluetoothScanningMode
+from homeassistant.components.bluetooth.passive_update_processor import (
+    PassiveBluetoothProcessorCoordinator,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Kegtron BLE device from a config entry."""
+    address = entry.unique_id
+    assert address is not None
+    data = KegtronBluetoothDeviceData()
+    coordinator = hass.data.setdefault(DOMAIN, {})[
+        entry.entry_id
+    ] = PassiveBluetoothProcessorCoordinator(
+        hass,
+        _LOGGER,
+        address=address,
+        mode=BluetoothScanningMode.PASSIVE,
+        update_method=data.update,
+    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(
+        coordinator.async_start()
+    )  # only start after all platforms have had a chance to subscribe
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/kegtron/config_flow.py
+++ b/homeassistant/components/kegtron/config_flow.py
@@ -1,0 +1,94 @@
+"""Config flow for Kegtron ble integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from kegtron_ble import KegtronBluetoothDeviceData as DeviceData
+import voluptuous as vol
+
+from homeassistant.components.bluetooth import (
+    BluetoothServiceInfoBleak,
+    async_discovered_service_info,
+)
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+
+class KegtronConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for kegtron."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovery_info: BluetoothServiceInfoBleak | None = None
+        self._discovered_device: DeviceData | None = None
+        self._discovered_devices: dict[str, str] = {}
+
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> FlowResult:
+        """Handle the bluetooth discovery step."""
+        await self.async_set_unique_id(discovery_info.address)
+        self._abort_if_unique_id_configured()
+        device = DeviceData()
+        if not device.supported(discovery_info):
+            return self.async_abort(reason="not_supported")
+        self._discovery_info = discovery_info
+        self._discovered_device = device
+        return await self.async_step_bluetooth_confirm()
+
+    async def async_step_bluetooth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm discovery."""
+        assert self._discovered_device is not None
+        device = self._discovered_device
+        assert self._discovery_info is not None
+        discovery_info = self._discovery_info
+        title = device.title or device.get_device_name() or discovery_info.name
+        if user_input is not None:
+            return self.async_create_entry(title=title, data={})
+
+        self._set_confirm_only()
+        placeholders = {"name": title}
+        self.context["title_placeholders"] = placeholders
+        return self.async_show_form(
+            step_id="bluetooth_confirm", description_placeholders=placeholders
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the user step to pick discovered device."""
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS]
+            await self.async_set_unique_id(address, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=self._discovered_devices[address], data={}
+            )
+
+        current_addresses = self._async_current_ids()
+        for discovery_info in async_discovered_service_info(self.hass, False):
+            address = discovery_info.address
+            if address in current_addresses or address in self._discovered_devices:
+                continue
+            device = DeviceData()
+            if device.supported(discovery_info):
+                self._discovered_devices[address] = (
+                    device.title or device.get_device_name() or discovery_info.name
+                )
+
+        if not self._discovered_devices:
+            return self.async_abort(reason="no_devices_found")
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_ADDRESS): vol.In(self._discovered_devices)}
+            ),
+        )

--- a/homeassistant/components/kegtron/const.py
+++ b/homeassistant/components/kegtron/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Kegtron integration."""
+
+DOMAIN = "kegtron"

--- a/homeassistant/components/kegtron/device.py
+++ b/homeassistant/components/kegtron/device.py
@@ -1,0 +1,31 @@
+"""Support for Kegtron devices."""
+from __future__ import annotations
+
+from kegtron_ble import DeviceKey, SensorDeviceInfo
+
+from homeassistant.components.bluetooth.passive_update_processor import (
+    PassiveBluetoothEntityKey,
+)
+from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
+from homeassistant.helpers.entity import DeviceInfo
+
+
+def device_key_to_bluetooth_entity_key(
+    device_key: DeviceKey,
+) -> PassiveBluetoothEntityKey:
+    """Convert a device key to an entity key."""
+    return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
+
+
+def sensor_device_info_to_hass(
+    sensor_device_info: SensorDeviceInfo,
+) -> DeviceInfo:
+    """Convert a sensor device info to a sensor device info."""
+    hass_device_info = DeviceInfo({})
+    if sensor_device_info.name is not None:
+        hass_device_info[ATTR_NAME] = sensor_device_info.name
+    if sensor_device_info.manufacturer is not None:
+        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
+    if sensor_device_info.model is not None:
+        hass_device_info[ATTR_MODEL] = sensor_device_info.model
+    return hass_device_info

--- a/homeassistant/components/kegtron/device.py
+++ b/homeassistant/components/kegtron/device.py
@@ -1,6 +1,8 @@
 """Support for Kegtron devices."""
 from __future__ import annotations
 
+import logging
+
 from kegtron_ble import DeviceKey, SensorDeviceInfo
 
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -8,6 +10,8 @@ from homeassistant.components.bluetooth.passive_update_processor import (
 )
 from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
 from homeassistant.helpers.entity import DeviceInfo
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def device_key_to_bluetooth_entity_key(

--- a/homeassistant/components/kegtron/manifest.json
+++ b/homeassistant/components/kegtron/manifest.json
@@ -9,7 +9,7 @@
       "manufacturer_id": 65535
     }
   ],
-  "requirements": ["kegtron-ble==0.3.0"],
+  "requirements": ["kegtron-ble==0.4.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/kegtron/manifest.json
+++ b/homeassistant/components/kegtron/manifest.json
@@ -9,7 +9,7 @@
       "manufacturer_id": 65535
     }
   ],
-  "requirements": ["kegtron-ble==0.1.1"],
+  "requirements": ["kegtron-ble==0.3.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/kegtron/manifest.json
+++ b/homeassistant/components/kegtron/manifest.json
@@ -1,0 +1,16 @@
+{
+  "domain": "kegtron",
+  "name": "Kegtron",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/kegtron",
+  "bluetooth": [
+    {
+      "connectable": false,
+      "manufacturer_id": 65535
+    }
+  ],
+  "requirements": ["kegtron-ble==0.1.1"],
+  "dependencies": ["bluetooth"],
+  "codeowners": ["@Ernst79"],
+  "iot_class": "local_push"
+}

--- a/homeassistant/components/kegtron/sensor.py
+++ b/homeassistant/components/kegtron/sensor.py
@@ -1,0 +1,140 @@
+"""Support for Kegtron sensors."""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from kegtron_ble import (
+    SensorDeviceClass as KegtronSensorDeviceClass,
+    SensorUpdate,
+    Units,
+)
+
+from homeassistant import config_entries
+from homeassistant.components.bluetooth.passive_update_processor import (
+    PassiveBluetoothDataProcessor,
+    PassiveBluetoothDataUpdate,
+    PassiveBluetoothProcessorCoordinator,
+    PassiveBluetoothProcessorEntity,
+)
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT, VOLUME_LITERS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+
+SENSOR_DESCRIPTIONS = {
+    ("keg_size"): SensorEntityDescription(
+        key="keg_size",
+        icon="mdi:keg",
+        native_unit_of_measurement=VOLUME_LITERS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ("keg_type"): SensorEntityDescription(
+        key="keg_type",
+        icon="mdi:keg",
+    ),
+    ("volume_start"): SensorEntityDescription(
+        key="volume_start",
+        icon="mdi:keg",
+        native_unit_of_measurement=VOLUME_LITERS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ("port_count"): SensorEntityDescription(
+        key="port_count",
+        icon="mdi:keg",
+    ),
+    ("port_index"): SensorEntityDescription(
+        key="port_index",
+        icon="mdi:keg",
+    ),
+    ("port_state"): SensorEntityDescription(
+        key="port_state",
+        icon="mdi:keg",
+    ),
+    ("volume_dispensed_port_1"): SensorEntityDescription(
+        key="volume_dispensed_port_1",
+        icon="mdi:keg",
+        native_unit_of_measurement=VOLUME_LITERS,
+        state_class=SensorStateClass.TOTAL,
+    ),
+    ("volume_dispensed_port_2"): SensorEntityDescription(
+        key="volume_dispensed_port_2",
+        icon="mdi:keg",
+        native_unit_of_measurement=VOLUME_LITERS,
+        state_class=SensorStateClass.TOTAL,
+    ),
+    ("signal_strength"): SensorEntityDescription(
+        key=f"{KegtronSensorDeviceClass.SIGNAL_STRENGTH}_{Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT}",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+}
+
+
+def sensor_update_to_bluetooth_data_update(
+    sensor_update: SensorUpdate,
+) -> PassiveBluetoothDataUpdate:
+    """Convert a sensor update to a bluetooth data update."""
+    return PassiveBluetoothDataUpdate(
+        devices={
+            device_id: sensor_device_info_to_hass(device_info)
+            for device_id, device_info in sensor_update.devices.items()
+        },
+        entity_descriptions={
+            device_key_to_bluetooth_entity_key(device_key): SENSOR_DESCRIPTIONS[
+                (description.device_key.key)
+            ]
+            for device_key, description in sensor_update.entity_descriptions.items()
+        },
+        entity_data={
+            device_key_to_bluetooth_entity_key(device_key): sensor_values.native_value
+            for device_key, sensor_values in sensor_update.entity_values.items()
+        },
+        entity_names={
+            device_key_to_bluetooth_entity_key(device_key): sensor_values.name
+            for device_key, sensor_values in sensor_update.entity_values.items()
+        },
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Kegtron BLE sensors."""
+    coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
+        entry.entry_id
+    ]
+    processor = PassiveBluetoothDataProcessor(sensor_update_to_bluetooth_data_update)
+    entry.async_on_unload(
+        processor.async_add_entities_listener(
+            KegtronBluetoothSensorEntity, async_add_entities
+        )
+    )
+    entry.async_on_unload(coordinator.async_register_processor(processor))
+
+
+class KegtronBluetoothSensorEntity(
+    PassiveBluetoothProcessorEntity[
+        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
+    ],
+    SensorEntity,
+):
+    """Representation of a Kegtron sensor."""
+
+    @property
+    def native_value(self) -> int | float | None:
+        """Return the native value."""
+        return self.processor.entity_data.get(self.entity_key)

--- a/homeassistant/components/kegtron/sensor.py
+++ b/homeassistant/components/kegtron/sensor.py
@@ -31,47 +31,41 @@ from .const import DOMAIN
 from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
 
 SENSOR_DESCRIPTIONS = {
-    ("keg_size"): SensorEntityDescription(
+    "port_count": SensorEntityDescription(
+        key="port_count",
+        icon="mdi:water-pump",
+    ),
+    "keg_size": SensorEntityDescription(
         key="keg_size",
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    ("keg_type"): SensorEntityDescription(
+    "keg_type": SensorEntityDescription(
         key="keg_type",
         icon="mdi:keg",
     ),
-    ("volume_start"): SensorEntityDescription(
+    "volume_start": SensorEntityDescription(
         key="volume_start",
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    ("port_count"): SensorEntityDescription(
-        key="port_count",
+    "volume_dispensed": SensorEntityDescription(
+        key="volume_dispensed",
         icon="mdi:keg",
+        native_unit_of_measurement=VOLUME_LITERS,
+        state_class=SensorStateClass.TOTAL,
     ),
-    ("port_index"): SensorEntityDescription(
-        key="port_index",
-        icon="mdi:keg",
-    ),
-    ("port_state"): SensorEntityDescription(
+    "port_state": SensorEntityDescription(
         key="port_state",
-        icon="mdi:keg",
+        icon="mdi:water-pump",
     ),
-    ("volume_dispensed_port_1"): SensorEntityDescription(
-        key="volume_dispensed_port_1",
-        icon="mdi:keg",
-        native_unit_of_measurement=VOLUME_LITERS,
-        state_class=SensorStateClass.TOTAL,
+    "port_name": SensorEntityDescription(
+        key="port_name",
+        icon="mdi:water-pump",
     ),
-    ("volume_dispensed_port_2"): SensorEntityDescription(
-        key="volume_dispensed_port_2",
-        icon="mdi:keg",
-        native_unit_of_measurement=VOLUME_LITERS,
-        state_class=SensorStateClass.TOTAL,
-    ),
-    ("signal_strength"): SensorEntityDescription(
+    "signal_strength": SensorEntityDescription(
         key=f"{KegtronSensorDeviceClass.SIGNAL_STRENGTH}_{Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT}",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
@@ -93,7 +87,9 @@ def sensor_update_to_bluetooth_data_update(
         },
         entity_descriptions={
             device_key_to_bluetooth_entity_key(device_key): SENSOR_DESCRIPTIONS[
-                (description.device_key.key)
+                description.device_key.key.removesuffix("_port_1").removesuffix(
+                    "_port_2"
+                )
             ]
             for device_key, description in sensor_update.entity_descriptions.items()
         },

--- a/homeassistant/components/kegtron/sensor.py
+++ b/homeassistant/components/kegtron/sensor.py
@@ -32,37 +32,37 @@ from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_ha
 
 SENSOR_DESCRIPTIONS = {
     KegtronSensorDeviceClass.PORT_COUNT: SensorEntityDescription(
-        key=f"{KegtronSensorDeviceClass.PORT_COUNT}",
+        key=KegtronSensorDeviceClass.PORT_COUNT,
         icon="mdi:water-pump",
     ),
     KegtronSensorDeviceClass.KEG_SIZE: SensorEntityDescription(
-        key=f"{KegtronSensorDeviceClass.KEG_SIZE}",
+        key=KegtronSensorDeviceClass.KEG_SIZE,
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     KegtronSensorDeviceClass.KEG_TYPE: SensorEntityDescription(
-        key=f"{KegtronSensorDeviceClass.KEG_TYPE}",
+        key=KegtronSensorDeviceClass.KEG_TYPE,
         icon="mdi:keg",
     ),
     KegtronSensorDeviceClass.VOLUME_START: SensorEntityDescription(
-        key=f"{KegtronSensorDeviceClass.VOLUME_START}",
+        key=KegtronSensorDeviceClass.VOLUME_START,
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     KegtronSensorDeviceClass.VOLUME_DISPENSED: SensorEntityDescription(
-        key=f"{KegtronSensorDeviceClass.VOLUME_DISPENSED}",
+        key=KegtronSensorDeviceClass.VOLUME_DISPENSED,
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         state_class=SensorStateClass.TOTAL,
     ),
     KegtronSensorDeviceClass.PORT_STATE: SensorEntityDescription(
-        key=f"{KegtronSensorDeviceClass.PORT_STATE}",
+        key=KegtronSensorDeviceClass.PORT_STATE,
         icon="mdi:water-pump",
     ),
     KegtronSensorDeviceClass.PORT_NAME: SensorEntityDescription(
-        key=f"{KegtronSensorDeviceClass.PORT_NAME}",
+        key=KegtronSensorDeviceClass.PORT_NAME,
         icon="mdi:water-pump",
     ),
     KegtronSensorDeviceClass.SIGNAL_STRENGTH: SensorEntityDescription(

--- a/homeassistant/components/kegtron/sensor.py
+++ b/homeassistant/components/kegtron/sensor.py
@@ -31,41 +31,41 @@ from .const import DOMAIN
 from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
 
 SENSOR_DESCRIPTIONS = {
-    "port_count": SensorEntityDescription(
-        key="port_count",
+    KegtronSensorDeviceClass.PORT_COUNT: SensorEntityDescription(
+        key=f"{KegtronSensorDeviceClass.PORT_COUNT}",
         icon="mdi:water-pump",
     ),
-    "keg_size": SensorEntityDescription(
-        key="keg_size",
+    KegtronSensorDeviceClass.KEG_SIZE: SensorEntityDescription(
+        key=f"{KegtronSensorDeviceClass.KEG_SIZE}",
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    "keg_type": SensorEntityDescription(
-        key="keg_type",
+    KegtronSensorDeviceClass.KEG_TYPE: SensorEntityDescription(
+        key=f"{KegtronSensorDeviceClass.KEG_TYPE}",
         icon="mdi:keg",
     ),
-    "volume_start": SensorEntityDescription(
-        key="volume_start",
+    KegtronSensorDeviceClass.VOLUME_START: SensorEntityDescription(
+        key=f"{KegtronSensorDeviceClass.VOLUME_START}",
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    "volume_dispensed": SensorEntityDescription(
-        key="volume_dispensed",
+    KegtronSensorDeviceClass.VOLUME_DISPENSED: SensorEntityDescription(
+        key=f"{KegtronSensorDeviceClass.VOLUME_DISPENSED}",
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         state_class=SensorStateClass.TOTAL,
     ),
-    "port_state": SensorEntityDescription(
-        key="port_state",
+    KegtronSensorDeviceClass.PORT_STATE: SensorEntityDescription(
+        key=f"{KegtronSensorDeviceClass.PORT_STATE}",
         icon="mdi:water-pump",
     ),
-    "port_name": SensorEntityDescription(
-        key="port_name",
+    KegtronSensorDeviceClass.PORT_NAME: SensorEntityDescription(
+        key=f"{KegtronSensorDeviceClass.PORT_NAME}",
         icon="mdi:water-pump",
     ),
-    "signal_strength": SensorEntityDescription(
+    KegtronSensorDeviceClass.SIGNAL_STRENGTH: SensorEntityDescription(
         key=f"{KegtronSensorDeviceClass.SIGNAL_STRENGTH}_{Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT}",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
@@ -87,11 +87,10 @@ def sensor_update_to_bluetooth_data_update(
         },
         entity_descriptions={
             device_key_to_bluetooth_entity_key(device_key): SENSOR_DESCRIPTIONS[
-                description.device_key.key.removesuffix("_port_1").removesuffix(
-                    "_port_2"
-                )
+                description.device_class
             ]
             for device_key, description in sensor_update.entity_descriptions.items()
+            if description.device_class
         },
         entity_data={
             device_key_to_bluetooth_entity_key(device_key): sensor_values.native_value

--- a/homeassistant/components/kegtron/strings.json
+++ b/homeassistant/components/kegtron/strings.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "flow_title": "[%key:component::bluetooth::config::flow_title%]",
+    "step": {
+      "user": {
+        "description": "[%key:component::bluetooth::config::step::user::description%]",
+        "data": {
+          "address": "[%key:component::bluetooth::config::step::user::data::address%]"
+        }
+      },
+      "bluetooth_confirm": {
+        "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]"
+      }
+    },
+    "abort": {
+      "not_supported": "Device not supported",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/kegtron/translations/en.json
+++ b/homeassistant/components/kegtron/translations/en.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured",
+            "already_in_progress": "Configuration flow is already in progress",
+            "no_devices_found": "No devices found on the network",
+            "not_supported": "Device not supported"
+        },
+        "flow_title": "{name}",
+        "step": {
+            "bluetooth_confirm": {
+                "description": "Do you want to setup {name}?"
+            },
+            "user": {
+                "data": {
+                    "address": "Device"
+                },
+                "description": "Choose a device to setup"
+            }
+        }
+    }
+}

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -149,6 +149,11 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
         "connectable": False,
     },
     {
+        "domain": "kegtron",
+        "connectable": False,
+        "manufacturer_id": 65535
+    },
+    {
         "domain": "led_ble",
         "local_name": "LEDnet*",
     },

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -151,7 +151,7 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
     {
         "domain": "kegtron",
         "connectable": False,
-        "manufacturer_id": 65535
+        "manufacturer_id": 65535,
     },
     {
         "domain": "led_ble",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -190,6 +190,7 @@ FLOWS = {
         "justnimbus",
         "kaleidescape",
         "keenetic_ndms2",
+        "kegtron",
         "kmtronic",
         "knx",
         "kodi",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -956,6 +956,9 @@ kaiterra-async-client==1.0.0
 # homeassistant.components.keba
 keba-kecontact==1.1.0
 
+# homeassistant.components.kegtron
+kegtron-ble==0.1.1
+
 # homeassistant.components.kiwi
 kiwiki-client==0.1.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -957,7 +957,7 @@ kaiterra-async-client==1.0.0
 keba-kecontact==1.1.0
 
 # homeassistant.components.kegtron
-kegtron-ble==0.3.0
+kegtron-ble==0.4.0
 
 # homeassistant.components.kiwi
 kiwiki-client==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -957,7 +957,7 @@ kaiterra-async-client==1.0.0
 keba-kecontact==1.1.0
 
 # homeassistant.components.kegtron
-kegtron-ble==0.1.1
+kegtron-ble==0.3.0
 
 # homeassistant.components.kiwi
 kiwiki-client==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -698,7 +698,7 @@ jsonpath==0.82
 justnimbus==0.6.0
 
 # homeassistant.components.kegtron
-kegtron-ble==0.3.0
+kegtron-ble==0.4.0
 
 # homeassistant.components.konnected
 konnected==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -697,6 +697,9 @@ jsonpath==0.82
 # homeassistant.components.justnimbus
 justnimbus==0.6.0
 
+# homeassistant.components.kegtron
+kegtron-ble==0.1.1
+
 # homeassistant.components.konnected
 konnected==1.2.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -698,7 +698,7 @@ jsonpath==0.82
 justnimbus==0.6.0
 
 # homeassistant.components.kegtron
-kegtron-ble==0.1.1
+kegtron-ble==0.3.0
 
 # homeassistant.components.konnected
 konnected==1.2.0

--- a/tests/components/kegtron/__init__.py
+++ b/tests/components/kegtron/__init__.py
@@ -24,7 +24,19 @@ KEGTRON_KT100_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
-KEGTRON_KT200_SERVICE_INFO = BluetoothServiceInfo(
+KEGTRON_KT200_PORT_1_SERVICE_INFO = BluetoothServiceInfo(
+    name="D0:CF:5E:5C:9B:75",
+    manufacturer_data={
+        65535: b"#P\xc3P2\xc8APort 1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    },
+    address="D0:CF:5E:5C:9B:75",
+    rssi=-82,
+    service_uuids=[],
+    service_data={},
+    source="local",
+)
+
+KEGTRON_KT200_PORT_2_SERVICE_INFO = BluetoothServiceInfo(
     name="D0:CF:5E:5C:9B:75",
     manufacturer_data={
         65535: b"\xe62:\x98\x02\xe2Q2nd Port\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"

--- a/tests/components/kegtron/__init__.py
+++ b/tests/components/kegtron/__init__.py
@@ -1,0 +1,37 @@
+"""Tests for the Kegtron integration."""
+
+from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
+
+NOT_KEGTRON_SERVICE_INFO = BluetoothServiceInfo(
+    name="Not it",
+    address="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+    rssi=-63,
+    manufacturer_data={3234: b"\x00\x01"},
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+
+KEGTRON_KT100_SERVICE_INFO = BluetoothServiceInfo(
+    name="D0:CF:5E:5C:9B:75",
+    manufacturer_data={
+        65535: b"I\xef\x13\x88\x02\xe2\x01Single Port\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    },
+    address="D0:CF:5E:5C:9B:75",
+    rssi=-82,
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+
+KEGTRON_KT200_SERVICE_INFO = BluetoothServiceInfo(
+    name="D0:CF:5E:5C:9B:75",
+    manufacturer_data={
+        65535: b"\xe62:\x98\x02\xe2Q2nd Port\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    },
+    address="D0:CF:5E:5C:9B:75",
+    rssi=-82,
+    service_uuids=[],
+    service_data={},
+    source="local",
+)

--- a/tests/components/kegtron/conftest.py
+++ b/tests/components/kegtron/conftest.py
@@ -1,0 +1,8 @@
+"""Kegtron session fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_bluetooth(enable_bluetooth):
+    """Auto mock bluetooth."""

--- a/tests/components/kegtron/test_config_flow.py
+++ b/tests/components/kegtron/test_config_flow.py
@@ -1,0 +1,196 @@
+"""Test the Kegtron config flow."""
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.kegtron.const import DOMAIN
+from homeassistant.data_entry_flow import FlowResultType
+
+from . import (
+    KEGTRON_KT100_SERVICE_INFO,
+    KEGTRON_KT200_SERVICE_INFO,
+    NOT_KEGTRON_SERVICE_INFO,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_async_step_bluetooth_valid_device(hass):
+    """Test discovery via bluetooth with a valid device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=KEGTRON_KT100_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+    with patch("homeassistant.components.kegtron.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Kegtron KT-100 9B75"
+    assert result2["data"] == {}
+    assert result2["result"].unique_id == "D0:CF:5E:5C:9B:75"
+
+
+async def test_async_step_bluetooth_not_kegtron(hass):
+    """Test discovery via bluetooth not kegtron."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=NOT_KEGTRON_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "not_supported"
+
+
+async def test_async_step_user_no_devices_found(hass):
+    """Test setup from service info cache with no devices found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+
+
+async def test_async_step_user_with_found_devices(hass):
+    """Test setup from service info cache with devices found."""
+    with patch(
+        "homeassistant.components.kegtron.config_flow.async_discovered_service_info",
+        return_value=[KEGTRON_KT200_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    with patch("homeassistant.components.kegtron.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"address": "D0:CF:5E:5C:9B:75"},
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Kegtron KT-200 9B75"
+    assert result2["data"] == {}
+    assert result2["result"].unique_id == "D0:CF:5E:5C:9B:75"
+
+
+async def test_async_step_user_device_added_between_steps(hass):
+    """Test the device gets added via another flow between steps."""
+    with patch(
+        "homeassistant.components.kegtron.config_flow.async_discovered_service_info",
+        return_value=[KEGTRON_KT100_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="D0:CF:5E:5C:9B:75",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.kegtron.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"address": "D0:CF:5E:5C:9B:75"},
+        )
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_async_step_user_with_found_devices_already_setup(hass):
+    """Test setup from service info cache with devices found."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="D0:CF:5E:5C:9B:75",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.kegtron.config_flow.async_discovered_service_info",
+        return_value=[KEGTRON_KT100_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+
+
+async def test_async_step_bluetooth_devices_already_setup(hass):
+    """Test we can't start a flow if there is already a config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="D0:CF:5E:5C:9B:75",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=KEGTRON_KT100_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_async_step_bluetooth_already_in_progress(hass):
+    """Test we can't start a flow for the same device twice."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=KEGTRON_KT100_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=KEGTRON_KT100_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_in_progress"
+
+
+async def test_async_step_user_takes_precedence_over_discovery(hass):
+    """Test manual setup takes precedence over discovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=KEGTRON_KT100_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+
+    with patch(
+        "homeassistant.components.kegtron.config_flow.async_discovered_service_info",
+        return_value=[KEGTRON_KT100_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        assert result["type"] == FlowResultType.FORM
+
+    with patch("homeassistant.components.kegtron.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"address": "D0:CF:5E:5C:9B:75"},
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Kegtron KT-100 9B75"
+    assert result2["data"] == {}
+    assert result2["result"].unique_id == "D0:CF:5E:5C:9B:75"
+
+    # Verify the original one was aborted
+    assert not hass.config_entries.flow.async_progress(DOMAIN)

--- a/tests/components/kegtron/test_config_flow.py
+++ b/tests/components/kegtron/test_config_flow.py
@@ -8,7 +8,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
     KEGTRON_KT100_SERVICE_INFO,
-    KEGTRON_KT200_SERVICE_INFO,
+    KEGTRON_KT200_PORT_2_SERVICE_INFO,
     NOT_KEGTRON_SERVICE_INFO,
 )
 
@@ -59,7 +59,7 @@ async def test_async_step_user_with_found_devices(hass):
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.kegtron.config_flow.async_discovered_service_info",
-        return_value=[KEGTRON_KT200_SERVICE_INFO],
+        return_value=[KEGTRON_KT200_PORT_2_SERVICE_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/kegtron/test_sensor.py
+++ b/tests/components/kegtron/test_sensor.py
@@ -1,0 +1,98 @@
+"""Test the Kegtron sensors."""
+
+from unittest.mock import patch
+
+from homeassistant.components.bluetooth import BluetoothChange
+from homeassistant.components.kegtron.const import DOMAIN
+from homeassistant.components.sensor import ATTR_STATE_CLASS
+from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+
+from . import KEGTRON_KT100_SERVICE_INFO
+
+from tests.common import MockConfigEntry
+
+
+async def test_sensors(hass):
+    """Test setting up creates the sensors for Kegtron KT-100."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="D0:CF:5E:5C:9B:75",
+    )
+    entry.add_to_hass(hass)
+
+    saved_callback = None
+
+    def _async_register_callback(_hass, _callback, _matcher, _mode):
+        nonlocal saved_callback
+        saved_callback = _callback
+        return lambda: None
+
+    with patch(
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
+        _async_register_callback,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(hass.states.async_all("sensor")) == 0
+    saved_callback(KEGTRON_KT100_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all("sensor")) == 7
+
+    keg_size_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_keg_size")
+    keg_size_sensor_attrs = keg_size_sensor.attributes
+    assert keg_size_sensor.state == "18.927"
+    assert keg_size_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Keg Size"
+    assert keg_size_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert keg_size_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
+
+    keg_type_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_keg_type")
+    keg_type_sensor_attrs = keg_type_sensor.attributes
+    assert keg_type_sensor.state == "Corny (5.0 gal)"
+    assert keg_type_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Keg Type"
+
+    volume_start_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_volume_start")
+    volume_start_sensor_attrs = volume_start_sensor.attributes
+    assert volume_start_sensor.state == "5.0"
+    assert (
+        volume_start_sensor_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-100 9B75 Volume Start"
+    )
+    assert volume_start_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert volume_start_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
+
+    port_count_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_port_count")
+    port_count_sensor_attrs = port_count_sensor.attributes
+    assert port_count_sensor.state == "Single port device"
+    assert (
+        port_count_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Port Count"
+    )
+
+    port_index_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_port_index")
+    port_index_sensor_attrs = port_index_sensor.attributes
+    assert port_index_sensor.state == "1"
+    assert (
+        port_index_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Port Index"
+    )
+
+    port_state_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_port_state")
+    port_state_sensor_attrs = port_state_sensor.attributes
+    assert port_state_sensor.state == "Configured"
+    assert (
+        port_state_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Port State"
+    )
+
+    volume_dispensed_port_1_sensor = hass.states.get(
+        "sensor.kegtron_kt_100_9b75_volume_dispensed_single_port"
+    )
+    volume_dispensed_port_1_attrs = volume_dispensed_port_1_sensor.attributes
+    assert volume_dispensed_port_1_sensor.state == "0.738"
+    assert (
+        volume_dispensed_port_1_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-100 9B75 Volume Dispensed Single Port"
+    )
+    assert volume_dispensed_port_1_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert volume_dispensed_port_1_attrs[ATTR_STATE_CLASS] == "total"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/kegtron/test_sensor.py
+++ b/tests/components/kegtron/test_sensor.py
@@ -1,8 +1,5 @@
 """Test the Kegtron sensors."""
 
-from unittest.mock import patch
-
-from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.kegtron.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -10,6 +7,7 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from . import KEGTRON_KT100_SERVICE_INFO
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(hass):
@@ -20,22 +18,15 @@ async def test_sensors(hass):
     )
     entry.add_to_hass(hass)
 
-    saved_callback = None
-
-    def _async_register_callback(_hass, _callback, _matcher, _mode):
-        nonlocal saved_callback
-        saved_callback = _callback
-        return lambda: None
-
-    with patch(
-        "homeassistant.components.bluetooth.update_coordinator.async_register_callback",
-        _async_register_callback,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_all("sensor")) == 0
-    saved_callback(KEGTRON_KT100_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
+
+    inject_bluetooth_service_info(
+        hass,
+        KEGTRON_KT100_SERVICE_INFO,
+    )
     await hass.async_block_till_done()
     assert len(hass.states.async_all("sensor")) == 7
 

--- a/tests/components/kegtron/test_sensor.py
+++ b/tests/components/kegtron/test_sensor.py
@@ -4,13 +4,17 @@ from homeassistant.components.kegtron.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 
-from . import KEGTRON_KT100_SERVICE_INFO
+from . import (
+    KEGTRON_KT100_SERVICE_INFO,
+    KEGTRON_KT200_PORT_1_SERVICE_INFO,
+    KEGTRON_KT200_PORT_2_SERVICE_INFO,
+)
 
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass):
+async def test_sensors_kt100(hass):
     """Test setting up creates the sensors for Kegtron KT-100."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -29,6 +33,13 @@ async def test_sensors(hass):
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all("sensor")) == 7
+
+    port_count_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_port_count")
+    port_count_sensor_attrs = port_count_sensor.attributes
+    assert port_count_sensor.state == "Single port device"
+    assert (
+        port_count_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Port Count"
+    )
 
     keg_size_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_keg_size")
     keg_size_sensor_attrs = keg_size_sensor.attributes
@@ -52,19 +63,17 @@ async def test_sensors(hass):
     assert volume_start_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
     assert volume_start_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
-    port_count_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_port_count")
-    port_count_sensor_attrs = port_count_sensor.attributes
-    assert port_count_sensor.state == "Single port device"
-    assert (
-        port_count_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Port Count"
+    volume_dispensed_sensor = hass.states.get(
+        "sensor.kegtron_kt_100_9b75_volume_dispensed"
     )
-
-    port_index_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_port_index")
-    port_index_sensor_attrs = port_index_sensor.attributes
-    assert port_index_sensor.state == "1"
+    volume_dispensed_attrs = volume_dispensed_sensor.attributes
+    assert volume_dispensed_sensor.state == "0.738"
     assert (
-        port_index_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Port Index"
+        volume_dispensed_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-100 9B75 Volume Dispensed"
     )
+    assert volume_dispensed_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert volume_dispensed_attrs[ATTR_STATE_CLASS] == "total"
 
     port_state_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_port_state")
     port_state_sensor_attrs = port_state_sensor.attributes
@@ -73,17 +82,167 @@ async def test_sensors(hass):
         port_state_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Port State"
     )
 
-    volume_dispensed_port_1_sensor = hass.states.get(
-        "sensor.kegtron_kt_100_9b75_volume_dispensed_single_port"
+    port_name_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_port_name")
+    port_name_attrs = port_name_sensor.attributes
+    assert port_name_sensor.state == "Single Port"
+    assert port_name_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Port Name"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_sensors_kt200(hass):
+    """Test setting up creates the sensors for Kegtron KT-200."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="D0:CF:5E:5C:9B:75",
     )
-    volume_dispensed_port_1_attrs = volume_dispensed_port_1_sensor.attributes
-    assert volume_dispensed_port_1_sensor.state == "0.738"
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all("sensor")) == 0
+
+    # Kegtron KT-200 has two ports that are reported separately, start with port 2
+    inject_bluetooth_service_info(
+        hass,
+        KEGTRON_KT200_PORT_2_SERVICE_INFO,
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all("sensor")) == 7
+
+    port_count_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_port_count")
+    port_count_sensor_attrs = port_count_sensor.attributes
+    assert port_count_sensor.state == "Dual port device"
     assert (
-        volume_dispensed_port_1_attrs[ATTR_FRIENDLY_NAME]
-        == "Kegtron KT-100 9B75 Volume Dispensed Single Port"
+        port_count_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-200 9B75 Port Count"
     )
-    assert volume_dispensed_port_1_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
-    assert volume_dispensed_port_1_attrs[ATTR_STATE_CLASS] == "total"
+
+    keg_size_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_keg_size_port_2")
+    keg_size_sensor_attrs = keg_size_sensor.attributes
+    assert keg_size_sensor.state == "58.93"
+    assert (
+        keg_size_sensor_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Keg Size Port 2"
+    )
+    assert keg_size_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert keg_size_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
+
+    keg_type_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_keg_type_port_2")
+    keg_type_sensor_attrs = keg_type_sensor.attributes
+    assert keg_type_sensor.state == "Other (58.93 L)"
+    assert (
+        keg_type_sensor_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Keg Type Port 2"
+    )
+
+    volume_start_sensor = hass.states.get(
+        "sensor.kegtron_kt_200_9b75_volume_start_port_2"
+    )
+    volume_start_sensor_attrs = volume_start_sensor.attributes
+    assert volume_start_sensor.state == "15.0"
+    assert (
+        volume_start_sensor_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Volume Start Port 2"
+    )
+    assert volume_start_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert volume_start_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
+
+    volume_dispensed_sensor = hass.states.get(
+        "sensor.kegtron_kt_200_9b75_volume_dispensed_port_2"
+    )
+    volume_dispensed_attrs = volume_dispensed_sensor.attributes
+    assert volume_dispensed_sensor.state == "0.738"
+    assert (
+        volume_dispensed_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Volume Dispensed Port 2"
+    )
+    assert volume_dispensed_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert volume_dispensed_attrs[ATTR_STATE_CLASS] == "total"
+
+    port_state_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_port_state_port_2")
+    port_state_sensor_attrs = port_state_sensor.attributes
+    assert port_state_sensor.state == "Configured"
+    assert (
+        port_state_sensor_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Port State Port 2"
+    )
+
+    port_name_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_port_name_port_2")
+    port_name_attrs = port_name_sensor.attributes
+    assert port_name_sensor.state == "2nd Port"
+    assert port_name_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-200 9B75 Port Name Port 2"
+
+    # Followed by a BLE advertisement of port 1
+    inject_bluetooth_service_info(
+        hass,
+        KEGTRON_KT200_PORT_1_SERVICE_INFO,
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all("sensor")) == 13
+
+    port_count_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_port_count")
+    port_count_sensor_attrs = port_count_sensor.attributes
+    assert port_count_sensor.state == "Dual port device"
+    assert (
+        port_count_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-200 9B75 Port Count"
+    )
+
+    keg_size_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_keg_size_port_1")
+    keg_size_sensor_attrs = keg_size_sensor.attributes
+    assert keg_size_sensor.state == "9.04"
+    assert (
+        keg_size_sensor_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Keg Size Port 1"
+    )
+    assert keg_size_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert keg_size_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
+
+    keg_type_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_keg_type_port_1")
+    keg_type_sensor_attrs = keg_type_sensor.attributes
+    assert keg_type_sensor.state == "Other (9.04 L)"
+    assert (
+        keg_type_sensor_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Keg Type Port 1"
+    )
+
+    volume_start_sensor = hass.states.get(
+        "sensor.kegtron_kt_200_9b75_volume_start_port_1"
+    )
+    volume_start_sensor_attrs = volume_start_sensor.attributes
+    assert volume_start_sensor.state == "50.0"
+    assert (
+        volume_start_sensor_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Volume Start Port 1"
+    )
+    assert volume_start_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert volume_start_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
+
+    volume_dispensed_sensor = hass.states.get(
+        "sensor.kegtron_kt_200_9b75_volume_dispensed_port_1"
+    )
+    volume_dispensed_attrs = volume_dispensed_sensor.attributes
+    assert volume_dispensed_sensor.state == "13.0"
+    assert (
+        volume_dispensed_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Volume Dispensed Port 1"
+    )
+    assert volume_dispensed_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
+    assert volume_dispensed_attrs[ATTR_STATE_CLASS] == "total"
+
+    port_state_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_port_state_port_1")
+    port_state_sensor_attrs = port_state_sensor.attributes
+    assert port_state_sensor.state == "Configured"
+    assert (
+        port_state_sensor_attrs[ATTR_FRIENDLY_NAME]
+        == "Kegtron KT-200 9B75 Port State Port 1"
+    )
+
+    port_name_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_port_name_port_1")
+    port_name_attrs = port_name_sensor.attributes
+    assert port_name_sensor.state == "Port 1"
+    assert port_name_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-200 9B75 Port Name Port 1"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for Kegtron Smart Keg Monitor (Gen 1) BLE devices. These devices send data about keg size, beer volume dispensed, etc over BLE. Gen 1 devices are generally for Home Use Beer tap installations. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24172

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
