### PR TITLE
Fix velbus matching ignored entries in config flow

### DIFF
--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -21,7 +21,9 @@ from .const import DOMAIN
 def velbus_entries(hass: HomeAssistant) -> set[str]:
     """Return connections for Velbus domain."""
     return {
-        entry.data[CONF_PORT] for entry in hass.config_entries.async_entries(DOMAIN)
+        entry.data[CONF_PORT]
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if CONF_PORT in entry.data
     }
 
 

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -10,21 +10,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import usb
 from homeassistant.const import CONF_NAME, CONF_PORT
-from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.util import slugify
 
 from .const import DOMAIN
-
-
-@callback
-def velbus_entries(hass: HomeAssistant) -> set[str]:
-    """Return connections for Velbus domain."""
-    return {
-        entry.data[CONF_PORT]
-        for entry in hass.config_entries.async_entries(DOMAIN)
-        if CONF_PORT in entry.data
-    }
 
 
 class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -53,10 +42,6 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return False
         return True
 
-    def _prt_in_configuration_exists(self, prt: str) -> bool:
-        """Return True if port exists in configuration."""
-        return prt in velbus_entries(self.hass)
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -65,11 +50,9 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             name = slugify(user_input[CONF_NAME])
             prt = user_input[CONF_PORT]
-            if not self._prt_in_configuration_exists(prt):
-                if await self._test_connection(prt):
-                    return self._create_device(name, prt)
-            else:
-                self._errors[CONF_PORT] = "already_configured"
+            self._async_abort_entries_match({CONF_PORT: prt})
+            if await self._test_connection(prt):
+                return self._create_device(name, prt)
         else:
             user_input = {}
             user_input[CONF_NAME] = ""
@@ -95,8 +78,7 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             usb.get_serial_by_id, discovery_info.device
         )
         # check if this device is not already configured
-        if self._prt_in_configuration_exists(dev_path):
-            return self.async_abort(reason="already_configured")
+        self._async_abort_entries_match({CONF_PORT: dev_path})
         # check if we can make a valid velbus connection
         if not await self._test_connection(dev_path):
             return self.async_abort(reason="cannot_connect")

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -7,9 +7,8 @@ from velbusaio.exceptions import VelbusConnectionFailed
 
 from homeassistant import data_entry_flow
 from homeassistant.components import usb
-from homeassistant.components.velbus import config_flow
 from homeassistant.components.velbus.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USB
+from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
 from homeassistant.const import CONF_NAME, CONF_PORT, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 
@@ -53,63 +52,76 @@ def mock_controller_connection_failed():
         yield
 
 
-def init_config_flow(hass: HomeAssistant):
-    """Init a configuration flow."""
-    flow = config_flow.VelbusConfigFlow()
-    flow.hass = hass
-    return flow
-
-
 @pytest.mark.usefixtures("controller")
 async def test_user(hass: HomeAssistant):
     """Test user config."""
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "user"
-
-    result = await flow.async_step_user(
-        {CONF_NAME: "Velbus Test Serial", CONF_PORT: PORT_SERIAL}
+    # simple user form
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result["title"] == "velbus_test_serial"
-    assert result["data"][CONF_PORT] == PORT_SERIAL
+    assert result
+    assert result.get("flow_id")
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
+    assert result.get("step_id") == "user"
 
-    result = await flow.async_step_user(
-        {CONF_NAME: "Velbus Test TCP", CONF_PORT: PORT_TCP}
+    # try with a serial port
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_NAME: "Velbus Test Serial", CONF_PORT: PORT_SERIAL},
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result["title"] == "velbus_test_tcp"
-    assert result["data"][CONF_PORT] == PORT_TCP
+    assert result
+    assert result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result.get("title") == "velbus_test_serial"
+    data = result.get("data")
+    assert data[CONF_PORT] == PORT_SERIAL
+
+    # try with a ip:port combination
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_NAME: "Velbus Test TCP", CONF_PORT: PORT_TCP},
+    )
+    assert result
+    assert result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result.get("title") == "velbus_test_tcp"
+    data = result.get("data")
+    assert data[CONF_PORT] == PORT_TCP
 
 
 @pytest.mark.usefixtures("controller_connection_failed")
 async def test_user_fail(hass: HomeAssistant):
     """Test user config."""
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_user(
-        {CONF_NAME: "Velbus Test Serial", CONF_PORT: PORT_SERIAL}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_NAME: "Velbus Test Serial", CONF_PORT: PORT_SERIAL},
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["errors"] == {CONF_PORT: "cannot_connect"}
+    assert result
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
+    assert result.get("errors") == {CONF_PORT: "cannot_connect"}
 
-    result = await flow.async_step_user(
-        {CONF_NAME: "Velbus Test TCP", CONF_PORT: PORT_TCP}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_NAME: "Velbus Test TCP", CONF_PORT: PORT_TCP},
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["errors"] == {CONF_PORT: "cannot_connect"}
+    assert result
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
+    assert result.get("errors") == {CONF_PORT: "cannot_connect"}
 
 
 @pytest.mark.usefixtures("config_entry")
 async def test_abort_if_already_setup(hass: HomeAssistant):
     """Test we abort if Velbus is already setup."""
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_user({CONF_PORT: PORT_TCP, CONF_NAME: "velbus test"})
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["errors"] == {"port": "already_configured"}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_PORT: PORT_TCP, CONF_NAME: "velbus test"},
+    )
+    assert result
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
 
 
 @pytest.mark.usefixtures("controller")
@@ -121,14 +133,16 @@ async def test_flow_usb(hass: HomeAssistant):
         context={CONF_SOURCE: SOURCE_USB},
         data=DISCOVERY_INFO,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "discovery_confirm"
+    assert result
+    assert result.get("type") == data_entry_flow.FlowResultType.FORM
+    assert result.get("step_id") == "discovery_confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={},
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result
+    assert result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # test an already configured discovery
     entry = MockConfigEntry(
@@ -141,8 +155,9 @@ async def test_flow_usb(hass: HomeAssistant):
         context={CONF_SOURCE: SOURCE_USB},
         data=DISCOVERY_INFO,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
 
 
 @pytest.mark.usefixtures("controller_connection_failed")
@@ -154,5 +169,6 @@ async def test_flow_usb_failed(hass: HomeAssistant):
         context={CONF_SOURCE: SOURCE_USB},
         data=DISCOVERY_INFO,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
+    assert result
+    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
+    assert result.get("reason") == "cannot_connect"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With th introduction of USB discovery in velbus the concept of ignored entities was introduced, these ignored entries do not have data in the entities registration.

The code in the config flow could not handle these ignored entries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X]  Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #78826
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
