### PR TITLE
Bumped AIOAladdinConnect 0.1.46

### DIFF
--- a/homeassistant/components/aladdin_connect/__init__.py
+++ b/homeassistant/components/aladdin_connect/__init__.py
@@ -4,7 +4,8 @@ import logging
 from typing import Final
 
 from AIOAladdinConnect import AladdinConnectClient
-from aiohttp import ClientConnectionError, ClientError
+from AIOAladdinConnect.session_manager import InvalidPasswordError
+from aiohttp import ClientConnectionError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
@@ -30,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await acc.login()
     except (ClientConnectionError, asyncio.TimeoutError) as ex:
         raise ConfigEntryNotReady("Can not connect to host") from ex
-    except ClientError as ex:
+    except InvalidPasswordError as ex:
         raise ConfigEntryAuthFailed("Incorrect Password") from ex
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = acc

--- a/homeassistant/components/aladdin_connect/__init__.py
+++ b/homeassistant/components/aladdin_connect/__init__.py
@@ -4,7 +4,7 @@ import logging
 from typing import Final
 
 from AIOAladdinConnect import AladdinConnectClient
-from aiohttp import ClientConnectionError
+from aiohttp import ClientConnectionError, ClientError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
@@ -27,10 +27,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         username, password, async_get_clientsession(hass), CLIENT_ID
     )
     try:
-        if not await acc.login():
-            raise ConfigEntryAuthFailed("Incorrect Password")
+        await acc.login()
     except (ClientConnectionError, asyncio.TimeoutError) as ex:
         raise ConfigEntryNotReady("Can not connect to host") from ex
+    except ClientError as ex:
+        raise ConfigEntryAuthFailed("Incorrect Password") from ex
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = acc
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/aladdin_connect/config_flow.py
+++ b/homeassistant/components/aladdin_connect/config_flow.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any
 
 from AIOAladdinConnect import AladdinConnectClient
-from aiohttp import ClientError
+from AIOAladdinConnect.session_manager import InvalidPasswordError
 from aiohttp.client_exceptions import ClientConnectionError
 import voluptuous as vol
 
@@ -48,7 +48,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     except (ClientConnectionError, asyncio.TimeoutError) as ex:
         raise ex
 
-    except ClientError as ex:
+    except InvalidPasswordError as ex:
         raise InvalidAuth from ex
 
 

--- a/homeassistant/components/aladdin_connect/manifest.json
+++ b/homeassistant/components/aladdin_connect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "aladdin_connect",
   "name": "Aladdin Connect",
   "documentation": "https://www.home-assistant.io/integrations/aladdin_connect",
-  "requirements": ["AIOAladdinConnect==0.1.44"],
+  "requirements": ["AIOAladdinConnect==0.1.45"],
   "codeowners": ["@mkmer"],
   "iot_class": "cloud_polling",
   "loggers": ["aladdin_connect"],

--- a/homeassistant/components/aladdin_connect/manifest.json
+++ b/homeassistant/components/aladdin_connect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "aladdin_connect",
   "name": "Aladdin Connect",
   "documentation": "https://www.home-assistant.io/integrations/aladdin_connect",
-  "requirements": ["AIOAladdinConnect==0.1.45"],
+  "requirements": ["AIOAladdinConnect==0.1.46"],
   "codeowners": ["@mkmer"],
   "iot_class": "cloud_polling",
   "loggers": ["aladdin_connect"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,7 +5,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.44
+AIOAladdinConnect==0.1.45
 
 # homeassistant.components.adax
 Adax-local==0.1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,7 +5,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.45
+AIOAladdinConnect==0.1.46
 
 # homeassistant.components.adax
 Adax-local==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.44
+AIOAladdinConnect==0.1.45
 
 # homeassistant.components.adax
 Adax-local==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.45
+AIOAladdinConnect==0.1.46
 
 # homeassistant.components.adax
 Adax-local==0.1.4

--- a/tests/components/aladdin_connect/test_config_flow.py
+++ b/tests/components/aladdin_connect/test_config_flow.py
@@ -1,7 +1,8 @@
 """Test the Aladdin Connect config flow."""
 from unittest.mock import MagicMock, patch
 
-from aiohttp.client_exceptions import ClientConnectionError, ClientError
+from AIOAladdinConnect.session_manager import InvalidPasswordError
+from aiohttp.client_exceptions import ClientConnectionError
 
 from homeassistant import config_entries
 from homeassistant.components.aladdin_connect.const import DOMAIN
@@ -54,7 +55,7 @@ async def test_form_failed_auth(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     mock_aladdinconnect_api.login.return_value = False
-    mock_aladdinconnect_api.login.side_effect = ClientError
+    mock_aladdinconnect_api.login.side_effect = InvalidPasswordError
     with patch(
         "homeassistant.components.aladdin_connect.config_flow.AladdinConnectClient",
         return_value=mock_aladdinconnect_api,
@@ -232,7 +233,7 @@ async def test_reauth_flow_auth_error(
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
     mock_aladdinconnect_api.login.return_value = False
-    mock_aladdinconnect_api.login.side_effect = ClientError
+    mock_aladdinconnect_api.login.side_effect = InvalidPasswordError
     with patch(
         "homeassistant.components.aladdin_connect.config_flow.AladdinConnectClient",
         return_value=mock_aladdinconnect_api,

--- a/tests/components/aladdin_connect/test_config_flow.py
+++ b/tests/components/aladdin_connect/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Aladdin Connect config flow."""
 from unittest.mock import MagicMock, patch
 
-from aiohttp.client_exceptions import ClientConnectionError
+from aiohttp.client_exceptions import ClientConnectionError, ClientError
 
 from homeassistant import config_entries
 from homeassistant.components.aladdin_connect.const import DOMAIN
@@ -54,6 +54,7 @@ async def test_form_failed_auth(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     mock_aladdinconnect_api.login.return_value = False
+    mock_aladdinconnect_api.login.side_effect = ClientError
     with patch(
         "homeassistant.components.aladdin_connect.config_flow.AladdinConnectClient",
         return_value=mock_aladdinconnect_api,
@@ -231,6 +232,7 @@ async def test_reauth_flow_auth_error(
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
     mock_aladdinconnect_api.login.return_value = False
+    mock_aladdinconnect_api.login.side_effect = ClientError
     with patch(
         "homeassistant.components.aladdin_connect.config_flow.AladdinConnectClient",
         return_value=mock_aladdinconnect_api,

--- a/tests/components/aladdin_connect/test_init.py
+++ b/tests/components/aladdin_connect/test_init.py
@@ -1,7 +1,8 @@
 """Test for Aladdin Connect init logic."""
 from unittest.mock import MagicMock, patch
 
-from aiohttp import ClientConnectionError, ClientError
+from AIOAladdinConnect.session_manager import InvalidPasswordError
+from aiohttp import ClientConnectionError
 
 from homeassistant.components.aladdin_connect.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -43,7 +44,7 @@ async def test_setup_login_error(
     )
     config_entry.add_to_hass(hass)
     mock_aladdinconnect_api.login.return_value = False
-    mock_aladdinconnect_api.login.side_effect = ClientError
+    mock_aladdinconnect_api.login.side_effect = InvalidPasswordError
     with patch(
         "homeassistant.components.aladdin_connect.cover.AladdinConnectClient",
         return_value=mock_aladdinconnect_api,
@@ -101,7 +102,7 @@ async def test_entry_password_fail(
     )
     entry.add_to_hass(hass)
     mock_aladdinconnect_api.login = AsyncMock(return_value=False)
-    mock_aladdinconnect_api.login.side_effect = ClientError
+    mock_aladdinconnect_api.login.side_effect = InvalidPasswordError
     with patch(
         "homeassistant.components.aladdin_connect.AladdinConnectClient",
         return_value=mock_aladdinconnect_api,

--- a/tests/components/aladdin_connect/test_init.py
+++ b/tests/components/aladdin_connect/test_init.py
@@ -1,7 +1,7 @@
 """Test for Aladdin Connect init logic."""
 from unittest.mock import MagicMock, patch
 
-from aiohttp import ClientConnectionError
+from aiohttp import ClientConnectionError, ClientError
 
 from homeassistant.components.aladdin_connect.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -43,6 +43,7 @@ async def test_setup_login_error(
     )
     config_entry.add_to_hass(hass)
     mock_aladdinconnect_api.login.return_value = False
+    mock_aladdinconnect_api.login.side_effect = ClientError
     with patch(
         "homeassistant.components.aladdin_connect.cover.AladdinConnectClient",
         return_value=mock_aladdinconnect_api,
@@ -100,6 +101,7 @@ async def test_entry_password_fail(
     )
     entry.add_to_hass(hass)
     mock_aladdinconnect_api.login = AsyncMock(return_value=False)
+    mock_aladdinconnect_api.login.side_effect = ClientError
     with patch(
         "homeassistant.components.aladdin_connect.AladdinConnectClient",
         return_value=mock_aladdinconnect_api,


### PR DESCRIPTION
seperated password error from connection error
updated tests

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump AIOAladdinConnect to 0.1.45 (https://github.com/mkmer/AIOAladdinConnect/compare/0.1.44...0.1.45)
Bump AIOAladdinConnect to 0.1.46 (https://github.com/mkmer/AIOAladdinConnect/compare/0.1.45...0.1.46)
Separate password error from connection errors - original code: a connection error caused HA do declare password failure :(


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
