### PR TITLE
Add support for `WetDry`, `WindHeading`, and `Flex` fields in LaCrosse View

### DIFF
--- a/homeassistant/components/lacrosse_view/sensor.py
+++ b/homeassistant/components/lacrosse_view/sensor.py
@@ -50,8 +50,8 @@ def get_value(sensor: Sensor, field: str) -> float | int | str:
     try:
         value = float(value)
     except ValueError:
-        return str(value)  # str
-    return int(value) if value.is_integer() else value  # int, else float
+        return str(value)  # handle non-numericals
+    return int(value) if value.is_integer() else value
 
 
 PARALLEL_UPDATES = 0
@@ -95,17 +95,6 @@ SENSOR_DESCRIPTIONS = {
         value_fn=get_value,
         native_unit_of_measurement=UnitOfPrecipitationDepth.INCHES,
         device_class=SensorDeviceClass.PRECIPITATION,
-    ),
-    "WindHeading": LaCrosseSensorEntityDescription(
-        key="WindHeading",
-        name="Wind heading",
-        value_fn=get_value,
-        native_unit_of_measurement=DEGREE,
-    ),
-    "WetDry": LaCrosseSensorEntityDescription(
-        key="WetDry",
-        name="Wet/Dry",
-        value_fn=get_value,
     ),
     "WindHeading": LaCrosseSensorEntityDescription(
         key="WindHeading",

--- a/homeassistant/components/lacrosse_view/sensor.py
+++ b/homeassistant/components/lacrosse_view/sensor.py
@@ -47,6 +47,12 @@ class LaCrosseSensorEntityDescription(
 def get_value(sensor: Sensor, field: str) -> float | int | str:
     """Get the value of a sensor field."""
     value = sensor.data[field]["values"][-1]["s"]
+    # Check if it is already a float or int
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return value
+
     if (value.find("-") <= 0) and value.replace(
         "-", "", 1
     ).isdigit():  # Check if int, then return int

--- a/homeassistant/components/lacrosse_view/sensor.py
+++ b/homeassistant/components/lacrosse_view/sensor.py
@@ -115,6 +115,17 @@ SENSOR_DESCRIPTIONS = {
         name="Wet/Dry",
         value_fn=get_value,
     ),
+    "WindHeading": LaCrosseSensorEntityDescription(
+        key="WindHeading",
+        name="Wind heading",
+        value_fn=get_value,
+        native_unit_of_measurement=DEGREE,
+    ),
+    "WetDry": LaCrosseSensorEntityDescription(
+        key="WetDry",
+        name="Wet/Dry",
+        value_fn=get_value,
+    ),
 }
 
 

--- a/homeassistant/components/lacrosse_view/sensor.py
+++ b/homeassistant/components/lacrosse_view/sensor.py
@@ -47,25 +47,11 @@ class LaCrosseSensorEntityDescription(
 def get_value(sensor: Sensor, field: str) -> float | int | str:
     """Get the value of a sensor field."""
     value = sensor.data[field]["values"][-1]["s"]
-    # Check if it is already a float or int
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return value
-
-    if (value.find("-") <= 0) and value.replace(
-        "-", "", 1
-    ).isdigit():  # Check if int, then return int
-        return int(value)
-    if (
-        (value.find("-") <= 0)
-        and (value.count(".") < 2)
-        and (value.replace("-", "", 1).replace(".", "", 1).isdigit())
-    ):  # Check if float, then return float
-        return float(value)
-
-    # Return string value of field
-    return str(value)
+    try:
+        value = float(value)
+    except ValueError:
+        return str(value)  # str
+    return int(value) if value.is_integer() else value  # int, else float
 
 
 PARALLEL_UPDATES = 0

--- a/homeassistant/components/lacrosse_view/sensor.py
+++ b/homeassistant/components/lacrosse_view/sensor.py
@@ -118,6 +118,11 @@ SENSOR_DESCRIPTIONS = {
         name="Wet/Dry",
         value_fn=get_value,
     ),
+    "Flex": LaCrosseSensorEntityDescription(
+        key="Flex",
+        name="Flex",
+        value_fn=get_value,
+    ),
 }
 
 

--- a/tests/components/lacrosse_view/__init__.py
+++ b/tests/components/lacrosse_view/__init__.py
@@ -41,3 +41,25 @@ TEST_UNSUPPORTED_SENSOR = Sensor(
     permissions={"read": True},
     model="Test",
 )
+TEST_FLOAT_SENSOR = Sensor(
+    name="Test",
+    device_id="1",
+    type="Test",
+    sensor_id="2",
+    sensor_field_names=["Temperature"],
+    location=Location(id="1", name="Test"),
+    data={"Temperature": {"values": [{"s": "2.3"}], "unit": "degrees_celsius"}},
+    permissions={"read": True},
+    model="Test",
+)
+TEST_STRING_SENSOR = Sensor(
+    name="Test",
+    device_id="1",
+    type="Test",
+    sensor_id="2",
+    sensor_field_names=["WetDry"],
+    location=Location(id="1", name="Test"),
+    data={"WetDry": {"values": [{"s": "dry"}], "unit": "wet_dry"}},
+    permissions={"read": True},
+    model="Test",
+)

--- a/tests/components/lacrosse_view/__init__.py
+++ b/tests/components/lacrosse_view/__init__.py
@@ -63,3 +63,25 @@ TEST_STRING_SENSOR = Sensor(
     permissions={"read": True},
     model="Test",
 )
+TEST_ALREADY_FLOAT_SENSOR = Sensor(
+    name="Test",
+    device_id="1",
+    type="Test",
+    sensor_id="2",
+    sensor_field_names=["HeatIndex"],
+    location=Location(id="1", name="Test"),
+    data={"HeatIndex": {"values": [{"s": 2.3}], "unit": "degrees_celsius"}},
+    permissions={"read": True},
+    model="Test",
+)
+TEST_ALREADY_INT_SENSOR = Sensor(
+    name="Test",
+    device_id="1",
+    type="Test",
+    sensor_id="2",
+    sensor_field_names=["WindSpeed"],
+    location=Location(id="1", name="Test"),
+    data={"WindSpeed": {"values": [{"s": 2}], "unit": "degrees_celsius"}},
+    permissions={"read": True},
+    model="Test",
+)

--- a/tests/components/lacrosse_view/__init__.py
+++ b/tests/components/lacrosse_view/__init__.py
@@ -85,3 +85,14 @@ TEST_ALREADY_INT_SENSOR = Sensor(
     permissions={"read": True},
     model="Test",
 )
+TEST_NO_FIELD_SENSOR = Sensor(
+    name="Test",
+    device_id="1",
+    type="Test",
+    sensor_id="2",
+    sensor_field_names=["Temperature"],
+    location=Location(id="1", name="Test"),
+    data={},
+    permissions={"read": True},
+    model="Test",
+)

--- a/tests/components/lacrosse_view/test_sensor.py
+++ b/tests/components/lacrosse_view/test_sensor.py
@@ -14,6 +14,7 @@ from . import (
     TEST_ALREADY_FLOAT_SENSOR,
     TEST_ALREADY_INT_SENSOR,
     TEST_FLOAT_SENSOR,
+    TEST_NO_FIELD_SENSOR,
     TEST_NO_PERMISSION_SENSOR,
     TEST_SENSOR,
     TEST_STRING_SENSOR,
@@ -110,3 +111,24 @@ async def test_field_types(
     assert len(entries) == 1
     assert entries[0].state == ConfigEntryState.LOADED
     assert hass.states.get(f"sensor.test_{entity_id}").state == expected
+
+
+async def test_no_field(hass: HomeAssistant, caplog: Any) -> None:
+    """Test behavior when the expected field is not present."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRY_DATA)
+    config_entry.add_to_hass(hass)
+
+    with patch("lacrosse_view.LaCrosse.login", return_value=True), patch(
+        "lacrosse_view.LaCrosse.get_sensors",
+        return_value=[TEST_NO_FIELD_SENSOR],
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.data[DOMAIN]
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert entries
+    assert len(entries) == 1
+    assert entries[0].state == ConfigEntryState.LOADED
+    assert hass.states.get("sensor.test_temperature").state == "unknown"
+    assert "No field Temperature in response for Test (Test)" in caplog.text

--- a/tests/components/lacrosse_view/test_sensor.py
+++ b/tests/components/lacrosse_view/test_sensor.py
@@ -1,5 +1,9 @@
 """Test the LaCrosse View sensors."""
+from typing import Any
 from unittest.mock import patch
+
+from lacrosse_view import Sensor
+import pytest
 
 from homeassistant.components.lacrosse_view import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -77,19 +81,25 @@ async def test_field_not_supported(hass: HomeAssistant, caplog) -> None:
     assert "Unsupported sensor field" in caplog.text
 
 
-async def test_field_types(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "test_input,expected,entity_id",
+    [
+        (TEST_FLOAT_SENSOR, "2.3", "temperature"),
+        (TEST_STRING_SENSOR, "dry", "wet_dry"),
+        (TEST_ALREADY_FLOAT_SENSOR, "-16.5", "heat_index"),
+        (TEST_ALREADY_INT_SENSOR, "2", "wind_speed"),
+    ],
+)
+async def test_field_types(
+    hass: HomeAssistant, test_input: Sensor, expected: Any, entity_id: str
+) -> None:
     """Test the different data types for fields."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRY_DATA)
     config_entry.add_to_hass(hass)
 
     with patch("lacrosse_view.LaCrosse.login", return_value=True), patch(
         "lacrosse_view.LaCrosse.get_sensors",
-        return_value=[
-            TEST_FLOAT_SENSOR,
-            TEST_STRING_SENSOR,
-            TEST_ALREADY_FLOAT_SENSOR,
-            TEST_ALREADY_INT_SENSOR,
-        ],
+        return_value=[test_input],
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -99,7 +109,4 @@ async def test_field_types(hass: HomeAssistant) -> None:
     assert entries
     assert len(entries) == 1
     assert entries[0].state == ConfigEntryState.LOADED
-    assert hass.states.get("sensor.test_temperature")
-    assert hass.states.get("sensor.test_wet_dry")
-    assert hass.states.get("sensor.test_wind_speed")
-    assert hass.states.get("sensor.test_heat_index")
+    assert hass.states.get(f"sensor.test_{entity_id}").state == expected

--- a/tests/components/lacrosse_view/test_sensor.py
+++ b/tests/components/lacrosse_view/test_sensor.py
@@ -7,6 +7,8 @@ from homeassistant.core import HomeAssistant
 
 from . import (
     MOCK_ENTRY_DATA,
+    TEST_ALREADY_FLOAT_SENSOR,
+    TEST_ALREADY_INT_SENSOR,
     TEST_FLOAT_SENSOR,
     TEST_NO_PERMISSION_SENSOR,
     TEST_SENSOR,
@@ -82,7 +84,12 @@ async def test_field_types(hass: HomeAssistant) -> None:
 
     with patch("lacrosse_view.LaCrosse.login", return_value=True), patch(
         "lacrosse_view.LaCrosse.get_sensors",
-        return_value=[TEST_FLOAT_SENSOR, TEST_STRING_SENSOR],
+        return_value=[
+            TEST_FLOAT_SENSOR,
+            TEST_STRING_SENSOR,
+            TEST_ALREADY_FLOAT_SENSOR,
+            TEST_ALREADY_INT_SENSOR,
+        ],
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -94,3 +101,5 @@ async def test_field_types(hass: HomeAssistant) -> None:
     assert entries[0].state == ConfigEntryState.LOADED
     assert hass.states.get("sensor.test_temperature")
     assert hass.states.get("sensor.test_wet_dry")
+    assert hass.states.get("sensor.test_wind_speed")
+    assert hass.states.get("sensor.test_heat_index")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for new fields `WetDry`, `WindHeading`, and `Flex` in LaCrosse View

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #78006 and fixes #79529
(79529 was closed because it was stale :/ )
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
