### PR TITLE
Avoid creating iBeacon trackers when the device has no name

### DIFF
--- a/homeassistant/components/ibeacon/coordinator.py
+++ b/homeassistant/components/ibeacon/coordinator.py
@@ -234,7 +234,10 @@ class IBeaconCoordinator:
         unique_id = f"{group_id}_{address}"
         new = unique_id not in self._last_rssi_by_unique_id
         # Reject creating new trackers if the name is not set
-        if new and service_info.device.name is None:
+        if new and (
+            service_info.device.name is None
+            or service_info.device.name.replace("-", ":") == service_info.device.address
+        ):
             return
         self._last_rssi_by_unique_id[unique_id] = service_info.rssi
         self._async_track_ibeacon_with_unique_address(address, group_id, unique_id)

--- a/homeassistant/components/ibeacon/coordinator.py
+++ b/homeassistant/components/ibeacon/coordinator.py
@@ -67,7 +67,7 @@ def async_name(
         base_name = service_info.name
     if unique_address:
         short_address = make_short_address(service_info.address)
-        if not base_name.endswith(short_address):
+        if not base_name.upper().endswith(short_address):
             return f"{base_name} {short_address}"
     return base_name
 
@@ -233,6 +233,9 @@ class IBeaconCoordinator:
         address = service_info.address
         unique_id = f"{group_id}_{address}"
         new = unique_id not in self._last_rssi_by_unique_id
+        # Reject creating new trackers if the name is not set
+        if new and service_info.device.name is None:
+            return
         self._last_rssi_by_unique_id[unique_id] = service_info.rssi
         self._async_track_ibeacon_with_unique_address(address, group_id, unique_id)
         if address not in self._unavailable_trackers:

--- a/tests/components/ibeacon/__init__.py
+++ b/tests/components/ibeacon/__init__.py
@@ -28,6 +28,15 @@ BLUECHARM_BEACON_SERVICE_INFO_2 = BluetoothServiceInfo(
     service_uuids=["0000feaa-0000-1000-8000-00805f9b34fb"],
     source="local",
 )
+BLUECHARM_BEACON_SERVICE_INFO_DBUS = BluetoothServiceInfo(
+    name="BlueCharm_177999",
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-63,
+    service_data={},
+    manufacturer_data={76: b"\x02\x15BlueCharmBeacons\x0e\xfe\x13U\xc5"},
+    service_uuids=[],
+    source="local",
+)
 NO_NAME_BEACON_SERVICE_INFO = BluetoothServiceInfo(
     name="61DE521B-F0BF-9F44-64D4-75BBE1738105",
     address="61DE521B-F0BF-9F44-64D4-75BBE1738105",

--- a/tests/components/ibeacon/test_coordinator.py
+++ b/tests/components/ibeacon/test_coordinator.py
@@ -73,3 +73,22 @@ async def test_ignore_not_ibeacons(hass):
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids()) == before_entity_count
+
+
+async def test_ignore_no_name(hass):
+    """Test we ignore devices with no name."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    before_entity_count = len(hass.states.async_entity_ids())
+    inject_bluetooth_service_info(
+        hass,
+        replace(BLUECHARM_BEACON_SERVICE_INFO, name=None),
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids()) == before_entity_count


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the beacon is too far away from the receiver it will
not be able to get the name of the device. As these devices
are not useful to track since they will flip-flop state as
RSSI fluctuates and they go in and out of range.

In the rare case it is desirable to track these devices
at the edge of bluetooth range, temporarily moving the beacon near
the bluetooth receiver will allow it to pick up the name and start
being tracked.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
