### PR TITLE
Cleanup add browse media forked daapd #79009

### DIFF
--- a/homeassistant/components/forked_daapd/browse_media.py
+++ b/homeassistant/components/forked_daapd/browse_media.py
@@ -55,13 +55,11 @@ OWNTONE_TYPE_TO_MEDIA_TYPE = {
 }
 MEDIA_TYPE_TO_OWNTONE_TYPE = {v: k for k, v in OWNTONE_TYPE_TO_MEDIA_TYPE.items()}
 
-"""
-media_content_id is a uri in the form of SCHEMA:Title:OwnToneURI:Subtype (Subtype only used for Genre)
-OwnToneURI is in format library:type:id (for directories, id is path)
-media_content_type - type of item (mostly used to check if playable or can expand)
-Owntone type may differ from media_content_type when media_content_type is a directory
-Owntown type is used in our own branching, but media_content_type is used for determining playability
-"""
+# media_content_id is a uri in the form of SCHEMA:Title:OwnToneURI:Subtype (Subtype only used for Genre)
+# OwnToneURI is in format library:type:id (for directories, id is path)
+# media_content_type - type of item (mostly used to check if playable or can expand)
+# Owntone type may differ from media_content_type when media_content_type is a directory
+# Owntone type is used in our own branching, but media_content_type is used for determining playability
 
 
 @dataclass

--- a/homeassistant/components/forked_daapd/media_player.py
+++ b/homeassistant/components/forked_daapd/media_player.py
@@ -840,8 +840,6 @@ class ForkedDaapdMaster(MediaPlayerEntity):
                 # This is the base level, so we combine our library with the media source
                 return library(ms_result.children)
             return ms_result
-        # media_content_type should only be None if media_content_id is None
-        assert media_content_type
         return await get_owntone_content(self, media_content_id)
 
     async def async_get_browse_image(

--- a/tests/components/forked_daapd/test_browse_media.py
+++ b/tests/components/forked_daapd/test_browse_media.py
@@ -126,7 +126,7 @@ async def test_async_browse_media(hass, hass_ws_client, config_entry):
             },
         ]
 
-        # Request playlist through WebSocket
+        # Request browse root through WebSocket
         client = await hass_ws_client(hass)
         await client.send_json(
             {
@@ -185,7 +185,7 @@ async def test_async_browse_media_not_found(hass, hass_ws_client, config_entry):
         mock_api.return_value.get_genres.return_value = None
         mock_api.return_value.get_playlists.return_value = None
 
-        # Request playlist through WebSocket
+        # Request different types of media through WebSocket
         client = await hass_ws_client(hass)
         msg_id = 1
         for media_type in (

--- a/tests/components/forked_daapd/test_browse_media.py
+++ b/tests/components/forked_daapd/test_browse_media.py
@@ -23,7 +23,7 @@ async def test_async_browse_media(hass, hass_ws_client, config_entry):
         autospec=True,
     ) as mock_api:
         config_entry.add_to_hass(hass)
-        await config_entry.async_setup(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
         mock_api.return_value.full_url = lambda x: "http://owntone_instance/" + x
@@ -177,7 +177,7 @@ async def test_async_browse_media_not_found(hass, hass_ws_client, config_entry):
         autospec=True,
     ) as mock_api:
         config_entry.add_to_hass(hass)
-        await config_entry.async_setup(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
         mock_api.return_value.get_directory.return_value = None
@@ -229,7 +229,7 @@ async def test_async_browse_image(hass, hass_client, config_entry):
         autospec=True,
     ) as mock_api:
         config_entry.add_to_hass(hass)
-        await config_entry.async_setup(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         client = await hass_client()
         mock_api.return_value.full_url = lambda x: "http://owntone_instance/" + x
@@ -279,7 +279,7 @@ async def test_async_browse_image_missing(hass, hass_client, config_entry, caplo
         autospec=True,
     ) as mock_api:
         config_entry.add_to_hass(hass)
-        await config_entry.async_setup(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         client = await hass_client()
         mock_api.return_value.full_url = lambda x: "http://owntone_instance/" + x

--- a/tests/components/forked_daapd/test_browse_media.py
+++ b/tests/components/forked_daapd/test_browse_media.py
@@ -148,7 +148,6 @@ async def test_async_browse_media(hass, hass_ws_client, config_entry):
             nonlocal msg_id
             for child in children:
                 if child["can_expand"]:
-                    print("EXPANDING CHILD", child)
                     await client.send_json(
                         {
                             "id": msg_id,

--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -225,7 +225,7 @@ async def test_options_flow(hass, config_entry):
     ) as mock_get_request:
         mock_get_request.return_value = SAMPLE_CONFIG
         config_entry.add_to_hass(hass)
-        await config_entry.async_setup(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)

--- a/tests/components/forked_daapd/test_media_player.py
+++ b/tests/components/forked_daapd/test_media_player.py
@@ -315,7 +315,7 @@ async def mock_api_object_fixture(hass, config_entry, get_request_return_values)
         mock_api.return_value.get_pipes.return_value = SAMPLE_PIPES
         mock_api.return_value.get_playlists.return_value = SAMPLE_PLAYLISTS
         config_entry.add_to_hass(hass)
-        await config_entry.async_setup(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     mock_api.return_value.start_websocket_handler.assert_called_once()
@@ -775,7 +775,7 @@ async def test_invalid_websocket_port(hass, config_entry):
     ) as mock_api:
         mock_api.return_value.get_request.return_value = SAMPLE_CONFIG_NO_WEBSOCKET
         config_entry.add_to_hass(hass)
-        await config_entry.async_setup(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert hass.states.get(TEST_MASTER_ENTITY_NAME).state == STATE_UNAVAILABLE
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup for #79009

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
