### PR TITLE
Increase code coverage for migrated utilities

### DIFF
--- a/tests/util/test_temperature.py
+++ b/tests/util/test_temperature.py
@@ -8,6 +8,23 @@ INVALID_SYMBOL = "bob"
 VALID_SYMBOL = TEMP_CELSIUS
 
 
+@pytest.mark.parametrize(
+    "function_name, value, expected",
+    [
+        ("fahrenheit_to_celsius", 75.2, 24),
+        ("kelvin_to_celsius", 297.65, 24.5),
+        ("celsius_to_fahrenheit", 23, 73.4),
+        ("celsius_to_kelvin", 23, 296.15),
+    ],
+)
+def test_deprecated_functions(
+    function_name: str, value: float, expected: float
+) -> None:
+    """Test that deprecated function still work."""
+    convert = getattr(temperature_util, function_name)
+    assert convert(value) == expected
+
+
 def test_convert_same_unit():
     """Test conversion from any unit to same unit."""
     assert temperature_util.convert(2, TEMP_CELSIUS, TEMP_CELSIUS) == 2

--- a/tests/util/test_volume.py
+++ b/tests/util/test_volume.py
@@ -16,6 +16,23 @@ INVALID_SYMBOL = "bob"
 VALID_SYMBOL = VOLUME_LITERS
 
 
+@pytest.mark.parametrize(
+    "function_name, value, expected",
+    [
+        ("liter_to_gallon", 2, pytest.approx(0.528344)),
+        ("gallon_to_liter", 2, 7.570823568),
+        ("cubic_meter_to_cubic_feet", 2, pytest.approx(70.629333)),
+        ("cubic_feet_to_cubic_meter", 2, pytest.approx(0.0566337)),
+    ],
+)
+def test_deprecated_functions(
+    function_name: str, value: float, expected: float
+) -> None:
+    """Test that deprecated function still work."""
+    convert = getattr(volume_util, function_name)
+    assert convert(value) == expected
+
+
 def test_convert_same_unit():
     """Test conversion from any unit to same unit."""
     assert volume_util.convert(2, VOLUME_LITERS, VOLUME_LITERS) == 2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Increase code coverage for migrated utilities:

These lines were previously tested as sub-routines for the main convert function.
Since the sub-routines were moved to the main `unit_conversion` module (see #78955 and #78960), these were not longer being tested.

```console
pytest tests/util/test_temperature.py --cov homeassistant.util.temperature --cov-report term-missing
pytest tests/util/test_volume.py --cov homeassistant.util.volume --cov-report term-missing
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
