### PR TITLE
Add LaMetric button tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -648,8 +648,6 @@ omit =
     homeassistant/components/kostal_plenticore/switch.py
     homeassistant/components/kwb/sensor.py
     homeassistant/components/lacrosse/sensor.py
-    homeassistant/components/lametric/button.py
-    homeassistant/components/lametric/entity.py
     homeassistant/components/lametric/notify.py
     homeassistant/components/lametric/number.py
     homeassistant/components/lannouncer/notify.py

--- a/tests/components/lametric/conftest.py
+++ b/tests/components/lametric/conftest.py
@@ -94,3 +94,16 @@ def mock_lametric() -> Generator[MagicMock, None, None]:
             load_fixture("device.json", DOMAIN)
         )
         yield lametric
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_lametric: MagicMock
+) -> MockConfigEntry:
+    """Set up the LaMetric integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry

--- a/tests/components/lametric/test_button.py
+++ b/tests/components/lametric/test_button.py
@@ -1,0 +1,113 @@
+"""Tests for the LaMetric button platform."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.lametric.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity import EntityCategory
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.freeze_time("2022-09-19 12:07:30")
+async def test_button_app_next(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_lametric: MagicMock,
+) -> None:
+    """Test the LaMetric next app button."""
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get("button.frenck_s_lametric_next_app")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:arrow-right-bold"
+    assert state.state == STATE_UNKNOWN
+
+    entry = entity_registry.async_get("button.frenck_s_lametric_next_app")
+    assert entry
+    assert entry.unique_id == "SA110405124500W00BS9-app_next"
+    assert entry.entity_category == EntityCategory.CONFIG
+
+    assert entry.device_id
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry
+    assert device_entry.configuration_url is None
+    assert device_entry.connections == {
+        (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")
+    }
+    assert device_entry.entry_type is None
+    assert device_entry.identifiers == {(DOMAIN, "SA110405124500W00BS9")}
+    assert device_entry.manufacturer == "LaMetric Inc."
+    assert device_entry.model == "LM 37X8"
+    assert device_entry.name == "Frenck's LaMetric"
+    assert device_entry.sw_version == "2.2.2"
+    assert device_entry.hw_version is None
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.frenck_s_lametric_next_app"},
+        blocking=True,
+    )
+
+    assert len(mock_lametric.app_next.mock_calls) == 1
+    mock_lametric.app_next.assert_called_with()
+
+    state = hass.states.get("button.frenck_s_lametric_next_app")
+    assert state
+    assert state.state == "2022-09-19T12:07:30+00:00"
+
+
+@pytest.mark.freeze_time("2022-09-19 12:07:30")
+async def test_button_app_previous(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_lametric: MagicMock,
+) -> None:
+    """Test the LaMetric previous app button."""
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get("button.frenck_s_lametric_previous_app")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:arrow-left-bold"
+    assert state.state == STATE_UNKNOWN
+
+    entry = entity_registry.async_get("button.frenck_s_lametric_previous_app")
+    assert entry
+    assert entry.unique_id == "SA110405124500W00BS9-app_previous"
+    assert entry.entity_category == EntityCategory.CONFIG
+
+    assert entry.device_id
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry
+    assert device_entry.configuration_url is None
+    assert device_entry.connections == {
+        (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")
+    }
+    assert device_entry.entry_type is None
+    assert device_entry.identifiers == {(DOMAIN, "SA110405124500W00BS9")}
+    assert device_entry.manufacturer == "LaMetric Inc."
+    assert device_entry.model == "LM 37X8"
+    assert device_entry.name == "Frenck's LaMetric"
+    assert device_entry.sw_version == "2.2.2"
+    assert device_entry.hw_version is None
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.frenck_s_lametric_previous_app"},
+        blocking=True,
+    )
+
+    assert len(mock_lametric.app_previous.mock_calls) == 1
+    mock_lametric.app_previous.assert_called_with()
+
+    state = hass.states.get("button.frenck_s_lametric_previous_app")
+    assert state
+    assert state.state == "2022-09-19T12:07:30+00:00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds tests for the LaMetric button platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
