### PR TITLE
Change bluetooth source to be the address of the adapter on Linux

### DIFF
--- a/homeassistant/components/bluetooth/scanner.py
+++ b/homeassistant/components/bluetooth/scanner.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.package import is_docker_env
 
 from .const import (
+    DEFAULT_ADDRESS,
     SCANNER_WATCHDOG_INTERVAL,
     SCANNER_WATCHDOG_TIMEOUT,
     SOURCE_LOCAL,
@@ -132,7 +133,7 @@ class HaScanner(BaseHaScanner):
         self._start_time = 0.0
         self._callbacks: list[Callable[[BluetoothServiceInfoBleak], None]] = []
         self.name = adapter_human_name(adapter, address)
-        self.source = self.adapter or SOURCE_LOCAL
+        self.source = address if address != DEFAULT_ADDRESS else adapter or SOURCE_LOCAL
 
     @property
     def discovered_devices(self) -> list[BLEDevice]:

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -19,6 +19,11 @@ def bluez_dbus_mock():
 def macos_adapter():
     """Fixture that mocks the macos adapter."""
     with patch(
+        "homeassistant.components.bluetooth.platform.system", return_value="Darwin"
+    ), patch(
+        "homeassistant.components.bluetooth.scanner.platform.system",
+        return_value="Darwin",
+    ), patch(
         "homeassistant.components.bluetooth.util.platform.system", return_value="Darwin"
     ):
         yield

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, patch
 from bleak.backends.scanner import BLEDevice
 
 from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth.const import DEFAULT_ADDRESS
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
@@ -117,7 +118,7 @@ async def test_diagnostics(
                         ],
                         "last_detection": ANY,
                         "name": "hci0 (00:00:00:00:00:01)",
-                        "source": "hci0",
+                        "source": "00:00:00:00:00:01",
                         "start_time": ANY,
                         "type": "HaScanner",
                     },
@@ -128,7 +129,7 @@ async def test_diagnostics(
                         ],
                         "last_detection": ANY,
                         "name": "hci0 (00:00:00:00:00:01)",
-                        "source": "hci0",
+                        "source": "00:00:00:00:00:01",
                         "start_time": ANY,
                         "type": "HaScanner",
                     },
@@ -139,10 +140,77 @@ async def test_diagnostics(
                         ],
                         "last_detection": ANY,
                         "name": "hci1 (00:00:00:00:00:02)",
-                        "source": "hci1",
+                        "source": "00:00:00:00:00:02",
                         "start_time": ANY,
                         "type": "HaScanner",
                     },
+                ],
+            },
+        }
+
+
+async def test_diagnostics_macos(
+    hass, hass_client, mock_bleak_scanner_start, mock_bluetooth_adapters, macos_adapter
+):
+    """Test we can setup and unsetup bluetooth with multiple adapters."""
+    # Normally we do not want to patch our classes, but since bleak will import
+    # a different scanner based on the operating system, we need to patch here
+    # because we cannot import the scanner class directly without it throwing an
+    # error if the test is not running on linux since we won't have the correct
+    # deps installed when testing on MacOS.
+
+    with patch(
+        "homeassistant.components.bluetooth.scanner.HaScanner.discovered_devices",
+        [BLEDevice(name="x", rssi=-60, address="44:44:33:11:23:45")],
+    ), patch(
+        "homeassistant.components.bluetooth.diagnostics.platform.system",
+        return_value="Darwin",
+    ), patch(
+        "homeassistant.components.bluetooth.diagnostics.get_dbus_managed_objects",
+        return_value={},
+    ):
+        entry1 = MockConfigEntry(
+            domain=bluetooth.DOMAIN,
+            data={},
+            title="Core Bluetooth",
+            unique_id=DEFAULT_ADDRESS,
+        )
+        entry1.add_to_hass(hass)
+
+        assert await hass.config_entries.async_setup(entry1.entry_id)
+        await hass.async_block_till_done()
+
+        diag = await get_diagnostics_for_config_entry(hass, hass_client, entry1)
+        assert diag == {
+            "adapters": {
+                "Core Bluetooth": {
+                    "address": "00:00:00:00:00:00",
+                    "passive_scan": False,
+                    "sw_version": "21.6.0",
+                }
+            },
+            "manager": {
+                "adapters": {
+                    "Core Bluetooth": {
+                        "address": "00:00:00:00:00:00",
+                        "passive_scan": False,
+                        "sw_version": "21.6.0",
+                    }
+                },
+                "connectable_history": [],
+                "history": [],
+                "scanners": [
+                    {
+                        "adapter": "Core Bluetooth",
+                        "discovered_devices": [
+                            {"address": "44:44:33:11:23:45", "name": "x", "rssi": -60}
+                        ],
+                        "last_detection": ANY,
+                        "name": "Core Bluetooth",
+                        "source": "Core Bluetooth",
+                        "start_time": ANY,
+                        "type": "HaScanner",
+                    }
                 ],
             },
         }

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -186,7 +186,7 @@ async def test_diagnostics_macos(
                 "Core Bluetooth": {
                     "address": "00:00:00:00:00:00",
                     "passive_scan": False,
-                    "sw_version": "21.6.0",
+                    "sw_version": ANY,
                 }
             },
             "manager": {
@@ -194,7 +194,7 @@ async def test_diagnostics_macos(
                     "Core Bluetooth": {
                         "address": "00:00:00:00:00:00",
                         "passive_scan": False,
-                        "sw_version": "21.6.0",
+                        "sw_version": ANY,
                     }
                 },
                 "connectable_history": [],


### PR DESCRIPTION
I didn't write a blog post for this because I'm honestly not sure it's even breaking change worthy and might just be noise since no integration exposes this property.
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
On Linux systems, the scanner source is now the mac address of the adapter instead of name of the device (ex hci0)

This change ensures that the source is always a stable value since the name of the device can change between restarts or when a usb device is hot-plugged

This value was only exposed in diagnostics and in the code which makes this breaking change only for developers


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
