### PR TITLE
Add unique ID to dsmr_reader sensors

### DIFF
--- a/homeassistant/components/dsmr_reader/sensor.py
+++ b/homeassistant/components/dsmr_reader/sensor.py
@@ -59,6 +59,7 @@ class DSMRSensor(SensorEntity):
 
         slug = slugify(description.key.replace("/", "_"))
         self.entity_id = f"sensor.{slug}"
+        self._attr_unique_id = slug
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""

--- a/homeassistant/components/dsmr_reader/sensor.py
+++ b/homeassistant/components/dsmr_reader/sensor.py
@@ -45,7 +45,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up DSMR Reader sensors from config entry."""
-    async_add_entities(DSMRSensor(description) for description in SENSORS)
+    async_add_entities(DSMRSensor(description, config) for description in SENSORS)
 
 
 class DSMRSensor(SensorEntity):
@@ -53,13 +53,15 @@ class DSMRSensor(SensorEntity):
 
     entity_description: DSMRReaderSensorEntityDescription
 
-    def __init__(self, description: DSMRReaderSensorEntityDescription) -> None:
+    def __init__(
+        self, description: DSMRReaderSensorEntityDescription, config: ConfigEntry
+    ) -> None:
         """Initialize the sensor."""
         self.entity_description = description
 
         slug = slugify(description.key.replace("/", "_"))
         self.entity_id = f"sensor.{slug}"
-        self._attr_unique_id = slug
+        self._attr_unique_id = f"{config.entry_id}-{slug}"
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""

--- a/homeassistant/components/dsmr_reader/sensor.py
+++ b/homeassistant/components/dsmr_reader/sensor.py
@@ -40,12 +40,12 @@ async def async_setup_platform(
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    config: ConfigEntry,
+    _: HomeAssistant,
+    config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up DSMR Reader sensors from config entry."""
-    async_add_entities(DSMRSensor(description, config) for description in SENSORS)
+    async_add_entities(DSMRSensor(description, config_entry) for description in SENSORS)
 
 
 class DSMRSensor(SensorEntity):
@@ -54,14 +54,14 @@ class DSMRSensor(SensorEntity):
     entity_description: DSMRReaderSensorEntityDescription
 
     def __init__(
-        self, description: DSMRReaderSensorEntityDescription, config: ConfigEntry
+        self, description: DSMRReaderSensorEntityDescription, config_entry: ConfigEntry
     ) -> None:
         """Initialize the sensor."""
         self.entity_description = description
 
         slug = slugify(description.key.replace("/", "_"))
         self.entity_id = f"sensor.{slug}"
-        self._attr_unique_id = f"{config.entry_id}-{slug}"
+        self._attr_unique_id = f"{config_entry.entry_id}-{slug}"
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""


### PR DESCRIPTION
## Proposed change
The various sensors added by dsmr_reader currently do not have a unique ID, making it impossible or at the very least impractical to manage these sensors. This very small pull request adds a unique ID, based on the MQTT topic name.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #61755, fixes #76885, fixes #54209

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. -> I'm working on a separate branch to add tests for the integration as a whole.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] -> N/A

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
      -> No new requirements
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
      -> No updated dependencies
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
