### PR TITLE
Add typing hints to mikrotik tests

### DIFF
--- a/homeassistant/components/mikrotik/device.py
+++ b/homeassistant/components/mikrotik/device.py
@@ -25,7 +25,7 @@ class Device:
     @property
     def name(self) -> str:
         """Return device name."""
-        return self._params.get("host-name", self.mac)
+        return str(self._params.get("host-name", self.mac))
 
     @property
     def ip_address(self) -> str | None:

--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -83,7 +83,7 @@ class MikrotikDataUpdateCoordinatorTracker(
         """Initialize the tracked device."""
         super().__init__(coordinator)
         self.device = device
-        self._attr_name = str(device.name)
+        self._attr_name = device.name
         self._attr_unique_id = device.mac
 
     @property

--- a/tests/components/mikrotik/__init__.py
+++ b/tests/components/mikrotik/__init__.py
@@ -1,4 +1,7 @@
 """Tests for the Mikrotik component."""
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant.components import mikrotik
@@ -16,6 +19,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -137,13 +141,13 @@ ARP_DATA = [
 ]
 
 
-async def setup_mikrotik_entry(hass, **kwargs):
+async def setup_mikrotik_entry(hass: HomeAssistant, **kwargs: Any) -> None:
     """Set up Mikrotik integration successfully."""
-    support_wireless = kwargs.get("support_wireless", True)
-    dhcp_data = kwargs.get("dhcp_data", DHCP_DATA)
-    wireless_data = kwargs.get("wireless_data", WIRELESS_DATA)
+    support_wireless: bool = kwargs.get("support_wireless", True)
+    dhcp_data: list[dict[str, Any]] = kwargs.get("dhcp_data", DHCP_DATA)
+    wireless_data: list[dict[str, Any]] = kwargs.get("wireless_data", WIRELESS_DATA)
 
-    def mock_command(self, cmd, params=None):
+    def mock_command(self, cmd: str, params: dict[str, Any] | None = None) -> Any:
         if cmd == mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.IS_WIRELESS]:
             return support_wireless
         if cmd == mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.DHCP]:
@@ -154,16 +158,17 @@ async def setup_mikrotik_entry(hass, **kwargs):
             return ARP_DATA
         return {}
 
-    config_entry = MockConfigEntry(
-        domain=mikrotik.DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS
-    )
-    config_entry.add_to_hass(hass)
-
+    options: dict[str, Any] = {}
     if "force_dhcp" in kwargs:
-        config_entry.options = {**config_entry.options, "force_dhcp": True}
+        options.update({"force_dhcp": True})
 
     if "arp_ping" in kwargs:
-        config_entry.options = {**config_entry.options, "arp_ping": True}
+        options.update({"arp_ping": True})
+
+    config_entry = MockConfigEntry(
+        domain=mikrotik.DOMAIN, data=MOCK_DATA, options=options
+    )
+    config_entry.add_to_hass(hass)
 
     with patch("librouteros.connect"), patch.object(
         mikrotik.hub.MikrotikData, "command", new=mock_command

--- a/tests/components/mikrotik/test_device_tracker.py
+++ b/tests/components/mikrotik/test_device_tracker.py
@@ -1,5 +1,8 @@
 """The tests for the Mikrotik device tracker platform."""
+from __future__ import annotations
+
 from datetime import timedelta
+from typing import Any
 
 from freezegun import freeze_time
 import pytest
@@ -7,6 +10,7 @@ import pytest
 from homeassistant.components import mikrotik
 import homeassistant.components.device_tracker as device_tracker
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -25,7 +29,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed, patch
 
 
 @pytest.fixture
-def mock_device_registry_devices(hass):
+def mock_device_registry_devices(hass: HomeAssistant) -> None:
     """Create device registry devices so the device tracker entities are enabled."""
     dev_reg = dr.async_get(hass)
     config_entry = MockConfigEntry(domain="something_else")
@@ -44,7 +48,7 @@ def mock_device_registry_devices(hass):
         )
 
 
-def mock_command(self, cmd, params=None):
+def mock_command(self, cmd: str, params: dict[str, Any] | None = None) -> Any:
     """Mock the Mikrotik command method."""
     if cmd == mikrotik.const.MIKROTIK_SERVICES[mikrotik.const.IS_WIRELESS]:
         return True
@@ -55,20 +59,20 @@ def mock_command(self, cmd, params=None):
     return {}
 
 
-async def test_device_trackers(hass, mock_device_registry_devices):
+async def test_device_trackers(
+    hass: HomeAssistant, mock_device_registry_devices
+) -> None:
     """Test device_trackers created by mikrotik."""
 
     # test devices are added from wireless list only
     await setup_mikrotik_entry(hass)
 
     device_1 = hass.states.get("device_tracker.device_1")
-    assert device_1 is not None
+    assert device_1
     assert device_1.state == "home"
     assert device_1.attributes["ip"] == "0.0.0.1"
-    assert "ip_address" not in device_1.attributes
     assert device_1.attributes["mac"] == "00:00:00:00:00:01"
     assert device_1.attributes["host_name"] == "Device_1"
-    assert "mac_address" not in device_1.attributes
     device_2 = hass.states.get("device_tracker.device_2")
     assert device_2 is None
 
@@ -80,33 +84,33 @@ async def test_device_trackers(hass, mock_device_registry_devices):
         await hass.async_block_till_done()
 
         device_2 = hass.states.get("device_tracker.device_2")
-        assert device_2 is not None
+        assert device_2
         assert device_2.state == "home"
         assert device_2.attributes["ip"] == "0.0.0.2"
-        assert "ip_address" not in device_2.attributes
         assert device_2.attributes["mac"] == "00:00:00:00:00:02"
-        assert "mac_address" not in device_2.attributes
         assert device_2.attributes["host_name"] == "Device_2"
 
-        # test state remains home if last_seen  consider_home_interval
+        # test state remains home if last_seen within consider_home_interval
         del WIRELESS_DATA[1]  # device 2 is removed from wireless list
         with freeze_time(utcnow() + timedelta(minutes=4)):
             async_fire_time_changed(hass, utcnow() + timedelta(minutes=4))
             await hass.async_block_till_done()
 
         device_2 = hass.states.get("device_tracker.device_2")
+        assert device_2
         assert device_2.state == "home"
 
-        # test state changes to away if last_seen > consider_home_interval
+        # test state changes to away if last_seen past consider_home_interval
         with freeze_time(utcnow() + timedelta(minutes=6)):
             async_fire_time_changed(hass, utcnow() + timedelta(minutes=6))
             await hass.async_block_till_done()
 
         device_2 = hass.states.get("device_tracker.device_2")
+        assert device_2
         assert device_2.state == "not_home"
 
 
-async def test_force_dhcp(hass, mock_device_registry_devices):
+async def test_force_dhcp(hass: HomeAssistant, mock_device_registry_devices) -> None:
     """Test updating hub that supports wireless with forced dhcp method."""
 
     # hub supports wireless by default, force_dhcp is enabled to override
@@ -120,7 +124,9 @@ async def test_force_dhcp(hass, mock_device_registry_devices):
     assert device_2.state == "home"
 
 
-async def test_hub_not_support_wireless(hass, mock_device_registry_devices):
+async def test_hub_not_support_wireless(
+    hass: HomeAssistant, mock_device_registry_devices
+) -> None:
     """Test device_trackers created when hub doesn't support wireless."""
 
     await setup_mikrotik_entry(hass, support_wireless=False)
@@ -133,7 +139,9 @@ async def test_hub_not_support_wireless(hass, mock_device_registry_devices):
     assert device_2.state == "home"
 
 
-async def test_arp_ping_success(hass, mock_device_registry_devices):
+async def test_arp_ping_success(
+    hass: HomeAssistant, mock_device_registry_devices
+) -> None:
     """Test arp ping devices to confirm they are connected."""
 
     with patch.object(mikrotik.hub.MikrotikData, "do_arp_ping", return_value=True):
@@ -145,7 +153,9 @@ async def test_arp_ping_success(hass, mock_device_registry_devices):
         assert device_2.state == "home"
 
 
-async def test_arp_ping_timeout(hass, mock_device_registry_devices):
+async def test_arp_ping_timeout(
+    hass: HomeAssistant, mock_device_registry_devices
+) -> None:
     """Test arp ping timeout so devices are shown away."""
     with patch.object(mikrotik.hub.MikrotikData, "do_arp_ping", return_value=False):
         await setup_mikrotik_entry(hass, arp_ping=True, force_dhcp=True)
@@ -156,7 +166,9 @@ async def test_arp_ping_timeout(hass, mock_device_registry_devices):
         assert device_2.state == "not_home"
 
 
-async def test_device_trackers_numerical_name(hass, mock_device_registry_devices):
+async def test_device_trackers_numerical_name(
+    hass: HomeAssistant, mock_device_registry_devices
+) -> None:
     """Test device_trackers created by mikrotik with numerical device name."""
 
     await setup_mikrotik_entry(
@@ -164,17 +176,15 @@ async def test_device_trackers_numerical_name(hass, mock_device_registry_devices
     )
 
     device_3 = hass.states.get("device_tracker.123")
-    assert device_3 is not None
+    assert device_3
     assert device_3.state == "home"
     assert device_3.attributes["friendly_name"] == "123"
     assert device_3.attributes["ip"] == "0.0.0.3"
-    assert "ip_address" not in device_3.attributes
     assert device_3.attributes["mac"] == "00:00:00:00:00:03"
-    assert device_3.attributes["host_name"] == 123
-    assert "mac_address" not in device_3.attributes
+    assert device_3.attributes["host_name"] == "123"
 
 
-async def test_restoring_devices(hass):
+async def test_restoring_devices(hass: HomeAssistant) -> None:
     """Test restoring existing device_tracker entities if not detected on startup."""
     config_entry = MockConfigEntry(
         domain=mikrotik.DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS
@@ -219,7 +229,7 @@ async def test_restoring_devices(hass):
     assert device_3 is None
 
 
-async def test_update_failed(hass, mock_device_registry_devices):
+async def test_update_failed(hass: HomeAssistant, mock_device_registry_devices) -> None:
     """Test failing to connect during update."""
 
     await setup_mikrotik_entry(hass)
@@ -231,4 +241,5 @@ async def test_update_failed(hass, mock_device_registry_devices):
         await hass.async_block_till_done()
 
     device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1
     assert device_1.state == STATE_UNAVAILABLE

--- a/tests/components/mikrotik/test_init.py
+++ b/tests/components/mikrotik/test_init.py
@@ -1,5 +1,5 @@
 """Test Mikrotik setup process."""
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from librouteros.exceptions import ConnectionClosed, LibRouterosError
 import pytest
@@ -7,7 +7,7 @@ import pytest
 from homeassistant.components import mikrotik
 from homeassistant.components.mikrotik.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.setup import async_setup_component
+from homeassistant.core import HomeAssistant
 
 from . import MOCK_DATA
 
@@ -23,13 +23,7 @@ def mock_api():
         yield mock_api
 
 
-async def test_setup_with_no_config(hass):
-    """Test that we do not discover anything or try to set up a hub."""
-    assert await async_setup_component(hass, mikrotik.DOMAIN, {}) is True
-    assert mikrotik.DOMAIN not in hass.data
-
-
-async def test_successful_config_entry(hass):
+async def test_successful_config_entry(hass: HomeAssistant) -> None:
     """Test config entry successful setup."""
     entry = MockConfigEntry(
         domain=mikrotik.DOMAIN,
@@ -41,8 +35,8 @@ async def test_successful_config_entry(hass):
     assert entry.state == ConfigEntryState.LOADED
 
 
-async def test_hub_conn_error(hass, mock_api):
-    """Test that a failed setup will not store the hub."""
+async def test_hub_connection_error(hass: HomeAssistant, mock_api: MagicMock) -> None:
+    """Test setup fails due to connection error."""
     entry = MockConfigEntry(
         domain=mikrotik.DOMAIN,
         data=MOCK_DATA,
@@ -56,8 +50,10 @@ async def test_hub_conn_error(hass, mock_api):
     assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_hub_auth_error(hass, mock_api):
-    """Test that a failed setup will not store the hub."""
+async def test_hub_authentication_error(
+    hass: HomeAssistant, mock_api: MagicMock
+) -> None:
+    """Test setup fails due to authentication error."""
     entry = MockConfigEntry(
         domain=mikrotik.DOMAIN,
         data=MOCK_DATA,
@@ -71,8 +67,8 @@ async def test_hub_auth_error(hass, mock_api):
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
 
-async def test_unload_entry(hass) -> None:
-    """Test being able to unload an entry."""
+async def test_unload_entry(hass: HomeAssistant) -> None:
+    """Test unloading an entry."""
     entry = MockConfigEntry(
         domain=mikrotik.DOMAIN,
         data=MOCK_DATA,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add type hints to mikrotik tests. 
- Ensure the `Device` name attribute is a string to make sure the device_tracker `name` and `host_name` are strings (a refinement for PR #72788).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
