### PR TITLE
Simplify energy settings

### DIFF
--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -32,12 +32,11 @@ class FlowFromGridSourceType(TypedDict):
     stat_energy_from: str
 
     # statistic_id of costs ($) incurred from the energy meter
-    # If set to None and entity_energy_from and entity_energy_price are configured,
+    # If set to None and entity_energy_price or number_energy_price are configured,
     # an EnergyCostSensor will be automatically created
     stat_cost: str | None
 
     # Used to generate costs if stat_cost is set to None
-    entity_energy_from: str | None  # entity_id of an energy meter (kWh), entity_id of the energy meter for stat_energy_from
     entity_energy_price: str | None  # entity_id of an entity providing price ($/kWh)
     number_energy_price: float | None  # Price for energy ($/kWh)
 
@@ -49,12 +48,11 @@ class FlowToGridSourceType(TypedDict):
     stat_energy_to: str
 
     # statistic_id of compensation ($) received for contributing back
-    # If set to None and entity_energy_from and entity_energy_price are configured,
+    # If set to None and entity_energy_price or number_energy_price are configured,
     # an EnergyCostSensor will be automatically created
     stat_compensation: str | None
 
     # Used to generate costs if stat_compensation is set to None
-    entity_energy_to: str | None  # entity_id of an energy meter (kWh), entity_id of the energy meter for stat_energy_to
     entity_energy_price: str | None  # entity_id of an entity providing price ($/kWh)
     number_energy_price: float | None  # Price for energy ($/kWh)
 
@@ -96,12 +94,11 @@ class GasSourceType(TypedDict):
     stat_energy_from: str
 
     # statistic_id of costs ($) incurred from the energy meter
-    # If set to None and entity_energy_from and entity_energy_price are configured,
+    # If set to None and entity_energy_price or number_energy_price are configured,
     # an EnergyCostSensor will be automatically created
     stat_cost: str | None
 
     # Used to generate costs if stat_cost is set to None
-    entity_energy_from: str | None  # entity_id of an gas meter (m³), entity_id of the gas meter for stat_energy_from
     entity_energy_price: str | None  # entity_id of an entity providing price ($/m³)
     number_energy_price: float | None  # Price for energy ($/m³)
 
@@ -145,7 +142,6 @@ FLOW_FROM_GRID_SOURCE_SCHEMA = vol.All(
         {
             vol.Required("stat_energy_from"): str,
             vol.Optional("stat_cost"): vol.Any(str, None),
-            vol.Optional("entity_energy_from"): vol.Any(str, None),
             vol.Optional("entity_energy_price"): vol.Any(str, None),
             vol.Optional("number_energy_price"): vol.Any(vol.Coerce(float), None),
         }
@@ -158,7 +154,6 @@ FLOW_TO_GRID_SOURCE_SCHEMA = vol.Schema(
     {
         vol.Required("stat_energy_to"): str,
         vol.Optional("stat_compensation"): vol.Any(str, None),
-        vol.Optional("entity_energy_to"): vol.Any(str, None),
         vol.Optional("entity_energy_price"): vol.Any(str, None),
         vol.Optional("number_energy_price"): vol.Any(vol.Coerce(float), None),
     }
@@ -216,7 +211,6 @@ GAS_SOURCE_SCHEMA = vol.Schema(
         vol.Required("type"): "gas",
         vol.Required("stat_energy_from"): str,
         vol.Optional("stat_cost"): vol.Any(str, None),
-        vol.Optional("entity_energy_from"): vol.Any(str, None),
         vol.Optional("entity_energy_price"): vol.Any(str, None),
         vol.Optional("number_energy_price"): vol.Any(vol.Coerce(float), None),
     }

--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -142,6 +142,8 @@ FLOW_FROM_GRID_SOURCE_SCHEMA = vol.All(
         {
             vol.Required("stat_energy_from"): str,
             vol.Optional("stat_cost"): vol.Any(str, None),
+            # entity_energy_from was removed in HA Core 2022.10
+            vol.Remove("entity_energy_from"): vol.Any(str, None),
             vol.Optional("entity_energy_price"): vol.Any(str, None),
             vol.Optional("number_energy_price"): vol.Any(vol.Coerce(float), None),
         }
@@ -154,6 +156,8 @@ FLOW_TO_GRID_SOURCE_SCHEMA = vol.Schema(
     {
         vol.Required("stat_energy_to"): str,
         vol.Optional("stat_compensation"): vol.Any(str, None),
+        # entity_energy_to was removed in HA Core 2022.10
+        vol.Remove("entity_energy_to"): vol.Any(str, None),
         vol.Optional("entity_energy_price"): vol.Any(str, None),
         vol.Optional("number_energy_price"): vol.Any(vol.Coerce(float), None),
     }
@@ -211,6 +215,8 @@ GAS_SOURCE_SCHEMA = vol.Schema(
         vol.Required("type"): "gas",
         vol.Required("stat_energy_from"): str,
         vol.Optional("stat_cost"): vol.Any(str, None),
+        # entity_energy_from was removed in HA Core 2022.10
+        vol.Remove("entity_energy_from"): vol.Any(str, None),
         vol.Optional("entity_energy_price"): vol.Any(str, None),
         vol.Optional("number_energy_price"): vol.Any(vol.Coerce(float), None),
     }

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -322,7 +322,7 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                         )
                     )
 
-                if flow.get("entity_energy_from") is not None and (
+                if (
                     flow.get("entity_energy_price") is not None
                     or flow.get("number_energy_price") is not None
                 ):
@@ -330,7 +330,7 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                         functools.partial(
                             _async_validate_auto_generated_cost_entity,
                             hass,
-                            flow["entity_energy_from"],
+                            flow["stat_energy_from"],
                             source_result,
                         )
                     )
@@ -373,7 +373,7 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                         )
                     )
 
-                if flow.get("entity_energy_to") is not None and (
+                if (
                     flow.get("entity_energy_price") is not None
                     or flow.get("number_energy_price") is not None
                 ):
@@ -381,7 +381,7 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                         functools.partial(
                             _async_validate_auto_generated_cost_entity,
                             hass,
-                            flow["entity_energy_to"],
+                            flow["stat_energy_to"],
                             source_result,
                         )
                     )
@@ -424,7 +424,7 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                     )
                 )
 
-            if source.get("entity_energy_from") is not None and (
+            if (
                 source.get("entity_energy_price") is not None
                 or source.get("number_energy_price") is not None
             ):
@@ -432,7 +432,7 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                     functools.partial(
                         _async_validate_auto_generated_cost_entity,
                         hass,
-                        source["entity_energy_from"],
+                        source["stat_energy_from"],
                         source_result,
                     )
                 )

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -58,7 +58,6 @@ async def test_cost_sensor_no_states(hass, hass_storage, setup_integration) -> N
             "flow_from": [
                 {
                     "stat_energy_from": "foo",
-                    "entity_energy_from": "foo",
                     "stat_cost": None,
                     "entity_energy_price": "bar",
                     "number_energy_price": None,
@@ -85,7 +84,6 @@ async def test_cost_sensor_attributes(hass, hass_storage, setup_integration) -> 
             "flow_from": [
                 {
                     "stat_energy_from": "sensor.energy_consumption",
-                    "entity_energy_from": "sensor.energy_consumption",
                     "stat_cost": None,
                     "entity_energy_price": None,
                     "number_energy_price": 1,
@@ -155,7 +153,6 @@ async def test_cost_sensor_price_entity_total_increasing(
             "flow_from": [
                 {
                     "stat_energy_from": "sensor.energy_consumption",
-                    "entity_energy_from": "sensor.energy_consumption",
                     "stat_cost": None,
                     "entity_energy_price": price_entity,
                     "number_energy_price": fixed_price,
@@ -166,7 +163,6 @@ async def test_cost_sensor_price_entity_total_increasing(
             "flow_to": [
                 {
                     "stat_energy_to": "sensor.energy_production",
-                    "entity_energy_to": "sensor.energy_production",
                     "stat_compensation": None,
                     "entity_energy_price": price_entity,
                     "number_energy_price": fixed_price,
@@ -361,7 +357,6 @@ async def test_cost_sensor_price_entity_total(
             "flow_from": [
                 {
                     "stat_energy_from": "sensor.energy_consumption",
-                    "entity_energy_from": "sensor.energy_consumption",
                     "stat_cost": None,
                     "entity_energy_price": price_entity,
                     "number_energy_price": fixed_price,
@@ -372,7 +367,6 @@ async def test_cost_sensor_price_entity_total(
             "flow_to": [
                 {
                     "stat_energy_to": "sensor.energy_production",
-                    "entity_energy_to": "sensor.energy_production",
                     "stat_compensation": None,
                     "entity_energy_price": price_entity,
                     "number_energy_price": fixed_price,
@@ -569,7 +563,6 @@ async def test_cost_sensor_price_entity_total_no_reset(
             "flow_from": [
                 {
                     "stat_energy_from": "sensor.energy_consumption",
-                    "entity_energy_from": "sensor.energy_consumption",
                     "stat_cost": None,
                     "entity_energy_price": price_entity,
                     "number_energy_price": fixed_price,
@@ -580,7 +573,6 @@ async def test_cost_sensor_price_entity_total_no_reset(
             "flow_to": [
                 {
                     "stat_energy_to": "sensor.energy_production",
-                    "entity_energy_to": "sensor.energy_production",
                     "stat_compensation": None,
                     "entity_energy_price": price_entity,
                     "number_energy_price": fixed_price,
@@ -728,7 +720,6 @@ async def test_cost_sensor_handle_energy_units(
             "flow_from": [
                 {
                     "stat_energy_from": "sensor.energy_consumption",
-                    "entity_energy_from": "sensor.energy_consumption",
                     "stat_cost": None,
                     "entity_energy_price": None,
                     "number_energy_price": 0.5,
@@ -798,7 +789,6 @@ async def test_cost_sensor_handle_price_units(
             "flow_from": [
                 {
                     "stat_energy_from": "sensor.energy_consumption",
-                    "entity_energy_from": "sensor.energy_consumption",
                     "stat_cost": None,
                     "entity_energy_price": "sensor.energy_price",
                     "number_energy_price": None,
@@ -856,7 +846,6 @@ async def test_cost_sensor_handle_gas(
         {
             "type": "gas",
             "stat_energy_from": "sensor.gas_consumption",
-            "entity_energy_from": "sensor.gas_consumption",
             "stat_cost": None,
             "entity_energy_price": None,
             "number_energy_price": 0.5,
@@ -907,7 +896,6 @@ async def test_cost_sensor_handle_gas_kwh(
         {
             "type": "gas",
             "stat_energy_from": "sensor.gas_consumption",
-            "entity_energy_from": "sensor.gas_consumption",
             "stat_cost": None,
             "entity_energy_price": None,
             "number_energy_price": 0.5,
@@ -961,7 +949,6 @@ async def test_cost_sensor_wrong_state_class(
             "flow_from": [
                 {
                     "stat_energy_from": "sensor.energy_consumption",
-                    "entity_energy_from": "sensor.energy_consumption",
                     "stat_cost": None,
                     "entity_energy_price": None,
                     "number_energy_price": 0.5,
@@ -1023,7 +1010,6 @@ async def test_cost_sensor_state_class_measurement_no_reset(
             "flow_from": [
                 {
                     "stat_energy_from": "sensor.energy_consumption",
-                    "entity_energy_from": "sensor.energy_consumption",
                     "stat_cost": None,
                     "entity_energy_price": None,
                     "number_energy_price": 0.5,
@@ -1072,7 +1058,6 @@ async def test_inherit_source_unique_id(hass, hass_storage, setup_integration):
         {
             "type": "gas",
             "stat_energy_from": "sensor.gas_consumption",
-            "entity_energy_from": "sensor.gas_consumption",
             "stat_cost": None,
             "entity_energy_price": None,
             "number_energy_price": 0.5,

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -580,7 +580,6 @@ async def test_validation_grid_price_not_exist(
                     "flow_from": [
                         {
                             "stat_energy_from": "sensor.grid_consumption_1",
-                            "entity_energy_from": "sensor.grid_consumption_1",
                             "entity_energy_price": "sensor.grid_price_1",
                             "number_energy_price": None,
                         }
@@ -588,7 +587,6 @@ async def test_validation_grid_price_not_exist(
                     "flow_to": [
                         {
                             "stat_energy_to": "sensor.grid_production_1",
-                            "entity_energy_to": "sensor.grid_production_1",
                             "entity_energy_price": None,
                             "number_energy_price": 0.10,
                         }
@@ -657,7 +655,6 @@ async def test_validation_grid_auto_cost_entity_errors(
                     "flow_from": [
                         {
                             "stat_energy_from": "sensor.grid_consumption_1",
-                            "entity_energy_from": None,
                             "entity_energy_price": None,
                             "number_energy_price": 0.20,
                         }
@@ -665,7 +662,6 @@ async def test_validation_grid_auto_cost_entity_errors(
                     "flow_to": [
                         {
                             "stat_energy_to": "sensor.grid_production_1",
-                            "entity_energy_to": "invalid",
                             "entity_energy_price": None,
                             "number_energy_price": 0.10,
                         }
@@ -731,7 +727,6 @@ async def test_validation_grid_price_errors(
                     "flow_from": [
                         {
                             "stat_energy_from": "sensor.grid_consumption_1",
-                            "entity_energy_from": "sensor.grid_consumption_1",
                             "entity_energy_price": "sensor.grid_price_1",
                             "number_energy_price": None,
                         }
@@ -778,13 +773,11 @@ async def test_validation_gas(
                 {
                     "type": "gas",
                     "stat_energy_from": "sensor.gas_consumption_4",
-                    "entity_energy_from": "sensor.gas_consumption_4",
                     "entity_energy_price": "sensor.gas_price_1",
                 },
                 {
                     "type": "gas",
                     "stat_energy_from": "sensor.gas_consumption_3",
-                    "entity_energy_from": "sensor.gas_consumption_3",
                     "entity_energy_price": "sensor.gas_price_2",
                 },
             ]
@@ -890,7 +883,6 @@ async def test_validation_gas_no_costs_tracking(
                     "type": "gas",
                     "stat_energy_from": "sensor.gas_consumption_1",
                     "stat_cost": None,
-                    "entity_energy_from": None,
                     "entity_energy_price": None,
                     "number_energy_price": None,
                 },
@@ -926,7 +918,6 @@ async def test_validation_grid_no_costs_tracking(
                         {
                             "stat_energy_from": "sensor.grid_energy",
                             "stat_cost": None,
-                            "entity_energy_from": "sensor.grid_energy",
                             "entity_energy_price": None,
                             "number_energy_price": None,
                         },
@@ -935,7 +926,6 @@ async def test_validation_grid_no_costs_tracking(
                         {
                             "stat_energy_to": "sensor.grid_energy",
                             "stat_cost": None,
-                            "entity_energy_to": "sensor.grid_energy",
                             "entity_energy_price": None,
                             "number_energy_price": None,
                         },

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -97,14 +97,12 @@ async def test_save_preferences(
                     {
                         "stat_energy_from": "sensor.heat_pump_meter",
                         "stat_cost": "heat_pump_kwh_cost",
-                        "entity_energy_from": None,
                         "entity_energy_price": None,
                         "number_energy_price": None,
                     },
                     {
                         "stat_energy_from": "sensor.heat_pump_meter_2",
                         "stat_cost": None,
-                        "entity_energy_from": "sensor.heat_pump_meter_2",
                         "entity_energy_price": None,
                         "number_energy_price": 0.20,
                     },
@@ -113,14 +111,12 @@ async def test_save_preferences(
                     {
                         "stat_energy_to": "sensor.return_to_grid_peak",
                         "stat_compensation": None,
-                        "entity_energy_to": None,
                         "entity_energy_price": None,
                         "number_energy_price": None,
                     },
                     {
                         "stat_energy_to": "sensor.return_to_grid_offpeak",
                         "stat_compensation": None,
-                        "entity_energy_to": "sensor.return_to_grid_offpeak",
                         "entity_energy_price": None,
                         "number_energy_price": 0.20,
                     },
@@ -181,7 +177,6 @@ async def test_save_preferences(
                     {
                         "stat_energy_from": "sensor.heat_pump_meter",
                         "stat_cost": None,
-                        "entity_energy_from": None,
                         "entity_energy_price": None,
                         "number_energy_price": None,
                     }
@@ -221,14 +216,12 @@ async def test_handle_duplicate_from_stat(hass, hass_ws_client) -> None:
                         {
                             "stat_energy_from": "sensor.heat_pump_meter",
                             "stat_cost": None,
-                            "entity_energy_from": None,
                             "entity_energy_price": None,
                             "number_energy_price": None,
                         },
                         {
                             "stat_energy_from": "sensor.heat_pump_meter",
                             "stat_cost": None,
-                            "entity_energy_from": None,
                             "entity_energy_price": None,
                             "number_energy_price": None,
                         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify energy settings by removing `entity_energy_from` and `entity_energy_to`; those were added before it was clear that statistic ids for sensors are the same as entity id.

Frontend PR: https://github.com/home-assistant/frontend/pull/13846

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
