### PR TITLE
Add spotify support to forked-daapd

### DIFF
--- a/homeassistant/components/forked_daapd/const.py
+++ b/homeassistant/components/forked_daapd/const.py
@@ -17,6 +17,8 @@ CAN_PLAY_TYPE = {
     MediaType.ALBUM,
     MediaType.GENRE,
     MediaType.MUSIC,
+    MediaType.EPISODE,
+    "show",  # this is a spotify constant
 }
 CONF_LIBRESPOT_JAVA_PORT = "librespot_java_port"
 CONF_MAX_PLAYLISTS = "max_playlists"

--- a/homeassistant/components/forked_daapd/manifest.json
+++ b/homeassistant/components/forked_daapd/manifest.json
@@ -4,6 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/forked_daapd",
   "codeowners": ["@uvjustin"],
   "requirements": ["pyforked-daapd==0.1.11", "pylibrespot-java==0.1.0"],
+  "after_dependencies": ["spotify"],
   "config_flow": true,
   "zeroconf": ["_daap._tcp.local."],
   "iot_class": "local_push",

--- a/homeassistant/components/forked_daapd/media_player.py
+++ b/homeassistant/components/forked_daapd/media_player.py
@@ -21,6 +21,12 @@ from homeassistant.components.media_player import (
     MediaType,
     async_process_play_media_url,
 )
+from homeassistant.components.spotify import (
+    async_browse_media as spotify_async_browse_media,
+    is_spotify_media_type,
+    resolve_spotify_media_type,
+    spotify_uri_from_media_browser_url,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
@@ -677,6 +683,9 @@ class ForkedDaapdMaster(MediaPlayerEntity):
             media_id = play_item.url
         elif is_owntone_media_content_id(media_id):
             media_id = convert_to_owntone_uri(media_id)
+        elif is_spotify_media_type(media_type):
+            media_type = resolve_spotify_media_type(media_type)
+            media_id = spotify_uri_from_media_browser_url(media_id)
 
         if media_type not in CAN_PLAY_TYPE:
             _LOGGER.warning("Media type '%s' not supported", media_type)
@@ -836,10 +845,27 @@ class ForkedDaapdMaster(MediaPlayerEntity):
                 media_content_id,
                 content_filter=lambda bm: bm.media_content_type in CAN_PLAY_TYPE,
             )
-            if media_content_type is None:
-                # This is the base level, so we combine our library with the media source
-                return library(ms_result.children)
-            return ms_result
+            if media_content_type is not None:
+                return ms_result
+            other_sources: list[BrowseMedia] = (
+                list(ms_result.children) if ms_result.children else []
+            )
+        if "spotify" in self.hass.config.components and (
+            media_content_type is None or is_spotify_media_type(media_content_type)
+        ):
+            spotify_result = await spotify_async_browse_media(
+                self.hass, media_content_type, media_content_id
+            )
+            if media_content_type is not None:
+                return spotify_result
+            if spotify_result.children:
+                other_sources += spotify_result.children
+
+        if media_content_id is None or media_content_type is None:
+            # This is the base level, so we combine our library with the other sources
+            return library(other_sources)
+
+        # media_content_type should only be None if media_content_id is None
         return await get_owntone_content(self, media_content_id)
 
     async def async_get_browse_image(

--- a/tests/components/forked_daapd/test_media_player.py
+++ b/tests/components/forked_daapd/test_media_player.py
@@ -891,3 +891,27 @@ async def test_play_owntone_media(hass, mock_api_object):
         position=0,
         playback_from_position=0,
     )
+
+
+async def test_play_spotify_media(hass, mock_api_object):
+    """Test async play media with a spotify source."""
+    initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
+    await _service_call(
+        hass,
+        TEST_MASTER_ENTITY_NAME,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_MEDIA_CONTENT_TYPE: "spotify://track",
+            ATTR_MEDIA_CONTENT_ID: "spotify://open.spotify.com/spotify:track:abcdefghi",
+            ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.PLAY,
+        },
+    )
+    state = hass.states.get(TEST_MASTER_ENTITY_NAME)
+    assert state.state == initial_state.state
+    assert state.last_updated > initial_state.last_updated
+    mock_api_object.add_to_queue.assert_called_with(
+        uris="spotify:track:abcdefghi",
+        playback="start",
+        position=0,
+        playback_from_position=0,
+    )

--- a/tests/components/forked_daapd/test_media_player.py
+++ b/tests/components/forked_daapd/test_media_player.py
@@ -54,6 +54,7 @@ from homeassistant.components.media_player import (
     MediaPlayerEnqueue,
     MediaType,
 )
+from homeassistant.components.media_source import PlayMedia
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
@@ -911,6 +912,34 @@ async def test_play_spotify_media(hass, mock_api_object):
     assert state.last_updated > initial_state.last_updated
     mock_api_object.add_to_queue.assert_called_with(
         uris="spotify:track:abcdefghi",
+        playback="start",
+        position=0,
+        playback_from_position=0,
+    )
+
+
+async def test_play_media_source(hass, mock_api_object):
+    """Test async play media with a spotify source."""
+    initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
+    with patch(
+        "homeassistant.components.media_source.async_resolve_media",
+        return_value=PlayMedia("http://my_hass/song.m4a", "audio/aac"),
+    ):
+        await _service_call(
+            hass,
+            TEST_MASTER_ENTITY_NAME,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_MEDIA_CONTENT_TYPE: "audio/aac",
+                ATTR_MEDIA_CONTENT_ID: "media-source://media_source/test_dir/song.m4a",
+                ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.PLAY,
+            },
+        )
+    state = hass.states.get(TEST_MASTER_ENTITY_NAME)
+    assert state.state == initial_state.state
+    assert state.last_updated > initial_state.last_updated
+    mock_api_object.add_to_queue.assert_called_with(
+        uris="http://my_hass/song.m4a",
         playback="start",
         position=0,
         playback_from_position=0,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for browsing and playing spotify to forked-daapd

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
