### PR TITLE
Cleanup EntityFeature in tests

### DIFF
--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -12,11 +12,8 @@ from homeassistant.components.cover import (
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
-    SUPPORT_CLOSE,
-    SUPPORT_OPEN,
-    SUPPORT_SET_POSITION,
-    SUPPORT_STOP,
     CoverDeviceClass,
+    CoverEntityFeature,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -107,11 +104,11 @@ async def test_init_gatecontroller(gatecontroller, hass, config):
     assert state.attributes[ATTR_DEVICE_CLASS] == CoverDeviceClass.GATE
 
     supported_features = state.attributes[ATTR_SUPPORTED_FEATURES]
-    assert supported_features & SUPPORT_OPEN
-    assert supported_features & SUPPORT_CLOSE
-    assert supported_features & SUPPORT_STOP
+    assert supported_features & CoverEntityFeature.OPEN
+    assert supported_features & CoverEntityFeature.CLOSE
+    assert supported_features & CoverEntityFeature.STOP
 
-    assert supported_features & SUPPORT_SET_POSITION
+    assert supported_features & CoverEntityFeature.SET_POSITION
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
@@ -137,11 +134,11 @@ async def test_init_shutterbox(shutterbox, hass, config):
     assert entry.original_device_class == CoverDeviceClass.SHUTTER
 
     supported_features = state.attributes[ATTR_SUPPORTED_FEATURES]
-    assert supported_features & SUPPORT_OPEN
-    assert supported_features & SUPPORT_CLOSE
-    assert supported_features & SUPPORT_STOP
+    assert supported_features & CoverEntityFeature.OPEN
+    assert supported_features & CoverEntityFeature.CLOSE
+    assert supported_features & CoverEntityFeature.STOP
 
-    assert supported_features & SUPPORT_SET_POSITION
+    assert supported_features & CoverEntityFeature.SET_POSITION
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
@@ -167,13 +164,13 @@ async def test_init_gatebox(gatebox, hass, config):
     assert state.attributes[ATTR_DEVICE_CLASS] == CoverDeviceClass.DOOR
 
     supported_features = state.attributes[ATTR_SUPPORTED_FEATURES]
-    assert supported_features & SUPPORT_OPEN
-    assert supported_features & SUPPORT_CLOSE
+    assert supported_features & CoverEntityFeature.OPEN
+    assert supported_features & CoverEntityFeature.CLOSE
 
     # Not available during init since requires fetching state to detect
-    assert not supported_features & SUPPORT_STOP
+    assert not supported_features & CoverEntityFeature.STOP
 
-    assert not supported_features & SUPPORT_SET_POSITION
+    assert not supported_features & CoverEntityFeature.SET_POSITION
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
@@ -350,7 +347,7 @@ async def test_with_stop(gatebox, hass, config):
 
     state = hass.states.get(entity_id)
     supported_features = state.attributes[ATTR_SUPPORTED_FEATURES]
-    assert supported_features & SUPPORT_STOP
+    assert supported_features & CoverEntityFeature.STOP
 
 
 async def test_with_no_stop(gatebox, hass, config):
@@ -364,7 +361,7 @@ async def test_with_no_stop(gatebox, hass, config):
 
     state = hass.states.get(entity_id)
     supported_features = state.attributes[ATTR_SUPPORTED_FEATURES]
-    assert not supported_features & SUPPORT_STOP
+    assert not supported_features & CoverEntityFeature.STOP
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -17,19 +17,9 @@ from homeassistant.components import media_player, tts
 from homeassistant.components.cast import media_player as cast
 from homeassistant.components.cast.media_player import ChromecastInfo
 from homeassistant.components.media_player import (
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE,
-    SUPPORT_PLAY,
-    SUPPORT_PLAY_MEDIA,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SEEK,
-    SUPPORT_STOP,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET,
     BrowseMedia,
     MediaClass,
+    MediaPlayerEntityFeature,
 )
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import (
@@ -840,11 +830,11 @@ async def test_entity_cast_status(hass: HomeAssistant):
 
     # No media status, pause, play, stop not supported
     assert state.attributes.get("supported_features") == (
-        SUPPORT_PLAY_MEDIA
-        | SUPPORT_TURN_OFF
-        | SUPPORT_TURN_ON
-        | SUPPORT_VOLUME_MUTE
-        | SUPPORT_VOLUME_SET
+        MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_SET
     )
 
     cast_status = MagicMock()
@@ -883,7 +873,9 @@ async def test_entity_cast_status(hass: HomeAssistant):
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)
     assert state.attributes.get("supported_features") == (
-        SUPPORT_PLAY_MEDIA | SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+        MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.TURN_ON
     )
 
 
@@ -892,51 +884,51 @@ async def test_entity_cast_status(hass: HomeAssistant):
     [
         (
             pychromecast.const.CAST_TYPE_AUDIO,
-            SUPPORT_PAUSE
-            | SUPPORT_PLAY
-            | SUPPORT_PLAY_MEDIA
-            | SUPPORT_STOP
-            | SUPPORT_TURN_OFF
-            | SUPPORT_TURN_ON
-            | SUPPORT_VOLUME_MUTE
-            | SUPPORT_VOLUME_SET,
-            SUPPORT_PLAY_MEDIA
-            | SUPPORT_TURN_OFF
-            | SUPPORT_TURN_ON
-            | SUPPORT_VOLUME_MUTE
-            | SUPPORT_VOLUME_SET,
+            MediaPlayerEntityFeature.PAUSE
+            | MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.PLAY_MEDIA
+            | MediaPlayerEntityFeature.STOP
+            | MediaPlayerEntityFeature.TURN_OFF
+            | MediaPlayerEntityFeature.TURN_ON
+            | MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_SET,
+            MediaPlayerEntityFeature.PLAY_MEDIA
+            | MediaPlayerEntityFeature.TURN_OFF
+            | MediaPlayerEntityFeature.TURN_ON
+            | MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_SET,
         ),
         (
             pychromecast.const.CAST_TYPE_CHROMECAST,
-            SUPPORT_PAUSE
-            | SUPPORT_PLAY
-            | SUPPORT_PLAY_MEDIA
-            | SUPPORT_STOP
-            | SUPPORT_TURN_OFF
-            | SUPPORT_TURN_ON
-            | SUPPORT_VOLUME_MUTE
-            | SUPPORT_VOLUME_SET,
-            SUPPORT_PLAY_MEDIA
-            | SUPPORT_TURN_OFF
-            | SUPPORT_TURN_ON
-            | SUPPORT_VOLUME_MUTE
-            | SUPPORT_VOLUME_SET,
+            MediaPlayerEntityFeature.PAUSE
+            | MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.PLAY_MEDIA
+            | MediaPlayerEntityFeature.STOP
+            | MediaPlayerEntityFeature.TURN_OFF
+            | MediaPlayerEntityFeature.TURN_ON
+            | MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_SET,
+            MediaPlayerEntityFeature.PLAY_MEDIA
+            | MediaPlayerEntityFeature.TURN_OFF
+            | MediaPlayerEntityFeature.TURN_ON
+            | MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_SET,
         ),
         (
             pychromecast.const.CAST_TYPE_GROUP,
-            SUPPORT_PAUSE
-            | SUPPORT_PLAY
-            | SUPPORT_PLAY_MEDIA
-            | SUPPORT_STOP
-            | SUPPORT_TURN_OFF
-            | SUPPORT_TURN_ON
-            | SUPPORT_VOLUME_MUTE
-            | SUPPORT_VOLUME_SET,
-            SUPPORT_PLAY_MEDIA
-            | SUPPORT_TURN_OFF
-            | SUPPORT_TURN_ON
-            | SUPPORT_VOLUME_MUTE
-            | SUPPORT_VOLUME_SET,
+            MediaPlayerEntityFeature.PAUSE
+            | MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.PLAY_MEDIA
+            | MediaPlayerEntityFeature.STOP
+            | MediaPlayerEntityFeature.TURN_OFF
+            | MediaPlayerEntityFeature.TURN_ON
+            | MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_SET,
+            MediaPlayerEntityFeature.PLAY_MEDIA
+            | MediaPlayerEntityFeature.TURN_OFF
+            | MediaPlayerEntityFeature.TURN_ON
+            | MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_SET,
         ),
     ],
 )
@@ -1394,14 +1386,14 @@ async def test_entity_control(hass: HomeAssistant, quick_play_mock):
     assert entity_id == reg.async_get_entity_id("media_player", "cast", str(info.uuid))
 
     assert state.attributes.get("supported_features") == (
-        SUPPORT_PAUSE
-        | SUPPORT_PLAY
-        | SUPPORT_PLAY_MEDIA
-        | SUPPORT_STOP
-        | SUPPORT_TURN_OFF
-        | SUPPORT_TURN_ON
-        | SUPPORT_VOLUME_MUTE
-        | SUPPORT_VOLUME_SET
+        MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_SET
     )
 
     # Turn on
@@ -1460,17 +1452,17 @@ async def test_entity_control(hass: HomeAssistant, quick_play_mock):
 
     state = hass.states.get(entity_id)
     assert state.attributes.get("supported_features") == (
-        SUPPORT_PAUSE
-        | SUPPORT_PLAY
-        | SUPPORT_PLAY_MEDIA
-        | SUPPORT_STOP
-        | SUPPORT_TURN_OFF
-        | SUPPORT_TURN_ON
-        | SUPPORT_PREVIOUS_TRACK
-        | SUPPORT_NEXT_TRACK
-        | SUPPORT_SEEK
-        | SUPPORT_VOLUME_MUTE
-        | SUPPORT_VOLUME_SET
+        MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.PREVIOUS_TRACK
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.SEEK
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_SET
     )
 
     # Media previous
@@ -1598,11 +1590,11 @@ async def test_entity_media_states_lovelace_app(hass: HomeAssistant):
     state = hass.states.get(entity_id)
     assert state.state == "playing"
     assert state.attributes.get("supported_features") == (
-        SUPPORT_PLAY_MEDIA
-        | SUPPORT_TURN_OFF
-        | SUPPORT_TURN_ON
-        | SUPPORT_VOLUME_MUTE
-        | SUPPORT_VOLUME_SET
+        MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_SET
     )
 
     media_status = MagicMock(images=None)

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -2,17 +2,7 @@
 import pytest
 
 import homeassistant.components.automation as automation
-from homeassistant.components.cover import (
-    DOMAIN,
-    SUPPORT_CLOSE,
-    SUPPORT_CLOSE_TILT,
-    SUPPORT_OPEN,
-    SUPPORT_OPEN_TILT,
-    SUPPORT_SET_POSITION,
-    SUPPORT_SET_TILT_POSITION,
-    SUPPORT_STOP,
-    SUPPORT_STOP_TILT,
-)
+from homeassistant.components.cover import DOMAIN, CoverEntityFeature
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.helpers import device_registry
@@ -48,21 +38,21 @@ def entity_reg(hass):
     "set_state,features_reg,features_state,expected_action_types",
     [
         (False, 0, 0, []),
-        (False, SUPPORT_CLOSE_TILT, 0, ["close_tilt"]),
-        (False, SUPPORT_CLOSE, 0, ["close"]),
-        (False, SUPPORT_OPEN_TILT, 0, ["open_tilt"]),
-        (False, SUPPORT_OPEN, 0, ["open"]),
-        (False, SUPPORT_SET_POSITION, 0, ["set_position"]),
-        (False, SUPPORT_SET_TILT_POSITION, 0, ["set_tilt_position"]),
-        (False, SUPPORT_STOP, 0, ["stop"]),
+        (False, CoverEntityFeature.CLOSE_TILT, 0, ["close_tilt"]),
+        (False, CoverEntityFeature.CLOSE, 0, ["close"]),
+        (False, CoverEntityFeature.OPEN_TILT, 0, ["open_tilt"]),
+        (False, CoverEntityFeature.OPEN, 0, ["open"]),
+        (False, CoverEntityFeature.SET_POSITION, 0, ["set_position"]),
+        (False, CoverEntityFeature.SET_TILT_POSITION, 0, ["set_tilt_position"]),
+        (False, CoverEntityFeature.STOP, 0, ["stop"]),
         (True, 0, 0, []),
-        (True, 0, SUPPORT_CLOSE_TILT, ["close_tilt"]),
-        (True, 0, SUPPORT_CLOSE, ["close"]),
-        (True, 0, SUPPORT_OPEN_TILT, ["open_tilt"]),
-        (True, 0, SUPPORT_OPEN, ["open"]),
-        (True, 0, SUPPORT_SET_POSITION, ["set_position"]),
-        (True, 0, SUPPORT_SET_TILT_POSITION, ["set_tilt_position"]),
-        (True, 0, SUPPORT_STOP, ["stop"]),
+        (True, 0, CoverEntityFeature.CLOSE_TILT, ["close_tilt"]),
+        (True, 0, CoverEntityFeature.CLOSE, ["close"]),
+        (True, 0, CoverEntityFeature.OPEN_TILT, ["open_tilt"]),
+        (True, 0, CoverEntityFeature.OPEN, ["open"]),
+        (True, 0, CoverEntityFeature.SET_POSITION, ["set_position"]),
+        (True, 0, CoverEntityFeature.SET_TILT_POSITION, ["set_tilt_position"]),
+        (True, 0, CoverEntityFeature.STOP, ["stop"]),
     ],
 )
 async def test_get_actions(
@@ -141,7 +131,7 @@ async def test_get_actions_hidden_auxiliary(
         device_id=device_entry.id,
         entity_category=entity_category,
         hidden_by=hidden_by,
-        supported_features=SUPPORT_CLOSE,
+        supported_features=CoverEntityFeature.CLOSE,
     )
     expected_actions = []
     expected_actions += [
@@ -172,12 +162,12 @@ async def test_get_action_capabilities(
             is_on=True,
             unique_id="unique_set_pos_cover",
             current_cover_position=50,
-            supported_features=SUPPORT_OPEN
-            | SUPPORT_CLOSE
-            | SUPPORT_STOP
-            | SUPPORT_OPEN_TILT
-            | SUPPORT_CLOSE_TILT
-            | SUPPORT_STOP_TILT,
+            supported_features=CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.STOP
+            | CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.STOP_TILT,
         ),
     )
     ent = platform.ENTITIES[0]

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -2,13 +2,7 @@
 import pytest
 
 import homeassistant.components.automation as automation
-from homeassistant.components.cover import (
-    DOMAIN,
-    SUPPORT_CLOSE,
-    SUPPORT_OPEN,
-    SUPPORT_SET_POSITION,
-    SUPPORT_SET_TILT_POSITION,
-)
+from homeassistant.components.cover import DOMAIN, CoverEntityFeature
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import (
     CONF_PLATFORM,
@@ -57,15 +51,35 @@ def calls(hass):
     "set_state,features_reg,features_state,expected_condition_types",
     [
         (False, 0, 0, []),
-        (False, SUPPORT_CLOSE, 0, ["is_open", "is_closed", "is_opening", "is_closing"]),
-        (False, SUPPORT_OPEN, 0, ["is_open", "is_closed", "is_opening", "is_closing"]),
-        (False, SUPPORT_SET_POSITION, 0, ["is_position"]),
-        (False, SUPPORT_SET_TILT_POSITION, 0, ["is_tilt_position"]),
+        (
+            False,
+            CoverEntityFeature.CLOSE,
+            0,
+            ["is_open", "is_closed", "is_opening", "is_closing"],
+        ),
+        (
+            False,
+            CoverEntityFeature.OPEN,
+            0,
+            ["is_open", "is_closed", "is_opening", "is_closing"],
+        ),
+        (False, CoverEntityFeature.SET_POSITION, 0, ["is_position"]),
+        (False, CoverEntityFeature.SET_TILT_POSITION, 0, ["is_tilt_position"]),
         (True, 0, 0, []),
-        (True, 0, SUPPORT_CLOSE, ["is_open", "is_closed", "is_opening", "is_closing"]),
-        (True, 0, SUPPORT_OPEN, ["is_open", "is_closed", "is_opening", "is_closing"]),
-        (True, 0, SUPPORT_SET_POSITION, ["is_position"]),
-        (True, 0, SUPPORT_SET_TILT_POSITION, ["is_tilt_position"]),
+        (
+            True,
+            0,
+            CoverEntityFeature.CLOSE,
+            ["is_open", "is_closed", "is_opening", "is_closing"],
+        ),
+        (
+            True,
+            0,
+            CoverEntityFeature.OPEN,
+            ["is_open", "is_closed", "is_opening", "is_closing"],
+        ),
+        (True, 0, CoverEntityFeature.SET_POSITION, ["is_position"]),
+        (True, 0, CoverEntityFeature.SET_TILT_POSITION, ["is_tilt_position"]),
     ],
 )
 async def test_get_conditions(
@@ -145,7 +159,7 @@ async def test_get_conditions_hidden_auxiliary(
         device_id=device_entry.id,
         entity_category=entity_category,
         hidden_by=hidden_by,
-        supported_features=SUPPORT_CLOSE,
+        supported_features=CoverEntityFeature.CLOSE,
     )
     expected_conditions = [
         {

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -4,12 +4,7 @@ from datetime import timedelta
 import pytest
 
 import homeassistant.components.automation as automation
-from homeassistant.components.cover import (
-    DOMAIN,
-    SUPPORT_OPEN,
-    SUPPORT_SET_POSITION,
-    SUPPORT_SET_TILT_POSITION,
-)
+from homeassistant.components.cover import DOMAIN, CoverEntityFeature
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import (
     CONF_PLATFORM,
@@ -58,30 +53,30 @@ def calls(hass):
 @pytest.mark.parametrize(
     "set_state,features_reg,features_state,expected_trigger_types",
     [
-        (False, SUPPORT_OPEN, 0, ["opened", "closed", "opening", "closing"]),
+        (False, CoverEntityFeature.OPEN, 0, ["opened", "closed", "opening", "closing"]),
         (
             False,
-            SUPPORT_OPEN | SUPPORT_SET_POSITION,
+            CoverEntityFeature.OPEN | CoverEntityFeature.SET_POSITION,
             0,
             ["opened", "closed", "opening", "closing", "position"],
         ),
         (
             False,
-            SUPPORT_OPEN | SUPPORT_SET_TILT_POSITION,
+            CoverEntityFeature.OPEN | CoverEntityFeature.SET_TILT_POSITION,
             0,
             ["opened", "closed", "opening", "closing", "tilt_position"],
         ),
-        (True, 0, SUPPORT_OPEN, ["opened", "closed", "opening", "closing"]),
+        (True, 0, CoverEntityFeature.OPEN, ["opened", "closed", "opening", "closing"]),
         (
             True,
             0,
-            SUPPORT_OPEN | SUPPORT_SET_POSITION,
+            CoverEntityFeature.OPEN | CoverEntityFeature.SET_POSITION,
             ["opened", "closed", "opening", "closing", "position"],
         ),
         (
             True,
             0,
-            SUPPORT_OPEN | SUPPORT_SET_TILT_POSITION,
+            CoverEntityFeature.OPEN | CoverEntityFeature.SET_TILT_POSITION,
             ["opened", "closed", "opening", "closing", "tilt_position"],
         ),
     ],
@@ -165,7 +160,7 @@ async def test_get_triggers_hidden_auxiliary(
         device_id=device_entry.id,
         entity_category=entity_category,
         hidden_by=hidden_by,
-        supported_features=SUPPORT_OPEN,
+        supported_features=CoverEntityFeature.OPEN,
     )
     expected_triggers = [
         {

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -27,15 +27,8 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_TITLE,
     DOMAIN as MP_DOMAIN,
     SERVICE_PLAY_MEDIA,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE,
-    SUPPORT_PLAY,
-    SUPPORT_PLAY_MEDIA,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_STOP,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
     MediaPlayerDeviceClass,
+    MediaPlayerEntityFeature,
     MediaType,
 )
 from homeassistant.const import (
@@ -180,26 +173,26 @@ async def test_supported_features(
     # Features supported for main DVR
     state = hass.states.get(MAIN_ENTITY_ID)
     assert (
-        SUPPORT_PAUSE
-        | SUPPORT_TURN_ON
-        | SUPPORT_TURN_OFF
-        | SUPPORT_PLAY_MEDIA
-        | SUPPORT_STOP
-        | SUPPORT_NEXT_TRACK
-        | SUPPORT_PREVIOUS_TRACK
-        | SUPPORT_PLAY
+        MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.PREVIOUS_TRACK
+        | MediaPlayerEntityFeature.PLAY
         == state.attributes.get("supported_features")
     )
 
     # Feature supported for clients.
     state = hass.states.get(CLIENT_ENTITY_ID)
     assert (
-        SUPPORT_PAUSE
-        | SUPPORT_PLAY_MEDIA
-        | SUPPORT_STOP
-        | SUPPORT_NEXT_TRACK
-        | SUPPORT_PREVIOUS_TRACK
-        | SUPPORT_PLAY
+        MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.PREVIOUS_TRACK
+        | MediaPlayerEntityFeature.PLAY
         == state.attributes.get("supported_features")
     )
 

--- a/tests/components/ecobee/test_humidifier.py
+++ b/tests/components/ecobee/test_humidifier.py
@@ -15,8 +15,8 @@ from homeassistant.components.humidifier import (
     MODE_AUTO,
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_MODE,
-    SUPPORT_MODES,
     HumidifierDeviceClass,
+    HumidifierEntityFeature,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -51,7 +51,9 @@ async def test_attributes(hass):
     ]
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "ecobee"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == HumidifierDeviceClass.HUMIDIFIER
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == SUPPORT_MODES
+    assert (
+        state.attributes.get(ATTR_SUPPORTED_FEATURES) == HumidifierEntityFeature.MODES
+    )
 
 
 async def test_turn_on(hass):

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -17,9 +17,8 @@ from ismartgate.common import (
 
 from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
-    SUPPORT_CLOSE,
-    SUPPORT_OPEN,
     CoverDeviceClass,
+    CoverEntityFeature,
 )
 from homeassistant.components.gogogate2.const import (
     DEVICE_TYPE_GOGOGATE2,
@@ -117,7 +116,7 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
         "device_class": "garage",
         "door_id": 1,
         "friendly_name": "Door1",
-        "supported_features": SUPPORT_CLOSE | SUPPORT_OPEN,
+        "supported_features": CoverEntityFeature.CLOSE | CoverEntityFeature.OPEN,
     }
 
     api = MagicMock(GogoGate2Api)
@@ -256,7 +255,7 @@ async def test_availability(ismartgateapi_mock, hass: HomeAssistant) -> None:
         "device_class": "garage",
         "door_id": 1,
         "friendly_name": "Door1",
-        "supported_features": SUPPORT_CLOSE | SUPPORT_OPEN,
+        "supported_features": CoverEntityFeature.CLOSE | CoverEntityFeature.OPEN,
     }
 
     api = MagicMock(ISmartGateApi)

--- a/tests/components/group/test_fan.py
+++ b/tests/components/group/test_fan.py
@@ -18,9 +18,7 @@ from homeassistant.components.fan import (
     SERVICE_SET_PERCENTAGE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    SUPPORT_DIRECTION,
-    SUPPORT_OSCILLATE,
-    SUPPORT_SET_SPEED,
+    FanEntityFeature,
 )
 from homeassistant.components.group import SERVICE_RELOAD
 from homeassistant.components.group.fan import DEFAULT_NAME
@@ -54,7 +52,9 @@ FULL_FAN_ENTITY_IDS = [LIVING_ROOM_FAN_ENTITY_ID, PERCENTAGE_FULL_FAN_ENTITY_ID]
 LIMITED_FAN_ENTITY_IDS = [CEILING_FAN_ENTITY_ID, PERCENTAGE_LIMITED_FAN_ENTITY_ID]
 
 
-FULL_SUPPORT_FEATURES = SUPPORT_SET_SPEED | SUPPORT_DIRECTION | SUPPORT_OSCILLATE
+FULL_SUPPORT_FEATURES = (
+    FanEntityFeature.SET_SPEED | FanEntityFeature.DIRECTION | FanEntityFeature.OSCILLATE
+)
 
 
 CONFIG_MISSING_FAN = {
@@ -233,7 +233,7 @@ async def test_attributes(hass, setup_comp):
         CEILING_FAN_ENTITY_ID,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.SET_SPEED,
             ATTR_PERCENTAGE: 50,
         },
     )
@@ -242,7 +242,7 @@ async def test_attributes(hass, setup_comp):
     state = hass.states.get(FAN_GROUP)
     assert state.state == STATE_ON
     assert ATTR_ASSUMED_STATE not in state.attributes
-    assert state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SET_SPEED
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == FanEntityFeature.SET_SPEED
     assert ATTR_PERCENTAGE in state.attributes
     assert state.attributes[ATTR_PERCENTAGE] == 50
     assert ATTR_ASSUMED_STATE not in state.attributes
@@ -256,7 +256,7 @@ async def test_attributes(hass, setup_comp):
         PERCENTAGE_LIMITED_FAN_ENTITY_ID,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.SET_SPEED,
             ATTR_PERCENTAGE: 75,
         },
     )

--- a/tests/components/group/test_media_player.py
+++ b/tests/components/group/test_media_player.py
@@ -6,11 +6,15 @@ import pytest
 
 from homeassistant.components.group import DOMAIN
 from homeassistant.components.media_player import (
+    ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_SHUFFLE,
+    ATTR_MEDIA_TRACK,
     ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
     DOMAIN as MEDIA_DOMAIN,
+    SERVICE_CLEAR_PLAYLIST,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_SEEK,
     SERVICE_PLAY_MEDIA,
@@ -18,20 +22,7 @@ from homeassistant.components.media_player import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     SERVICE_VOLUME_SET,
-    SUPPORT_PAUSE,
-    SUPPORT_PLAY,
-    SUPPORT_PLAY_MEDIA,
-    SUPPORT_SEEK,
-    SUPPORT_STOP,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_STEP,
-)
-from homeassistant.components.media_player.const import (
-    ATTR_MEDIA_CONTENT_ID,
-    ATTR_MEDIA_TRACK,
-    ATTR_MEDIA_VOLUME_MUTED,
-    SERVICE_CLEAR_PLAYLIST,
+    MediaPlayerEntityFeature,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -188,9 +179,17 @@ async def test_state_reporting(hass):
 
 async def test_supported_features(hass):
     """Test supported features reporting."""
-    pause_play_stop = SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_STOP
-    play_media = SUPPORT_PLAY_MEDIA
-    volume = SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_STEP
+    pause_play_stop = (
+        MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.STOP
+    )
+    play_media = MediaPlayerEntityFeature.PLAY_MEDIA
+    volume = (
+        MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_STEP
+    )
 
     await async_setup_component(
         hass,
@@ -352,7 +351,7 @@ async def test_service_calls(hass, mock_media_seek):
     )
 
     state = hass.states.get("media_player.media_group")
-    assert state.attributes[ATTR_SUPPORTED_FEATURES] & SUPPORT_SEEK
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] & MediaPlayerEntityFeature.SEEK
     assert not mock_media_seek.called
 
     await hass.services.async_call(

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -32,11 +32,7 @@ from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
     SERVICE_UNJOIN,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE,
-    SUPPORT_PLAY,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_STOP,
+    MediaPlayerEntityFeature,
     MediaType,
 )
 from homeassistant.const import (
@@ -90,11 +86,11 @@ async def test_state_attributes(hass, config_entry, config, controller):
     assert state.attributes[ATTR_FRIENDLY_NAME] == "Test Player"
     assert (
         state.attributes[ATTR_SUPPORTED_FEATURES]
-        == SUPPORT_PLAY
-        | SUPPORT_PAUSE
-        | SUPPORT_STOP
-        | SUPPORT_NEXT_TRACK
-        | SUPPORT_PREVIOUS_TRACK
+        == MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.PREVIOUS_TRACK
         | media_player.BASE_SUPPORTED_FEATURES
     )
     assert ATTR_INPUT_SOURCE not in state.attributes

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -6,9 +6,7 @@ from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     DOMAIN,
-    SUPPORT_SET_POSITION,
-    SUPPORT_SET_TILT_POSITION,
-    SUPPORT_STOP,
+    CoverEntityFeature,
 )
 from homeassistant.components.homekit.const import (
     ATTR_OBSTRUCTION_DETECTED,
@@ -136,7 +134,9 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     entity_id = "cover.window"
 
     hass.states.async_set(
-        entity_id, STATE_UNKNOWN, {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_POSITION}
+        entity_id,
+        STATE_UNKNOWN,
+        {ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION},
     )
     await hass.async_block_till_done()
     acc = WindowCovering(hass, hk_driver, "Cover", entity_id, 2, None)
@@ -152,7 +152,10 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     hass.states.async_set(
         entity_id,
         STATE_UNKNOWN,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_POSITION, ATTR_CURRENT_POSITION: None},
+        {
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
+            ATTR_CURRENT_POSITION: None,
+        },
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 0
@@ -162,7 +165,10 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     hass.states.async_set(
         entity_id,
         STATE_OPENING,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_POSITION, ATTR_CURRENT_POSITION: 60},
+        {
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
+            ATTR_CURRENT_POSITION: 60,
+        },
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 60
@@ -172,7 +178,10 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     hass.states.async_set(
         entity_id,
         STATE_OPENING,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_POSITION, ATTR_CURRENT_POSITION: 70.0},
+        {
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
+            ATTR_CURRENT_POSITION: 70.0,
+        },
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 70
@@ -182,7 +191,10 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     hass.states.async_set(
         entity_id,
         STATE_CLOSING,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_POSITION, ATTR_CURRENT_POSITION: 50},
+        {
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
+            ATTR_CURRENT_POSITION: 50,
+        },
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 50
@@ -192,7 +204,10 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     hass.states.async_set(
         entity_id,
         STATE_OPEN,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_POSITION, ATTR_CURRENT_POSITION: 50},
+        {
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
+            ATTR_CURRENT_POSITION: 50,
+        },
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 50
@@ -230,7 +245,10 @@ async def test_window_instantiate_set_position(hass, hk_driver, events):
     hass.states.async_set(
         entity_id,
         STATE_OPEN,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_POSITION, ATTR_CURRENT_POSITION: 0},
+        {
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
+            ATTR_CURRENT_POSITION: 0,
+        },
     )
     await hass.async_block_till_done()
     acc = Window(hass, hk_driver, "Window", entity_id, 2, None)
@@ -246,7 +264,10 @@ async def test_window_instantiate_set_position(hass, hk_driver, events):
     hass.states.async_set(
         entity_id,
         STATE_OPEN,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_POSITION, ATTR_CURRENT_POSITION: 50},
+        {
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
+            ATTR_CURRENT_POSITION: 50,
+        },
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 50
@@ -257,7 +278,7 @@ async def test_window_instantiate_set_position(hass, hk_driver, events):
         entity_id,
         STATE_OPEN,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_POSITION,
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
             ATTR_CURRENT_POSITION: "GARBAGE",
         },
     )
@@ -272,7 +293,9 @@ async def test_windowcovering_cover_set_tilt(hass, hk_driver, events):
     entity_id = "cover.window"
 
     hass.states.async_set(
-        entity_id, STATE_UNKNOWN, {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_TILT_POSITION}
+        entity_id,
+        STATE_UNKNOWN,
+        {ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_TILT_POSITION},
     )
     await hass.async_block_till_done()
     acc = WindowCovering(hass, hk_driver, "Cover", entity_id, 2, None)
@@ -339,7 +362,9 @@ async def test_windowcovering_tilt_only(hass, hk_driver, events):
     entity_id = "cover.window"
 
     hass.states.async_set(
-        entity_id, STATE_UNKNOWN, {ATTR_SUPPORTED_FEATURES: SUPPORT_SET_TILT_POSITION}
+        entity_id,
+        STATE_UNKNOWN,
+        {ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_TILT_POSITION},
     )
     await hass.async_block_till_done()
     acc = WindowCovering(hass, hk_driver, "Cover", entity_id, 2, None)
@@ -441,7 +466,7 @@ async def test_windowcovering_open_close_stop(hass, hk_driver, events):
     entity_id = "cover.window"
 
     hass.states.async_set(
-        entity_id, STATE_UNKNOWN, {ATTR_SUPPORTED_FEATURES: SUPPORT_STOP}
+        entity_id, STATE_UNKNOWN, {ATTR_SUPPORTED_FEATURES: CoverEntityFeature.STOP}
     )
     acc = WindowCoveringBasic(hass, hk_driver, "Cover", entity_id, 2, None)
     await acc.run()
@@ -492,7 +517,10 @@ async def test_windowcovering_open_close_with_position_and_stop(
     hass.states.async_set(
         entity_id,
         STATE_UNKNOWN,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_STOP | SUPPORT_SET_POSITION},
+        {
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.STOP
+            | CoverEntityFeature.SET_POSITION
+        },
     )
     acc = WindowCovering(hass, hk_driver, "Cover", entity_id, 2, None)
     await acc.run()
@@ -532,7 +560,7 @@ async def test_windowcovering_basic_restore(hass, hk_driver, events):
         "9012",
         suggested_object_id="all_info_set",
         capabilities={},
-        supported_features=SUPPORT_STOP,
+        supported_features=CoverEntityFeature.STOP,
         original_device_class="mock-device-class",
     )
 
@@ -570,7 +598,7 @@ async def test_windowcovering_restore(hass, hk_driver, events):
         "9012",
         suggested_object_id="all_info_set",
         capabilities={},
-        supported_features=SUPPORT_STOP,
+        supported_features=CoverEntityFeature.STOP,
         original_device_class="mock-device-class",
     )
 

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -12,10 +12,7 @@ from homeassistant.components.fan import (
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
     DOMAIN,
-    SUPPORT_DIRECTION,
-    SUPPORT_OSCILLATE,
-    SUPPORT_PRESET_MODE,
-    SUPPORT_SET_SPEED,
+    FanEntityFeature,
 )
 from homeassistant.components.homekit.const import ATTR_VALUE, PROP_MIN_STEP
 from homeassistant.components.homekit.type_fans import Fan
@@ -118,7 +115,10 @@ async def test_fan_direction(hass, hk_driver, events):
     hass.states.async_set(
         entity_id,
         STATE_ON,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_DIRECTION, ATTR_DIRECTION: DIRECTION_FORWARD},
+        {
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.DIRECTION,
+            ATTR_DIRECTION: DIRECTION_FORWARD,
+        },
     )
     await hass.async_block_till_done()
     acc = Fan(hass, hk_driver, "Fan", entity_id, 1, None)
@@ -186,7 +186,7 @@ async def test_fan_oscillate(hass, hk_driver, events):
     hass.states.async_set(
         entity_id,
         STATE_ON,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_OSCILLATE, ATTR_OSCILLATING: False},
+        {ATTR_SUPPORTED_FEATURES: FanEntityFeature.OSCILLATE, ATTR_OSCILLATING: False},
     )
     await hass.async_block_till_done()
     acc = Fan(hass, hk_driver, "Fan", entity_id, 1, None)
@@ -256,7 +256,7 @@ async def test_fan_speed(hass, hk_driver, events):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.SET_SPEED,
             ATTR_PERCENTAGE: 0,
             ATTR_PERCENTAGE_STEP: 25,
         },
@@ -342,9 +342,9 @@ async def test_fan_set_all_one_shot(hass, hk_driver, events):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED
-            | SUPPORT_OSCILLATE
-            | SUPPORT_DIRECTION,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.SET_SPEED
+            | FanEntityFeature.OSCILLATE
+            | FanEntityFeature.DIRECTION,
             ATTR_PERCENTAGE: 0,
             ATTR_OSCILLATING: False,
             ATTR_DIRECTION: DIRECTION_FORWARD,
@@ -364,9 +364,9 @@ async def test_fan_set_all_one_shot(hass, hk_driver, events):
         entity_id,
         STATE_OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED
-            | SUPPORT_OSCILLATE
-            | SUPPORT_DIRECTION,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.SET_SPEED
+            | FanEntityFeature.OSCILLATE
+            | FanEntityFeature.DIRECTION,
             ATTR_PERCENTAGE: 0,
             ATTR_OSCILLATING: False,
             ATTR_DIRECTION: DIRECTION_FORWARD,
@@ -435,9 +435,9 @@ async def test_fan_set_all_one_shot(hass, hk_driver, events):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED
-            | SUPPORT_OSCILLATE
-            | SUPPORT_DIRECTION,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.SET_SPEED
+            | FanEntityFeature.OSCILLATE
+            | FanEntityFeature.DIRECTION,
             ATTR_PERCENTAGE: 0,
             ATTR_OSCILLATING: False,
             ATTR_DIRECTION: DIRECTION_FORWARD,
@@ -545,7 +545,9 @@ async def test_fan_restore(hass, hk_driver, events):
         "9012",
         suggested_object_id="all_info_set",
         capabilities={"speed_list": ["off", "low", "medium", "high"]},
-        supported_features=SUPPORT_SET_SPEED | SUPPORT_OSCILLATE | SUPPORT_DIRECTION,
+        supported_features=FanEntityFeature.SET_SPEED
+        | FanEntityFeature.OSCILLATE
+        | FanEntityFeature.DIRECTION,
         original_device_class="mock-device-class",
     )
 
@@ -575,7 +577,7 @@ async def test_fan_multiple_preset_modes(hass, hk_driver, events):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_PRESET_MODE,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.PRESET_MODE,
             ATTR_PRESET_MODE: "auto",
             ATTR_PRESET_MODES: ["auto", "smart"],
         },
@@ -594,7 +596,7 @@ async def test_fan_multiple_preset_modes(hass, hk_driver, events):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_PRESET_MODE,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.PRESET_MODE,
             ATTR_PRESET_MODE: "smart",
             ATTR_PRESET_MODES: ["auto", "smart"],
         },
@@ -655,7 +657,8 @@ async def test_fan_single_preset_mode(hass, hk_driver, events):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_PRESET_MODE | SUPPORT_SET_SPEED,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.SET_SPEED,
             ATTR_PERCENTAGE: 42,
             ATTR_PRESET_MODE: "smart",
             ATTR_PRESET_MODES: ["smart"],
@@ -718,7 +721,8 @@ async def test_fan_single_preset_mode(hass, hk_driver, events):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_PRESET_MODE | SUPPORT_SET_SPEED,
+            ATTR_SUPPORTED_FEATURES: FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.SET_SPEED,
             ATTR_PERCENTAGE: 42,
             ATTR_PRESET_MODE: None,
             ATTR_PRESET_MODES: ["smart"],

--- a/tests/components/homekit/test_type_remote.py
+++ b/tests/components/homekit/test_type_remote.py
@@ -16,7 +16,7 @@ from homeassistant.components.remote import (
     ATTR_ACTIVITY_LIST,
     ATTR_CURRENT_ACTIVITY,
     DOMAIN,
-    SUPPORT_ACTIVITY,
+    RemoteEntityFeature,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -36,7 +36,7 @@ async def test_activity_remote(hass, hk_driver, events, caplog):
         entity_id,
         None,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_ACTIVITY,
+            ATTR_SUPPORTED_FEATURES: RemoteEntityFeature.ACTIVITY,
             ATTR_CURRENT_ACTIVITY: "Apple TV",
             ATTR_ACTIVITY_LIST: ["TV", "Apple TV"],
         },
@@ -57,7 +57,7 @@ async def test_activity_remote(hass, hk_driver, events, caplog):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_ACTIVITY,
+            ATTR_SUPPORTED_FEATURES: RemoteEntityFeature.ACTIVITY,
             ATTR_CURRENT_ACTIVITY: "Apple TV",
             ATTR_ACTIVITY_LIST: ["TV", "Apple TV"],
         },
@@ -81,7 +81,7 @@ async def test_activity_remote(hass, hk_driver, events, caplog):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_ACTIVITY,
+            ATTR_SUPPORTED_FEATURES: RemoteEntityFeature.ACTIVITY,
             ATTR_CURRENT_ACTIVITY: "TV",
             ATTR_ACTIVITY_LIST: ["TV", "Apple TV"],
         },
@@ -93,7 +93,7 @@ async def test_activity_remote(hass, hk_driver, events, caplog):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_ACTIVITY,
+            ATTR_SUPPORTED_FEATURES: RemoteEntityFeature.ACTIVITY,
             ATTR_CURRENT_ACTIVITY: "Apple TV",
             ATTR_ACTIVITY_LIST: ["TV", "Apple TV"],
         },
@@ -160,7 +160,7 @@ async def test_activity_remote(hass, hk_driver, events, caplog):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_ACTIVITY,
+            ATTR_SUPPORTED_FEATURES: RemoteEntityFeature.ACTIVITY,
             ATTR_CURRENT_ACTIVITY: "Amazon TV",
             ATTR_ACTIVITY_LIST: ["TV", "Apple TV", "Amazon TV"],
         },
@@ -176,7 +176,7 @@ async def test_activity_remote_bad_names(hass, hk_driver, events, caplog):
         entity_id,
         None,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_ACTIVITY,
+            ATTR_SUPPORTED_FEATURES: RemoteEntityFeature.ACTIVITY,
             ATTR_CURRENT_ACTIVITY: "Apple TV",
             ATTR_ACTIVITY_LIST: ["TV", "Apple TV", "[[[--Special--]]]", "Super"],
         },
@@ -197,7 +197,7 @@ async def test_activity_remote_bad_names(hass, hk_driver, events, caplog):
         entity_id,
         STATE_ON,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_ACTIVITY,
+            ATTR_SUPPORTED_FEATURES: RemoteEntityFeature.ACTIVITY,
             ATTR_CURRENT_ACTIVITY: "[[[--Special--]]]",
             ATTR_ACTIVITY_LIST: ["TV", "Apple TV", "[[[--Special--]]]", "Super"],
         },

--- a/tests/components/homekit/test_type_security_systems.py
+++ b/tests/components/homekit/test_type_security_systems.py
@@ -4,10 +4,7 @@ import pytest
 
 from homeassistant.components.alarm_control_panel import (
     DOMAIN,
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_NIGHT,
-    SUPPORT_ALARM_TRIGGER,
+    AlarmControlPanelEntityFeature,
 )
 from homeassistant.components.homekit.const import ATTR_VALUE
 from homeassistant.components.homekit.type_security_systems import SecuritySystem
@@ -208,7 +205,7 @@ async def test_supported_states(hass, hk_driver, events):
     # Set up a number of test configuration
     test_configs = [
         {
-            "features": SUPPORT_ALARM_ARM_HOME,
+            "features": AlarmControlPanelEntityFeature.ARM_HOME,
             "current_values": [
                 default_current_states["Disarmed"],
                 default_current_states["AlarmTriggered"],
@@ -220,7 +217,7 @@ async def test_supported_states(hass, hk_driver, events):
             ],
         },
         {
-            "features": SUPPORT_ALARM_ARM_AWAY,
+            "features": AlarmControlPanelEntityFeature.ARM_AWAY,
             "current_values": [
                 default_current_states["Disarmed"],
                 default_current_states["AlarmTriggered"],
@@ -232,7 +229,8 @@ async def test_supported_states(hass, hk_driver, events):
             ],
         },
         {
-            "features": SUPPORT_ALARM_ARM_HOME | SUPPORT_ALARM_ARM_AWAY,
+            "features": AlarmControlPanelEntityFeature.ARM_HOME
+            | AlarmControlPanelEntityFeature.ARM_AWAY,
             "current_values": [
                 default_current_states["Disarmed"],
                 default_current_states["AlarmTriggered"],
@@ -246,9 +244,9 @@ async def test_supported_states(hass, hk_driver, events):
             ],
         },
         {
-            "features": SUPPORT_ALARM_ARM_HOME
-            | SUPPORT_ALARM_ARM_AWAY
-            | SUPPORT_ALARM_ARM_NIGHT,
+            "features": AlarmControlPanelEntityFeature.ARM_HOME
+            | AlarmControlPanelEntityFeature.ARM_AWAY
+            | AlarmControlPanelEntityFeature.ARM_NIGHT,
             "current_values": [
                 default_current_states["Disarmed"],
                 default_current_states["AlarmTriggered"],
@@ -264,10 +262,10 @@ async def test_supported_states(hass, hk_driver, events):
             ],
         },
         {
-            "features": SUPPORT_ALARM_ARM_HOME
-            | SUPPORT_ALARM_ARM_AWAY
-            | SUPPORT_ALARM_ARM_NIGHT
-            | SUPPORT_ALARM_TRIGGER,
+            "features": AlarmControlPanelEntityFeature.ARM_HOME
+            | AlarmControlPanelEntityFeature.ARM_AWAY
+            | AlarmControlPanelEntityFeature.ARM_NIGHT
+            | AlarmControlPanelEntityFeature.TRIGGER,
             "current_values": [
                 default_current_states["Disarmed"],
                 default_current_states["AlarmTriggered"],

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -26,8 +26,7 @@ from homeassistant.components.vacuum import (
     SERVICE_TURN_ON,
     STATE_CLEANING,
     STATE_DOCKED,
-    SUPPORT_RETURN_HOME,
-    SUPPORT_START,
+    VacuumEntityFeature,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -212,7 +211,12 @@ async def test_vacuum_set_state_with_returnhome_and_start_support(
     entity_id = "vacuum.roomba"
 
     hass.states.async_set(
-        entity_id, None, {ATTR_SUPPORTED_FEATURES: SUPPORT_RETURN_HOME | SUPPORT_START}
+        entity_id,
+        None,
+        {
+            ATTR_SUPPORTED_FEATURES: VacuumEntityFeature.RETURN_HOME
+            | VacuumEntityFeature.START
+        },
     )
     await hass.async_block_till_done()
 
@@ -227,7 +231,10 @@ async def test_vacuum_set_state_with_returnhome_and_start_support(
     hass.states.async_set(
         entity_id,
         STATE_CLEANING,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_RETURN_HOME | SUPPORT_START},
+        {
+            ATTR_SUPPORTED_FEATURES: VacuumEntityFeature.RETURN_HOME
+            | VacuumEntityFeature.START
+        },
     )
     await hass.async_block_till_done()
     assert acc.char_on.value == 1
@@ -235,7 +242,10 @@ async def test_vacuum_set_state_with_returnhome_and_start_support(
     hass.states.async_set(
         entity_id,
         STATE_DOCKED,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_RETURN_HOME | SUPPORT_START},
+        {
+            ATTR_SUPPORTED_FEATURES: VacuumEntityFeature.RETURN_HOME
+            | VacuumEntityFeature.START
+        },
     )
     await hass.async_block_till_done()
     assert acc.char_on.value == 0

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -33,13 +33,10 @@ from homeassistant.components.climate import (
     FAN_ON,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_SWING_MODE,
-    SUPPORT_FAN_MODE,
-    SUPPORT_SWING_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_TARGET_TEMPERATURE_RANGE,
     SWING_BOTH,
     SWING_HORIZONTAL,
     SWING_OFF,
+    ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )
@@ -88,7 +85,7 @@ async def test_thermostat(hass, hk_driver, events):
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE,
             ATTR_HVAC_MODES: [
                 HVACMode.HEAT,
                 HVACMode.HEAT_COOL,
@@ -324,7 +321,7 @@ async def test_thermostat(hass, hk_driver, events):
         entity_id,
         HVACMode.DRY,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE,
             ATTR_TEMPERATURE: 22.0,
             ATTR_CURRENT_TEMPERATURE: 22.0,
             ATTR_HVAC_ACTION: HVACAction.DRYING,
@@ -429,8 +426,8 @@ async def test_thermostat_auto(hass, hk_driver, events):
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
             ATTR_HVAC_MODES: [
                 HVACMode.HEAT,
                 HVACMode.HEAT_COOL,
@@ -583,8 +580,8 @@ async def test_thermostat_mode_and_temp_change(hass, hk_driver, events):
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
             ATTR_HVAC_MODES: [
                 HVACMode.HEAT,
                 HVACMode.HEAT_COOL,
@@ -875,8 +872,8 @@ async def test_thermostat_fahrenheit(hass, hk_driver, events):
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         },
     )
     await hass.async_block_till_done()
@@ -894,8 +891,8 @@ async def test_thermostat_fahrenheit(hass, hk_driver, events):
             ATTR_TARGET_TEMP_LOW: 68.1,
             ATTR_TEMPERATURE: 71.6,
             ATTR_CURRENT_TEMPERATURE: 73.4,
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
         },
     )
     await hass.async_block_till_done()
@@ -1528,7 +1525,7 @@ async def test_thermostat_without_target_temp_only_range(hass, hk_driver, events
     hass.states.async_set(
         entity_id,
         HVACMode.OFF,
-        {ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE_RANGE},
+        {ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE_RANGE},
     )
     await hass.async_block_till_done()
     acc = Thermostat(hass, hk_driver, "Climate", entity_id, 1, None)
@@ -1555,7 +1552,7 @@ async def test_thermostat_without_target_temp_only_range(hass, hk_driver, events
             ATTR_TARGET_TEMP_LOW: 20.0,
             ATTR_CURRENT_TEMPERATURE: 18.0,
             ATTR_HVAC_ACTION: HVACAction.HEATING,
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
             ATTR_HVAC_MODES: [
                 HVACMode.HEAT,
                 HVACMode.HEAT_COOL,
@@ -1582,7 +1579,7 @@ async def test_thermostat_without_target_temp_only_range(hass, hk_driver, events
             ATTR_TARGET_TEMP_LOW: 19.0,
             ATTR_CURRENT_TEMPERATURE: 24.0,
             ATTR_HVAC_ACTION: HVACAction.COOLING,
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
             ATTR_HVAC_MODES: [
                 HVACMode.HEAT,
                 HVACMode.HEAT_COOL,
@@ -1609,7 +1606,7 @@ async def test_thermostat_without_target_temp_only_range(hass, hk_driver, events
             ATTR_TARGET_TEMP_LOW: 19.0,
             ATTR_CURRENT_TEMPERATURE: 21.0,
             ATTR_HVAC_ACTION: HVACAction.IDLE,
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
             ATTR_HVAC_MODES: [
                 HVACMode.HEAT,
                 HVACMode.HEAT_COOL,
@@ -1663,7 +1660,7 @@ async def test_thermostat_without_target_temp_only_range(hass, hk_driver, events
             ATTR_TARGET_TEMP_LOW: 19.0,
             ATTR_CURRENT_TEMPERATURE: 21.0,
             ATTR_HVAC_ACTION: HVACAction.IDLE,
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
         },
     )
     await hass.async_block_till_done()
@@ -1882,8 +1879,8 @@ async def test_thermostat_with_no_modes_when_we_first_see(hass, hk_driver, event
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
             ATTR_HVAC_MODES: [],
         },
     )
@@ -1935,8 +1932,8 @@ async def test_thermostat_with_no_off_after_recheck(hass, hk_driver, events):
         entity_id,
         HVACMode.COOL,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
             ATTR_HVAC_MODES: [],
         },
     )
@@ -1987,8 +1984,8 @@ async def test_thermostat_with_temp_clamps(hass, hk_driver, events):
         entity_id,
         HVACMode.COOL,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
             ATTR_HVAC_MODES: [],
             ATTR_MAX_TEMP: 50,
             ATTR_MIN_TEMP: 100,
@@ -2040,10 +2037,10 @@ async def test_thermostat_with_fan_modes_with_auto(hass, hk_driver, events):
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE
-            | SUPPORT_FAN_MODE
-            | SUPPORT_SWING_MODE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.SWING_MODE,
             ATTR_FAN_MODES: [FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH],
             ATTR_SWING_MODES: [SWING_BOTH, SWING_OFF, SWING_HORIZONTAL],
             ATTR_HVAC_ACTION: HVACAction.IDLE,
@@ -2079,10 +2076,10 @@ async def test_thermostat_with_fan_modes_with_auto(hass, hk_driver, events):
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE
-            | SUPPORT_FAN_MODE
-            | SUPPORT_SWING_MODE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.SWING_MODE,
             ATTR_FAN_MODES: [FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH],
             ATTR_SWING_MODES: [SWING_BOTH, SWING_OFF, SWING_HORIZONTAL],
             ATTR_HVAC_ACTION: HVACAction.IDLE,
@@ -2244,10 +2241,10 @@ async def test_thermostat_with_fan_modes_with_off(hass, hk_driver, events):
         entity_id,
         HVACMode.COOL,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE
-            | SUPPORT_FAN_MODE
-            | SUPPORT_SWING_MODE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.SWING_MODE,
             ATTR_FAN_MODES: [FAN_ON, FAN_OFF],
             ATTR_SWING_MODES: [SWING_BOTH, SWING_OFF, SWING_HORIZONTAL],
             ATTR_HVAC_ACTION: HVACAction.IDLE,
@@ -2283,10 +2280,10 @@ async def test_thermostat_with_fan_modes_with_off(hass, hk_driver, events):
         entity_id,
         HVACMode.COOL,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE
-            | SUPPORT_FAN_MODE
-            | SUPPORT_SWING_MODE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.SWING_MODE,
             ATTR_FAN_MODES: [FAN_ON, FAN_OFF],
             ATTR_SWING_MODES: [SWING_BOTH, SWING_OFF, SWING_HORIZONTAL],
             ATTR_HVAC_ACTION: HVACAction.IDLE,
@@ -2351,10 +2348,10 @@ async def test_thermostat_with_fan_modes_set_to_none(hass, hk_driver, events):
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE
-            | SUPPORT_FAN_MODE
-            | SUPPORT_SWING_MODE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.SWING_MODE,
             ATTR_FAN_MODES: None,
             ATTR_SWING_MODES: [SWING_BOTH, SWING_OFF, SWING_HORIZONTAL],
             ATTR_HVAC_ACTION: HVACAction.IDLE,
@@ -2395,9 +2392,9 @@ async def test_thermostat_with_fan_modes_set_to_none_not_supported(
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE
-            | SUPPORT_SWING_MODE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            | ClimateEntityFeature.SWING_MODE,
             ATTR_FAN_MODES: None,
             ATTR_SWING_MODES: [SWING_BOTH, SWING_OFF, SWING_HORIZONTAL],
             ATTR_HVAC_ACTION: HVACAction.IDLE,
@@ -2438,7 +2435,7 @@ async def test_thermostat_with_supported_features_target_temp_but_fan_mode_set(
         entity_id,
         HVACMode.OFF,
         {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_TARGET_TEMPERATURE,
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE,
             ATTR_MIN_TEMP: 44.6,
             ATTR_MAX_TEMP: 95,
             ATTR_PRESET_MODES: ["home", "away"],

--- a/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
@@ -3,11 +3,7 @@ Regression tests for Aqara Gateway V3.
 
 https://github.com/home-assistant/core/issues/20957
 """
-from homeassistant.components.alarm_control_panel import (
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_NIGHT,
-)
+from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
 from homeassistant.components.number import NumberMode
 from homeassistant.helpers.entity import EntityCategory
 
@@ -42,9 +38,9 @@ async def test_aqara_gateway_setup(hass):
                     "alarm_control_panel.aqara_hub_1563_security_system",
                     friendly_name="Aqara Hub-1563 Security System",
                     unique_id="homekit-0000000123456789-66304",
-                    supported_features=SUPPORT_ALARM_ARM_NIGHT
-                    | SUPPORT_ALARM_ARM_HOME
-                    | SUPPORT_ALARM_ARM_AWAY,
+                    supported_features=AlarmControlPanelEntityFeature.ARM_NIGHT
+                    | AlarmControlPanelEntityFeature.ARM_HOME
+                    | AlarmControlPanelEntityFeature.ARM_AWAY,
                     state="disarmed",
                 ),
                 EntityTestInfo(
@@ -101,9 +97,9 @@ async def test_aqara_gateway_e1_setup(hass):
                     "alarm_control_panel.aqara_hub_e1_00a0_security_system",
                     friendly_name="Aqara-Hub-E1-00A0 Security System",
                     unique_id="homekit-00aa00000a0-16",
-                    supported_features=SUPPORT_ALARM_ARM_NIGHT
-                    | SUPPORT_ALARM_ARM_HOME
-                    | SUPPORT_ALARM_ARM_AWAY,
+                    supported_features=AlarmControlPanelEntityFeature.ARM_NIGHT
+                    | AlarmControlPanelEntityFeature.ARM_HOME
+                    | AlarmControlPanelEntityFeature.ARM_AWAY,
                     state="disarmed",
                 ),
                 EntityTestInfo(

--- a/tests/components/homekit_controller/specific_devices/test_haa_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_haa_fan.py
@@ -1,6 +1,6 @@
 """Make sure that a H.A.A. fan can be setup."""
 
-from homeassistant.components.fan import ATTR_PERCENTAGE, SUPPORT_SET_SPEED
+from homeassistant.components.fan import ATTR_PERCENTAGE, FanEntityFeature
 from homeassistant.helpers.entity import EntityCategory
 
 from ..common import (
@@ -58,7 +58,7 @@ async def test_haa_fan_setup(hass):
                     friendly_name="HAA-C718B3",
                     unique_id="homekit-C718B3-1-8",
                     state="on",
-                    supported_features=SUPPORT_SET_SPEED,
+                    supported_features=FanEntityFeature.SET_SPEED,
                     capabilities={
                         "preset_modes": None,
                     },

--- a/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
@@ -1,10 +1,6 @@
 """Test against characteristics captured from the Home Assistant HomeKit bridge running demo platforms."""
 
-from homeassistant.components.fan import (
-    SUPPORT_DIRECTION,
-    SUPPORT_OSCILLATE,
-    SUPPORT_SET_SPEED,
-)
+from homeassistant.components.fan import FanEntityFeature
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -49,9 +45,9 @@ async def test_homeassistant_bridge_fan_setup(hass):
                             friendly_name="Living Room Fan",
                             unique_id="homekit-fan.living_room_fan-8",
                             supported_features=(
-                                SUPPORT_DIRECTION
-                                | SUPPORT_SET_SPEED
-                                | SUPPORT_OSCILLATE
+                                FanEntityFeature.DIRECTION
+                                | FanEntityFeature.SET_SPEED
+                                | FanEntityFeature.OSCILLATE
                             ),
                             capabilities={
                                 "preset_modes": None,

--- a/tests/components/homekit_controller/specific_devices/test_mysa_living.py
+++ b/tests/components/homekit_controller/specific_devices/test_mysa_living.py
@@ -1,6 +1,6 @@
 """Make sure that Mysa Living is enumerated properly."""
 
-from homeassistant.components.climate import SUPPORT_TARGET_TEMPERATURE
+from homeassistant.components.climate import ClimateEntityFeature
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
 
@@ -35,7 +35,7 @@ async def test_mysa_living_setup(hass):
                     entity_id="climate.mysa_85dda9_thermostat",
                     friendly_name="Mysa-85dda9 Thermostat",
                     unique_id="homekit-AAAAAAA000-20",
-                    supported_features=SUPPORT_TARGET_TEMPERATURE,
+                    supported_features=ClimateEntityFeature.TARGET_TEMPERATURE,
                     capabilities={
                         "hvac_modes": ["off", "heat", "cool", "heat_cool"],
                         "max_temp": 35,

--- a/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
@@ -1,10 +1,6 @@
 """Test against characteristics captured from a ryse smart bridge platforms."""
 
-from homeassistant.components.cover import (
-    SUPPORT_CLOSE,
-    SUPPORT_OPEN,
-    SUPPORT_SET_POSITION,
-)
+from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE
 
@@ -17,7 +13,9 @@ from ..common import (
     setup_test_accessories,
 )
 
-RYSE_SUPPORTED_FEATURES = SUPPORT_CLOSE | SUPPORT_SET_POSITION | SUPPORT_OPEN
+RYSE_SUPPORTED_FEATURES = (
+    CoverEntityFeature.CLOSE | CoverEntityFeature.SET_POSITION | CoverEntityFeature.OPEN
+)
 
 
 async def test_ryse_smart_bridge_setup(hass):

--- a/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
@@ -4,7 +4,7 @@ Test against characteristics captured from a SIMPLEconnect Fan.
 https://github.com/home-assistant/core/issues/26180
 """
 
-from homeassistant.components.fan import SUPPORT_DIRECTION, SUPPORT_SET_SPEED
+from homeassistant.components.fan import FanEntityFeature
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -37,7 +37,8 @@ async def test_simpleconnect_fan_setup(hass):
                     entity_id="fan.simpleconnect_fan_06f674_hunter_fan",
                     friendly_name="SIMPLEconnect Fan-06F674 Hunter Fan",
                     unique_id="homekit-1234567890abcd-8",
-                    supported_features=SUPPORT_DIRECTION | SUPPORT_SET_SPEED,
+                    supported_features=FanEntityFeature.DIRECTION
+                    | FanEntityFeature.SET_SPEED,
                     capabilities={
                         "preset_modes": None,
                     },

--- a/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
@@ -4,11 +4,7 @@ Test against characteristics captured from a Velux Gateway.
 https://github.com/home-assistant/core/issues/44314
 """
 
-from homeassistant.components.cover import (
-    SUPPORT_CLOSE,
-    SUPPORT_OPEN,
-    SUPPORT_SET_POSITION,
-)
+from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
@@ -56,9 +52,9 @@ async def test_velux_cover_setup(hass):
                             entity_id="cover.velux_window_roof_window",
                             friendly_name="VELUX Window Roof Window",
                             unique_id="homekit-1111111a114a111a-8",
-                            supported_features=SUPPORT_CLOSE
-                            | SUPPORT_SET_POSITION
-                            | SUPPORT_OPEN,
+                            supported_features=CoverEntityFeature.CLOSE
+                            | CoverEntityFeature.SET_POSITION
+                            | CoverEntityFeature.OPEN,
                             state="closed",
                         ),
                     ],

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
@@ -1,6 +1,6 @@
 """Make sure that Vocolinc Flowerbud is enumerated properly."""
 
-from homeassistant.components.humidifier import SUPPORT_MODES
+from homeassistant.components.humidifier import HumidifierEntityFeature
 from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE
@@ -37,7 +37,7 @@ async def test_vocolinc_flowerbud_setup(hass):
                     entity_id="humidifier.vocolinc_flowerbud_0d324b",
                     friendly_name="VOCOlinc-Flowerbud-0d324b",
                     unique_id="homekit-AM01121849000327-30",
-                    supported_features=SUPPORT_MODES,
+                    supported_features=HumidifierEntityFeature.MODES,
                     capabilities={
                         "available_modes": ["normal", "auto"],
                         "max_humidity": 100.0,

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.camera import SUPPORT_STREAM as CAMERA_SUPPORT_STREAM
+from homeassistant.components.camera import CameraEntityFeature
 from homeassistant.components.mobile_app.const import CONF_SECRET
 from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
 from homeassistant.const import (
@@ -783,7 +783,9 @@ async def test_webhook_camera_stream_stream_available(
 ):
     """Test fetching camera stream URLs for an HLS/stream-supporting camera."""
     hass.states.async_set(
-        "camera.stream_camera", "idle", {"supported_features": CAMERA_SUPPORT_STREAM}
+        "camera.stream_camera",
+        "idle",
+        {"supported_features": CameraEntityFeature.STREAM},
     )
 
     webhook_id = create_registrations[1]["webhook_id"]
@@ -811,7 +813,9 @@ async def test_webhook_camera_stream_stream_available_but_errors(
 ):
     """Test fetching camera stream URLs for an HLS/stream-supporting camera but that streaming errors."""
     hass.states.async_set(
-        "camera.stream_camera", "idle", {"supported_features": CAMERA_SUPPORT_STREAM}
+        "camera.stream_camera",
+        "idle",
+        {"supported_features": CameraEntityFeature.STREAM},
     )
 
     webhook_id = create_registrations[1]["webhook_id"]

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -5,10 +5,7 @@ import pytest
 
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_DOMAIN,
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_CUSTOM_BYPASS,
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_NIGHT,
+    AlarmControlPanelEntityFeature,
 )
 from homeassistant.components.risco import CannotConnectError, UnauthorizedError
 from homeassistant.components.risco.const import DOMAIN
@@ -72,7 +69,9 @@ FULL_CUSTOM_MAPPING = {
 }
 
 EXPECTED_FEATURES = (
-    SUPPORT_ALARM_ARM_AWAY | SUPPORT_ALARM_ARM_HOME | SUPPORT_ALARM_ARM_NIGHT
+    AlarmControlPanelEntityFeature.ARM_AWAY
+    | AlarmControlPanelEntityFeature.ARM_HOME
+    | AlarmControlPanelEntityFeature.ARM_NIGHT
 )
 
 
@@ -294,7 +293,8 @@ async def test_cloud_sets_full_custom_mapping(
     registry = er.async_get(hass)
     entity = registry.async_get(FIRST_CLOUD_ENTITY_ID)
     assert (
-        entity.supported_features == EXPECTED_FEATURES | SUPPORT_ALARM_ARM_CUSTOM_BYPASS
+        entity.supported_features
+        == EXPECTED_FEATURES | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
     )
 
     await _test_cloud_service_call(
@@ -669,7 +669,8 @@ async def test_local_sets_full_custom_mapping(
     registry = er.async_get(hass)
     entity = registry.async_get(FIRST_LOCAL_ENTITY_ID)
     assert (
-        entity.supported_features == EXPECTED_FEATURES | SUPPORT_ALARM_ARM_CUSTOM_BYPASS
+        entity.supported_features
+        == EXPECTED_FEATURES | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
     )
 
     await _test_local_service_call(

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -20,19 +20,9 @@ from homeassistant.components.media_player import (
     DOMAIN as MP_DOMAIN,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
-    SUPPORT_BROWSE_MEDIA,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE,
-    SUPPORT_PLAY,
-    SUPPORT_PLAY_MEDIA,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_STEP,
     MediaClass,
     MediaPlayerDeviceClass,
+    MediaPlayerEntityFeature,
     MediaType,
 )
 from homeassistant.components.roku.const import (
@@ -197,17 +187,17 @@ async def test_supported_features(
     # Features supported for Rokus
     state = hass.states.get(MAIN_ENTITY_ID)
     assert (
-        SUPPORT_PREVIOUS_TRACK
-        | SUPPORT_NEXT_TRACK
-        | SUPPORT_VOLUME_STEP
-        | SUPPORT_VOLUME_MUTE
-        | SUPPORT_SELECT_SOURCE
-        | SUPPORT_PAUSE
-        | SUPPORT_PLAY
-        | SUPPORT_PLAY_MEDIA
-        | SUPPORT_TURN_ON
-        | SUPPORT_TURN_OFF
-        | SUPPORT_BROWSE_MEDIA
+        MediaPlayerEntityFeature.PREVIOUS_TRACK
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.BROWSE_MEDIA
         == state.attributes.get("supported_features")
     )
 
@@ -222,17 +212,17 @@ async def test_tv_supported_features(
     state = hass.states.get(TV_ENTITY_ID)
     assert state
     assert (
-        SUPPORT_PREVIOUS_TRACK
-        | SUPPORT_NEXT_TRACK
-        | SUPPORT_VOLUME_STEP
-        | SUPPORT_VOLUME_MUTE
-        | SUPPORT_SELECT_SOURCE
-        | SUPPORT_PAUSE
-        | SUPPORT_PLAY
-        | SUPPORT_PLAY_MEDIA
-        | SUPPORT_TURN_ON
-        | SUPPORT_TURN_OFF
-        | SUPPORT_BROWSE_MEDIA
+        MediaPlayerEntityFeature.PREVIOUS_TRACK
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.BROWSE_MEDIA
         == state.attributes.get("supported_features")
     )
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -32,8 +32,8 @@ from homeassistant.components.media_player import (
     DOMAIN,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
-    SUPPORT_TURN_ON,
     MediaPlayerDeviceClass,
+    MediaPlayerEntityFeature,
     MediaType,
 )
 from homeassistant.components.samsungtv.const import (
@@ -749,7 +749,8 @@ async def test_supported_features_with_turnon(hass: HomeAssistant) -> None:
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
     assert (
-        state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SAMSUNGTV | SUPPORT_TURN_ON
+        state.attributes[ATTR_SUPPORTED_FEATURES]
+        == SUPPORT_SAMSUNGTV | MediaPlayerEntityFeature.TURN_ON
     )
 
 

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -33,15 +33,7 @@ from homeassistant.components.vacuum import (
     STATE_IDLE,
     STATE_PAUSED,
     STATE_RETURNING,
-    SUPPORT_BATTERY,
-    SUPPORT_FAN_SPEED,
-    SUPPORT_LOCATE,
-    SUPPORT_PAUSE,
-    SUPPORT_RETURN_HOME,
-    SUPPORT_START,
-    SUPPORT_STATE,
-    SUPPORT_STATUS,
-    SUPPORT_STOP,
+    VacuumEntityFeature,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -65,15 +57,15 @@ from tests.common import MockConfigEntry
 
 VAC_ENTITY_ID = f"vacuum.{SHARK_DEVICE_DICT['product_name'].lower()}"
 EXPECTED_FEATURES = (
-    SUPPORT_BATTERY
-    | SUPPORT_FAN_SPEED
-    | SUPPORT_PAUSE
-    | SUPPORT_RETURN_HOME
-    | SUPPORT_START
-    | SUPPORT_STATE
-    | SUPPORT_STATUS
-    | SUPPORT_STOP
-    | SUPPORT_LOCATE
+    VacuumEntityFeature.BATTERY
+    | VacuumEntityFeature.FAN_SPEED
+    | VacuumEntityFeature.PAUSE
+    | VacuumEntityFeature.RETURN_HOME
+    | VacuumEntityFeature.START
+    | VacuumEntityFeature.STATE
+    | VacuumEntityFeature.STATUS
+    | VacuumEntityFeature.STOP
+    | VacuumEntityFeature.LOCATE
 )
 
 

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -9,7 +9,7 @@ from pysmartthings import Attribute, Capability
 from homeassistant.components.fan import (
     ATTR_PERCENTAGE,
     DOMAIN as FAN_DOMAIN,
-    SUPPORT_SET_SPEED,
+    FanEntityFeature,
 )
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.config_entries import ConfigEntryState
@@ -36,7 +36,7 @@ async def test_entity_state(hass, device_factory):
     # Dimmer 1
     state = hass.states.get("fan.fan_1")
     assert state.state == "on"
-    assert state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SET_SPEED
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == FanEntityFeature.SET_SPEED
     assert state.attributes[ATTR_PERCENTAGE] == 66
 
 

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -11,8 +11,7 @@ from homeassistant.components.fan import (
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
     DOMAIN,
-    SUPPORT_PRESET_MODE,
-    SUPPORT_SET_SPEED,
+    FanEntityFeature,
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 
@@ -879,7 +878,7 @@ async def test_implemented_percentage(hass, speed_count, percentage_step):
     state = hass.states.get("fan.mechanical_ventilation")
     attributes = state.attributes
     assert attributes["percentage_step"] == percentage_step
-    assert attributes.get("supported_features") & SUPPORT_SET_SPEED
+    assert attributes.get("supported_features") & FanEntityFeature.SET_SPEED
 
 
 @pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
@@ -947,4 +946,4 @@ async def test_implemented_preset_mode(hass, start_ha):
     state = hass.states.get("fan.mechanical_ventilation")
     attributes = state.attributes
     assert attributes.get("percentage") is None
-    assert attributes.get("supported_features") & SUPPORT_PRESET_MODE
+    assert attributes.get("supported_features") & FanEntityFeature.PRESET_MODE

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -9,7 +9,6 @@ from homeassistant.components.light import (
     ATTR_EFFECT,
     ATTR_HS_COLOR,
     ATTR_TRANSITION,
-    SUPPORT_TRANSITION,
     ColorMode,
     LightEntityFeature,
 )
@@ -342,7 +341,7 @@ async def test_on_action_with_transition(hass, setup_light, calls):
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
     assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
-    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
+    assert state.attributes["supported_features"] == LightEntityFeature.TRANSITION
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -357,7 +356,7 @@ async def test_on_action_with_transition(hass, setup_light, calls):
     assert state.state == STATE_OFF
     assert "color_mode" not in state.attributes
     assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
-    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
+    assert state.attributes["supported_features"] == LightEntityFeature.TRANSITION
 
 
 @pytest.mark.parametrize("count", [1])
@@ -498,7 +497,7 @@ async def test_off_action_with_transition(hass, setup_light, calls):
     assert state.state == STATE_ON
     assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
     assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
-    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
+    assert state.attributes["supported_features"] == LightEntityFeature.TRANSITION
 
     await hass.services.async_call(
         light.DOMAIN,
@@ -512,7 +511,7 @@ async def test_off_action_with_transition(hass, setup_light, calls):
     assert state.state == STATE_ON
     assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
     assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
-    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
+    assert state.attributes["supported_features"] == LightEntityFeature.TRANSITION
 
 
 @pytest.mark.parametrize("count", [1])

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -8,7 +8,7 @@ from pyunifiprotect.data import Camera as ProtectCamera, CameraChannel, StateTyp
 from pyunifiprotect.exceptions import NvrError
 
 from homeassistant.components.camera import (
-    SUPPORT_STREAM,
+    CameraEntityFeature,
     async_get_image,
     async_get_stream_source,
 )
@@ -112,7 +112,7 @@ def validate_common_camera_state(
     hass: HomeAssistant,
     channel: CameraChannel,
     entity_id: str,
-    features: int = SUPPORT_STREAM,
+    features: int = CameraEntityFeature.STREAM,
 ):
     """Validate state that is common to all camera entity, regradless of type."""
     entity_state = hass.states.get(entity_id)
@@ -131,7 +131,7 @@ async def validate_rtsps_camera_state(
     camera_obj: ProtectCamera,
     channel_id: int,
     entity_id: str,
-    features: int = SUPPORT_STREAM,
+    features: int = CameraEntityFeature.STREAM,
 ):
     """Validate a camera's state."""
     channel = camera_obj.channels[channel_id]
@@ -145,7 +145,7 @@ async def validate_rtsp_camera_state(
     camera_obj: ProtectCamera,
     channel_id: int,
     entity_id: str,
-    features: int = SUPPORT_STREAM,
+    features: int = CameraEntityFeature.STREAM,
 ):
     """Validate a camera's state."""
     channel = camera_obj.channels[channel_id]
@@ -159,7 +159,7 @@ async def validate_no_stream_camera_state(
     camera_obj: ProtectCamera,
     channel_id: int,
     entity_id: str,
-    features: int = SUPPORT_STREAM,
+    features: int = CameraEntityFeature.STREAM,
 ):
     """Validate a camera's state."""
     channel = camera_obj.channels[channel_id]

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -11,7 +11,7 @@ from homeassistant.components.camera import (
     SERVICE_DISABLE_MOTION,
     SERVICE_ENABLE_MOTION,
     STATE_RECORDING,
-    SUPPORT_STREAM,
+    CameraEntityFeature,
     async_get_image,
     async_get_stream_source,
 )
@@ -331,7 +331,7 @@ async def test_properties(hass, mock_remote):
     assert state.state == STATE_RECORDING
     assert state.attributes["brand"] == "Ubiquiti"
     assert state.attributes["model_name"] == "UVC"
-    assert state.attributes["supported_features"] == SUPPORT_STREAM
+    assert state.attributes["supported_features"] == CameraEntityFeature.STREAM
 
 
 async def test_motion_recording_mode_properties(hass, mock_remote):

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -17,9 +17,8 @@ from homeassistant.components.media_player import (
     DOMAIN as MP_DOMAIN,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_SET,
     MediaPlayerDeviceClass,
+    MediaPlayerEntityFeature,
     MediaType,
 )
 from homeassistant.components.webostv.const import (
@@ -523,7 +522,7 @@ async def test_supported_features(hass, client, monkeypatch):
     # Support volume mute, step, set
     monkeypatch.setattr(client, "sound_output", "speaker")
     await client.mock_state_update()
-    supported = supported | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
+    supported = supported | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
@@ -550,7 +549,7 @@ async def test_supported_features(hass, client, monkeypatch):
             ],
         },
     )
-    supported |= SUPPORT_TURN_ON
+    supported |= MediaPlayerEntityFeature.TURN_ON
     await client.mock_state_update()
     attrs = hass.states.get(ENTITY_ID).attributes
 
@@ -561,7 +560,9 @@ async def test_cached_supported_features(hass, client, monkeypatch):
     """Test test supported features."""
     monkeypatch.setattr(client, "is_on", False)
     monkeypatch.setattr(client, "sound_output", None)
-    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_TURN_ON
+    supported = (
+        SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.TURN_ON
+    )
     mock_restore_cache(
         hass,
         [
@@ -581,7 +582,9 @@ async def test_cached_supported_features(hass, client, monkeypatch):
     # validate SUPPORT_TURN_ON is not cached
     attrs = hass.states.get(ENTITY_ID).attributes
 
-    assert attrs[ATTR_SUPPORTED_FEATURES] == supported & ~SUPPORT_TURN_ON
+    assert (
+        attrs[ATTR_SUPPORTED_FEATURES] == supported & ~MediaPlayerEntityFeature.TURN_ON
+    )
 
     # TV on, support volume mute, step
     monkeypatch.setattr(client, "is_on", True)
@@ -608,7 +611,9 @@ async def test_cached_supported_features(hass, client, monkeypatch):
     monkeypatch.setattr(client, "sound_output", "speaker")
     await client.mock_state_update()
 
-    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
+    supported = (
+        SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET
+    )
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
@@ -618,7 +623,9 @@ async def test_cached_supported_features(hass, client, monkeypatch):
     monkeypatch.setattr(client, "sound_output", None)
     await client.mock_state_update()
 
-    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
+    supported = (
+        SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET
+    )
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
@@ -649,7 +656,9 @@ async def test_cached_supported_features(hass, client, monkeypatch):
 
     attrs = hass.states.get(ENTITY_ID).attributes
 
-    assert attrs[ATTR_SUPPORTED_FEATURES] == supported | SUPPORT_TURN_ON
+    assert (
+        attrs[ATTR_SUPPORTED_FEATURES] == supported | MediaPlayerEntityFeature.TURN_ON
+    )
 
 
 async def test_supported_features_no_cache(hass, client, monkeypatch):
@@ -658,7 +667,9 @@ async def test_supported_features_no_cache(hass, client, monkeypatch):
     monkeypatch.setattr(client, "sound_output", None)
     await setup_webostv(hass)
 
-    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
+    supported = (
+        SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET
+    )
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
@@ -680,7 +691,9 @@ async def test_supported_features_ignore_cache(hass, client):
     )
     await setup_webostv(hass)
 
-    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
+    supported = (
+        SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET
+    )
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -14,7 +14,7 @@ from homeassistant.components.fan import (
     ATTR_PRESET_MODES,
     DOMAIN as FAN_DOMAIN,
     SERVICE_SET_PRESET_MODE,
-    SUPPORT_PRESET_MODE,
+    FanEntityFeature,
     NotValidPresetModeError,
 )
 from homeassistant.components.zwave_js.fan import ATTR_FAN_STATE
@@ -587,7 +587,7 @@ async def test_thermostat_fan(hass, client, climate_adc_t3000, integration):
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_FAN_STATE) == "Idle / off"
     assert state.attributes.get(ATTR_PRESET_MODE) == "Auto low"
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == SUPPORT_PRESET_MODE
+    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == FanEntityFeature.PRESET_MODE
 
     # Test setting preset mode
     await hass.services.async_call(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
