### PR TITLE
Fix bug wherein RainMachine services use the wrong controller

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import timedelta
-from functools import partial
+from functools import partial, wraps
 from typing import Any
 
 from regenmaschine import Client
@@ -22,7 +23,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import (
     aiohttp_client,
     config_validation as cv,
@@ -152,9 +153,9 @@ class RainMachineData:
 
 
 @callback
-def async_get_controller_for_service_call(
+def async_get_entry_for_service_call(
     hass: HomeAssistant, call: ServiceCall
-) -> Controller:
+) -> ConfigEntry:
     """Get the controller related to a service call (by device ID)."""
     device_id = call.data[CONF_DEVICE_ID]
     device_registry = dr.async_get(hass)
@@ -166,8 +167,7 @@ def async_get_controller_for_service_call(
         if (entry := hass.config_entries.async_get_entry(entry_id)) is None:
             continue
         if entry.domain == DOMAIN:
-            data: RainMachineData = hass.data[DOMAIN][entry_id]
-            return data.controller
+            return entry
 
     raise ValueError(f"No controller for device ID: {device_id}")
 
@@ -288,15 +288,42 @@ async def async_setup_entry(  # noqa: C901
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
-    async def async_pause_watering(call: ServiceCall) -> None:
-        """Pause watering for a set number of seconds."""
-        controller = async_get_controller_for_service_call(hass, call)
-        await controller.watering.pause_all(call.data[CONF_SECONDS])
-        await async_update_programs_and_zones(hass, entry)
+    def call_with_controller(update_programs_and_zones: bool = True) -> Callable:
+        """Hydrate a service call with the appropriate controller."""
 
-    async def async_push_weather_data(call: ServiceCall) -> None:
+        def decorator(func: Callable) -> Callable[..., Awaitable]:
+            """Define the decorator."""
+
+            @wraps(func)
+            async def wrapper(call: ServiceCall) -> None:
+                """Wrap the service function."""
+                entry = async_get_entry_for_service_call(hass, call)
+                data: RainMachineData = hass.data[DOMAIN][entry.entry_id]
+
+                try:
+                    await func(call, data.controller)
+                except RainMachineError as err:
+                    raise HomeAssistantError(
+                        f"Error while executing {func.__name__}: {err}"
+                    ) from err
+
+                if update_programs_and_zones:
+                    await async_update_programs_and_zones(hass, entry)
+
+            return wrapper
+
+        return decorator
+
+    @call_with_controller()
+    async def async_pause_watering(call: ServiceCall, controller: Controller) -> None:
+        """Pause watering for a set number of seconds."""
+        await controller.watering.pause_all(call.data[CONF_SECONDS])
+
+    @call_with_controller(update_programs_and_zones=False)
+    async def async_push_weather_data(
+        call: ServiceCall, controller: Controller
+    ) -> None:
         """Push weather data to the device."""
-        controller = async_get_controller_for_service_call(hass, call)
         await controller.parsers.post_data(
             {
                 CONF_WEATHER: [
@@ -309,9 +336,11 @@ async def async_setup_entry(  # noqa: C901
             }
         )
 
-    async def async_restrict_watering(call: ServiceCall) -> None:
+    @call_with_controller()
+    async def async_restrict_watering(
+        call: ServiceCall, controller: Controller
+    ) -> None:
         """Restrict watering for a time period."""
-        controller = async_get_controller_for_service_call(hass, call)
         duration = call.data[CONF_DURATION]
         await controller.restrictions.set_universal(
             {
@@ -319,30 +348,28 @@ async def async_setup_entry(  # noqa: C901
                 "rainDelayDuration": duration.total_seconds(),
             },
         )
-        await async_update_programs_and_zones(hass, entry)
 
-    async def async_stop_all(call: ServiceCall) -> None:
+    @call_with_controller()
+    async def async_stop_all(call: ServiceCall, controller: Controller) -> None:
         """Stop all watering."""
-        controller = async_get_controller_for_service_call(hass, call)
         await controller.watering.stop_all()
-        await async_update_programs_and_zones(hass, entry)
 
-    async def async_unpause_watering(call: ServiceCall) -> None:
+    @call_with_controller()
+    async def async_unpause_watering(call: ServiceCall, controller: Controller) -> None:
         """Unpause watering."""
-        controller = async_get_controller_for_service_call(hass, call)
         await controller.watering.unpause_all()
-        await async_update_programs_and_zones(hass, entry)
 
-    async def async_unrestrict_watering(call: ServiceCall) -> None:
+    @call_with_controller()
+    async def async_unrestrict_watering(
+        call: ServiceCall, controller: Controller
+    ) -> None:
         """Unrestrict watering."""
-        controller = async_get_controller_for_service_call(hass, call)
         await controller.restrictions.set_universal(
             {
                 "rainDelayStartTime": round(as_timestamp(utcnow())),
                 "rainDelayDuration": 0,
             },
         )
-        await async_update_programs_and_zones(hass, entry)
 
     for service_name, schema, method in (
         (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Most RainMachine services are supposed to update program/zone data after they're called; in the current code, the most recently added controller is updated, _not_ (necessarily) the one to which the service call was attached. This PR fixes that issue and makes the service set more robust against error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
