### PR TITLE
Bump zwave-js-server-python to 0.42.0

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -88,6 +88,7 @@ from .const import (
     DOMAIN,
     EVENT_DEVICE_ADDED_TO_REGISTRY,
     LOGGER,
+    USER_AGENT,
     ZWAVE_JS_NOTIFICATION_EVENT,
     ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
     ZWAVE_JS_VALUE_UPDATED_EVENT,
@@ -129,7 +130,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if use_addon := entry.data.get(CONF_USE_ADDON):
         await async_ensure_addon_running(hass, entry)
 
-    client = ZwaveClient(entry.data[CONF_URL], async_get_clientsession(hass))
+    client = ZwaveClient(
+        entry.data[CONF_URL],
+        async_get_clientsession(hass),
+        additional_user_agent_components=USER_AGENT,
+    )
 
     # connect and throw error if connection failed
     try:

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -467,8 +467,7 @@ async def websocket_network_status(
         )
         return
     controller = driver.controller
-    new_state = await controller.async_get_state()
-    controller.update(new_state)
+    controller.update(await controller.async_get_state())
     client_version_info = client.version
     assert client_version_info  # When client is connected version info is set.
     data = {

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -68,6 +68,7 @@ from .const import (
     DATA_CLIENT,
     DOMAIN,
     EVENT_DEVICE_ADDED_TO_REGISTRY,
+    USER_AGENT,
 )
 from .helpers import (
     async_enable_statistics,
@@ -466,7 +467,8 @@ async def websocket_network_status(
         )
         return
     controller = driver.controller
-    await controller.async_get_state()
+    new_state = await controller.async_get_state()
+    controller.update(new_state)
     client_version_info = client.version
     assert client_version_info  # When client is connected version info is set.
     data = {
@@ -2064,6 +2066,7 @@ class FirmwareUploadView(HomeAssistantView):
                 uploaded_file.filename,
                 await hass.async_add_executor_job(uploaded_file.file.read),
                 async_get_clientsession(hass),
+                additional_user_agent_components=USER_AGENT,
                 target=target,
             )
         except BaseZwaveJSServerError as err:

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -1,6 +1,10 @@
 """Constants for the Z-Wave JS integration."""
 import logging
 
+from homeassistant.const import APPLICATION_NAME, __version__ as HA_VERSION
+
+USER_AGENT = {APPLICATION_NAME: HA_VERSION}
+
 CONF_ADDON_DEVICE = "device"
 CONF_ADDON_EMULATE_HARDWARE = "emulate_hardware"
 CONF_ADDON_LOG_LEVEL = "log_level"

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.lock import ATTR_CODE_SLOT, ATTR_USERCODE
 from zwave_js_server.const.command_class.meter import CC_SPECIFIC_METER_TYPE
-from zwave_js_server.model.value import get_value_id
+from zwave_js_server.model.value import get_value_id_str
 from zwave_js_server.util.command_class.meter import get_meter_type
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
@@ -341,7 +341,7 @@ async def async_get_action_capabilities(
         }
 
     if action_type == SERVICE_SET_CONFIG_PARAMETER:
-        value_id = get_value_id(
+        value_id = get_value_id_str(
             node,
             CommandClass.CONFIGURATION,
             config[ATTR_CONFIG_PARAMETER],

--- a/homeassistant/components/zwave_js/diagnostics.py
+++ b/homeassistant/components/zwave_js/diagnostics.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DATA_CLIENT, DOMAIN
+from .const import DATA_CLIENT, DOMAIN, USER_AGENT
 from .helpers import (
     get_home_and_node_id_from_device_entry,
     get_state_key_from_unique_id,
@@ -138,7 +138,9 @@ async def async_get_config_entry_diagnostics(
 ) -> list[dict]:
     """Return diagnostics for a config entry."""
     msgs: list[dict] = async_redact_data(
-        await dump_msgs(config_entry.data[CONF_URL], async_get_clientsession(hass)),
+        await dump_msgs(
+            config_entry.data[CONF_URL], async_get_clientsession(hass), USER_AGENT
+        ),
         KEYS_TO_REDACT,
     )
     handshake_msgs = msgs[:-1]

--- a/homeassistant/components/zwave_js/discovery_data_template.py
+++ b/homeassistant/components/zwave_js/discovery_data_template.py
@@ -80,7 +80,7 @@ from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.value import (
     ConfigurationValue as ZwaveConfigurationValue,
     Value as ZwaveValue,
-    get_value_id,
+    get_value_id_str,
 )
 from zwave_js_server.util.command_class.meter import get_meter_scale_type
 from zwave_js_server.util.command_class.multilevel_sensor import (
@@ -263,7 +263,7 @@ class BaseDiscoverySchemaDataTemplate:
         node: ZwaveNode, value_id_obj: ZwaveValueID
     ) -> ZwaveValue | ZwaveConfigurationValue | None:
         """Get a ZwaveValue from a node using a ZwaveValueDict."""
-        value_id = get_value_id(
+        value_id = get_value_id_str(
             node,
             value_id_obj.command_class,
             value_id_obj.property_,

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from zwave_js_server.const import NodeStatus
 from zwave_js_server.model.driver import Driver
-from zwave_js_server.model.value import Value as ZwaveValue, get_value_id
+from zwave_js_server.model.value import Value as ZwaveValue, get_value_id_str
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
@@ -242,7 +242,7 @@ class ZWaveBaseEntity(Entity):
             endpoint = self.info.primary_value.endpoint
 
         # lookup value by value_id
-        value_id = get_value_id(
+        value_id = get_value_id_str(
             self.info.node,
             command_class,
             value_property,
@@ -256,7 +256,7 @@ class ZWaveBaseEntity(Entity):
         if return_value is None and check_all_endpoints:
             for endpoint_idx in self.info.node.endpoints:
                 if endpoint_idx != self.info.primary_value.endpoint:
-                    value_id = get_value_id(
+                    value_id = get_value_id_str(
                         self.info.node,
                         command_class,
                         value_property,

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -14,7 +14,7 @@ from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.value import (
     ConfigurationValue,
     Value as ZwaveValue,
-    get_value_id,
+    get_value_id_str,
 )
 
 from homeassistant.components.group import expand_entity_ids
@@ -317,7 +317,7 @@ def get_zwave_value_from_config(node: ZwaveNode, config: ConfigType) -> ZwaveVal
     property_key = None
     if config.get(ATTR_PROPERTY_KEY):
         property_key = config[ATTR_PROPERTY_KEY]
-    value_id = get_value_id(
+    value_id = get_value_id_str(
         node,
         config[ATTR_COMMAND_CLASS],
         config[ATTR_PROPERTY],

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.41.1"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.42.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["usb", "http", "websocket_api"],
   "iot_class": "local_push",

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -12,7 +12,7 @@ from zwave_js_server.const import CommandClass, CommandStatus
 from zwave_js_server.exceptions import SetValueFailed
 from zwave_js_server.model.endpoint import Endpoint
 from zwave_js_server.model.node import Node as ZwaveNode
-from zwave_js_server.model.value import ValueDataType, get_value_id
+from zwave_js_server.model.value import ValueDataType, get_value_id_str
 from zwave_js_server.util.multicast import async_multicast_set_value
 from zwave_js_server.util.node import (
     async_bulk_set_partial_config_parameters,
@@ -497,7 +497,7 @@ class ZWaveServices:
 
         coros = []
         for node in nodes:
-            value_id = get_value_id(
+            value_id = get_value_id_str(
                 node,
                 command_class,
                 property_,
@@ -582,13 +582,15 @@ class ZWaveServices:
             first_node = next(
                 node
                 for node in client.driver.controller.nodes.values()
-                if get_value_id(node, command_class, property_, endpoint, property_key)
+                if get_value_id_str(
+                    node, command_class, property_, endpoint, property_key
+                )
                 in node.values
             )
 
         # If value has a string type but the new value is not a string, we need to
         # convert it to one
-        value_id = get_value_id(
+        value_id = get_value_id_str(
             first_node, command_class, property_, endpoint, property_key
         )
         if (

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -5,7 +5,7 @@ import functools
 
 import voluptuous as vol
 from zwave_js_server.const import CommandClass
-from zwave_js_server.model.value import Value, get_value_id
+from zwave_js_server.model.value import Value, get_value_id_str
 
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, CONF_PLATFORM, MATCH_ALL
 from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
@@ -164,7 +164,9 @@ async def async_attach_trigger(
         device_identifier = get_device_id(driver, node)
         device = dev_reg.async_get_device({device_identifier})
         assert device
-        value_id = get_value_id(node, command_class, property_, endpoint, property_key)
+        value_id = get_value_id_str(
+            node, command_class, property_, endpoint, property_key
+        )
         value = node.values[value_id]
         # We need to store the current value and device for the callback
         unsubs.append(

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,6 +5,7 @@ from typing import Final
 
 from .backports.enum import StrEnum
 
+APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 10
 PATCH_VERSION: Final = "0.dev0"

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -16,7 +16,7 @@ from aiohttp.web_exceptions import HTTPBadGateway, HTTPGatewayTimeout
 import async_timeout
 
 from homeassistant import config_entries
-from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
+from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
 from homeassistant.util import ssl as ssl_util
@@ -32,8 +32,8 @@ DATA_CONNECTOR = "aiohttp_connector"
 DATA_CONNECTOR_NOTVERIFY = "aiohttp_connector_notverify"
 DATA_CLIENTSESSION = "aiohttp_clientsession"
 DATA_CLIENTSESSION_NOTVERIFY = "aiohttp_clientsession_notverify"
-SERVER_SOFTWARE = "HomeAssistant/{0} aiohttp/{1} Python/{2[0]}.{2[1]}".format(
-    __version__, aiohttp.__version__, sys.version_info
+SERVER_SOFTWARE = "{0}/{1} aiohttp/{2} Python/{3[0]}.{3[1]}".format(
+    APPLICATION_NAME, __version__, aiohttp.__version__, sys.version_info
 )
 
 WARN_CLOSE_MSG = "closes the Home Assistant aiohttp session"

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import httpx
 
-from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
+from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
 
@@ -15,8 +15,8 @@ from .frame import warn_use
 
 DATA_ASYNC_CLIENT = "httpx_async_client"
 DATA_ASYNC_CLIENT_NOVERIFY = "httpx_async_client_noverify"
-SERVER_SOFTWARE = "HomeAssistant/{0} httpx/{1} Python/{2[0]}.{2[1]}".format(
-    __version__, httpx.__version__, sys.version_info
+SERVER_SOFTWARE = "{0}/{1} httpx/{2} Python/{3[0]}.{3[1]}".format(
+    APPLICATION_NAME, __version__, httpx.__version__, sys.version_info
 )
 USER_AGENT = "User-Agent"
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2619,7 +2619,7 @@ zigpy==0.50.3
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.41.1
+zwave-js-server-python==0.42.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.2.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1805,7 +1805,7 @@ zigpy-znp==0.8.2
 zigpy==0.50.3
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.41.1
+zwave-js-server-python==0.42.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.2.6

--- a/tests/components/zwave_js/fixtures/controller_state.json
+++ b/tests/components/zwave_js/fixtures/controller_state.json
@@ -11,6 +11,7 @@
     "isStaticUpdateController": true,
     "isSlave": false,
     "serialApiVersion": "1.0",
+    "nodeType": 0,
     "manufacturerId": 134,
     "productType": 257,
     "productId": 90,

--- a/tests/components/zwave_js/fixtures/controller_state.json
+++ b/tests/components/zwave_js/fixtures/controller_state.json
@@ -11,7 +11,6 @@
     "isStaticUpdateController": true,
     "isSlave": false,
     "serialApiVersion": "1.0",
-    "nodeType": 0,
     "manufacturerId": 134,
     "productType": 257,
     "productId": 90,

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 from http import HTTPStatus
 import json
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 import pytest
 from zwave_js_server.const import (
@@ -2816,9 +2816,9 @@ async def test_firmware_upload_view(
     device = get_device(hass, multisensor_6)
     with patch(
         "homeassistant.components.zwave_js.api.begin_firmware_update",
-    ) as mock_cmd, patch(
+    ) as mock_cmd, patch.dict(
         "homeassistant.components.zwave_js.api.USER_AGENT",
-        new_callable=PropertyMock(return_value={"HomeAssistant": "0.0.0"}),
+        {"HomeAssistant": "0.0.0"},
     ):
         resp = await client.post(
             f"/api/zwave_js/firmware/upload/{device.id}",

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 from http import HTTPStatus
 import json
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from zwave_js_server.const import (
@@ -2816,7 +2816,10 @@ async def test_firmware_upload_view(
     device = get_device(hass, multisensor_6)
     with patch(
         "homeassistant.components.zwave_js.api.begin_firmware_update",
-    ) as mock_cmd:
+    ) as mock_cmd, patch(
+        "homeassistant.components.zwave_js.api.USER_AGENT",
+        new_callable=PropertyMock(return_value={"HomeAssistant": "0.0.0"}),
+    ):
         resp = await client.post(
             f"/api/zwave_js/firmware/upload/{device.id}",
             data={"file": firmware_file, "target": "15"},
@@ -2824,7 +2827,7 @@ async def test_firmware_upload_view(
         assert mock_cmd.call_args[0][1:4] == (multisensor_6, "file", bytes(10))
         assert mock_cmd.call_args[1] == {
             "target": 15,
-            "additional_user_agent_components": {"HomeAssistant": "2022.10.0.dev0"},
+            "additional_user_agent_components": {"HomeAssistant": "0.0.0"},
         }
         assert json.loads(await resp.text()) is None
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -86,13 +86,18 @@ def get_device(hass, node):
     return dev_reg.async_get_device({device_id})
 
 
-async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
+async def test_network_status(
+    hass, multisensor_6, controller_state, integration, hass_ws_client
+):
     """Test the network status websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
 
     # Try API call with entry ID
-    with patch("zwave_js_server.model.controller.Controller.async_get_state"):
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_get_state",
+        return_value=controller_state["controller"],
+    ):
         await ws_client.send_json(
             {
                 ID: 1,
@@ -113,7 +118,10 @@ async def test_network_status(hass, multisensor_6, integration, hass_ws_client):
         identifiers={(DOMAIN, "3245146787-52")},
     )
     assert device
-    with patch("zwave_js_server.model.controller.Controller.async_get_state"):
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_get_state",
+        return_value=controller_state["controller"],
+    ):
         await ws_client.send_json(
             {
                 ID: 2,
@@ -2585,27 +2593,10 @@ async def test_set_config_parameter(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
-        "propertyName": "Group 2: Send battery reports",
         "propertyKey": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -2633,27 +2624,10 @@ async def test_set_config_parameter(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
-        "propertyName": "Group 2: Send battery reports",
         "propertyKey": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -2822,7 +2822,10 @@ async def test_firmware_upload_view(
             data={"file": firmware_file, "target": "15"},
         )
         assert mock_cmd.call_args[0][1:4] == (multisensor_6, "file", bytes(10))
-        assert mock_cmd.call_args[1] == {"target": 15}
+        assert mock_cmd.call_args[1] == {
+            "target": 15,
+            "additional_user_agent_components": {"HomeAssistant": "2022.10.0.dev0"},
+        }
         assert json.loads(await resp.text()) is None
 
 

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -86,21 +86,9 @@ async def test_thermostat_v2(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
-        "commandClassName": "Thermostat Mode",
         "commandClass": 64,
         "endpoint": 1,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 31,
-            "label": "Thermostat mode",
-            "states": {"0": "Off", "1": "Heat", "2": "Cool", "3": "Auto"},
-        },
-        "value": 1,
     }
     assert args["value"] == 2
 
@@ -123,42 +111,19 @@ async def test_thermostat_v2(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
-        "commandClassName": "Thermostat Mode",
         "commandClass": 64,
         "endpoint": 1,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 31,
-            "label": "Thermostat mode",
-            "states": {"0": "Off", "1": "Heat", "2": "Cool", "3": "Auto"},
-        },
-        "value": 1,
     }
     assert args["value"] == 2
     args = client.async_send_command.call_args_list[1][0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
-        "commandClassName": "Thermostat Setpoint",
         "commandClass": 67,
         "endpoint": 1,
         "property": "setpoint",
         "propertyKey": 1,
-        "propertyName": "setpoint",
-        "propertyKeyName": "Heating",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "unit": "°F",
-            "ccSpecific": {"setpointType": 1},
-        },
-        "value": 72,
     }
     assert args["value"] == 77
 
@@ -232,21 +197,10 @@ async def test_thermostat_v2(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
-        "commandClassName": "Thermostat Setpoint",
         "commandClass": 67,
         "endpoint": 1,
         "property": "setpoint",
         "propertyKey": 1,
-        "propertyName": "setpoint",
-        "propertyKeyName": "Heating",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "unit": "°F",
-            "ccSpecific": {"setpointType": 1},
-        },
-        "value": 72,
     }
     assert args["value"] == 77
 
@@ -254,21 +208,10 @@ async def test_thermostat_v2(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
-        "commandClassName": "Thermostat Setpoint",
         "commandClass": 67,
         "endpoint": 1,
         "property": "setpoint",
         "propertyKey": 2,
-        "propertyName": "setpoint",
-        "propertyKeyName": "Cooling",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "unit": "°F",
-            "ccSpecific": {"setpointType": 2},
-        },
-        "value": 73,
     }
     assert args["value"] == 86
 
@@ -306,20 +249,7 @@ async def test_thermostat_v2(
     assert args["valueId"] == {
         "endpoint": 1,
         "commandClass": 68,
-        "commandClassName": "Thermostat Fan Mode",
         "property": "mode",
-        "propertyName": "mode",
-        "ccVersion": 0,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "states": {"0": "Auto low", "1": "Low"},
-            "label": "Thermostat fan mode",
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -408,20 +338,8 @@ async def test_setpoint_thermostat(hass, client, climate_danfoss_lc_13, integrat
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 67,
-        "commandClassName": "Thermostat Setpoint",
         "property": "setpoint",
-        "propertyName": "setpoint",
         "propertyKey": 1,
-        "propertyKeyName": "Heating",
-        "ccVersion": 2,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "unit": "\u00b0C",
-            "ccSpecific": {"setpointType": 1},
-        },
-        "value": 14,
     }
     assert args["value"] == 21.5
 
@@ -627,27 +545,9 @@ async def test_preset_and_no_setpoint(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 8
     assert args["valueId"] == {
-        "commandClassName": "Thermostat Mode",
         "commandClass": 64,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "ccVersion": 3,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 31,
-            "label": "Thermostat mode",
-            "states": {
-                "0": "Off",
-                "1": "Heat",
-                "11": "Energy heat",
-                "15": "Full power",
-            },
-        },
-        "value": 1,
     }
     assert args["value"] == 15
 

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -50,20 +50,9 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 6
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-        },
     }
     assert args["value"] == 50
 
@@ -82,20 +71,9 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 6
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-        },
     }
     assert args["value"] == 0
 
@@ -114,20 +92,9 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 6
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-        },
     }
     assert args["value"]
 
@@ -145,18 +112,9 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 6
     assert open_args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "Open",
-        "propertyName": "Open",
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Perform a level change (Open)",
-            "ccSpecific": {"switchType": 3},
-        },
     }
     assert not open_args["value"]
 
@@ -164,18 +122,9 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     assert close_args["command"] == "node.set_value"
     assert close_args["nodeId"] == 6
     assert close_args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "Close",
-        "propertyName": "Close",
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Perform a level change (Close)",
-            "ccSpecific": {"switchType": 3},
-        },
     }
     assert not close_args["value"]
 
@@ -215,20 +164,9 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 6
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-        },
     }
     assert args["value"] == 0
 
@@ -247,18 +185,9 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 6
     assert open_args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "Open",
-        "propertyName": "Open",
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Perform a level change (Open)",
-            "ccSpecific": {"switchType": 3},
-        },
     }
     assert not open_args["value"]
 
@@ -266,18 +195,9 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     assert close_args["command"] == "node.set_value"
     assert close_args["nodeId"] == 6
     assert close_args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "Close",
-        "propertyName": "Close",
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Perform a level change (Close)",
-            "ccSpecific": {"switchType": 3},
-        },
     }
     assert not close_args["value"]
 
@@ -332,21 +252,8 @@ async def test_fibaro_FGR222_shutter_cover(
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 145,
-        "commandClassName": "Manufacturer Proprietary",
         "property": "fibaro",
         "propertyKey": "venetianBlindsTilt",
-        "propertyName": "fibaro",
-        "propertyKeyName": "venetianBlindsTilt",
-        "ccVersion": 0,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Venetian blinds tilt",
-            "min": 0,
-            "max": 99,
-        },
-        "value": 0,
     }
     assert args["value"] == 99
 
@@ -366,21 +273,8 @@ async def test_fibaro_FGR222_shutter_cover(
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 145,
-        "commandClassName": "Manufacturer Proprietary",
         "property": "fibaro",
         "propertyKey": "venetianBlindsTilt",
-        "propertyName": "fibaro",
-        "propertyKeyName": "venetianBlindsTilt",
-        "ccVersion": 0,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Venetian blinds tilt",
-            "min": 0,
-            "max": 99,
-        },
-        "value": 0,
     }
     assert args["value"] == 0
 
@@ -411,23 +305,9 @@ async def test_aeotec_nano_shutter_cover(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 3
     assert args["valueId"] == {
-        "ccVersion": 4,
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "value": 0,
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "valueChangeOptions": ["transitionDuration"],
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-        },
     }
     assert args["value"]
 
@@ -445,20 +325,9 @@ async def test_aeotec_nano_shutter_cover(
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 3
     assert open_args["valueId"] == {
-        "ccVersion": 4,
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "On",
-        "propertyName": "On",
-        "value": False,
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Perform a level change (On)",
-            "ccSpecific": {"switchType": 1},
-        },
     }
     assert not open_args["value"]
 
@@ -466,20 +335,9 @@ async def test_aeotec_nano_shutter_cover(
     assert close_args["command"] == "node.set_value"
     assert close_args["nodeId"] == 3
     assert close_args["valueId"] == {
-        "ccVersion": 4,
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "Off",
-        "propertyName": "Off",
-        "value": False,
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Perform a level change (Off)",
-            "ccSpecific": {"switchType": 1},
-        },
     }
     assert not close_args["value"]
 
@@ -520,23 +378,9 @@ async def test_aeotec_nano_shutter_cover(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 3
     assert args["valueId"] == {
-        "ccVersion": 4,
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "value": 0,
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-            "label": "Target value",
-        },
     }
     assert args["value"] == 0
 
@@ -555,20 +399,9 @@ async def test_aeotec_nano_shutter_cover(
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 3
     assert open_args["valueId"] == {
-        "ccVersion": 4,
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "On",
-        "propertyName": "On",
-        "value": False,
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Perform a level change (On)",
-            "ccSpecific": {"switchType": 1},
-        },
     }
     assert not open_args["value"]
 
@@ -576,20 +409,9 @@ async def test_aeotec_nano_shutter_cover(
     assert close_args["command"] == "node.set_value"
     assert close_args["nodeId"] == 3
     assert close_args["valueId"] == {
-        "ccVersion": 4,
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "Off",
-        "propertyName": "Off",
-        "value": False,
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Perform a level change (Off)",
-            "ccSpecific": {"switchType": 1},
-        },
     }
     assert not close_args["value"]
 
@@ -631,21 +453,9 @@ async def test_motor_barrier_cover(hass, client, gdc_zw062, integration):
     assert args["nodeId"] == 12
     assert args["value"] == 255
     assert args["valueId"] == {
-        "ccVersion": 0,
         "commandClass": 102,
-        "commandClassName": "Barrier Operator",
         "endpoint": 0,
-        "metadata": {
-            "label": "Target Barrier State",
-            "max": 255,
-            "min": 0,
-            "readable": True,
-            "states": {"0": "Closed", "255": "Open"},
-            "type": "number",
-            "writeable": True,
-        },
         "property": "targetState",
-        "propertyName": "targetState",
     }
 
     # state doesn't change until currentState value update is received
@@ -665,21 +475,9 @@ async def test_motor_barrier_cover(hass, client, gdc_zw062, integration):
     assert args["nodeId"] == 12
     assert args["value"] == 0
     assert args["valueId"] == {
-        "ccVersion": 0,
         "commandClass": 102,
-        "commandClassName": "Barrier Operator",
         "endpoint": 0,
-        "metadata": {
-            "label": "Target Barrier State",
-            "max": 255,
-            "min": 0,
-            "readable": True,
-            "states": {"0": "Closed", "255": "Open"},
-            "type": "number",
-            "writeable": True,
-        },
         "property": "targetState",
-        "propertyName": "targetState",
     }
 
     # state doesn't change until currentState value update is received

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -54,19 +54,9 @@ async def test_generic_fan(hass, client, fan_generic, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 17
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-        },
     }
     assert args["value"] == 66
 
@@ -96,19 +86,9 @@ async def test_generic_fan(hass, client, fan_generic, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 17
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-        },
     }
     assert args["value"] == 255
 
@@ -127,19 +107,9 @@ async def test_generic_fan(hass, client, fan_generic, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 17
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-        },
     }
     assert args["value"] == 0
 
@@ -602,22 +572,9 @@ async def test_thermostat_fan(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 3,
-        "commandClassName": "Thermostat Fan Mode",
         "commandClass": CommandClass.THERMOSTAT_FAN_MODE.value,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "label": "Thermostat fan mode",
-            "max": 255,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "states": {"0": "Auto low", "1": "Low", "6": "Circulation"},
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -647,19 +604,9 @@ async def test_thermostat_fan(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 3,
-        "commandClassName": "Thermostat Fan Mode",
         "commandClass": CommandClass.THERMOSTAT_FAN_MODE.value,
         "endpoint": 0,
         "property": "off",
-        "propertyName": "off",
-        "metadata": {
-            "label": "Thermostat fan turned off",
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-        },
-        "value": False,
     }
     assert args["value"]
 
@@ -678,19 +625,9 @@ async def test_thermostat_fan(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 3,
-        "commandClassName": "Thermostat Fan Mode",
         "commandClass": CommandClass.THERMOSTAT_FAN_MODE.value,
         "endpoint": 0,
         "property": "off",
-        "propertyName": "off",
-        "metadata": {
-            "label": "Thermostat fan turned off",
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-        },
-        "value": False,
     }
     assert not args["value"]
 

--- a/tests/components/zwave_js/test_humidifier.py
+++ b/tests/components/zwave_js/test_humidifier.py
@@ -56,24 +56,10 @@ async def test_humidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 1,
-        "commandClassName": "Humidity Control Setpoint",
         "commandClass": CommandClass.HUMIDITY_CONTROL_SETPOINT,
         "endpoint": 0,
         "property": "setpoint",
         "propertyKey": 1,
-        "propertyName": "setpoint",
-        "propertyKeyName": "Humidifier",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "unit": "%",
-            "min": 10,
-            "max": 70,
-            "ccSpecific": {"setpointType": 1},
-        },
-        "value": 35,
     }
     assert args["value"] == 41
 
@@ -186,22 +172,9 @@ async def test_humidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 2,
-        "commandClassName": "Humidity Control Mode",
         "commandClass": CommandClass.HUMIDITY_CONTROL_MODE,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Humidity control mode",
-            "states": {"0": "Off", "1": "Humidify", "2": "De-humidify", "3": "Auto"},
-        },
-        "value": int(HumidityControlMode.HUMIDIFY),
     }
     assert args["value"] == int(HumidityControlMode.OFF)
 
@@ -239,22 +212,9 @@ async def test_humidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 2,
-        "commandClassName": "Humidity Control Mode",
         "commandClass": CommandClass.HUMIDITY_CONTROL_MODE,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Humidity control mode",
-            "states": {"0": "Off", "1": "Humidify", "2": "De-humidify", "3": "Auto"},
-        },
-        "value": int(HumidityControlMode.AUTO),
     }
     assert args["value"] == int(HumidityControlMode.DEHUMIDIFY)
 
@@ -416,22 +376,9 @@ async def test_humidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 2,
-        "commandClassName": "Humidity Control Mode",
         "commandClass": CommandClass.HUMIDITY_CONTROL_MODE,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Humidity control mode",
-            "states": {"0": "Off", "1": "Humidify", "2": "De-humidify", "3": "Auto"},
-        },
-        "value": int(HumidityControlMode.DEHUMIDIFY),
     }
     assert args["value"] == int(HumidityControlMode.AUTO)
 
@@ -469,22 +416,9 @@ async def test_humidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 2,
-        "commandClassName": "Humidity Control Mode",
         "commandClass": CommandClass.HUMIDITY_CONTROL_MODE,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Humidity control mode",
-            "states": {"0": "Off", "1": "Humidify", "2": "De-humidify", "3": "Auto"},
-        },
-        "value": int(HumidityControlMode.OFF),
     }
     assert args["value"] == int(HumidityControlMode.HUMIDIFY)
 
@@ -570,22 +504,9 @@ async def test_humidifier_missing_mode(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 2,
-        "commandClassName": "Humidity Control Mode",
         "commandClass": CommandClass.HUMIDITY_CONTROL_MODE,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Humidity control mode",
-            "states": {"0": "Off", "1": "Humidify", "3": "Auto"},
-        },
-        "value": int(HumidityControlMode.AUTO),
     }
     assert args["value"] == int(HumidityControlMode.OFF)
 
@@ -623,24 +544,10 @@ async def test_dehumidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 1,
-        "commandClassName": "Humidity Control Setpoint",
         "commandClass": CommandClass.HUMIDITY_CONTROL_SETPOINT,
         "endpoint": 0,
         "property": "setpoint",
         "propertyKey": 2,
-        "propertyName": "setpoint",
-        "propertyKeyName": "De-humidifier",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "unit": "%",
-            "min": 30,
-            "max": 90,
-            "ccSpecific": {"setpointType": 2},
-        },
-        "value": 60,
     }
     assert args["value"] == 41
 
@@ -753,22 +660,9 @@ async def test_dehumidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 2,
-        "commandClassName": "Humidity Control Mode",
         "commandClass": CommandClass.HUMIDITY_CONTROL_MODE,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Humidity control mode",
-            "states": {"0": "Off", "1": "Humidify", "2": "De-humidify", "3": "Auto"},
-        },
-        "value": int(HumidityControlMode.DEHUMIDIFY),
     }
     assert args["value"] == int(HumidityControlMode.OFF)
 
@@ -806,22 +700,9 @@ async def test_dehumidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 2,
-        "commandClassName": "Humidity Control Mode",
         "commandClass": CommandClass.HUMIDITY_CONTROL_MODE,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Humidity control mode",
-            "states": {"0": "Off", "1": "Humidify", "2": "De-humidify", "3": "Auto"},
-        },
-        "value": int(HumidityControlMode.AUTO),
     }
     assert args["value"] == int(HumidityControlMode.HUMIDIFY)
 
@@ -983,22 +864,9 @@ async def test_dehumidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 2,
-        "commandClassName": "Humidity Control Mode",
         "commandClass": CommandClass.HUMIDITY_CONTROL_MODE,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Humidity control mode",
-            "states": {"0": "Off", "1": "Humidify", "2": "De-humidify", "3": "Auto"},
-        },
-        "value": int(HumidityControlMode.HUMIDIFY),
     }
     assert args["value"] == int(HumidityControlMode.AUTO)
 
@@ -1036,21 +904,8 @@ async def test_dehumidifier(hass, client, climate_adc_t3000, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 68
     assert args["valueId"] == {
-        "ccVersion": 2,
-        "commandClassName": "Humidity Control Mode",
         "commandClass": CommandClass.HUMIDITY_CONTROL_MODE,
         "endpoint": 0,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Humidity control mode",
-            "states": {"0": "Off", "1": "Humidify", "2": "De-humidify", "3": "Auto"},
-        },
-        "value": int(HumidityControlMode.OFF),
     }
     assert args["value"] == int(HumidityControlMode.DEHUMIDIFY)

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -8,6 +8,7 @@ from zwave_js_server.client import Client
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import BaseZwaveJSServerError, InvalidServerVersion
 from zwave_js_server.model.node import Node
+from zwave_js_server.model.version import VersionInfo
 
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.zwave_js import DOMAIN
@@ -667,6 +668,7 @@ async def test_update_addon(
     backup_calls,
     update_addon_side_effect,
     create_backup_side_effect,
+    version_state,
 ):
     """Test update the Z-Wave JS add-on during entry setup."""
     device = "/test"
@@ -677,7 +679,9 @@ async def test_update_addon(
     addon_info.return_value["update_available"] = update_available
     create_backup.side_effect = create_backup_side_effect
     update_addon.side_effect = update_addon_side_effect
-    client.connect.side_effect = InvalidServerVersion("Invalid version")
+    client.connect.side_effect = InvalidServerVersion(
+        VersionInfo("a", "b", 1, 1, 1), 1, "Invalid version"
+    )
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Z-Wave JS",
@@ -703,7 +707,9 @@ async def test_issue_registry(hass, client, version_state):
     device = "/test"
     network_key = "abc123"
 
-    client.connect.side_effect = InvalidServerVersion("Invalid version")
+    client.connect.side_effect = InvalidServerVersion(
+        VersionInfo("a", "b", 1, 1, 1), 1, "Invalid version"
+    )
 
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -60,20 +60,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
     }
     assert args["value"] == 255
 
@@ -92,20 +81,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
     }
     assert args["value"] == 255
     assert args["options"]["transitionDuration"] == "10s"
@@ -164,20 +142,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
     }
     assert args["value"] == 50
     assert args["options"]["transitionDuration"] == "default"
@@ -201,20 +168,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
     }
     assert args["value"] == 50
     assert args["options"]["transitionDuration"] == "20s"
@@ -233,12 +189,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     args = client.async_send_command.call_args_list[0][0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
-    assert args["valueId"]["commandClassName"] == "Color Switch"
     assert args["valueId"]["commandClass"] == 51
     assert args["valueId"]["endpoint"] == 0
-    assert args["valueId"]["metadata"]["label"] == "Target Color"
     assert args["valueId"]["property"] == "targetColor"
-    assert args["valueId"]["propertyName"] == "targetColor"
     assert args["value"] == {
         "blue": 255,
         "coldWhite": 0,
@@ -332,12 +285,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     args = client.async_send_command.call_args_list[0][0][0]  # red 0
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
-    assert args["valueId"]["commandClassName"] == "Color Switch"
     assert args["valueId"]["commandClass"] == 51
     assert args["valueId"]["endpoint"] == 0
-    assert args["valueId"]["metadata"]["label"] == "Target Color"
     assert args["valueId"]["property"] == "targetColor"
-    assert args["valueId"]["propertyName"] == "targetColor"
     assert args["value"] == {
         "blue": 0,
         "coldWhite": 235,
@@ -438,20 +388,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
     }
     assert args["value"] == 0
 
@@ -493,20 +432,9 @@ async def test_rgbw_light(hass, client, zen_31, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 94
     assert args["valueId"] == {
-        "commandClassName": "Color Switch",
         "commandClass": 51,
         "endpoint": 1,
         "property": "targetColor",
-        "propertyName": "targetColor",
-        "ccVersion": 0,
-        "metadata": {
-            "label": "Target Color",
-            "type": "any",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
-        "value": {"blue": 70, "green": 159, "red": 255, "warmWhite": 141},
     }
     assert args["value"] == {"blue": 0, "green": 0, "red": 0, "warmWhite": 128}
 
@@ -514,22 +442,9 @@ async def test_rgbw_light(hass, client, zen_31, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 94
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 1,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "ccVersion": 0,
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
-        "value": 59,
     }
     assert args["value"] == 255
 
@@ -565,19 +480,9 @@ async def test_black_is_off(hass, client, express_controls_ezmultipli, integrati
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == node.node_id
     assert args["valueId"] == {
-        "commandClassName": "Color Switch",
         "commandClass": 51,
         "endpoint": 0,
         "property": "targetColor",
-        "propertyName": "targetColor",
-        "ccVersion": 1,
-        "metadata": {
-            "label": "Target Color",
-            "type": "any",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
     }
     assert args["value"] == {"red": 255, "green": 255, "blue": 255}
 
@@ -656,19 +561,9 @@ async def test_black_is_off(hass, client, express_controls_ezmultipli, integrati
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == node.node_id
     assert args["valueId"] == {
-        "commandClassName": "Color Switch",
         "commandClass": 51,
         "endpoint": 0,
         "property": "targetColor",
-        "propertyName": "targetColor",
-        "ccVersion": 1,
-        "metadata": {
-            "label": "Target Color",
-            "type": "any",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
     }
     assert args["value"] == {"red": 0, "green": 0, "blue": 0}
 
@@ -686,19 +581,9 @@ async def test_black_is_off(hass, client, express_controls_ezmultipli, integrati
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == node.node_id
     assert args["valueId"] == {
-        "commandClassName": "Color Switch",
         "commandClass": 51,
         "endpoint": 0,
         "property": "targetColor",
-        "propertyName": "targetColor",
-        "ccVersion": 1,
-        "metadata": {
-            "label": "Target Color",
-            "type": "any",
-            "readable": True,
-            "writeable": True,
-            "valueChangeOptions": ["transitionDuration"],
-        },
     }
     assert args["value"] == {"red": 0, "green": 255, "blue": 0}
 

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -44,29 +44,9 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 20
     assert args["valueId"] == {
-        "commandClassName": "Door Lock",
         "commandClass": 98,
         "endpoint": 0,
         "property": "targetMode",
-        "propertyName": "targetMode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Target lock mode",
-            "states": {
-                "0": "Unsecured",
-                "1": "UnsecuredWithTimeout",
-                "16": "InsideUnsecured",
-                "17": "InsideUnsecuredWithTimeout",
-                "32": "OutsideUnsecured",
-                "33": "OutsideUnsecuredWithTimeout",
-                "254": "Unknown",
-                "255": "Secured",
-            },
-        },
     }
     assert args["value"] == 255
 
@@ -109,29 +89,9 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 20
     assert args["valueId"] == {
-        "commandClassName": "Door Lock",
         "commandClass": 98,
         "endpoint": 0,
         "property": "targetMode",
-        "propertyName": "targetMode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Target lock mode",
-            "states": {
-                "0": "Unsecured",
-                "1": "UnsecuredWithTimeout",
-                "16": "InsideUnsecured",
-                "17": "InsideUnsecuredWithTimeout",
-                "32": "OutsideUnsecured",
-                "33": "OutsideUnsecuredWithTimeout",
-                "254": "Unknown",
-                "255": "Secured",
-            },
-        },
     }
     assert args["value"] == 0
 
@@ -154,22 +114,10 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 20
     assert args["valueId"] == {
-        "commandClassName": "User Code",
         "commandClass": 99,
         "endpoint": 0,
         "property": "userCode",
-        "propertyName": "userCode",
         "propertyKey": 1,
-        "propertyKeyName": "1",
-        "metadata": {
-            "type": "string",
-            "readable": True,
-            "writeable": True,
-            "minLength": 4,
-            "maxLength": 10,
-            "label": "User Code (1)",
-        },
-        "value": "**********",
     }
     assert args["value"] == "1234"
 
@@ -188,25 +136,10 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 20
     assert args["valueId"] == {
-        "commandClassName": "User Code",
         "commandClass": 99,
         "endpoint": 0,
         "property": "userIdStatus",
-        "propertyName": "userIdStatus",
         "propertyKey": 1,
-        "propertyKeyName": "1",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "User ID status (1)",
-            "states": {
-                "0": "Available",
-                "1": "Enabled",
-                "2": "Disabled",
-            },
-        },
-        "value": 1,
     }
     assert args["value"] == 0
 

--- a/tests/components/zwave_js/test_number.py
+++ b/tests/components/zwave_js/test_number.py
@@ -31,21 +31,9 @@ async def test_number(hass, client, aeotec_radiator_thermostat, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 4
     assert args["valueId"] == {
-        "commandClassName": "Multilevel Switch",
         "commandClass": 38,
-        "ccVersion": 1,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "label": "Target value",
-            "max": 99,
-            "min": 0,
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-        },
     }
     assert args["value"] == 30.0
 
@@ -101,20 +89,7 @@ async def test_volume_number(hass, client, aeotec_zw164_siren, integration):
     assert args["valueId"] == {
         "endpoint": 2,
         "commandClass": 121,
-        "commandClassName": "Sound Switch",
         "property": "defaultVolume",
-        "propertyName": "defaultVolume",
-        "ccVersion": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Default volume",
-            "min": 0,
-            "max": 100,
-            "unit": "%",
-        },
-        "value": 100,
     }
     assert args["value"] == 30
 

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -81,19 +81,7 @@ async def test_default_tone_select(
     assert args["valueId"] == {
         "endpoint": 2,
         "commandClass": 121,
-        "commandClassName": "Sound Switch",
         "property": "defaultToneId",
-        "propertyName": "defaultToneId",
-        "ccVersion": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Default tone ID",
-            "min": 0,
-            "max": 254,
-        },
-        "value": 17,
     }
     assert args["value"] == 30
 
@@ -164,22 +152,7 @@ async def test_protection_select(
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 117,
-        "commandClassName": "Protection",
         "property": "local",
-        "propertyName": "local",
-        "ccVersion": 2,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Local protection state",
-            "states": {
-                "0": "Unprotected",
-                "1": "ProtectedBySequence",
-                "2": "NoOperationPossible",
-            },
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -264,19 +237,7 @@ async def test_multilevel_switch_select(hass, client, fortrezz_ssa1_siren, integ
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 38,
-        "commandClassName": "Multilevel Switch",
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "ccVersion": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-            "valueChangeOptions": ["transitionDuration"],
-            "min": 0,
-            "max": 99,
-        },
     }
     assert args["value"] == 33
 

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -78,27 +78,10 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
-        "propertyName": "Group 2: Send battery reports",
         "propertyKey": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -122,27 +105,10 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
-        "propertyName": "Group 2: Send battery reports",
         "propertyKey": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -165,27 +131,10 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
-        "propertyName": "Group 2: Send battery reports",
         "propertyKey": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -208,27 +157,10 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 41,
-        "propertyName": "Temperature Threshold (Unit)",
         "propertyKey": 15,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 3,
-            "min": 1,
-            "max": 2,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": False,
-            "states": {"1": "Celsius", "2": "Fahrenheit"},
-            "label": "Temperature Threshold (Unit)",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 2
 
@@ -254,27 +186,10 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 41,
-        "propertyName": "Temperature Threshold (Unit)",
         "propertyKey": 15,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 3,
-            "min": 1,
-            "max": 2,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": False,
-            "states": {"1": "Celsius", "2": "Fahrenheit"},
-            "label": "Temperature Threshold (Unit)",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 2
 
@@ -298,27 +213,10 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
-        "propertyName": "Group 2: Send battery reports",
         "propertyKey": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -344,27 +242,10 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
-        "propertyName": "Group 2: Send battery reports",
         "propertyKey": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -431,27 +312,10 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
-        "propertyName": "Group 2: Send battery reports",
         "propertyKey": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -477,27 +341,10 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
-        "propertyName": "Group 2: Send battery reports",
         "propertyKey": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 
@@ -551,32 +398,7 @@ async def test_set_config_parameter_gather(
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 112,
-        "commandClassName": "Configuration",
         "property": 1,
-        "propertyName": "Temperature Reporting Threshold",
-        "ccVersion": 1,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "description": "Reporting threshold for changes in the ambient temperature",
-            "label": "Temperature Reporting Threshold",
-            "default": 2,
-            "min": 0,
-            "max": 4,
-            "states": {
-                "0": "Disabled",
-                "1": "0.5\u00b0 F",
-                "2": "1.0\u00b0 F",
-                "3": "1.5\u00b0 F",
-                "4": "2.0\u00b0 F",
-            },
-            "valueSize": 1,
-            "format": 0,
-            "allowManualEntry": False,
-            "isFromConfig": True,
-        },
-        "value": 1,
     }
     assert args["value"] == 1
 
@@ -847,26 +669,9 @@ async def test_refresh_value(
     assert args["command"] == "node.poll_value"
     assert args["nodeId"] == 26
     assert args["valueId"] == {
-        "commandClassName": "Thermostat Mode",
         "commandClass": 64,
         "endpoint": 1,
         "property": "mode",
-        "propertyName": "mode",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "min": 0,
-            "max": 255,
-            "label": "Thermostat mode",
-            "states": {
-                "0": "Off",
-                "1": "Heat",
-                "2": "Cool",
-            },
-        },
-        "value": 2,
-        "ccVersion": 0,
     }
 
     client.async_send_command.reset_mock()
@@ -950,20 +755,9 @@ async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 5
     assert args["valueId"] == {
-        "commandClassName": "Protection",
         "commandClass": 117,
         "endpoint": 0,
         "property": "local",
-        "propertyName": "local",
-        "ccVersion": 2,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Local protection state",
-            "states": {"0": "Unprotected", "2": "NoOperationPossible"},
-        },
-        "value": 0,
     }
     assert args["value"] == 2
 
@@ -988,20 +782,9 @@ async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 5
     assert args["valueId"] == {
-        "commandClassName": "Protection",
         "commandClass": 117,
         "endpoint": 0,
         "property": "local",
-        "propertyName": "local",
-        "ccVersion": 2,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Local protection state",
-            "states": {"0": "Unprotected", "2": "NoOperationPossible"},
-        },
-        "value": 0,
     }
     assert args["value"] == 2
 
@@ -1029,20 +812,9 @@ async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 5
     assert args["valueId"] == {
-        "commandClassName": "Protection",
         "commandClass": 117,
         "endpoint": 0,
         "property": "local",
-        "propertyName": "local",
-        "ccVersion": 2,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Local protection state",
-            "states": {"0": "Unprotected", "2": "NoOperationPossible"},
-        },
-        "value": 0,
     }
     assert args["value"] == 2
 
@@ -1069,20 +841,9 @@ async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 5
     assert args["valueId"] == {
-        "commandClassName": "Protection",
         "commandClass": 117,
         "endpoint": 0,
         "property": "local",
-        "propertyName": "local",
-        "ccVersion": 2,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Local protection state",
-            "states": {"0": "Unprotected", "2": "NoOperationPossible"},
-        },
-        "value": 0,
     }
     assert args["value"] == 2
 
@@ -1111,20 +872,9 @@ async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 5
     assert args["valueId"] == {
-        "commandClassName": "Protection",
         "commandClass": 117,
         "endpoint": 0,
         "property": "local",
-        "propertyName": "local",
-        "ccVersion": 2,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Local protection state",
-            "states": {"0": "Unprotected", "2": "NoOperationPossible"},
-        },
-        "value": 0,
     }
     assert args["value"] == 2
 
@@ -1170,22 +920,10 @@ async def test_set_value_string(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == lock_schlage_be469.node_id
     assert args["valueId"] == {
-        "commandClassName": "User Code",
         "commandClass": 99,
         "endpoint": 0,
         "property": "userCode",
-        "propertyName": "userCode",
         "propertyKey": 1,
-        "propertyKeyName": "1",
-        "metadata": {
-            "type": "string",
-            "readable": True,
-            "writeable": True,
-            "minLength": 4,
-            "maxLength": 10,
-            "label": "User Code (1)",
-        },
-        "value": "**********",
     }
     assert args["value"] == "12345"
 
@@ -1212,17 +950,7 @@ async def test_set_value_options(hass, client, aeon_smart_switch_6, integration)
     assert args["valueId"] == {
         "endpoint": 0,
         "commandClass": 37,
-        "commandClassName": "Binary Switch",
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "ccVersion": 1,
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-            "valueChangeOptions": ["transitionDuration"],
-        },
     }
     assert args["value"] == 2
     assert args["options"] == {"transitionDuration": 1}
@@ -1263,27 +991,10 @@ async def test_set_value_gather(
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
-        "commandClassName": "Configuration",
         "commandClass": 112,
         "endpoint": 0,
         "property": 102,
         "propertyKey": 1,
-        "propertyName": "Group 2: Send battery reports",
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "valueSize": 4,
-            "min": 0,
-            "max": 1,
-            "default": 1,
-            "format": 0,
-            "allowManualEntry": True,
-            "label": "Group 2: Send battery reports",
-            "description": "Include battery information in periodic reports to Group 2",
-            "isFromConfig": True,
-        },
-        "value": 0,
     }
     assert args["value"] == 1
 

--- a/tests/components/zwave_js/test_siren.py
+++ b/tests/components/zwave_js/test_siren.py
@@ -115,7 +115,11 @@ async def test_siren(hass, client, aeotec_zw164_siren, integration):
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == node.node_id
-    assert args["valueId"] == TONE_ID_VALUE_ID
+    assert args["valueId"] == {
+        "endpoint": 2,
+        "commandClass": 121,
+        "property": "toneId",
+    }
     assert args["value"] == 255
 
     client.async_send_command.reset_mock()
@@ -159,7 +163,11 @@ async def test_siren(hass, client, aeotec_zw164_siren, integration):
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == node.node_id
-    assert args["valueId"] == {**TONE_ID_VALUE_ID, "value": 255}
+    assert args["valueId"] == {
+        "endpoint": 2,
+        "commandClass": 121,
+        "property": "toneId",
+    }
     assert args["value"] == 1
     assert args["options"] == {"volume": 50}
 
@@ -181,7 +189,11 @@ async def test_siren(hass, client, aeotec_zw164_siren, integration):
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == node.node_id
-    assert args["valueId"] == {**TONE_ID_VALUE_ID, "value": 255}
+    assert args["valueId"] == {
+        "endpoint": 2,
+        "commandClass": 121,
+        "property": "toneId",
+    }
     assert args["value"] == 1
     assert args["options"] == {"volume": 50}
 
@@ -199,7 +211,11 @@ async def test_siren(hass, client, aeotec_zw164_siren, integration):
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == node.node_id
-    assert args["valueId"] == {**TONE_ID_VALUE_ID, "value": 255}
+    assert args["valueId"] == {
+        "endpoint": 2,
+        "commandClass": 121,
+        "property": "toneId",
+    }
     assert args["value"] == 0
 
     client.async_send_command.reset_mock()

--- a/tests/components/zwave_js/test_switch.py
+++ b/tests/components/zwave_js/test_switch.py
@@ -25,18 +25,9 @@ async def test_switch(hass, hank_binary_switch, integration, client):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 32
     assert args["valueId"] == {
-        "commandClassName": "Binary Switch",
         "commandClass": 37,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-        },
-        "value": False,
     }
     assert args["value"] is True
 
@@ -72,18 +63,9 @@ async def test_switch(hass, hank_binary_switch, integration, client):
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 32
     assert args["valueId"] == {
-        "commandClassName": "Binary Switch",
         "commandClass": 37,
         "endpoint": 0,
         "property": "targetValue",
-        "propertyName": "targetValue",
-        "metadata": {
-            "type": "boolean",
-            "readable": True,
-            "writeable": True,
-            "label": "Target value",
-        },
-        "value": False,
     }
     assert args["value"] is False
 
@@ -108,24 +90,10 @@ async def test_barrier_signaling_switch(hass, gdc_zw062, integration, client):
     assert args["nodeId"] == 12
     assert args["value"] == 0
     assert args["valueId"] == {
-        "ccVersion": 0,
         "commandClass": 102,
-        "commandClassName": "Barrier Operator",
         "endpoint": 0,
-        "metadata": {
-            "label": "Signaling State (Visual)",
-            "max": 255,
-            "min": 0,
-            "readable": True,
-            "states": {"0": "Off", "255": "On"},
-            "type": "number",
-            "writeable": True,
-        },
         "property": "signalingState",
         "propertyKey": 2,
-        "propertyKeyName": "2",
-        "propertyName": "signalingState",
-        "value": 255,
     }
 
     # state change is optimistic and writes state
@@ -149,24 +117,10 @@ async def test_barrier_signaling_switch(hass, gdc_zw062, integration, client):
     assert args["nodeId"] == 12
     assert args["value"] == 255
     assert args["valueId"] == {
-        "ccVersion": 0,
         "commandClass": 102,
-        "commandClassName": "Barrier Operator",
         "endpoint": 0,
-        "metadata": {
-            "label": "Signaling State (Visual)",
-            "max": 255,
-            "min": 0,
-            "readable": True,
-            "states": {"0": "Off", "255": "On"},
-            "type": "number",
-            "writeable": True,
-        },
         "property": "signalingState",
         "propertyKey": 2,
-        "propertyKeyName": "2",
-        "propertyName": "signalingState",
-        "value": 255,
     }
 
     # state change is optimistic and writes state


### PR DESCRIPTION
## Breaking change
You must use `zwave-js-server` 1.23.0 or greater (schema 23).

With this release, you will need to update your `zwave-js-server` instance.

- If you use the `zwave_js` addon, you need to have at least version 0.1.73.
- If you use the `zwavejs2mqtt` addon, you need to have at least version 1.0.1.
- If you use the `zwavejs2mqtt` Docker container, you need to have at least version 8.0.1.
- If you run your own Docker container, or some other installation method, you will need to update your `zwave-js-server` instance to at least 1.23.0.
## Proposed change
Changelog: https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.42.0

As part of this change we are adding a user agent so I thought it made sense to have a constant for the application name available to other consumers. We can get rid of this constant if it doesn't make sense.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
