### PR TITLE
Bump holidays to 0.16

### DIFF
--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -1,7 +1,7 @@
 """Sensor to indicate whether the current day is a workday."""
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 import logging
 from typing import Any
 
@@ -87,8 +87,8 @@ def setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the Workday sensor."""
-    add_holidays: list[str] = config[CONF_ADD_HOLIDAYS]
-    remove_holidays: list[str] = config[CONF_REMOVE_HOLIDAYS]
+    add_holidays: list[date | datetime | str | float | int] = config[CONF_ADD_HOLIDAYS]
+    remove_holidays: Any = config[CONF_REMOVE_HOLIDAYS]
     country: str = config[CONF_COUNTRY]
     days_offset: int = config[CONF_OFFSET]
     excludes: list[str] = config[CONF_EXCLUDES]
@@ -139,7 +139,7 @@ def setup_platform(
 
     _LOGGER.debug("Found the following holidays for your configuration:")
     for remove_holiday, name in sorted(obj_holidays.items()):
-        _LOGGER.debug("%s %s", remove_holiday, name)
+        _LOGGER.debug("%s %s", str(remove_holiday), name)
 
     add_entities(
         [IsWorkdaySensor(obj_holidays, workdays, excludes, days_offset, sensor_name)],

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -2,7 +2,7 @@
   "domain": "workday",
   "name": "Workday",
   "documentation": "https://www.home-assistant.io/integrations/workday",
-  "requirements": ["holidays==0.14.2"],
+  "requirements": ["holidays==0.16"],
   "codeowners": ["@fabaff"],
   "quality_scale": "internal",
   "iot_class": "local_polling",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -854,7 +854,7 @@ hlk-sw16==0.0.9
 hole==0.7.0
 
 # homeassistant.components.workday
-holidays==0.14.2
+holidays==0.16
 
 # homeassistant.components.frontend
 home-assistant-frontend==20220907.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -628,7 +628,7 @@ hlk-sw16==0.0.9
 hole==0.7.0
 
 # homeassistant.components.workday
-holidays==0.14.2
+holidays==0.16
 
 # homeassistant.components.frontend
 home-assistant-frontend==20220907.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A really 11th hour bump of `holidays` to reflect tomorrow being a national holiday in the UK. (Sorry didn't realise this until just now.

Library diff: https://github.com/dr-prodigy/python-holidays/compare/v.0.14.2...v.0.16

Note this includes a small temporary change to typing to reflect changes made upstream, we need to make our code a little more rigid to handle dates being dates. I'm hoping this can be done in a future PR.

Finally, this includes the removal of UK provinces, however we have had that marked as a breaking change since [2022.3](https://www.home-assistant.io/blog/2022/03/02/release-20223/#breaking-changes).



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
