### PR TITLE
Add base entity to switchbee

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1221,8 +1221,8 @@ omit =
     homeassistant/components/swisscom/device_tracker.py
     homeassistant/components/switchbee/__init__.py
     homeassistant/components/switchbee/button.py
-    homeassistant/components/switchbee/const.py
     homeassistant/components/switchbee/coordinator.py
+    homeassistant/components/switchbee/entity.py
     homeassistant/components/switchbee/switch.py
     homeassistant/components/switchbot/__init__.py
     homeassistant/components/switchbot/binary_sensor.py

--- a/homeassistant/components/switchbee/button.py
+++ b/homeassistant/components/switchbee/button.py
@@ -1,17 +1,17 @@
 """Support for SwitchBee scenario button."""
 
 from switchbee.api import SwitchBeeError
-from switchbee.device import ApiStateCommand, DeviceType, SwitchBeeBaseDevice
+from switchbee.device import ApiStateCommand, DeviceType
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import SwitchBeeCoordinator
+from .entity import SwitchBeeEntity
 
 
 async def async_setup_entry(
@@ -26,24 +26,13 @@ async def async_setup_entry(
     )
 
 
-class SwitchBeeButton(CoordinatorEntity[SwitchBeeCoordinator], ButtonEntity):
+class SwitchBeeButton(SwitchBeeEntity, ButtonEntity):
     """Representation of an Switchbee button."""
-
-    def __init__(
-        self,
-        device: SwitchBeeBaseDevice,
-        coordinator: SwitchBeeCoordinator,
-    ) -> None:
-        """Initialize the Switchbee switch."""
-        super().__init__(coordinator)
-        self._attr_name = device.name
-        self._device_id = device.id
-        self._attr_unique_id = f"{coordinator.mac_formated}-{device.id}"
 
     async def async_press(self) -> None:
         """Fire the scenario in the SwitchBee hub."""
         try:
-            await self.coordinator.api.set_state(self._device_id, ApiStateCommand.ON)
+            await self.coordinator.api.set_state(self._device.id, ApiStateCommand.ON)
         except SwitchBeeError as exp:
             raise HomeAssistantError(
                 f"Failed to fire scenario {self.name}, {str(exp)}"

--- a/homeassistant/components/switchbee/entity.py
+++ b/homeassistant/components/switchbee/entity.py
@@ -34,7 +34,7 @@ class SwitchBeeDeviceEntity(SwitchBeeEntity):
         device: SwitchBeeBaseDevice,
         coordinator: SwitchBeeCoordinator,
     ) -> None:
-        """Initialize the Switchbee switch."""
+        """Initialize the Switchbee device."""
         super().__init__(device, coordinator)
         self._attr_device_info = DeviceInfo(
             name=f"SwitchBee {device.unit_id}",

--- a/homeassistant/components/switchbee/entity.py
+++ b/homeassistant/components/switchbee/entity.py
@@ -24,6 +24,18 @@ class SwitchBeeEntity(CoordinatorEntity[SwitchBeeCoordinator]):
         self._device = device
         self._attr_name = device.name
         self._attr_unique_id = f"{coordinator.mac_formated}-{device.id}"
+
+
+class SwitchBeeDeviceEntity(SwitchBeeEntity):
+    """Representation of a Switchbee device entity."""
+
+    def __init__(
+        self,
+        device: SwitchBeeBaseDevice,
+        coordinator: SwitchBeeCoordinator,
+    ) -> None:
+        """Initialize the Switchbee switch."""
+        super().__init__(device, coordinator)
         self._attr_device_info = DeviceInfo(
             name=f"SwitchBee {device.unit_id}",
             identifiers={
@@ -40,3 +52,9 @@ class SwitchBeeEntity(CoordinatorEntity[SwitchBeeCoordinator]):
                 f"{coordinator.api.name} ({coordinator.api.mac})",
             ),
         )
+        self._is_online = True
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._is_online and super().available

--- a/homeassistant/components/switchbee/entity.py
+++ b/homeassistant/components/switchbee/entity.py
@@ -1,0 +1,42 @@
+"""Support for SwitchBee entity."""
+from switchbee import SWITCHBEE_BRAND
+from switchbee.device import SwitchBeeBaseDevice
+
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import SwitchBeeCoordinator
+
+
+class SwitchBeeEntity(CoordinatorEntity[SwitchBeeCoordinator]):
+    """Representation of a Switchbee entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        device: SwitchBeeBaseDevice,
+        coordinator: SwitchBeeCoordinator,
+    ) -> None:
+        """Initialize the Switchbee switch."""
+        super().__init__(coordinator)
+        self._device = device
+        self._attr_name = device.name
+        self._attr_unique_id = f"{coordinator.mac_formated}-{device.id}"
+        self._attr_device_info = DeviceInfo(
+            name=f"SwitchBee {device.unit_id}",
+            identifiers={
+                (
+                    DOMAIN,
+                    f"{device.unit_id}-{coordinator.mac_formated}",
+                )
+            },
+            manufacturer=SWITCHBEE_BRAND,
+            model=coordinator.api.module_display(device.unit_id),
+            suggested_area=device.zone,
+            via_device=(
+                DOMAIN,
+                f"{coordinator.api.name} ({coordinator.api.mac})",
+            ),
+        )

--- a/homeassistant/components/switchbee/entity.py
+++ b/homeassistant/components/switchbee/entity.py
@@ -19,7 +19,7 @@ class SwitchBeeEntity(CoordinatorEntity[SwitchBeeCoordinator]):
         device: SwitchBeeBaseDevice,
         coordinator: SwitchBeeCoordinator,
     ) -> None:
-        """Initialize the Switchbee switch."""
+        """Initialize the Switchbee entity."""
         super().__init__(coordinator)
         self._device = device
         self._attr_name = device.name

--- a/homeassistant/components/switchbee/entity.py
+++ b/homeassistant/components/switchbee/entity.py
@@ -52,9 +52,3 @@ class SwitchBeeDeviceEntity(SwitchBeeEntity):
                 f"{coordinator.api.name} ({coordinator.api.mac})",
             ),
         )
-        self._is_online = True
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self._is_online and super().available

--- a/homeassistant/components/switchbee/switch.py
+++ b/homeassistant/components/switchbee/switch.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import SwitchBeeCoordinator
-from .entity import SwitchBeeEntity
+from .entity import SwitchBeeDeviceEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ async def async_setup_entry(
     )
 
 
-class SwitchBeeSwitchEntity(SwitchBeeEntity, SwitchEntity):
+class SwitchBeeSwitchEntity(SwitchBeeDeviceEntity, SwitchEntity):
     """Representation of a Switchbee switch."""
 
     def __init__(
@@ -48,12 +48,6 @@ class SwitchBeeSwitchEntity(SwitchBeeEntity, SwitchEntity):
         """Initialize the Switchbee switch."""
         super().__init__(device, coordinator)
         self._attr_is_on = False
-        self._is_online = True
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self._is_online and super().available
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/switchbee/switch.py
+++ b/homeassistant/components/switchbee/switch.py
@@ -2,7 +2,6 @@
 import logging
 from typing import Any
 
-from switchbee import SWITCHBEE_BRAND
 from switchbee.api import SwitchBeeDeviceOfflineError, SwitchBeeError
 from switchbee.device import ApiStateCommand, DeviceType, SwitchBeeBaseDevice
 
@@ -10,12 +9,11 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import SwitchBeeCoordinator
+from .entity import SwitchBeeEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,8 +37,8 @@ async def async_setup_entry(
     )
 
 
-class SwitchBeeSwitchEntity(CoordinatorEntity[SwitchBeeCoordinator], SwitchEntity):
-    """Representation of an Switchbee switch."""
+class SwitchBeeSwitchEntity(SwitchBeeEntity, SwitchEntity):
+    """Representation of a Switchbee switch."""
 
     def __init__(
         self,
@@ -48,30 +46,9 @@ class SwitchBeeSwitchEntity(CoordinatorEntity[SwitchBeeCoordinator], SwitchEntit
         coordinator: SwitchBeeCoordinator,
     ) -> None:
         """Initialize the Switchbee switch."""
-        super().__init__(coordinator)
-        self._attr_name = f"{device.name}"
-        self._device_id = device.id
-        self._attr_unique_id = f"{coordinator.mac_formated}-{device.id}"
+        super().__init__(device, coordinator)
         self._attr_is_on = False
         self._is_online = True
-        self._attr_has_entity_name = True
-        self._device = device
-        self._attr_device_info = DeviceInfo(
-            name=f"SwitchBee_{str(device.unit_id)}",
-            identifiers={
-                (
-                    DOMAIN,
-                    f"{str(device.unit_id)}-{coordinator.mac_formated}",
-                )
-            },
-            manufacturer=SWITCHBEE_BRAND,
-            model=coordinator.api.module_display(device.unit_id),
-            suggested_area=device.zone,
-            via_device=(
-                DOMAIN,
-                f"{coordinator.api.name} ({coordinator.api.mac})",
-            ),
-        )
 
     @property
     def available(self) -> bool:
@@ -101,13 +78,13 @@ class SwitchBeeSwitchEntity(CoordinatorEntity[SwitchBeeCoordinator], SwitchEntit
             """
 
             try:
-                await self.coordinator.api.set_state(self._device_id, "dummy")
+                await self.coordinator.api.set_state(self._device.id, "dummy")
             except SwitchBeeDeviceOfflineError:
                 return
             except SwitchBeeError:
                 return
 
-        if self.coordinator.data[self._device_id].state == -1:
+        if self.coordinator.data[self._device.id].state == -1:
             # This specific call will refresh the state of the device in the CU
             self.hass.async_create_task(async_refresh_state())
 
@@ -132,7 +109,7 @@ class SwitchBeeSwitchEntity(CoordinatorEntity[SwitchBeeCoordinator], SwitchEntit
         # timed power switch state is an integer representing the number of minutes left until it goes off
         # regulare switches state is ON/OFF (1/0 respectively)
         self._attr_is_on = (
-            self.coordinator.data[self._device_id].state != ApiStateCommand.OFF
+            self.coordinator.data[self._device.id].state != ApiStateCommand.OFF
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -145,7 +122,7 @@ class SwitchBeeSwitchEntity(CoordinatorEntity[SwitchBeeCoordinator], SwitchEntit
 
     async def _async_set_state(self, state: ApiStateCommand) -> None:
         try:
-            await self.coordinator.api.set_state(self._device_id, state)
+            await self.coordinator.api.set_state(self._device.id, state)
         except (SwitchBeeError, SwitchBeeDeviceOfflineError) as exp:
             await self.coordinator.async_refresh()
             raise HomeAssistantError(

--- a/homeassistant/components/switchbee/switch.py
+++ b/homeassistant/components/switchbee/switch.py
@@ -48,6 +48,12 @@ class SwitchBeeSwitchEntity(SwitchBeeDeviceEntity, SwitchEntity):
         """Initialize the Switchbee switch."""
         super().__init__(device, coordinator)
         self._attr_is_on = False
+        self._is_online = True
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._is_online and super().available
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add base entity to switchbee
Whilst reviewing the new switchbee platform, it seemed there was a lot of duplicate code.

This moves `name`, `has_entity_name` and `unique_id` to the base entity, so that it doesn't need to be set in each platform.
As a side effect, this also adds `has_entity_name` to `button` platform, where I think it was missing.

Also, an extra base entity is created, which adds `device_info` where it is appropriate.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
