### PR TITLE
Handle timeout on pairing close in HomeKit Controller

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 
 import aiohomekit
@@ -41,7 +42,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await conn.async_setup()
     except (AccessoryNotFoundError, EncryptionError, AccessoryDisconnectedError) as ex:
         del hass.data[KNOWN_DEVICES][conn.unique_id]
-        await conn.pairing.close()
+        with contextlib.suppress(asyncio.TimeoutError):
+            await conn.pairing.close()
         raise ConfigEntryNotReady from ex
 
     return True


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes
```
Error setting up entry Nanoleaf Strip 3B32 for homekit_controller
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 534, in async_populate_accessories_state
    await self._async_populate_accessories_state(force_update)
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 110, in _async_wrap
    return await func(self, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/client.py", line 76, in _async_wrap
    return await func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 546, in _async_populate_accessories_state
    await self._populate_accessories_and_characteristics(force_update)
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 577, in _populate_accessories_and_characteristics
    await self._async_pair_verify()
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 359, in _async_pair_verify
    session_id, derive = await drive_pairing_state_machine(
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/client.py", line 253, in drive_pairing_state_machine
    iid = await client.get_characteristic_iid(char)
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/bleak.py", line 111, in get_characteristic_iid
    value = bytes(await self.read_gatt_descriptor(iid_handle.handle))
  File "/usr/local/lib/python3.10/site-packages/bleak/__init__.py", line 587, in read_gatt_descriptor
    return await self._backend.read_gatt_descriptor(handle, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/client.py", line 638, in read_gatt_descriptor
    assert_reply(reply)
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/utils.py", line 22, in assert_reply
    raise BleakDBusError(reply.error_name, reply.body)
bleak.exc.BleakDBusError: [org.bluez.Error.Failed] Not connected

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/homekit_controller/__init__.py", line 41, in async_setup_entry
    await conn.async_setup()
  File "/usr/src/homeassistant/homeassistant/components/homekit_controller/connection.py", line 198, in async_setup
    await self.pairing.async_populate_accessories_state(force_update=True)
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 536, in async_populate_accessories_state
    raise AccessoryDisconnectedError(
aiohomekit.exceptions.AccessoryDisconnectedError: Nanoleaf Strip 3B32 [EC:40:4F:A7:73:AC] (id=10:52:19:6F:41:7E) connection failed: [org.bluez.Error.Failed] Not connected; rssi=-60

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 365, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/homekit_controller/__init__.py", line 44, in async_setup_entry
    await conn.pairing.close()
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 467, in close
    await self._close_while_locked()
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 473, in _close_while_locked
    await self.client.disconnect()
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/models.py", line 336, in disconnect
    return await self._backend.disconnect()
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/client.py", line 336, in disconnect
    async with async_timeout.timeout(10):
  File "/usr/local/lib/python3.10/site-packages/async_timeout/__init__.py", line 129, in __aexit__
    self._do_exit(exc_type)
  File "/usr/local/lib/python3.10/site-packages/async_timeout/__init__.py", line 212, in _do_exit
    raise asyncio.TimeoutError
asyncio.exceptions.TimeoutError
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
