### PR TITLE
Increase interval to 30min, add interval to OptionsFlow

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -8,7 +8,13 @@ from bimmer_connected.vehicle import MyBMWVehicle
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DEVICE_ID, CONF_ENTITY_ID, CONF_NAME, Platform
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    CONF_SCAN_INTERVAL,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import discovery, entity_registry as er
 import homeassistant.helpers.config_validation as cv
@@ -16,7 +22,14 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTR_VIN, ATTRIBUTION, CONF_READ_ONLY, DATA_HASS_CONFIG, DOMAIN
+from .const import (
+    ATTR_VIN,
+    ATTRIBUTION,
+    CONF_READ_ONLY,
+    DATA_HASS_CONFIG,
+    DEFAULT_SCAN_INTERVAL_MINUTES,
+    DOMAIN,
+)
 from .coordinator import BMWDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,6 +46,7 @@ SERVICE_SCHEMA = vol.Schema(
 
 DEFAULT_OPTIONS = {
     CONF_READ_ONLY: False,
+    CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL_MINUTES,
 }
 
 PLATFORMS = [
@@ -66,6 +80,11 @@ def _async_migrate_options_from_data_if_missing(
     if CONF_READ_ONLY in data or list(options) != list(DEFAULT_OPTIONS):
         options = dict(DEFAULT_OPTIONS, **options)
         options[CONF_READ_ONLY] = data.pop(CONF_READ_ONLY, False)
+
+        hass.config_entries.async_update_entry(entry, data=data, options=options)
+
+    if CONF_SCAN_INTERVAL not in options:
+        options = dict(DEFAULT_OPTIONS, **options)
 
         hass.config_entries.async_update_entry(entry, data=data, options=options)
 

--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -9,12 +9,23 @@ from httpx import HTTPError
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
-from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_SOURCE, CONF_USERNAME
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_REGION,
+    CONF_SCAN_INTERVAL,
+    CONF_SOURCE,
+    CONF_USERNAME,
+)
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
 from . import DOMAIN
-from .const import CONF_ALLOWED_REGIONS, CONF_READ_ONLY, CONF_REFRESH_TOKEN
+from .const import (
+    CONF_ALLOWED_REGIONS,
+    CONF_READ_ONLY,
+    CONF_REFRESH_TOKEN,
+    DEFAULT_SCAN_INTERVAL_MINUTES,
+)
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -132,6 +143,12 @@ class BMWOptionsFlow(config_entries.OptionsFlow):
                         CONF_READ_ONLY,
                         default=self.config_entry.options.get(CONF_READ_ONLY, False),
                     ): bool,
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL_MINUTES
+                        ),
+                    ): vol.All(int, vol.Range(min=5)),
                 }
             ),
         )

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -17,6 +17,8 @@ CONF_READ_ONLY = "read_only"
 CONF_ACCOUNT = "account"
 CONF_REFRESH_TOKEN = "refresh_token"
 
+DEFAULT_SCAN_INTERVAL_MINUTES = 30
+
 DATA_HASS_CONFIG = "hass_config"
 
 UNIT_MAP = {

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -21,7 +21,8 @@
     "step": {
       "account_options": {
         "data": {
-          "read_only": "Read-only (only sensors and notify, no execution of services, no lock)"
+          "read_only": "Read-only (only sensors and notify, no execution of services, no lock)",
+          "scan_interval": "Polling interval in minutes"
         }
       }
     }

--- a/homeassistant/components/bmw_connected_drive/translations/en.json
+++ b/homeassistant/components/bmw_connected_drive/translations/en.json
@@ -21,7 +21,8 @@
         "step": {
             "account_options": {
                 "data": {
-                    "read_only": "Read-only (only sensors and notify, no execution of services, no lock)"
+                    "read_only": "Read-only (only sensors and notify, no execution of services, no lock)",
+                    "scan_interval": "Polling interval in minutes"
                 }
             }
         }

--- a/tests/components/bmw_connected_drive/__init__.py
+++ b/tests/components/bmw_connected_drive/__init__.py
@@ -12,7 +12,12 @@ from homeassistant.components.bmw_connected_drive.const import (
     CONF_REFRESH_TOKEN,
     DOMAIN as BMW_DOMAIN,
 )
-from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_REGION,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
@@ -35,7 +40,7 @@ FIXTURE_CONFIG_ENTRY = {
         CONF_REGION: FIXTURE_USER_INPUT[CONF_REGION],
         CONF_REFRESH_TOKEN: FIXTURE_REFRESH_TOKEN,
     },
-    "options": {CONF_READ_ONLY: False},
+    "options": {CONF_READ_ONLY: False, CONF_SCAN_INTERVAL: 30},
     "source": config_entries.SOURCE_USER,
     "unique_id": f"{FIXTURE_USER_INPUT[CONF_REGION]}-{FIXTURE_USER_INPUT[CONF_REGION]}",
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After recent introduction of API quotas on BMW side (apparently per account/day, even blocking the official app), we have to increase the default polling interval from 5 minutes  to 30 minutes (at least 20-something).

As this behaviour might change and we are reducing the overall number of API calls of the library in https://github.com/bimmerconnected/bimmer_connected/pull/486, we also add the option to configure the scan interval via the option flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/78792, https://github.com/bimmerconnected/bimmer_connected/issues/485
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
