### PR TITLE
Allow controlling PrusaLink print jobs

### DIFF
--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from datetime import timedelta
 import logging
+from time import monotonic
 from typing import Generic, TypeVar
 
 import async_timeout
@@ -11,7 +12,7 @@ from pyprusalink import InvalidAuth, JobInfo, PrinterInfo, PrusaLink, PrusaLinkE
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -22,7 +23,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.CAMERA]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.CAMERA, Platform.BUTTON]
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -63,29 +64,45 @@ class PrusaLinkUpdateCoordinator(DataUpdateCoordinator, Generic[T]):
     """Update coordinator for the printer."""
 
     config_entry: ConfigEntry
+    expect_change_until = 0.0
 
     def __init__(self, hass: HomeAssistant, api: PrusaLink) -> None:
         """Initialize the update coordinator."""
         self.api = api
 
         super().__init__(
-            hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=30)
+            hass, _LOGGER, name=DOMAIN, update_interval=self._get_update_interval(None)
         )
 
     async def _async_update_data(self) -> T:
         """Update the data."""
         try:
             with async_timeout.timeout(5):
-                return await self._fetch_data()
+                data = await self._fetch_data()
         except InvalidAuth:
             raise UpdateFailed("Invalid authentication") from None
         except PrusaLinkError as err:
             raise UpdateFailed(str(err)) from err
 
+        self.update_interval = self._get_update_interval(data)
+        return data
+
     @abstractmethod
     async def _fetch_data(self) -> T:
         """Fetch the actual data."""
         raise NotImplementedError
+
+    @callback
+    def expect_change(self) -> None:
+        """Expect a change."""
+        self.expect_change_until = monotonic() + 30
+
+    def _get_update_interval(self, data: T) -> timedelta:
+        """Get new update interval."""
+        if self.expect_change_until > monotonic():
+            return timedelta(seconds=3)
+
+        return timedelta(seconds=30)
 
 
 class PrinterUpdateCoordinator(PrusaLinkUpdateCoordinator[PrinterInfo]):
@@ -94,6 +111,15 @@ class PrinterUpdateCoordinator(PrusaLinkUpdateCoordinator[PrinterInfo]):
     async def _fetch_data(self) -> PrinterInfo:
         """Fetch the printer data."""
         return await self.api.get_printer()
+
+    def _get_update_interval(self, data: T) -> timedelta:
+        """Get new update interval."""
+        if data and any(
+            data["state"]["flags"][key] for key in ("pausing", "cancelling")
+        ):
+            return timedelta(seconds=3)
+
+        return super()._get_update_interval(data)
 
 
 class JobUpdateCoordinator(PrusaLinkUpdateCoordinator[JobInfo]):

--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -117,7 +117,7 @@ class PrinterUpdateCoordinator(PrusaLinkUpdateCoordinator[PrinterInfo]):
         if data and any(
             data["state"]["flags"][key] for key in ("pausing", "cancelling")
         ):
-            return timedelta(seconds=3)
+            return timedelta(seconds=5)
 
         return super()._get_update_interval(data)
 

--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.CAMERA, Platform.BUTTON]
+PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.CAMERA, Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -100,7 +100,7 @@ class PrusaLinkUpdateCoordinator(DataUpdateCoordinator, Generic[T]):
     def _get_update_interval(self, data: T) -> timedelta:
         """Get new update interval."""
         if self.expect_change_until > monotonic():
-            return timedelta(seconds=3)
+            return timedelta(seconds=5)
 
         return timedelta(seconds=30)
 

--- a/homeassistant/components/prusalink/button.py
+++ b/homeassistant/components/prusalink/button.py
@@ -1,0 +1,126 @@
+"""PrusaLink sensors."""
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar, cast
+
+from pyprusalink import Conflict, JobInfo, PrinterInfo, PrusaLink
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN, PrusaLinkEntity, PrusaLinkUpdateCoordinator
+
+T = TypeVar("T", PrinterInfo, JobInfo)
+
+
+@dataclass
+class PrusaLinkButtonEntityDescriptionMixin(Generic[T]):
+    """Mixin for required keys."""
+
+    press_fn: Callable[[PrusaLink], Coroutine[Any, Any, None]]
+
+
+@dataclass
+class PrusaLinkButtonEntityDescription(
+    ButtonEntityDescription, PrusaLinkButtonEntityDescriptionMixin[T], Generic[T]
+):
+    """Describes PrusaLink button entity."""
+
+    available_fn: Callable[[T], bool] = lambda _: True
+
+
+BUTTONS: dict[str, tuple[PrusaLinkButtonEntityDescription, ...]] = {
+    "printer": (
+        PrusaLinkButtonEntityDescription[PrinterInfo](
+            key="printer.cancel_job",
+            name="Cancel Job",
+            press_fn=lambda api: cast(Coroutine, api.cancel_job()),
+            available_fn=lambda data: any(
+                data["state"]["flags"][flag]
+                for flag in ("printing", "pausing", "paused")
+            ),
+        ),
+        PrusaLinkButtonEntityDescription[PrinterInfo](
+            key="job.pause_job",
+            name="Pause Job",
+            press_fn=lambda api: cast(Coroutine, api.pause_job()),
+            available_fn=lambda data: (
+                data["state"]["flags"]["printing"]
+                and not data["state"]["flags"]["paused"]
+            ),
+        ),
+        PrusaLinkButtonEntityDescription[PrinterInfo](
+            key="job.resume_job",
+            name="Resume Job",
+            press_fn=lambda api: cast(Coroutine, api.resume_job()),
+            available_fn=lambda data: cast(bool, data["state"]["flags"]["paused"]),
+        ),
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up PrusaLink buttons based on a config entry."""
+    coordinators: dict[str, PrusaLinkUpdateCoordinator] = hass.data[DOMAIN][
+        entry.entry_id
+    ]
+
+    entities: list[PrusaLinkEntity] = []
+
+    for coordinator_type, sensors in BUTTONS.items():
+        coordinator = coordinators[coordinator_type]
+        entities.extend(
+            PrusaLinkButtonEntity(coordinator, sensor_description)
+            for sensor_description in sensors
+        )
+
+    async_add_entities(entities)
+
+
+class PrusaLinkButtonEntity(PrusaLinkEntity, ButtonEntity):
+    """Defines a PrusaLink button."""
+
+    entity_description: PrusaLinkButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: PrusaLinkUpdateCoordinator,
+        description: PrusaLinkButtonEntityDescription,
+    ) -> None:
+        """Initialize a PrusaLink sensor entity."""
+        super().__init__(coordinator=coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
+
+    @property
+    def available(self) -> bool:
+        """Return if sensor is available."""
+        return super().available and self.entity_description.available_fn(
+            self.coordinator.data
+        )
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        try:
+            await self.entity_description.press_fn(self.coordinator.api)
+        except Conflict as err:
+            raise HomeAssistantError(
+                "Action conflicts with current printer state"
+            ) from err
+
+        coordinators: dict[str, PrusaLinkUpdateCoordinator] = self.hass.data[DOMAIN][
+            self.coordinator.config_entry.entry_id
+        ]
+
+        for coordinator in coordinators.values():
+            coordinator.expect_change()
+            await coordinator.async_request_refresh()

--- a/homeassistant/components/prusalink/manifest.json
+++ b/homeassistant/components/prusalink/manifest.json
@@ -3,7 +3,7 @@
   "name": "PrusaLink",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/prusalink",
-  "requirements": ["pyprusalink==1.0.1"],
+  "requirements": ["pyprusalink==1.1.0"],
   "dhcp": [
     {
       "macaddress": "109C70*"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1805,7 +1805,7 @@ pyprof2calltree==1.4.5
 pyprosegur==0.0.5
 
 # homeassistant.components.prusalink
-pyprusalink==1.0.1
+pyprusalink==1.1.0
 
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1270,7 +1270,7 @@ pyprof2calltree==1.4.5
 pyprosegur==0.0.5
 
 # homeassistant.components.prusalink
-pyprusalink==1.0.1
+pyprusalink==1.1.0
 
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.3.1

--- a/tests/components/prusalink/conftest.py
+++ b/tests/components/prusalink/conftest.py
@@ -68,23 +68,23 @@ def mock_printer_api(hass):
 @pytest.fixture
 def mock_job_api_idle(hass):
     """Mock PrusaLink job API having no job."""
-    with patch(
-        "pyprusalink.PrusaLink.get_job",
-        return_value={
-            "state": "Operational",
-            "job": None,
-            "progress": None,
-        },
-    ):
-        yield
+    resp = {
+        "state": "Operational",
+        "job": None,
+        "progress": None,
+    }
+    with patch("pyprusalink.PrusaLink.get_job", return_value=resp):
+        yield resp
 
 
 @pytest.fixture
-def mock_job_api_active(hass):
-    """Mock PrusaLink job API having no job."""
-    with patch(
-        "pyprusalink.PrusaLink.get_job",
-        return_value={
+def mock_job_api_printing(hass, mock_printer_api, mock_job_api_idle):
+    """Mock PrusaLink printing."""
+    mock_printer_api["state"]["text"] = "Printing"
+    mock_printer_api["state"]["flags"]["printing"] = True
+
+    mock_job_api_idle.update(
+        {
             "state": "Printing",
             "job": {
                 "estimatedPrintTime": 117007,
@@ -99,9 +99,18 @@ def mock_job_api_active(hass):
                 "printTime": 43987,
                 "printTimeLeft": 73020,
             },
-        },
-    ):
-        yield
+        }
+    )
+
+
+@pytest.fixture
+def mock_job_api_paused(hass, mock_printer_api, mock_job_api_idle):
+    """Mock PrusaLink paused printing."""
+    mock_printer_api["state"]["text"] = "Paused"
+    mock_printer_api["state"]["flags"]["printing"] = False
+    mock_printer_api["state"]["flags"]["paused"] = True
+
+    mock_job_api_idle["state"] = "Paused"
 
 
 @pytest.fixture

--- a/tests/components/prusalink/test_button.py
+++ b/tests/components/prusalink/test_button.py
@@ -41,6 +41,18 @@ async def test_button_pause_cancel(
     assert state is not None
     assert state.state == "unknown"
 
+    with patch(f"pyprusalink.PrusaLink.{method}") as mock_meth, patch(
+        "homeassistant.components.prusalink.PrusaLinkUpdateCoordinator._fetch_data"
+    ):
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+    assert len(mock_meth.mock_calls) == 1
+
     # Verify it calls correct method + does error handling
     with pytest.raises(HomeAssistantError), patch(
         f"pyprusalink.PrusaLink.{method}", side_effect=Conflict
@@ -72,6 +84,18 @@ async def test_button_resume(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == "unknown"
+
+    with patch(f"pyprusalink.PrusaLink.{method}") as mock_meth, patch(
+        "homeassistant.components.prusalink.PrusaLinkUpdateCoordinator._fetch_data"
+    ):
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+    assert len(mock_meth.mock_calls) == 1
 
     # Verify it calls correct method + does error handling
     with pytest.raises(HomeAssistantError), patch(

--- a/tests/components/prusalink/test_button.py
+++ b/tests/components/prusalink/test_button.py
@@ -1,0 +1,85 @@
+"""Test Prusalink buttons."""
+
+from unittest.mock import patch
+
+from pyprusalink import Conflict
+import pytest
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component
+
+
+@pytest.fixture(autouse=True)
+def setup_button_platform_only():
+    """Only setup button platform."""
+    with patch("homeassistant.components.prusalink.PLATFORMS", [Platform.BUTTON]):
+        yield
+
+
+@pytest.mark.parametrize(
+    "object_id, method",
+    (
+        ("mock_title_cancel_job", "cancel_job"),
+        ("mock_title_pause_job", "pause_job"),
+    ),
+)
+async def test_button_pause_cancel(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_api,
+    hass_client,
+    mock_job_api_printing,
+    object_id,
+    method,
+) -> None:
+    """Test cancel and pause button."""
+    entity_id = f"button.{object_id}"
+    assert await async_setup_component(hass, "prusalink", {})
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "unknown"
+
+    # Verify it calls correct method + does error handling
+    with pytest.raises(HomeAssistantError), patch(
+        f"pyprusalink.PrusaLink.{method}", side_effect=Conflict
+    ):
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "object_id, method",
+    (("mock_title_resume_job", "resume_job"),),
+)
+async def test_button_resume(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_api,
+    hass_client,
+    mock_job_api_paused,
+    object_id,
+    method,
+) -> None:
+    """Test resume button."""
+    entity_id = f"button.{object_id}"
+    assert await async_setup_component(hass, "prusalink", {})
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "unknown"
+
+    # Verify it calls correct method + does error handling
+    with pytest.raises(HomeAssistantError), patch(
+        f"pyprusalink.PrusaLink.{method}", side_effect=Conflict
+    ):
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": entity_id},
+            blocking=True,
+        )

--- a/tests/components/prusalink/test_button.py
+++ b/tests/components/prusalink/test_button.py
@@ -41,9 +41,7 @@ async def test_button_pause_cancel(
     assert state is not None
     assert state.state == "unknown"
 
-    with patch(f"pyprusalink.PrusaLink.{method}") as mock_meth, patch(
-        "homeassistant.components.prusalink.PrusaLinkUpdateCoordinator._fetch_data"
-    ):
+    with patch(f"pyprusalink.PrusaLink.{method}") as mock_meth:
         await hass.services.async_call(
             "button",
             "press",

--- a/tests/components/prusalink/test_camera.py
+++ b/tests/components/prusalink/test_camera.py
@@ -22,7 +22,7 @@ async def test_camera_no_job(
     mock_api,
     hass_client,
 ) -> None:
-    """Test sensors while no job active."""
+    """Test camera while no job active."""
     assert await async_setup_component(hass, "prusalink", {})
     state = hass.states.get("camera.mock_title_job_preview")
     assert state is not None
@@ -34,9 +34,13 @@ async def test_camera_no_job(
 
 
 async def test_camera_active_job(
-    hass: HomeAssistant, mock_config_entry, mock_api, mock_job_api_active, hass_client
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_api,
+    mock_job_api_printing,
+    hass_client,
 ):
-    """Test sensors while no job active."""
+    """Test camera while job active."""
     assert await async_setup_component(hass, "prusalink", {})
     state = hass.states.get("camera.mock_title_job_preview")
     assert state is not None

--- a/tests/components/prusalink/test_sensor.py
+++ b/tests/components/prusalink/test_sensor.py
@@ -79,11 +79,9 @@ async def test_sensors_active_job(
     mock_config_entry,
     mock_api,
     mock_printer_api,
-    mock_job_api_active,
+    mock_job_api_printing,
 ):
     """Test sensors while active job."""
-    mock_printer_api["state"]["flags"]["printing"] = True
-
     with patch(
         "homeassistant.components.prusalink.sensor.utcnow",
         return_value=datetime(2022, 8, 27, 14, 0, 0, tzinfo=timezone.utc),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow pausing, resuming and cancelling print jobs via PrusaLink.

https://github.com/home-assistant-libs/pyprusalink/releases/tag/1.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
