### PR TITLE
Add ability to bypass checks in unit conversion

### DIFF
--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -215,7 +215,10 @@ def _normalize_states(
         fstates.append(
             (
                 converter.convert(
-                    fstate, from_unit=state_unit, to_unit=converter.NORMALIZED_UNIT
+                    fstate,
+                    from_unit=state_unit,
+                    to_unit=converter.NORMALIZED_UNIT,
+                    bypass_checks=True,
                 ),
                 state,
             )

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -95,7 +95,9 @@ class BaseUnitConverter:
 
     @classmethod
     @abstractmethod
-    def convert(cls, value: float, from_unit: str, to_unit: str) -> float:
+    def convert(
+        cls, value: float, from_unit: str, to_unit: str, *, bypass_checks: bool = False
+    ) -> float:
         """Convert one unit of measurement to another."""
 
 
@@ -105,9 +107,12 @@ class BaseUnitConverterWithUnitConversion(BaseUnitConverter):
     UNIT_CONVERSION: dict[str, float]
 
     @classmethod
-    def convert(cls, value: float, from_unit: str, to_unit: str) -> float:
+    def convert(
+        cls, value: float, from_unit: str, to_unit: str, *, bypass_checks: bool = False
+    ) -> float:
         """Convert one unit of measurement to another."""
-        cls._check_arguments(value, from_unit, to_unit)
+        if not bypass_checks:
+            cls._check_arguments(value, from_unit, to_unit)
 
         if from_unit == to_unit:
             return value
@@ -244,10 +249,17 @@ class TemperatureConverter(BaseUnitConverter):
 
     @classmethod
     def convert(
-        cls, value: float, from_unit: str, to_unit: str, *, interval: bool = False
+        cls,
+        value: float,
+        from_unit: str,
+        to_unit: str,
+        *,
+        bypass_checks: bool = False,
+        interval: bool = False,
     ) -> float:
         """Convert a temperature from one unit to another."""
-        cls._check_arguments(value, from_unit, to_unit)
+        if not bypass_checks:
+            cls._check_arguments(value, from_unit, to_unit)
 
         if from_unit == to_unit:
             return value


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add ability to bypass checks in unit conversion

This is an optional follow-up to #78985
This version restores the previous behavior and bypasses number and unit validation.

The original discussion is in https://github.com/home-assistant/core/pull/78985#discussion_r978581777

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
