### PR TITLE
Bump aiounifi to v35

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -9,8 +9,13 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_CONTROLLER, DOMAIN as UNIFI_DOMAIN, UNIFI_WIRELESS_CLIENTS
-from .controller import PLATFORMS, UniFiController, get_unifi_controller
+from .const import (
+    CONF_CONTROLLER,
+    DOMAIN as UNIFI_DOMAIN,
+    PLATFORMS,
+    UNIFI_WIRELESS_CLIENTS,
+)
+from .controller import UniFiController, get_unifi_controller
 from .errors import AuthenticationRequired, CannotConnect
 from .services import async_setup_services, async_unload_services
 

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -1,8 +1,18 @@
 """Constants for the UniFi Network integration."""
+
 import logging
+
+from homeassistant.const import Platform
 
 LOGGER = logging.getLogger(__package__)
 DOMAIN = "unifi"
+
+PLATFORMS = [
+    Platform.DEVICE_TRACKER,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.UPDATE,
+]
 
 CONF_CONTROLLER = "controller"
 CONF_SITE_ID = "site"

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -3,19 +3,8 @@
 from datetime import timedelta
 import logging
 
-from aiounifi.api import SOURCE_DATA, SOURCE_EVENT
-from aiounifi.events import (
-    ACCESS_POINT_UPGRADED,
-    GATEWAY_UPGRADED,
-    SWITCH_UPGRADED,
-    WIRED_CLIENT_CONNECTED,
-    WIRELESS_CLIENT_CONNECTED,
-    WIRELESS_CLIENT_ROAM,
-    WIRELESS_CLIENT_ROAMRADIO,
-    WIRELESS_GUEST_CONNECTED,
-    WIRELESS_GUEST_ROAM,
-    WIRELESS_GUEST_ROAMRADIO,
-)
+from aiounifi.interfaces.api_handlers import SOURCE_DATA, SOURCE_EVENT
+from aiounifi.models.event import EventKey
 
 from homeassistant.components.device_tracker import DOMAIN, SourceType
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
@@ -60,16 +49,14 @@ CLIENT_STATIC_ATTRIBUTES = [
 
 CLIENT_CONNECTED_ALL_ATTRIBUTES = CLIENT_CONNECTED_ATTRIBUTES + CLIENT_STATIC_ATTRIBUTES
 
-DEVICE_UPGRADED = (ACCESS_POINT_UPGRADED, GATEWAY_UPGRADED, SWITCH_UPGRADED)
-
-WIRED_CONNECTION = (WIRED_CLIENT_CONNECTED,)
+WIRED_CONNECTION = (EventKey.WIRED_CLIENT_CONNECTED,)
 WIRELESS_CONNECTION = (
-    WIRELESS_CLIENT_CONNECTED,
-    WIRELESS_CLIENT_ROAM,
-    WIRELESS_CLIENT_ROAMRADIO,
-    WIRELESS_GUEST_CONNECTED,
-    WIRELESS_GUEST_ROAM,
-    WIRELESS_GUEST_ROAMRADIO,
+    EventKey.WIRELESS_CLIENT_CONNECTED,
+    EventKey.WIRELESS_CLIENT_ROAM,
+    EventKey.WIRELESS_CLIENT_ROAMRADIO,
+    EventKey.WIRELESS_GUEST_CONNECTED,
+    EventKey.WIRELESS_GUEST_ROAM,
+    EventKey.WIRELESS_GUEST_ROAMRADIO,
 )
 
 
@@ -233,8 +220,8 @@ class UniFiClientTracker(UniFiClientBase, ScannerEntity):
             and not self._only_listen_to_data_source
         ):
 
-            if (self.is_wired and self.client.event.event in WIRED_CONNECTION) or (
-                not self.is_wired and self.client.event.event in WIRELESS_CONNECTION
+            if (self.is_wired and self.client.event.key in WIRED_CONNECTION) or (
+                not self.is_wired and self.client.event.key in WIRELESS_CONNECTION
             ):
                 self._is_connected = True
                 self.schedule_update = False

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -3,7 +3,7 @@
   "name": "UniFi Network",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
-  "requirements": ["aiounifi==34"],
+  "requirements": ["aiounifi==35"],
   "codeowners": ["@Kane610"],
   "quality_scale": "platinum",
   "ssdp": [

--- a/homeassistant/components/unifi/services.py
+++ b/homeassistant/components/unifi/services.py
@@ -1,5 +1,6 @@
 """UniFi Network services."""
 
+from aiounifi.models.client import ClientReconnectRequest, ClientRemoveRequest
 import voluptuous as vol
 
 from homeassistant.const import ATTR_DEVICE_ID
@@ -77,7 +78,7 @@ async def async_reconnect_client(hass, data) -> None:
         ):
             continue
 
-        await controller.api.clients.reconnect(mac)
+        await controller.api.request(ClientReconnectRequest.create(mac))
 
 
 async def async_remove_clients(hass, data) -> None:
@@ -109,4 +110,4 @@ async def async_remove_clients(hass, data) -> None:
             clients_to_remove.append(client.mac)
 
         if clients_to_remove:
-            await controller.api.clients.remove_clients(macs=clients_to_remove)
+            await controller.api.request(ClientRemoveRequest.create(clients_to_remove))

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -8,13 +8,8 @@ Support for controlling deep packet inspection (DPI) restriction groups.
 import asyncio
 from typing import Any
 
-from aiounifi.api import SOURCE_EVENT
-from aiounifi.events import (
-    WIRED_CLIENT_BLOCKED,
-    WIRED_CLIENT_UNBLOCKED,
-    WIRELESS_CLIENT_BLOCKED,
-    WIRELESS_CLIENT_UNBLOCKED,
-)
+from aiounifi.interfaces.api_handlers import SOURCE_EVENT
+from aiounifi.models.event import EventKey
 
 from homeassistant.components.switch import DOMAIN, SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -39,8 +34,8 @@ DPI_SWITCH = "dpi"
 POE_SWITCH = "poe"
 OUTLET_SWITCH = "outlet"
 
-CLIENT_BLOCKED = (WIRED_CLIENT_BLOCKED, WIRELESS_CLIENT_BLOCKED)
-CLIENT_UNBLOCKED = (WIRED_CLIENT_UNBLOCKED, WIRELESS_CLIENT_UNBLOCKED)
+CLIENT_BLOCKED = (EventKey.WIRED_CLIENT_BLOCKED, EventKey.WIRELESS_CLIENT_BLOCKED)
+CLIENT_UNBLOCKED = (EventKey.WIRED_CLIENT_UNBLOCKED, EventKey.WIRELESS_CLIENT_UNBLOCKED)
 
 
 async def async_setup_entry(
@@ -324,9 +319,9 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchEntity):
         """Update the clients state."""
         if (
             self.client.last_updated == SOURCE_EVENT
-            and self.client.event.event in CLIENT_BLOCKED + CLIENT_UNBLOCKED
+            and self.client.event.key in CLIENT_BLOCKED + CLIENT_UNBLOCKED
         ):
-            self._is_blocked = self.client.event.event in CLIENT_BLOCKED
+            self._is_blocked = self.client.event.key in CLIENT_BLOCKED
 
         super().async_update_callback()
 

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from aiounifi.models.device import DeviceUpgradeRequest
+
 from homeassistant.components.update import (
     DOMAIN,
     UpdateDeviceClass,
@@ -136,4 +138,4 @@ class UniFiDeviceUpdateEntity(UniFiBase, UpdateEntity):
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
-        await self.controller.api.devices.upgrade(self.device.mac)
+        await self.controller.api.request(DeviceUpgradeRequest.create(self.device.mac))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -272,7 +272,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.4
 
 # homeassistant.components.unifi
-aiounifi==34
+aiounifi==35
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -247,7 +247,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.4
 
 # homeassistant.components.unifi
-aiounifi==34
+aiounifi==35
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -25,13 +25,10 @@ from homeassistant.components.unifi.const import (
     DEFAULT_TRACK_DEVICES,
     DEFAULT_TRACK_WIRED_CLIENTS,
     DOMAIN as UNIFI_DOMAIN,
+    PLATFORMS,
     UNIFI_WIRELESS_CLIENTS,
 )
-from homeassistant.components.unifi.controller import (
-    PLATFORMS,
-    RETRY_TIMER,
-    get_unifi_controller,
-)
+from homeassistant.components.unifi.controller import RETRY_TIMER, get_unifi_controller
 from homeassistant.components.unifi.errors import AuthenticationRequired, CannotConnect
 from homeassistant.const import (
     CONF_HOST,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/Kane610/aiounifi/compare/v34...v35
No functional changes in this PR but prepares for future changes
* Move some imports
* Change some constants to enums
* Change how requests are done


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #77864
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
