### PR TITLE
Add options to SelectEntityDescription

### DIFF
--- a/homeassistant/components/kostal_plenticore/select.py
+++ b/homeassistant/components/kostal_plenticore/select.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -67,8 +66,6 @@ async def async_setup_entry(
     for description in SELECT_SETTINGS_DATA:
         if description.module_id not in available_settings_data:
             continue
-        if TYPE_CHECKING:
-            assert isinstance(description.options, list)
         needed_data_ids = {
             data_id for data_id in description.options if data_id != "None"
         }

--- a/homeassistant/components/kostal_plenticore/select.py
+++ b/homeassistant/components/kostal_plenticore/select.py
@@ -64,6 +64,7 @@ async def async_setup_entry(
 
     entities = []
     for description in SELECT_SETTINGS_DATA:
+        assert description.options is not None
         if description.module_id not in available_settings_data:
             continue
         needed_data_ids = {

--- a/homeassistant/components/kostal_plenticore/select.py
+++ b/homeassistant/components/kostal_plenticore/select.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import TYPE_CHECKING
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -23,7 +24,6 @@ class PlenticoreRequiredKeysMixin:
     """A class that describes required properties for plenticore select entities."""
 
     module_id: str
-    options: list[str]
 
 
 @dataclass
@@ -67,6 +67,8 @@ async def async_setup_entry(
     for description in SELECT_SETTINGS_DATA:
         if description.module_id not in available_settings_data:
             continue
+        if TYPE_CHECKING:
+            assert isinstance(description.options, list)
         needed_data_ids = {
             data_id for data_id in description.options if data_id != "None"
         }
@@ -109,7 +111,6 @@ class PlenticoreDataSelect(CoordinatorEntity, SelectEntity):
         self.platform_name = platform_name
         self.module_id = description.module_id
         self.data_id = description.key
-        self._attr_options = description.options
         self._device_info = device_info
         self._attr_unique_id = f"{entry_id}_{description.module_id}"
 

--- a/homeassistant/components/lametric/select.py
+++ b/homeassistant/components/lametric/select.py
@@ -22,7 +22,6 @@ from .entity import LaMetricEntity
 class LaMetricEntityDescriptionMixin:
     """Mixin values for LaMetric entities."""
 
-    options: list[str]
     current_fn: Callable[[Device], str]
     select_fn: Callable[[LaMetricDevice, str], Awaitable[Any]]
 
@@ -77,7 +76,6 @@ class LaMetricSelectEntity(LaMetricEntity, SelectEntity):
         """Initiate LaMetric Select."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_options = description.options
         self._attr_unique_id = f"{coordinator.data.serial_number}-{description.key}"
 
     @property

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -21,7 +21,6 @@ from .entity import OverkizDescriptiveEntity, OverkizDeviceClass
 class OverkizSelectDescriptionMixin:
     """Define an entity description mixin for select entities."""
 
-    options: list[str | OverkizCommandParam]
     select_option: Callable[[str, Callable[..., Awaitable[None]]], Awaitable[None]]
 
 
@@ -148,11 +147,6 @@ class OverkizSelect(OverkizDescriptiveEntity, SelectEntity):
             return str(state.value)
 
         return None
-
-    @property
-    def options(self) -> list[str]:
-        """Return a set of selectable options."""
-        return self.entity_description.options
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/homeassistant/components/renault/select.py
+++ b/homeassistant/components/renault/select.py
@@ -24,7 +24,6 @@ class RenaultSelectRequiredKeysMixin:
 
     data_key: str
     icon_lambda: Callable[[RenaultSelectEntity], str]
-    options: list[str]
 
 
 @dataclass
@@ -73,11 +72,6 @@ class RenaultSelectEntity(
     def icon(self) -> str | None:
         """Icon handling."""
         return self.entity_description.icon_lambda(self)
-
-    @property
-    def options(self) -> list[str]:
-        """Return a set of selectable options."""
-        return self.entity_description.options
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -108,7 +108,7 @@ class SelectEntity(Entity):
             and self.entity_description.options is not UNDEFINED  # type: ignore[comparison-overlap]
         ):
             return self.entity_description.options
-        return self._attr_options
+        raise NotImplementedError()
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 )
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.typing import UNDEFINED, ConfigType
+from homeassistant.helpers.typing import ConfigType
 
 from .const import ATTR_OPTION, ATTR_OPTIONS, DOMAIN, SERVICE_SELECT_OPTION
 
@@ -72,7 +72,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class SelectEntityDescription(EntityDescription):
     """A class that describes select entities."""
 
-    options: list[str] = UNDEFINED  # type: ignore[assignment]
+    options: list[str] | None = None
 
 
 class SelectEntity(Entity):
@@ -105,7 +105,7 @@ class SelectEntity(Entity):
             return self._attr_options
         if (
             hasattr(self, "entity_description")
-            and self.entity_description.options is not UNDEFINED  # type: ignore[comparison-overlap]
+            and self.entity_description.options is not None
         ):
             return self.entity_description.options
         raise AttributeError()

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -101,11 +101,13 @@ class SelectEntity(Entity):
     @property
     def options(self) -> list[str]:
         """Return a set of selectable options."""
+        if hasattr(self, "_attr_options"):
+            return self._attr_options
         if (
             hasattr(self, "entity_description")
-            and (options := self.entity_description.options) is not UNDEFINED
+            and self.entity_description.options is not UNDEFINED
         ):
-            return options
+            return self.entity_description.options
         return self._attr_options
 
     @property

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 )
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.typing import UNDEFINED, ConfigType, UndefinedType
+from homeassistant.helpers.typing import UNDEFINED, ConfigType
 
 from .const import ATTR_OPTION, ATTR_OPTIONS, DOMAIN, SERVICE_SELECT_OPTION
 
@@ -72,7 +72,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class SelectEntityDescription(EntityDescription):
     """A class that describes select entities."""
 
-    options: list[str] | UndefinedType = UNDEFINED
+    options: list[str] = UNDEFINED  # type: ignore[assignment]
 
 
 class SelectEntity(Entity):
@@ -105,7 +105,7 @@ class SelectEntity(Entity):
             return self._attr_options
         if (
             hasattr(self, "entity_description")
-            and self.entity_description.options is not UNDEFINED
+            and self.entity_description.options is not UNDEFINED  # type: ignore[comparison-overlap]
         ):
             return self.entity_description.options
         return self._attr_options

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -108,7 +108,7 @@ class SelectEntity(Entity):
             and self.entity_description.options is not UNDEFINED  # type: ignore[comparison-overlap]
         ):
             return self.entity_description.options
-        raise NotImplementedError()
+        raise AttributeError()
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -72,7 +72,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class SelectEntityDescription(EntityDescription):
     """A class that describes select entities."""
 
-    current_option: str | None = None
     options: list[str] | None = None
 
 
@@ -114,9 +113,7 @@ class SelectEntity(Entity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        if hasattr(self, "_attr_current_option"):
-            return self._attr_current_option
-        return self.entity_description.current_option
+        return self._attr_current_option
 
     def select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -72,6 +72,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class SelectEntityDescription(EntityDescription):
     """A class that describes select entities."""
 
+    current_option: str | None = None
     options: list[str] | None = None
 
 
@@ -113,7 +114,9 @@ class SelectEntity(Entity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return self._attr_current_option
+        if hasattr(self, "_attr_current_option"):
+            return self._attr_current_option
+        return self.entity_description.current_option
 
     def select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 )
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import UNDEFINED, ConfigType, UndefinedType
 
 from .const import ATTR_OPTION, ATTR_OPTIONS, DOMAIN, SERVICE_SELECT_OPTION
 
@@ -72,6 +72,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class SelectEntityDescription(EntityDescription):
     """A class that describes select entities."""
 
+    options: list[str] | UndefinedType = UNDEFINED
+
 
 class SelectEntity(Entity):
     """Representation of a Select entity."""
@@ -99,6 +101,11 @@ class SelectEntity(Entity):
     @property
     def options(self) -> list[str]:
         """Return a set of selectable options."""
+        if (
+            hasattr(self, "entity_description")
+            and (options := self.entity_description.options) is not UNDEFINED
+        ):
+            return options
         return self._attr_options
 
     @property

--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -74,7 +74,6 @@ class XiaomiMiioSelectDescription(SelectEntityDescription):
     options_map: dict = field(default_factory=dict)
     set_method: str = ""
     set_method_error_message: str = ""
-    options: tuple = ()
 
 
 class AttributeEnumMapping(NamedTuple):
@@ -150,7 +149,7 @@ SELECTOR_TYPES = (
         set_method_error_message="Setting the display orientation failed.",
         icon="mdi:tablet",
         device_class="xiaomi_miio__display_orientation",
-        options=("forward", "left", "right"),
+        options=["forward", "left", "right"],
         entity_category=EntityCategory.CONFIG,
     ),
     XiaomiMiioSelectDescription(
@@ -161,7 +160,7 @@ SELECTOR_TYPES = (
         set_method_error_message="Setting the led brightness failed.",
         icon="mdi:brightness-6",
         device_class="xiaomi_miio__led_brightness",
-        options=("bright", "dim", "off"),
+        options=["bright", "dim", "off"],
         entity_category=EntityCategory.CONFIG,
     ),
     XiaomiMiioSelectDescription(
@@ -172,7 +171,7 @@ SELECTOR_TYPES = (
         set_method_error_message="Setting the ptc level failed.",
         icon="mdi:fire-circle",
         device_class="xiaomi_miio__ptc_level",
-        options=("low", "medium", "high"),
+        options=["low", "medium", "high"],
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -220,7 +219,6 @@ class XiaomiSelector(XiaomiCoordinatedMiioEntity, SelectEntity):
     def __init__(self, device, entry, unique_id, coordinator, description):
         """Initialize the generic Xiaomi attribute selector."""
         super().__init__(device, entry, unique_id, coordinator)
-        self._attr_options = list(description.options)
         self.entity_description = description
 
 


### PR DESCRIPTION
## Breaking change
FOR CUSTOM COMPONENTS ONLY:

As of Home Assistant Core 2022.11, `options` is available as a standard property of `SelectEntityDescription`.
This may cause issues in custom components if a custom `options` property was previously implemented.

Please adjust the custom component by either dropping or renaming the custom `options` property.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add options to `SelectEntityDescription`

I was originally surprised that `options` was not part of the standard `SelectEntityDescription` and I thought it was missed in the initial implementation.
Then I bumped into the issue that "we don't want a default" so I backed out.
Then I received the request from @MartinHjelmare in https://github.com/home-assistant/core/pull/78873#discussion_r976310814 so I worked on it again and found a (maybe not pretty) solution.

Looking at the `SelectEntityDescription` in the core, it looks like more components would also benefit:
- `kostal_plenticore`, `overkiz`, `renault` and `xiaomi_miio` use a custom `options` property that is updated in this PR
- `goodwe`, `lifx` and `senseme` use a local constant which could be moved to the `SelectEntityDescription`
- `litterrobot`, `roku`, `sensibo`, `tuya` and `unifiprotect` use a dynamic list, and would not be impacted by this PR
- `plugwise` uses `options` in a weird way, adjusted in #78935
- `rainmachine` uses `options` in a weird way, adjusted in #79249

So 7 out of 14 components would directly benefit from this, if it is accepted.

### HACS:
These use a custom `options` property that replicates this PR
- `LavermanJJ/home-assistant-solarfocus` https://github.com/LavermanJJ/home-assistant-solarfocus/issues/13
- `elad-bar/ha-shinobi` https://github.com/elad-bar/ha-shinobi/issues/35
- `iMicknl/ha-nest-protect` https://github.com/iMicknl/ha-nest-protect/issues/106
- `imicknl/ha-tahoma` https://github.com/iMicknl/ha-tahoma/issues/820
- `jcgoette/baby_buddy_homeassistant`: https://github.com/jcgoette/baby_buddy_homeassistant/issues/80
- `syssi/homeassistant-goecharger-mqtt`: https://github.com/syssi/homeassistant-goecharger-mqtt/issues/52
- `wills106/homsassistant-solax-modbus`: https://github.com/wills106/homeassistant-solax-modbus/issues/140

These do not use a custom  `options` property and are not impacted by the change
- `DeebotUniverse/Deebot-4-Home-Assistant`
- `MTrab/landroid_cloud`
- `dmamontov/hass-ledfx`
- `dmamontov/hass-miwifi`
- `eifinger/hass-foldingathomecontrol`
- `eifinger/hass-weenect`
- `mletenay/home-assistant-goodwe-inverter`- 
- `music-assistant/hass-music-assistant`
- `wlcrs/huawei_solar`

If it is not accepted, then I am happy to close (and maybe adjust the seven components to use the same code style).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1493

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
