### PR TITLE
Fix Z-Wave JS cover stop support

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -156,23 +156,14 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""
-        open_value = (
+        cover_property = (
             self.get_zwave_value(COVER_OPEN_PROPERTY)
             or self.get_zwave_value(COVER_UP_PROPERTY)
             or self.get_zwave_value(COVER_ON_PROPERTY)
         )
-        if open_value:
-            # Stop the cover if it's opening
-            await self.info.node.async_set_value(open_value, False)
-
-        close_value = (
-            self.get_zwave_value(COVER_CLOSE_PROPERTY)
-            or self.get_zwave_value(COVER_DOWN_PROPERTY)
-            or self.get_zwave_value(COVER_OFF_PROPERTY)
-        )
-        if close_value:
-            # Stop the cover if it's closing
-            await self.info.node.async_set_value(close_value, False)
+        if cover_property:
+            # Stop the cover, will stop regardless of the actual direction of travel.
+            await self.info.node.async_set_value(cover_property, False)
 
 
 class ZWaveTiltCover(ZWaveCover):

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -7,9 +7,6 @@ from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import TARGET_STATE_PROPERTY, TARGET_VALUE_PROPERTY
 from zwave_js_server.const.command_class.barrier_operator import BarrierState
 from zwave_js_server.const.command_class.multilevel_switch import (
-    COVER_CLOSE_PROPERTY,
-    COVER_DOWN_PROPERTY,
-    COVER_OFF_PROPERTY,
     COVER_ON_PROPERTY,
     COVER_OPEN_PROPERTY,
     COVER_UP_PROPERTY,

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -116,7 +116,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 2
+    assert len(client.async_send_command.call_args_list) == 1
     open_args = client.async_send_command.call_args_list[0][0][0]
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 6
@@ -126,16 +126,6 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         "property": "Open",
     }
     assert not open_args["value"]
-
-    close_args = client.async_send_command.call_args_list[1][0][0]
-    assert close_args["command"] == "node.set_value"
-    assert close_args["nodeId"] == 6
-    assert close_args["valueId"] == {
-        "commandClass": 38,
-        "endpoint": 0,
-        "property": "Close",
-    }
-    assert not close_args["value"]
 
     # Test position update from value updated event
     event = Event(
@@ -189,7 +179,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 2
+    assert len(client.async_send_command.call_args_list) == 1
     open_args = client.async_send_command.call_args_list[0][0][0]
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 6
@@ -199,16 +189,6 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         "property": "Open",
     }
     assert not open_args["value"]
-
-    close_args = client.async_send_command.call_args_list[1][0][0]
-    assert close_args["command"] == "node.set_value"
-    assert close_args["nodeId"] == 6
-    assert close_args["valueId"] == {
-        "commandClass": 38,
-        "endpoint": 0,
-        "property": "Close",
-    }
-    assert not close_args["value"]
 
     client.async_send_command.reset_mock()
 
@@ -329,7 +309,7 @@ async def test_aeotec_nano_shutter_cover(
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 2
+    assert len(client.async_send_command.call_args_list) == 1
     open_args = client.async_send_command.call_args_list[0][0][0]
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 3
@@ -339,16 +319,6 @@ async def test_aeotec_nano_shutter_cover(
         "property": "On",
     }
     assert not open_args["value"]
-
-    close_args = client.async_send_command.call_args_list[1][0][0]
-    assert close_args["command"] == "node.set_value"
-    assert close_args["nodeId"] == 3
-    assert close_args["valueId"] == {
-        "commandClass": 38,
-        "endpoint": 0,
-        "property": "Off",
-    }
-    assert not close_args["value"]
 
     # Test position update from value updated event
     event = Event(
@@ -403,7 +373,7 @@ async def test_aeotec_nano_shutter_cover(
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 2
+    assert len(client.async_send_command.call_args_list) == 1
     open_args = client.async_send_command.call_args_list[0][0][0]
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 3
@@ -413,16 +383,6 @@ async def test_aeotec_nano_shutter_cover(
         "property": "On",
     }
     assert not open_args["value"]
-
-    close_args = client.async_send_command.call_args_list[1][0][0]
-    assert close_args["command"] == "node.set_value"
-    assert close_args["nodeId"] == 3
-    assert close_args["valueId"] == {
-        "commandClass": 38,
-        "endpoint": 0,
-        "property": "Off",
-    }
-    assert not close_args["value"]
 
 
 async def test_blind_cover(hass, client, iblinds_v2, integration):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change fixes issues stopping covers (blinds) I was having with my home setup. The Z-Wave JS integration would blindly set the Up/Down property twice, causing the blinds to move again. The integration will now only stop one direction which will[ stop the cover](https://github.com/zwave-js/node-zwave-js/blob/1c2d267e0b4ad759681f3984de58c340b40b8a91/packages/cc/src/cc/MultilevelSwitchCC.ts#L444) regardless of actual direction of travel. 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
