### PR TITLE
Add config options support in volvooncall

### DIFF
--- a/homeassistant/components/volvooncall/strings.json
+++ b/homeassistant/components/volvooncall/strings.json
@@ -20,6 +20,18 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "unit_system": "Unit System"
+        }
+      }
+    },
+    "abort": {
+      "config_updated": "Configuration updated"
+    }
+  },
   "issues": {
     "deprecated_yaml": {
       "title": "The Volvo On Call YAML configuration is being removed",

--- a/homeassistant/components/volvooncall/translations/en.json
+++ b/homeassistant/components/volvooncall/translations/en.json
@@ -20,6 +20,18 @@
             "reauth_successful": "Re-authentication was successful"
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "unit_system": "Unit System"
+                }
+            }
+        },
+        "abort": {
+            "config_updated": "Configuration updated"
+        }
+    },
     "issues": {
         "deprecated_yaml": {
             "title": "The Volvo On Call YAML configuration is being removed",

--- a/tests/components/volvooncall/test_config_flow.py
+++ b/tests/components/volvooncall/test_config_flow.py
@@ -220,3 +220,41 @@ async def test_reauth(hass: HomeAssistant) -> None:
 
     assert result3["type"] == FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"
+
+
+async def test_options(hass: HomeAssistant) -> None:
+    """Test that we handle the options flow."""
+
+    first_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test-username",
+        data={
+            "username": "test-username",
+            "password": "test-password",
+            "region": "na",
+            "unit_system": "metric",
+            "mutable": True,
+        },
+    )
+    first_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(
+        first_entry.entry_id,
+        context={
+            "source": config_entries.SOURCE_USER,
+            "entry_id": first_entry.entry_id,
+        },
+    )
+
+    assert result["type"] == FlowResultType.FORM
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "unit_system": "imperial",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "config_updated"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Implementing a Config Options flow for volvooncall component. In https://github.com/home-assistant/core/pull/77669, we implemented support for choosing the Unit System, and in this PR we are providing the ability for the user to change it via the UI.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
