### PR TITLE
Deprecate conversion utilities

### DIFF
--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -13,6 +13,7 @@ from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
     LENGTH_YARD,
     UNIT_NOT_RECOGNIZED_TEMPLATE,
 )
+from homeassistant.helpers.frame import report
 
 from .unit_conversion import DistanceConverter
 
@@ -21,4 +22,10 @@ VALID_UNITS = DistanceConverter.VALID_UNITS
 
 def convert(value: float, from_unit: str, to_unit: str) -> float:
     """Convert one unit of measurement to another."""
+    report(
+        "uses distance utility. This is deprecated since 2022.10 and will "
+        "stop working in Home Assistant 2022.4, it should be updated to use "
+        "unit_conversion.DistanceConverter instead",
+        error_if_core=False,
+    )
     return DistanceConverter.convert(value, from_unit, to_unit)

--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -14,6 +14,7 @@ from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
     PRESSURE_PSI,
     UNIT_NOT_RECOGNIZED_TEMPLATE,
 )
+from homeassistant.helpers.frame import report
 
 from .unit_conversion import PressureConverter
 
@@ -24,5 +25,10 @@ VALID_UNITS = PressureConverter.VALID_UNITS
 
 def convert(value: float, from_unit: str, to_unit: str) -> float:
     """Convert one unit of measurement to another."""
-    # Need to add warning when core migration finished
+    report(
+        "uses pressure utility. This is deprecated since 2022.10 and will "
+        "stop working in Home Assistant 2022.4, it should be updated to use "
+        "unit_conversion.PressureConverter instead",
+        error_if_core=False,
+    )
     return PressureConverter.convert(value, from_unit, to_unit)

--- a/homeassistant/util/speed.py
+++ b/homeassistant/util/speed.py
@@ -13,6 +13,7 @@ from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
     SPEED_MILLIMETERS_PER_DAY,
     UNIT_NOT_RECOGNIZED_TEMPLATE,
 )
+from homeassistant.helpers.frame import report
 
 from .unit_conversion import (  # pylint: disable=unused-import # noqa: F401
     _FOOT_TO_M as FOOT_TO_M,
@@ -31,4 +32,10 @@ VALID_UNITS = SpeedConverter.VALID_UNITS
 
 def convert(value: float, from_unit: str, to_unit: str) -> float:
     """Convert one unit of measurement to another."""
+    report(
+        "uses speed utility. This is deprecated since 2022.10 and will "
+        "stop working in Home Assistant 2022.4, it should be updated to use "
+        "unit_conversion.SpeedConverter instead",
+        error_if_core=False,
+    )
     return SpeedConverter.convert(value, from_unit, to_unit)

--- a/homeassistant/util/temperature.py
+++ b/homeassistant/util/temperature.py
@@ -6,6 +6,7 @@ from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
     TEMPERATURE,
     UNIT_NOT_RECOGNIZED_TEMPLATE,
 )
+from homeassistant.helpers.frame import report
 
 from .unit_conversion import TemperatureConverter
 
@@ -14,25 +15,45 @@ VALID_UNITS = TemperatureConverter.VALID_UNITS
 
 def fahrenheit_to_celsius(fahrenheit: float, interval: bool = False) -> float:
     """Convert a temperature in Fahrenheit to Celsius."""
-    # Need to add warning when core migration finished
+    report(
+        "uses temperature utility. This is deprecated since 2022.10 and will "
+        "stop working in Home Assistant 2022.4, it should be updated to use "
+        "unit_conversion.TemperatureConverter instead",
+        error_if_core=False,
+    )
     return TemperatureConverter.fahrenheit_to_celsius(fahrenheit, interval)
 
 
 def kelvin_to_celsius(kelvin: float, interval: bool = False) -> float:
     """Convert a temperature in Kelvin to Celsius."""
-    # Need to add warning when core migration finished
+    report(
+        "uses temperature utility. This is deprecated since 2022.10 and will "
+        "stop working in Home Assistant 2022.4, it should be updated to use "
+        "unit_conversion.TemperatureConverter instead",
+        error_if_core=False,
+    )
     return TemperatureConverter.kelvin_to_celsius(kelvin, interval)
 
 
 def celsius_to_fahrenheit(celsius: float, interval: bool = False) -> float:
     """Convert a temperature in Celsius to Fahrenheit."""
-    # Need to add warning when core migration finished
+    report(
+        "uses temperature utility. This is deprecated since 2022.10 and will "
+        "stop working in Home Assistant 2022.4, it should be updated to use "
+        "unit_conversion.TemperatureConverter instead",
+        error_if_core=False,
+    )
     return TemperatureConverter.celsius_to_fahrenheit(celsius, interval)
 
 
 def celsius_to_kelvin(celsius: float, interval: bool = False) -> float:
     """Convert a temperature in Celsius to Fahrenheit."""
-    # Need to add warning when core migration finished
+    report(
+        "uses temperature utility. This is deprecated since 2022.10 and will "
+        "stop working in Home Assistant 2022.4, it should be updated to use "
+        "unit_conversion.TemperatureConverter instead",
+        error_if_core=False,
+    )
     return TemperatureConverter.celsius_to_kelvin(celsius, interval)
 
 
@@ -40,7 +61,12 @@ def convert(
     temperature: float, from_unit: str, to_unit: str, interval: bool = False
 ) -> float:
     """Convert a temperature from one unit to another."""
-    # Need to add warning when core migration finished
+    report(
+        "uses temperature utility. This is deprecated since 2022.10 and will "
+        "stop working in Home Assistant 2022.4, it should be updated to use "
+        "unit_conversion.TemperatureConverter instead",
+        error_if_core=False,
+    )
     return TemperatureConverter.convert(
         temperature, from_unit, to_unit, interval=interval
     )

--- a/homeassistant/util/temperature.py
+++ b/homeassistant/util/temperature.py
@@ -15,46 +15,22 @@ VALID_UNITS = TemperatureConverter.VALID_UNITS
 
 def fahrenheit_to_celsius(fahrenheit: float, interval: bool = False) -> float:
     """Convert a temperature in Fahrenheit to Celsius."""
-    report(
-        "uses temperature utility. This is deprecated since 2022.10 and will "
-        "stop working in Home Assistant 2022.4, it should be updated to use "
-        "unit_conversion.TemperatureConverter instead",
-        error_if_core=False,
-    )
-    return TemperatureConverter.fahrenheit_to_celsius(fahrenheit, interval)
+    return convert(fahrenheit, TEMP_FAHRENHEIT, TEMP_CELSIUS, interval)
 
 
 def kelvin_to_celsius(kelvin: float, interval: bool = False) -> float:
     """Convert a temperature in Kelvin to Celsius."""
-    report(
-        "uses temperature utility. This is deprecated since 2022.10 and will "
-        "stop working in Home Assistant 2022.4, it should be updated to use "
-        "unit_conversion.TemperatureConverter instead",
-        error_if_core=False,
-    )
-    return TemperatureConverter.kelvin_to_celsius(kelvin, interval)
+    return convert(kelvin, TEMP_KELVIN, TEMP_CELSIUS, interval)
 
 
 def celsius_to_fahrenheit(celsius: float, interval: bool = False) -> float:
     """Convert a temperature in Celsius to Fahrenheit."""
-    report(
-        "uses temperature utility. This is deprecated since 2022.10 and will "
-        "stop working in Home Assistant 2022.4, it should be updated to use "
-        "unit_conversion.TemperatureConverter instead",
-        error_if_core=False,
-    )
-    return TemperatureConverter.celsius_to_fahrenheit(celsius, interval)
+    return convert(celsius, TEMP_CELSIUS, TEMP_FAHRENHEIT, interval)
 
 
 def celsius_to_kelvin(celsius: float, interval: bool = False) -> float:
     """Convert a temperature in Celsius to Fahrenheit."""
-    report(
-        "uses temperature utility. This is deprecated since 2022.10 and will "
-        "stop working in Home Assistant 2022.4, it should be updated to use "
-        "unit_conversion.TemperatureConverter instead",
-        error_if_core=False,
-    )
-    return TemperatureConverter.celsius_to_kelvin(celsius, interval)
+    return convert(celsius, TEMP_CELSIUS, TEMP_KELVIN, interval)
 
 
 def convert(

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -11,6 +11,7 @@ from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
     VOLUME_LITERS,
     VOLUME_MILLILITERS,
 )
+from homeassistant.helpers.frame import report
 
 from .unit_conversion import VolumeConverter
 
@@ -21,35 +22,30 @@ VALID_UNITS = VolumeConverter.VALID_UNITS
 
 def liter_to_gallon(liter: float) -> float:
     """Convert a volume measurement in Liter to Gallon."""
-    # Need to add warning when core migration finished
-    return _convert(liter, VOLUME_LITERS, VOLUME_GALLONS)
+    return convert(liter, VOLUME_LITERS, VOLUME_GALLONS)
 
 
 def gallon_to_liter(gallon: float) -> float:
     """Convert a volume measurement in Gallon to Liter."""
-    # Need to add warning when core migration finished
-    return _convert(gallon, VOLUME_GALLONS, VOLUME_LITERS)
+    return convert(gallon, VOLUME_GALLONS, VOLUME_LITERS)
 
 
 def cubic_meter_to_cubic_feet(cubic_meter: float) -> float:
     """Convert a volume measurement in cubic meter to cubic feet."""
-    # Need to add warning when core migration finished
-    return _convert(cubic_meter, VOLUME_CUBIC_METERS, VOLUME_CUBIC_FEET)
+    return convert(cubic_meter, VOLUME_CUBIC_METERS, VOLUME_CUBIC_FEET)
 
 
 def cubic_feet_to_cubic_meter(cubic_feet: float) -> float:
     """Convert a volume measurement in cubic feet to cubic meter."""
-    # Need to add warning when core migration finished
-    return _convert(cubic_feet, VOLUME_CUBIC_FEET, VOLUME_CUBIC_METERS)
+    return convert(cubic_feet, VOLUME_CUBIC_FEET, VOLUME_CUBIC_METERS)
 
 
 def convert(volume: float, from_unit: str, to_unit: str) -> float:
     """Convert a volume from one unit to another."""
-    # Need to add warning when core migration finished
+    report(
+        "uses volume utility. This is deprecated since 2022.10 and will "
+        "stop working in Home Assistant 2022.4, it should be updated to use "
+        "unit_conversion.VolumeConverter instead",
+        error_if_core=False,
+    )
     return VolumeConverter.convert(volume, from_unit, to_unit)
-
-
-def _convert(volume: float, from_unit: str, to_unit: str) -> float:
-    """Convert a volume from one unit to another, bypassing checks."""
-    cubic_meter = volume / UNIT_CONVERSION[from_unit]
-    return cubic_meter * UNIT_CONVERSION[to_unit]

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -289,7 +289,7 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
     "homeassistant.util": [
         ObsoleteImportMatch(
             reason="replaced by unit_conversion.***Converter",
-            constant=re.compile(r"^(pressure|temperature|volume)$"),
+            constant=re.compile(r"^(distance|pressure|speed|temperature|volume)$"),
         ),
     ],
 }

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -286,6 +286,12 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
             constant=re.compile(r"^DISABLED_(\w*)$"),
         ),
     ],
+    "homeassistant.util": [
+        ObsoleteImportMatch(
+            reason="replaced by unit_conversion.***Converter",
+            constant=re.compile(r"^(pressure|temperature|volume)$"),
+        ),
+    ],
 }
 
 

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -19,6 +19,12 @@ INVALID_SYMBOL = "bob"
 VALID_SYMBOL = LENGTH_KILOMETERS
 
 
+def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure that a warning is raised on use of convert."""
+    assert distance_util.convert(2, LENGTH_METERS, LENGTH_METERS) == 2
+    assert "use unit_conversion.DistanceConverter instead" in caplog.text
+
+
 def test_convert_same_unit():
     """Test conversion from any unit to same unit."""
     assert distance_util.convert(5, LENGTH_KILOMETERS, LENGTH_KILOMETERS) == 5

--- a/tests/util/test_pressure.py
+++ b/tests/util/test_pressure.py
@@ -18,6 +18,12 @@ INVALID_SYMBOL = "bob"
 VALID_SYMBOL = PRESSURE_PA
 
 
+def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure that a warning is raised on use of convert."""
+    assert pressure_util.convert(2, PRESSURE_PA, PRESSURE_PA) == 2
+    assert "use unit_conversion.PressureConverter instead" in caplog.text
+
+
 def test_convert_same_unit():
     """Test conversion from any unit to same unit."""
     assert pressure_util.convert(2, PRESSURE_PA, PRESSURE_PA) == 2

--- a/tests/util/test_speed.py
+++ b/tests/util/test_speed.py
@@ -18,6 +18,12 @@ INVALID_SYMBOL = "bob"
 VALID_SYMBOL = SPEED_KILOMETERS_PER_HOUR
 
 
+def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure that a warning is raised on use of convert."""
+    assert speed_util.convert(2, SPEED_INCHES_PER_DAY, SPEED_INCHES_PER_DAY) == 2
+    assert "use unit_conversion.SpeedConverter instead" in caplog.text
+
+
 def test_convert_same_unit():
     """Test conversion from any unit to same unit."""
     assert speed_util.convert(2, SPEED_INCHES_PER_DAY, SPEED_INCHES_PER_DAY) == 2

--- a/tests/util/test_temperature.py
+++ b/tests/util/test_temperature.py
@@ -9,6 +9,12 @@ INVALID_SYMBOL = "bob"
 VALID_SYMBOL = TEMP_CELSIUS
 
 
+def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure that a warning is raised on use of convert."""
+    assert temperature_util.convert(2, TEMP_CELSIUS, TEMP_CELSIUS) == 2
+    assert "use unit_conversion.TemperatureConverter instead" in caplog.text
+
+
 @pytest.mark.parametrize(
     "function_name, value, expected",
     [

--- a/tests/util/test_volume.py
+++ b/tests/util/test_volume.py
@@ -17,6 +17,12 @@ INVALID_SYMBOL = "bob"
 VALID_SYMBOL = VOLUME_LITERS
 
 
+def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure that a warning is raised on use of convert."""
+    assert volume_util.convert(2, VOLUME_LITERS, VOLUME_LITERS) == 2
+    assert "use unit_conversion.VolumeConverter instead" in caplog.text
+
+
 @pytest.mark.parametrize(
     "function_name, value, expected",
     [


### PR DESCRIPTION
## Breaking change
The `distance`, `pressure`, `speed`, `temperature` and `volume` utilities is now deprecated. Please use the unit_conversion converters instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate `distance`, `pressure`, `speed`, `temperature` and `volume` utilities

Needs:
- [x] #78991
- [x] #79004
- [x] #79204

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1480

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
