### PR TITLE
Ensure bleak_retry_connector uses HaBleakClientWrapper

### DIFF
--- a/homeassistant/components/bluetooth/usage.py
+++ b/homeassistant/components/bluetooth/usage.py
@@ -3,20 +3,39 @@
 from __future__ import annotations
 
 import bleak
+from bleak.backends.service import BleakGATTServiceCollection
+import bleak_retry_connector
 
 from .models import HaBleakClientWrapper, HaBleakScannerWrapper
 
 ORIGINAL_BLEAK_SCANNER = bleak.BleakScanner
 ORIGINAL_BLEAK_CLIENT = bleak.BleakClient
+ORIGINAL_BLEAK_RETRY_CONNECTOR_CLIENT = (
+    bleak_retry_connector.BleakClientWithServiceCache
+)
 
 
 def install_multiple_bleak_catcher() -> None:
     """Wrap the bleak classes to return the shared instance if multiple instances are detected."""
     bleak.BleakScanner = HaBleakScannerWrapper  # type: ignore[misc, assignment]
     bleak.BleakClient = HaBleakClientWrapper  # type: ignore[misc]
+    bleak_retry_connector.BleakClientWithServiceCache = HaBleakClientWithServiceCache  # type: ignore[misc,assignment]
 
 
 def uninstall_multiple_bleak_catcher() -> None:
     """Unwrap the bleak classes."""
     bleak.BleakScanner = ORIGINAL_BLEAK_SCANNER  # type: ignore[misc]
     bleak.BleakClient = ORIGINAL_BLEAK_CLIENT  # type: ignore[misc]
+    bleak_retry_connector.BleakClientWithServiceCache = ORIGINAL_BLEAK_RETRY_CONNECTOR_CLIENT  # type: ignore[misc]
+
+
+class HaBleakClientWithServiceCache(HaBleakClientWrapper):
+    """A BleakClient that implements service caching."""
+
+    def set_cached_services(self, services: BleakGATTServiceCollection | None) -> None:
+        """Set the cached services.
+
+        No longer used since bleak 0.17+ has service caching built-in.
+
+        This was only kept for backwards compatibility.
+        """

--- a/tests/components/bluetooth/test_usage.py
+++ b/tests/components/bluetooth/test_usage.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import bleak
 from bleak.backends.device import BLEDevice
+import bleak_retry_connector
 
 from homeassistant.components.bluetooth.models import (
     HaBleakClientWrapper,
@@ -72,6 +73,35 @@ async def test_bleak_client_reports_with_address(hass, enable_bluetooth, caplog)
     caplog.clear()
 
     instance = bleak.BleakClient("00:00:00:00:00:00")
+
+    assert not isinstance(instance, HaBleakClientWrapper)
+    assert "BleakClient with an address instead of a BLEDevice" not in caplog.text
+
+
+async def test_bleak_retry_connector_client_reports_with_address(
+    hass, enable_bluetooth, caplog
+):
+    """Test we report when we pass an address to BleakClientWithServiceCache."""
+    install_multiple_bleak_catcher()
+
+    with patch.object(
+        _get_manager(),
+        "async_ble_device_from_address",
+        return_value=MOCK_BLE_DEVICE,
+    ):
+        instance = bleak_retry_connector.BleakClientWithServiceCache(
+            "00:00:00:00:00:00"
+        )
+
+    assert "BleakClient with an address instead of a BLEDevice" in caplog.text
+
+    assert isinstance(instance, HaBleakClientWrapper)
+
+    uninstall_multiple_bleak_catcher()
+
+    caplog.clear()
+
+    instance = bleak_retry_connector.BleakClientWithServiceCache("00:00:00:00:00:00")
 
     assert not isinstance(instance, HaBleakClientWrapper)
     assert "BleakClient with an address instead of a BLEDevice" not in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since we now import `bleak_retry_connector` in `bluetooth` we need to make sure we patch the BleakClientWithServiceCache as well before any integration uses it to point to our wrapped instance that can dispatch to proxies

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
