### PR TITLE
Pin Python patch versions [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,10 @@ env:
   CACHE_VERSION: 1
   PIP_CACHE_VERSION: 1
   HA_SHORT_VERSION: 2022.10
-  DEFAULT_PYTHON: 3.9
+  # Pin latest Python patch versions to avoid issues
+  # with runners using different versions.
+  DEFAULT_PYTHON: 3.9.14
+  ALL_PYTHON_VERSIONS: "['3.9.14', '3.10.7']"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   PIP_CACHE: /tmp/pip-cache
   SQLALCHEMY_WARN_20: 1
@@ -46,6 +49,7 @@ jobs:
       pre-commit_cache_key: ${{ steps.generate_pre-commit_cache_key.outputs.key }}
       python_cache_key: ${{ steps.generate_python_cache_key.outputs.key }}
       requirements: ${{ steps.core.outputs.requirements }}
+      python_versions: ${{ steps.info.outputs.python_versions }}
       test_full_suite: ${{ steps.info.outputs.test_full_suite }}
       test_group_count: ${{ steps.info.outputs.test_group_count }}
       test_groups: ${{ steps.info.outputs.test_groups }}
@@ -143,6 +147,8 @@ jobs:
           fi
 
           # Output & sent to GitHub Actions
+          echo "python_versions: ${ALL_PYTHON_VERSIONS}"
+          echo "::set-output name=python_versions::${ALL_PYTHON_VERSIONS}"
           echo "test_full_suite: ${test_full_suite}"
           echo "::set-output name=test_full_suite::${test_full_suite}"
           echo "integrations_glob: ${integrations_glob}"
@@ -463,7 +469,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ${{ fromJSON(needs.info.outputs.python_versions) }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2
@@ -483,7 +489,7 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-${{ matrix.python-version }}-${{
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.info.outputs.python_cache_key }}
       - name: Restore pip wheel cache
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -491,10 +497,10 @@ jobs:
         with:
           path: ${{ env.PIP_CACHE }}
           key: >-
-            ${{ runner.os }}-${{ matrix.python-version }}-${{
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-pip-key.outputs.key }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ env.PIP_CACHE_VERSION }}-${{ env.HA_SHORT_VERSION }}-
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-pip-${{ env.PIP_CACHE_VERSION }}-${{ env.HA_SHORT_VERSION }}-
       - name: Install additional OS dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -541,7 +547,7 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-${{
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.info.outputs.python_cache_key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -573,7 +579,7 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-${{
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.info.outputs.python_cache_key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -606,7 +612,7 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-${{
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.info.outputs.python_cache_key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -650,7 +656,7 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-${{
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.info.outputs.python_cache_key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -682,7 +688,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ${{ fromJson(needs.info.outputs.python_versions) }}
     name: Run pip check ${{ matrix.python-version }}
     steps:
       - name: Check out code from GitHub
@@ -698,7 +704,7 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-${{ matrix.python-version }}-${{
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.info.outputs.python_cache_key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -729,7 +735,7 @@ jobs:
       fail-fast: false
       matrix:
         group: ${{ fromJson(needs.info.outputs.test_groups) }}
-        python-version: ["3.9", "3.10"]
+        python-version: ${{ fromJson(needs.info.outputs.python_versions) }}
     name: >-
       Run tests Python ${{ matrix.python-version }} (${{ matrix.group }})
     steps:
@@ -751,7 +757,7 @@ jobs:
         uses: actions/cache@v3.0.8
         with:
           path: venv
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{
+          key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.info.outputs.python_cache_key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Proposed change
Fix flaky workflow runs by pinning the Python patch versions. This also reverse a change from #78398 which removed the patch version number from the cache key.

## Explanation
Recently we've seen a lot of these and similar errors
```
/home/runner/work/_temp/1c5e4715-4a89-42e9-b4db-cf7b4c52b9d8.sh: /home/runner/work/ha-core/ha-core/venv/bin/pre-commit:
  /home/runner/work/ha-core/ha-core/venv/bin/python: bad interpreter: No such file or directory
```
The reason is that different to local installations, Python is installed in a subdir which **includes** the patch version. I.e.
```
/opt/hostedtoolcache/Python/3.9.14/x64/bin/python
```
Thus the symlink inside the venv will also include it. If Github updates the default Python version, a runner might install `3.9.14` whereas the venv still includes a symlink to `3.9.13` which will fail.
```
lrwxrwxrwx 1 runner docker   49 Sep 16 21:03 python -> /opt/hostedtoolcache/Python/3.9.13/x64/bin/python
```

## Drawbacks
Pinning the latest Python patch version resolves this issue. Unfortunately though there are some minor drawbacks
* The pinned version needs to be updated manually.
* If an older version is preinstalled, the job needs 15-20s to install the requested Python version.

However, IMO these drawbacks are outweighed by having a stable CI workflow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
