### PR TITLE
Add reauth flow to Shelly integration

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -201,7 +201,7 @@ async def async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> bo
         except OSError as err:
             raise ConfigEntryNotReady(str(err) or "Error during device setup") from err
         except ClientResponseError as err:
-            if err.status == HTTPStatus.UNAUTHORIZED.value:
+            if err.status == HTTPStatus.UNAUTHORIZED:
                 raise ConfigEntryAuthFailed from err
 
         async_block_device_setup(hass, entry, device)

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, Final, cast
 from aiohttp import ClientResponseError
 import aioshelly
 from aioshelly.block_device import BlockDevice
-from aioshelly.exceptions import AuthRequired
+from aioshelly.exceptions import AuthRequired, InvalidAuthError
 from aioshelly.rpc_device import RpcDevice
 import async_timeout
 import voluptuous as vol
@@ -258,6 +258,8 @@ async def async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool
         raise ConfigEntryNotReady(str(err) or "Timeout during device setup") from err
     except OSError as err:
         raise ConfigEntryNotReady(str(err) or "Error during device setup") from err
+    except (AuthRequired, InvalidAuthError) as err:
+        raise ConfigEntryAuthFailed from err
 
     device_wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id][
         RPC

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Coroutine
 from datetime import timedelta
+from http import HTTPStatus
 from typing import Any, Final, cast
 
 from aiohttp import ClientResponseError
@@ -200,7 +201,7 @@ async def async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> bo
         except OSError as err:
             raise ConfigEntryNotReady(str(err) or "Error during device setup") from err
         except ClientResponseError as err:
-            if err.status == 401:
+            if err.status == HTTPStatus.UNAUTHORIZED.value:
                 raise ConfigEntryAuthFailed from err
 
         async_block_device_setup(hass, entry, device)

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 from aioshelly.block_device import Block
+from aioshelly.exceptions import AuthRequired
 import async_timeout
 
 from homeassistant.components.climate import (
@@ -318,11 +319,14 @@ class BlockSleepingClimate(
 
             assert self.block.channel
 
-            self._preset_modes = [
-                PRESET_NONE,
-                *self.wrapper.device.settings["thermostats"][int(self.block.channel)][
-                    "schedule_profile_names"
-                ],
-            ]
-
-            self.async_write_ha_state()
+            try:
+                self._preset_modes = [
+                    PRESET_NONE,
+                    *self.wrapper.device.settings["thermostats"][
+                        int(self.block.channel)
+                    ]["schedule_profile_names"],
+                ]
+            except AuthRequired:
+                self.wrapper.entry.async_start_reauth(self.hass)
+            else:
+                self.async_write_ha_state()

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from http import HTTPStatus
 from typing import Any, Final
 
@@ -91,6 +92,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     host: str = ""
     info: dict[str, Any] = {}
     device_info: dict[str, Any] = {}
+    entry: config_entries.ConfigEntry | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -259,6 +261,50 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "model": model,
                 "host": self.host,
             },
+            errors=errors,
+        )
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Handle configuration by re-auth."""
+        self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Dialog that informs the user that reauth is required."""
+        errors: dict[str, str] = {}
+        assert self.entry is not None
+        host = self.entry.data[CONF_HOST]
+
+        if user_input is not None:
+            info = await self._async_get_info(host)
+            if self.entry.data.get("gen", 1) == 2:
+                user_input[CONF_USERNAME] = "admin"
+            try:
+                await validate_input(self.hass, host, info, user_input)
+            except (aiohttp.ClientResponseError, aioshelly.exceptions.InvalidAuthError):
+                return self.async_abort(reason="reauth_unsuccessful")
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.entry, data={**self.entry.data, **user_input}
+                )
+                await self.hass.config_entries.async_reload(self.entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        if self.entry.data.get("gen", 1) == 2:
+            schema = {
+                vol.Required(CONF_PASSWORD): str,
+            }
+        else:
+            schema = {
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(schema),
             errors=errors,
         )
 

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -279,7 +279,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             info = await self._async_get_info(host)
-            if self.entry.data.get("gen", 1) == 2:
+            if self.entry.data.get("gen", 1) != 1:
                 user_input[CONF_USERNAME] = "admin"
             try:
                 await validate_input(self.hass, host, info, user_input)

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -297,9 +297,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.hass.config_entries.async_reload(self.entry.entry_id)
                 return self.async_abort(reason="reauth_successful")
 
-        schema = {vol.Required(CONF_PASSWORD): str}
         if self.entry.data.get("gen", 1) == 1:
-            schema.update({vol.Required(CONF_USERNAME): str})
+            schema = {
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        else:
+            schema = {vol.Required(CONF_PASSWORD): str}
 
         return self.async_show_form(
             step_id="reauth_confirm",

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -14,6 +14,12 @@
           "password": "[%key:common::config_flow::data::password%]"
         }
       },
+      "reauth_confirm": {
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
       "confirm_discovery": {
         "description": "Do you want to set up the {model} at {host}?\n\nBattery-powered devices that are password protected must be woken up before continuing with setting up.\nBattery-powered devices that are not password protected will be added when the device wakes up, you can now manually wake the device up using a button on it or wait for the next data update from the device."
       }
@@ -26,7 +32,9 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "unsupported_firmware": "The device is using an unsupported firmware version."
+      "unsupported_firmware": "The device is using an unsupported firmware version.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again."
     }
   },
   "device_automation": {

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -787,14 +787,14 @@ async def test_zeroconf_require_auth(hass):
     "test_data",
     [
         (1, {"username": "test user", "password": "test1 password"}),
-        (2, {"username": "admin", "password": "test2 password"}),
+        (2, {"password": "test2 password"}),
     ],
 )
 async def test_reauth_successful(hass, test_data):
     """Test starting a reauthentication flow."""
     gen, user_input = test_data
     entry = MockConfigEntry(
-        domain="shelly", unique_id="test-mac", data={"host": "0.0.0.0"}
+        domain="shelly", unique_id="test-mac", data={"host": "0.0.0.0", "gen": gen}
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -10,6 +10,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import zeroconf
 from homeassistant.components.shelly.const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH
 
 from tests.common import MockConfigEntry
 
@@ -780,3 +781,107 @@ async def test_zeroconf_require_auth(hass):
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    "test_data",
+    [
+        (1, {"username": "test user", "password": "test1 password"}),
+        (2, {"username": "admin", "password": "test2 password"}),
+    ],
+)
+async def test_reauth_successful(hass, test_data):
+    """Test starting a reauthentication flow."""
+    gen, user_input = test_data
+    entry = MockConfigEntry(
+        domain="shelly", unique_id="test-mac", data={"host": "0.0.0.0"}
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "aioshelly.common.get_info",
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": True, "gen": gen},
+    ), patch(
+        "aioshelly.block_device.BlockDevice.create",
+        new=AsyncMock(
+            return_value=Mock(
+                model="SHSW-1",
+                settings=MOCK_SETTINGS,
+            )
+        ),
+    ), patch(
+        "aioshelly.rpc_device.RpcDevice.create",
+        new=AsyncMock(
+            return_value=Mock(
+                shelly={"model": "SHSW-1", "gen": gen},
+                config=MOCK_CONFIG,
+                shutdown=AsyncMock(),
+            )
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+            data=entry.data,
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "reauth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=user_input,
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["reason"] == "reauth_successful"
+
+
+@pytest.mark.parametrize(
+    "test_data",
+    [
+        (
+            1,
+            {"username": "test user", "password": "test1 password"},
+            aioshelly.exceptions.InvalidAuthError(code=HTTPStatus.UNAUTHORIZED.value),
+        ),
+        (
+            2,
+            {"password": "test2 password"},
+            aiohttp.ClientResponseError(Mock(), (), status=HTTPStatus.UNAUTHORIZED),
+        ),
+    ],
+)
+async def test_reauth_unsuccessful(hass, test_data):
+    """Test reauthentication flow failed."""
+    gen, user_input, exc = test_data
+    entry = MockConfigEntry(
+        domain="shelly", unique_id="test-mac", data={"host": "0.0.0.0", "gen": gen}
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "aioshelly.common.get_info",
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": True, "gen": gen},
+    ), patch(
+        "aioshelly.block_device.BlockDevice.create",
+        new=AsyncMock(side_effect=exc),
+    ), patch(
+        "aioshelly.rpc_device.RpcDevice.create", new=AsyncMock(side_effect=exc)
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+            data=entry.data,
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "reauth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=user_input,
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["reason"] == "reauth_unsuccessful"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds reauth flow. I'm not able to test the change with sleeping gen1 devices so someone could help with that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #77378
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
