### PR TITLE
Improve performance of Bluetooth device fallback

### DIFF
--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -235,6 +235,23 @@ class BluetoothManager:
             self._cancel_unavailable_tracking.clear()
         uninstall_multiple_bleak_catcher()
 
+    async def async_get_devices_by_address(
+        self, address: str, connectable: bool
+    ) -> list[BLEDevice]:
+        """Get devices by address."""
+        types_ = (True,) if connectable else (True, False)
+        return [
+            device
+            for device in await asyncio.gather(
+                *(
+                    scanner.async_get_device_by_address(address)
+                    for type_ in types_
+                    for scanner in self._get_scanners_by_type(type_)
+                )
+            )
+            if device is not None
+        ]
+
     @hass_callback
     def async_all_discovered_devices(self, connectable: bool) -> Iterable[BLEDevice]:
         """Return all of discovered devices from all the scanners including duplicates."""

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -8,7 +8,7 @@
   "requirements": [
     "bleak==0.18.1",
     "bleak-retry-connector==2.1.0",
-    "bluetooth-adapters==0.5.1",
+    "bluetooth-adapters==0.5.2",
     "bluetooth-auto-recovery==0.3.3",
     "dbus-fast==1.14.0"
   ],

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -6,8 +6,8 @@
   "after_dependencies": ["hassio"],
   "quality_scale": "internal",
   "requirements": [
-    "bleak==0.18.0",
-    "bleak-retry-connector==2.0.2",
+    "bleak==0.18.1",
+    "bleak-retry-connector==2.1.0",
     "bluetooth-adapters==0.5.1",
     "bluetooth-auto-recovery==0.3.3",
     "dbus-fast==1.14.0"

--- a/homeassistant/components/bluetooth/usage.py
+++ b/homeassistant/components/bluetooth/usage.py
@@ -13,7 +13,7 @@ ORIGINAL_BLEAK_CLIENT = bleak.BleakClient
 def install_multiple_bleak_catcher() -> None:
     """Wrap the bleak classes to return the shared instance if multiple instances are detected."""
     bleak.BleakScanner = HaBleakScannerWrapper  # type: ignore[misc, assignment]
-    bleak.BleakClient = HaBleakClientWrapper  # type: ignore[misc, assignment]
+    bleak.BleakClient = HaBleakClientWrapper  # type: ignore[misc]
 
 
 def uninstall_multiple_bleak_catcher() -> None:

--- a/homeassistant/components/esphome/bluetooth.py
+++ b/homeassistant/components/esphome/bluetooth.py
@@ -1,4 +1,5 @@
 """Bluetooth scanner for esphome."""
+from __future__ import annotations
 
 from collections.abc import Callable
 import datetime
@@ -76,6 +77,10 @@ class ESPHomeScannner(BaseHaScanner):
     def discovered_devices(self) -> list[BLEDevice]:
         """Return a list of discovered devices."""
         return list(self._discovered_devices.values())
+
+    async def async_get_device_by_address(self, address: str) -> BLEDevice | None:
+        """Get a device by address."""
+        return self._discovered_devices.get(address)
 
     @callback
     def async_on_advertisement(self, adv: BluetoothLEAdvertisement) -> None:

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -10,8 +10,8 @@ atomicwrites-homeassistant==1.4.1
 attrs==21.2.0
 awesomeversion==22.9.0
 bcrypt==3.1.7
-bleak-retry-connector==2.0.2
-bleak==0.18.0
+bleak-retry-connector==2.1.0
+bleak==0.18.1
 bluetooth-adapters==0.5.1
 bluetooth-auto-recovery==0.3.3
 certifi>=2021.5.30

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -12,7 +12,7 @@ awesomeversion==22.9.0
 bcrypt==3.1.7
 bleak-retry-connector==2.1.0
 bleak==0.18.1
-bluetooth-adapters==0.5.1
+bluetooth-adapters==0.5.2
 bluetooth-auto-recovery==0.3.3
 certifi>=2021.5.30
 ciso8601==2.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -410,10 +410,10 @@ bimmer_connected==0.10.4
 bizkaibus==0.1.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.0.2
+bleak-retry-connector==2.1.0
 
 # homeassistant.components.bluetooth
-bleak==0.18.0
+bleak==0.18.1
 
 # homeassistant.components.blebox
 blebox_uniapi==2.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -435,7 +435,7 @@ bluemaestro-ble==0.2.0
 # bluepy==1.3.0
 
 # homeassistant.components.bluetooth
-bluetooth-adapters==0.5.1
+bluetooth-adapters==0.5.2
 
 # homeassistant.components.bluetooth
 bluetooth-auto-recovery==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -346,7 +346,7 @@ blinkpy==0.19.2
 bluemaestro-ble==0.2.0
 
 # homeassistant.components.bluetooth
-bluetooth-adapters==0.5.1
+bluetooth-adapters==0.5.2
 
 # homeassistant.components.bluetooth
 bluetooth-auto-recovery==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -331,10 +331,10 @@ bellows==0.33.1
 bimmer_connected==0.10.4
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.0.2
+bleak-retry-connector==2.1.0
 
 # homeassistant.components.bluetooth
-bleak==0.18.0
+bleak==0.18.1
 
 # homeassistant.components.blebox
 blebox_uniapi==2.0.2

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -297,9 +297,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
     ]
 
     client = HaBleakClientWrapper(switchbot_proxy_device_no_connection_slot)
-    with patch(
-        "homeassistant.components.bluetooth.models.get_platform_client_backend_type"
-    ):
+    with patch("bleak.get_platform_client_backend_type"):
         await client.connect()
     assert client.is_connected is True
     client.set_disconnected_callback(lambda client: None)

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -296,8 +296,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
     ]
 
     client = HaBleakClientWrapper(switchbot_proxy_device_no_connection_slot)
-    with patch("bleak.backends.corebluetooth.client.BleakClientCoreBluetooth.connect"):
-        await client.connect()
+    await client.connect()
     assert client.is_connected is True
     client.set_disconnected_callback(lambda client: None)
     await client.disconnect()

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -297,7 +297,10 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
     ]
 
     client = HaBleakClientWrapper(switchbot_proxy_device_no_connection_slot)
-    await client.connect()
+    with patch(
+        "homeassistant.components.bluetooth.models.get_platform_client_backend_type"
+    ):
+        await client.connect()
     assert client.is_connected is True
     client.set_disconnected_callback(lambda client: None)
     await client.disconnect()

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -1,4 +1,5 @@
 """Tests for the Bluetooth integration models."""
+from __future__ import annotations
 
 from unittest.mock import patch
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If the backend is offline or has reached the connection limit we need to fail over to a backend that can still reach the device.

We used to have to do a linear search of all discovered devices but we now have a way to find the BLEDevice by address with the latest bleak-retry-connector

changelogs: https://github.com/Bluetooth-Devices/bleak-retry-connector/compare/v2.0.2...v2.1.0 https://github.com/hbldh/bleak/compare/v0.18.0...v0.18.1 https://github.com/Bluetooth-Devices/bluetooth-adapters/compare/v0.5.1..v0.5.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
