### PR TITLE
Adjust switch as X to inherit entity category

### DIFF
--- a/homeassistant/components/switch_as_x/cover.py
+++ b/homeassistant/components/switch_as_x/cover.py
@@ -32,6 +32,7 @@ async def async_setup_entry(
     )
     wrapped_switch = registry.async_get(entity_id)
     device_id = wrapped_switch.device_id if wrapped_switch else None
+    entity_category = wrapped_switch.entity_category if wrapped_switch else None
 
     async_add_entities(
         [
@@ -40,6 +41,7 @@ async def async_setup_entry(
                 entity_id,
                 config_entry.entry_id,
                 device_id,
+                entity_category,
             )
         ]
     )

--- a/homeassistant/components/switch_as_x/entity.py
+++ b/homeassistant/components/switch_as_x/entity.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, callback
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity import Entity, ToggleEntity
+from homeassistant.helpers.entity import Entity, EntityCategory, ToggleEntity
 from homeassistant.helpers.event import async_track_state_change_event
 
 
@@ -28,9 +28,11 @@ class BaseEntity(Entity):
         switch_entity_id: str,
         unique_id: str | None,
         device_id: str | None = None,
+        entity_category: EntityCategory | None = None,
     ) -> None:
         """Initialize Light Switch."""
         self._device_id = device_id
+        self._attr_entity_category = entity_category
         self._attr_name = name
         self._attr_unique_id = unique_id
         self._switch_entity_id = switch_entity_id

--- a/homeassistant/components/switch_as_x/fan.py
+++ b/homeassistant/components/switch_as_x/fan.py
@@ -25,6 +25,7 @@ async def async_setup_entry(
     )
     wrapped_switch = registry.async_get(entity_id)
     device_id = wrapped_switch.device_id if wrapped_switch else None
+    entity_category = wrapped_switch.entity_category if wrapped_switch else None
 
     async_add_entities(
         [
@@ -33,6 +34,7 @@ async def async_setup_entry(
                 entity_id,
                 config_entry.entry_id,
                 device_id,
+                entity_category,
             )
         ]
     )

--- a/homeassistant/components/switch_as_x/light.py
+++ b/homeassistant/components/switch_as_x/light.py
@@ -23,6 +23,7 @@ async def async_setup_entry(
     )
     wrapped_switch = registry.async_get(entity_id)
     device_id = wrapped_switch.device_id if wrapped_switch else None
+    entity_category = wrapped_switch.entity_category if wrapped_switch else None
 
     async_add_entities(
         [
@@ -31,6 +32,7 @@ async def async_setup_entry(
                 entity_id,
                 config_entry.entry_id,
                 device_id,
+                entity_category,
             )
         ]
     )

--- a/homeassistant/components/switch_as_x/lock.py
+++ b/homeassistant/components/switch_as_x/lock.py
@@ -32,6 +32,7 @@ async def async_setup_entry(
     )
     wrapped_switch = registry.async_get(entity_id)
     device_id = wrapped_switch.device_id if wrapped_switch else None
+    entity_category = wrapped_switch.entity_category if wrapped_switch else None
 
     async_add_entities(
         [
@@ -40,6 +41,7 @@ async def async_setup_entry(
                 entity_id,
                 config_entry.entry_id,
                 device_id,
+                entity_category,
             )
         ]
     )

--- a/homeassistant/components/switch_as_x/siren.py
+++ b/homeassistant/components/switch_as_x/siren.py
@@ -23,6 +23,7 @@ async def async_setup_entry(
     )
     wrapped_switch = registry.async_get(entity_id)
     device_id = wrapped_switch.device_id if wrapped_switch else None
+    entity_category = wrapped_switch.entity_category if wrapped_switch else None
 
     async_add_entities(
         [
@@ -31,6 +32,7 @@ async def async_setup_entry(
                 entity_id,
                 config_entry.entry_id,
                 device_id,
+                entity_category,
             )
         ]
     )

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity import EntityCategory
 
 from tests.common import MockConfigEntry
 
@@ -403,3 +404,37 @@ async def test_reset_hidden_by(
     # Check hidden by is reset
     switch_entity_entry = registry.async_get(switch_entity_entry.entity_id)
     assert switch_entity_entry.hidden_by == hidden_by_after
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_entity_category_inheritance(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test the entity category is inherited from source device."""
+    registry = er.async_get(hass)
+
+    switch_entity_entry = registry.async_get_or_create("switch", "test", "unique")
+    registry.async_update_entity(
+        switch_entity_entry.entity_id, entity_category=EntityCategory.CONFIG
+    )
+
+    # Add the config entry
+    switch_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+    )
+    switch_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_entry = registry.async_get(f"{target_domain}.abc")
+    assert entity_entry
+    assert entity_entry.device_id == switch_entity_entry.device_id
+    assert entity_entry.entity_category is EntityCategory.CONFIG


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a `switch` entity is transformed to another entity using `switch_as_x`, it should inherit the entity category from the source entity.

This PR adds this behavior.

This prevents a secondary configuration entity (e.g., display backlight switch) to become a primary entity when the type is changed/wrapped.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
