### PR TITLE
Add support for newer Magic Home sockets

### DIFF
--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -58,7 +58,12 @@ PLATFORMS_BY_TYPE: Final = {
         Platform.SENSOR,
         Platform.SWITCH,
     ],
-    DeviceType.Switch: [Platform.BUTTON, Platform.SELECT, Platform.SWITCH],
+    DeviceType.Switch: [
+        Platform.BUTTON,
+        Platform.SELECT,
+        Platform.SENSOR,
+        Platform.SWITCH,
+    ],
 }
 DISCOVERY_INTERVAL: Final = timedelta(minutes=15)
 REQUEST_REFRESH_DELAY: Final = 1.5

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -185,6 +185,7 @@ def _mocked_switch() -> AIOWifiLedBulb:
     switch.ic_types = None
     switch.ic_type = None
     switch.requires_turn_on = True
+    switch.async_config_remotes = AsyncMock()
     switch.async_unpair_remotes = AsyncMock()
     switch.async_set_time = AsyncMock()
     switch.async_reboot = AsyncMock()

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -175,6 +175,8 @@ def _mocked_switch() -> AIOWifiLedBulb:
     switch.pixels_per_segment = None
     switch.segments = None
     switch.music_pixels_per_segment = None
+    switch.paired_remotes = 2
+    switch.remote_config = RemoteConfig.OPEN
     switch.music_segments = None
     switch.operating_mode = None
     switch.operating_modes = None
@@ -183,6 +185,7 @@ def _mocked_switch() -> AIOWifiLedBulb:
     switch.ic_types = None
     switch.ic_type = None
     switch.requires_turn_on = True
+    switch.async_unpair_remotes = AsyncMock()
     switch.async_set_time = AsyncMock()
     switch.async_reboot = AsyncMock()
     switch.async_setup = AsyncMock(side_effect=_save_setup_callback)

--- a/tests/components/flux_led/test_button.py
+++ b/tests/components/flux_led/test_button.py
@@ -44,8 +44,8 @@ async def test_button_reboot(hass: HomeAssistant) -> None:
     switch.async_reboot.assert_called_once()
 
 
-async def test_button_unpair_remotes(hass: HomeAssistant) -> None:
-    """Test that remotes can be unpaired."""
+async def test_button_unpair_remotes_bulb(hass: HomeAssistant) -> None:
+    """Test that remotes can be unpaired from a bulb."""
     _mock_config_entry_for_bulb(hass)
     bulb = _mocked_bulb()
     bulb.discovery = FLUX_DISCOVERY
@@ -60,3 +60,21 @@ async def test_button_unpair_remotes(hass: HomeAssistant) -> None:
         BUTTON_DOMAIN, "press", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
     bulb.async_unpair_remotes.assert_called_once()
+
+
+async def test_button_unpair_remotes_smart_switch(hass: HomeAssistant) -> None:
+    """Test that remotes can be unpaired from a smart switch."""
+    _mock_config_entry_for_bulb(hass)
+    switch = _mocked_switch()
+    switch.discovery = FLUX_DISCOVERY
+    with _patch_discovery(device=FLUX_DISCOVERY), _patch_wifibulb(device=switch):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "button.bulb_rgbcw_ddeeff_unpair_remotes"
+    assert hass.states.get(entity_id)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN, "press", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    switch.async_unpair_remotes.assert_called_once()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hardware: AK001-ZJ21410 has a remote sensor. The rest of the remote configuration already works with no changes.

No docs changes since this is just a newer revision of an existing device with 2.4ghz remote support.  Some of the newer devices already have hardware support for it but shipped with older firmware and can be upgraded from firmware 3.12 to 3.22.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
