### PR TITLE
Remove parametrization in recorder websocket api tests

### DIFF
--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -62,29 +62,14 @@ GAS_SENSOR_M3_ATTRIBUTES = {
 }
 
 
-@pytest.mark.parametrize(
-    "units, attributes, state, value",
-    [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, 10, 10),
-        (METRIC_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, 10, 10),
-        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, 10, 10),
-        (METRIC_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, 10, 10),
-        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_F_ATTRIBUTES, 10, 10),
-        (METRIC_SYSTEM, TEMPERATURE_SENSOR_F_ATTRIBUTES, 10, 10),
-        (IMPERIAL_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, 1000, 1000),
-        (METRIC_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, 1000, 1000),
-    ],
-)
-async def test_statistics_during_period(
-    hass, hass_ws_client, recorder_mock, units, attributes, state, value
-):
+async def test_statistics_during_period(hass, hass_ws_client, recorder_mock):
     """Test statistics_during_period."""
     now = dt_util.utcnow()
 
-    hass.config.units = units
+    hass.config.units = IMPERIAL_SYSTEM
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
-    hass.states.async_set("sensor.test", state, attributes=attributes)
+    hass.states.async_set("sensor.test", 10, attributes=POWER_SENSOR_KW_ATTRIBUTES)
     await async_wait_recording_done(hass)
 
     do_adhoc_statistics(hass, start=now)
@@ -122,9 +107,9 @@ async def test_statistics_during_period(
                 "statistic_id": "sensor.test",
                 "start": now.isoformat(),
                 "end": (now + timedelta(minutes=5)).isoformat(),
-                "mean": approx(value),
-                "min": approx(value),
-                "max": approx(value),
+                "mean": approx(10),
+                "min": approx(10),
+                "max": approx(10),
                 "last_reset": None,
                 "state": None,
                 "sum": None,
@@ -368,32 +353,21 @@ async def test_statistics_during_period_invalid_unit_conversion(
     assert response["error"]["code"] == "invalid_format"
 
 
-@pytest.mark.parametrize(
-    "units, attributes, state, value",
-    [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, 10, 10),
-        (METRIC_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, 10, 10),
-        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, 10, 10),
-        (METRIC_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, 10, 10),
-        (IMPERIAL_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, 1000, 1000),
-        (METRIC_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, 1000, 1000),
-    ],
-)
 async def test_statistics_during_period_in_the_past(
-    hass, hass_ws_client, recorder_mock, units, attributes, state, value
+    hass, hass_ws_client, recorder_mock
 ):
     """Test statistics_during_period in the past."""
     hass.config.set_time_zone("UTC")
     now = dt_util.utcnow().replace()
 
-    hass.config.units = units
+    hass.config.units = IMPERIAL_SYSTEM
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
 
     past = now - timedelta(days=3)
 
     with freeze_time(past):
-        hass.states.async_set("sensor.test", state, attributes=attributes)
+        hass.states.async_set("sensor.test", 10, attributes=POWER_SENSOR_KW_ATTRIBUTES)
         await async_wait_recording_done(hass)
 
     sensor_state = hass.states.get("sensor.test")
@@ -450,9 +424,9 @@ async def test_statistics_during_period_in_the_past(
                 "statistic_id": "sensor.test",
                 "start": stats_start.isoformat(),
                 "end": (stats_start + timedelta(minutes=5)).isoformat(),
-                "mean": approx(value),
-                "min": approx(value),
-                "max": approx(value),
+                "mean": approx(10),
+                "min": approx(10),
+                "max": approx(10),
                 "last_reset": None,
                 "state": None,
                 "sum": None,
@@ -478,9 +452,9 @@ async def test_statistics_during_period_in_the_past(
                 "statistic_id": "sensor.test",
                 "start": start_of_day.isoformat(),
                 "end": (start_of_day + timedelta(days=1)).isoformat(),
-                "mean": approx(value),
-                "min": approx(value),
-                "max": approx(value),
+                "mean": approx(10),
+                "min": approx(10),
+                "max": approx(10),
                 "last_reset": None,
                 "state": None,
                 "sum": None,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As requested by @emontnemery on Discord:

> I think these tests in tests/components/recorder/test_websocket_api.py could be updated with new parametrizations:
> `test_statistics_during_period` - maybe the parametrization of this test should be removed instead of adding more
> `test_statistics_during_period_in_the_past` - maybe the parametrization of this test should be removed instead of adding more

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
