### PR TITLE
Use SensorDeviceClass.DISTANCE for here_travel_time

### DIFF
--- a/homeassistant/components/here_travel_time/__init__.py
+++ b/homeassistant/components/here_travel_time/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_MODE, CONF_UNIT_SYSTEM, Platform
+from homeassistant.const import CONF_API_KEY, CONF_MODE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt
 
@@ -55,7 +55,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         origin_entity_id=config_entry.data.get(CONF_ORIGIN_ENTITY_ID),
         travel_mode=config_entry.data[CONF_MODE],
         route_mode=config_entry.options[CONF_ROUTE_MODE],
-        units=config_entry.options[CONF_UNIT_SYSTEM],
         arrival=arrival,
         departure=departure,
     )

--- a/homeassistant/components/here_travel_time/config_flow.py
+++ b/homeassistant/components/here_travel_time/config_flow.py
@@ -21,9 +21,8 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_MODE,
     CONF_NAME,
-    CONF_UNIT_SYSTEM,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import (
@@ -31,7 +30,6 @@ from homeassistant.helpers.selector import (
     LocationSelector,
     TimeSelector,
 )
-from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .const import (
     CONF_ARRIVAL_TIME,
@@ -47,17 +45,20 @@ from .const import (
     CONF_ROUTE_MODE,
     DEFAULT_NAME,
     DOMAIN,
-    IMPERIAL_UNITS,
-    METRIC_UNITS,
     ROUTE_MODE_FASTEST,
     ROUTE_MODES,
     TRAVEL_MODE_CAR,
     TRAVEL_MODE_PUBLIC,
     TRAVEL_MODES,
-    UNITS,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_OPTIONS = {
+    CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
+    CONF_ARRIVAL_TIME: None,
+    CONF_DEPARTURE_TIME: None,
+}
 
 
 async def async_validate_api_key(api_key: str) -> None:
@@ -88,19 +89,6 @@ def get_user_step_schema(data: dict[str, Any]) -> vol.Schema:
             ): vol.In(TRAVEL_MODES),
         }
     )
-
-
-def default_options(hass: HomeAssistant) -> dict[str, str | None]:
-    """Get the default options."""
-    default = {
-        CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
-        CONF_ARRIVAL_TIME: None,
-        CONF_DEPARTURE_TIME: None,
-        CONF_UNIT_SYSTEM: METRIC_UNITS,
-    }
-    if hass.config.units is US_CUSTOMARY_SYSTEM:
-        default[CONF_UNIT_SYSTEM] = IMPERIAL_UNITS
-    return default
 
 
 class HERETravelTimeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -198,7 +186,7 @@ class HERETravelTimeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(
                 title=self._config[CONF_NAME],
                 data=self._config,
-                options=default_options(self.hass),
+                options=DEFAULT_OPTIONS,
             )
         schema = vol.Schema(
             {
@@ -227,7 +215,7 @@ class HERETravelTimeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(
                 title=self._config[CONF_NAME],
                 data=self._config,
-                options=default_options(self.hass),
+                options=DEFAULT_OPTIONS,
             )
         schema = vol.Schema(
             {vol.Required(CONF_DESTINATION_ENTITY_ID): EntitySelector()}
@@ -254,21 +242,14 @@ class HERETravelTimeOptionsFlow(config_entries.OptionsFlow):
                 menu_options=["departure_time", "arrival_time", "no_time"],
             )
 
-        defaults = default_options(self.hass)
         schema = vol.Schema(
             {
                 vol.Optional(
                     CONF_ROUTE_MODE,
                     default=self.config_entry.options.get(
-                        CONF_ROUTE_MODE, defaults[CONF_ROUTE_MODE]
+                        CONF_ROUTE_MODE, DEFAULT_OPTIONS[CONF_ROUTE_MODE]
                     ),
                 ): vol.In(ROUTE_MODES),
-                vol.Optional(
-                    CONF_UNIT_SYSTEM,
-                    default=self.config_entry.options.get(
-                        CONF_UNIT_SYSTEM, defaults[CONF_UNIT_SYSTEM]
-                    ),
-                ): vol.In(UNITS),
             }
         )
 

--- a/homeassistant/components/here_travel_time/const.py
+++ b/homeassistant/components/here_travel_time/const.py
@@ -51,16 +51,10 @@ ICONS = {
     TRAVEL_MODE_TRUCK: ICON_TRUCK,
 }
 
-IMPERIAL_UNITS = "imperial"
-METRIC_UNITS = "metric"
-UNITS = [METRIC_UNITS, IMPERIAL_UNITS]
-
 ATTR_DURATION = "duration"
 ATTR_DISTANCE = "distance"
 ATTR_ORIGIN = "origin"
 ATTR_DESTINATION = "destination"
-
-ATTR_UNIT_SYSTEM = "unit_system"
 
 ATTR_DURATION_IN_TRAFFIC = "duration_in_traffic"
 ATTR_ORIGIN_NAME = "origin_name"

--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -16,7 +16,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.location import find_coordinates
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt
-from homeassistant.util.unit_conversion import DistanceConverter
 
 from .const import (
     ATTR_DESTINATION,

--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -10,7 +10,7 @@ import here_transit
 from here_transit import HERETransitApi
 import voluptuous as vol
 
-from homeassistant.const import ATTR_ATTRIBUTION, LENGTH_METERS, LENGTH_MILES
+from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.location import find_coordinates
@@ -28,7 +28,6 @@ from .const import (
     ATTR_ORIGIN_NAME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
-    IMPERIAL_UNITS,
     ROUTE_MODE_FASTEST,
 )
 from .model import HERETravelTimeConfig, HERETravelTimeData
@@ -100,13 +99,7 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator):
         mapped_origin_lon: float = section["departure"]["place"]["location"]["lng"]
         mapped_destination_lat: float = section["arrival"]["place"]["location"]["lat"]
         mapped_destination_lon: float = section["arrival"]["place"]["location"]["lng"]
-        distance: float = summary["length"]
-        if self.config.units == IMPERIAL_UNITS:
-            # Convert to miles.
-            distance = DistanceConverter.convert(distance, LENGTH_METERS, LENGTH_MILES)
-        else:
-            # Convert to kilometers
-            distance = distance / 1000
+        distance: float = summary["length"] / 1000
         origin_name: str | None = None
         if (names := section["spans"][0].get("names")) is not None:
             origin_name = names[0]["value"]
@@ -189,18 +182,12 @@ class HERETransitDataUpdateCoordinator(DataUpdateCoordinator):
         mapped_destination_lon: float = sections[-1]["arrival"]["place"]["location"][
             "lng"
         ]
-        distance: float = sum(
-            section["travelSummary"]["length"] for section in sections
+        distance: float = (
+            sum(section["travelSummary"]["length"] for section in sections) / 1000
         )
         duration: float = sum(
             section["travelSummary"]["duration"] for section in sections
         )
-        if self.config.units == IMPERIAL_UNITS:
-            # Convert to miles.
-            distance = DistanceConverter.convert(distance, LENGTH_METERS, LENGTH_MILES)
-        else:
-            # Convert to kilometers
-            distance = distance / 1000
         return HERETravelTimeData(
             {
                 ATTR_ATTRIBUTION: attribution,

--- a/homeassistant/components/here_travel_time/model.py
+++ b/homeassistant/components/here_travel_time/model.py
@@ -31,6 +31,5 @@ class HERETravelTimeConfig:
     origin_entity_id: str | None
     travel_mode: str
     route_mode: str
-    units: str
     arrival: time | None
     departure: time | None

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from typing import Any
 
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
@@ -18,7 +19,6 @@ from homeassistant.const import (
     CONF_MODE,
     CONF_NAME,
     LENGTH_KILOMETERS,
-    LENGTH_MILES,
     TIME_MINUTES,
 )
 from homeassistant.core import HomeAssistant
@@ -39,7 +39,6 @@ from .const import (
     DOMAIN,
     ICON_CAR,
     ICONS,
-    IMPERIAL_UNITS,
 )
 from .coordinator import HERERoutingDataUpdateCoordinator
 
@@ -62,6 +61,14 @@ def sensor_descriptions(travel_mode: str) -> tuple[SensorEntityDescription, ...]
             key=ATTR_DURATION_IN_TRAFFIC,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=TIME_MINUTES,
+        ),
+        SensorEntityDescription(
+            name="Distance",
+            icon=ICONS.get(travel_mode, ICON_CAR),
+            key=ATTR_DISTANCE,
+            state_class=SensorStateClass.MEASUREMENT,
+            device_class=SensorDeviceClass.DISTANCE,
+            native_unit_of_measurement=LENGTH_KILOMETERS,
         ),
     )
 
@@ -89,7 +96,6 @@ async def async_setup_entry(
         )
     sensors.append(OriginSensor(entry_id, name, coordinator))
     sensors.append(DestinationSensor(entry_id, name, coordinator))
-    sensors.append(DistanceSensor(entry_id, name, coordinator))
     async_add_entities(sensors)
 
 
@@ -193,29 +199,3 @@ class DestinationSensor(HERETravelTimeSensor):
                 ATTR_LONGITUDE: self.coordinator.data[ATTR_DESTINATION].split(",")[1],
             }
         return None
-
-
-class DistanceSensor(HERETravelTimeSensor):
-    """Sensor holding information about the distance."""
-
-    def __init__(
-        self,
-        unique_id_prefix: str,
-        name: str,
-        coordinator: HERERoutingDataUpdateCoordinator,
-    ) -> None:
-        """Initialize the sensor."""
-        sensor_description = SensorEntityDescription(
-            name="Distance",
-            icon=ICONS.get(coordinator.config.travel_mode, ICON_CAR),
-            key=ATTR_DISTANCE,
-            state_class=SensorStateClass.MEASUREMENT,
-        )
-        super().__init__(unique_id_prefix, name, sensor_description, coordinator)
-
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit of measurement of the sensor."""
-        if self.coordinator.config.units == IMPERIAL_UNITS:
-            return LENGTH_MILES
-        return LENGTH_KILOMETERS

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -18,8 +18,8 @@ from homeassistant.const import (
     ATTR_LONGITUDE,
     CONF_MODE,
     CONF_NAME,
-    LENGTH_KILOMETERS,
     TIME_MINUTES,
+    UnitOfLength,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -68,7 +68,7 @@ def sensor_descriptions(travel_mode: str) -> tuple[SensorEntityDescription, ...]
             key=ATTR_DISTANCE,
             state_class=SensorStateClass.MEASUREMENT,
             device_class=SensorDeviceClass.DISTANCE,
-            native_unit_of_measurement=LENGTH_KILOMETERS,
+            native_unit_of_measurement=UnitOfLength.KILOMETERS,
         ),
     )
 

--- a/tests/components/here_travel_time/test_config_flow.py
+++ b/tests/components/here_travel_time/test_config_flow.py
@@ -19,20 +19,8 @@ from homeassistant.components.here_travel_time.const import (
     TRAVEL_MODE_CAR,
     TRAVEL_MODE_PUBLIC,
 )
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_MODE,
-    CONF_NAME,
-    CONF_UNIT_SYSTEM,
-    CONF_UNIT_SYSTEM_IMPERIAL,
-    CONF_UNIT_SYSTEM_METRIC,
-)
+from homeassistant.const import CONF_API_KEY, CONF_MODE, CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.util.unit_system import (
-    METRIC_SYSTEM,
-    US_CUSTOMARY_SYSTEM,
-    UnitSystem,
-)
 
 from .const import (
     API_KEY,
@@ -98,7 +86,6 @@ async def option_init_result_fixture(hass: HomeAssistant) -> data_entry_flow.Flo
         flow["flow_id"],
         user_input={
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
-            CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
         },
     )
     return result
@@ -229,21 +216,11 @@ async def test_step_destination_coordinates(
 
 
 @pytest.mark.usefixtures("valid_response")
-@pytest.mark.parametrize(
-    "unit_system, expected_unit_option",
-    [
-        (METRIC_SYSTEM, CONF_UNIT_SYSTEM_METRIC),
-        (US_CUSTOMARY_SYSTEM, CONF_UNIT_SYSTEM_IMPERIAL),
-    ],
-)
 async def test_step_destination_entity(
     hass: HomeAssistant,
     origin_step_result: data_entry_flow.FlowResult,
-    unit_system: UnitSystem,
-    expected_unit_option: str,
 ) -> None:
     """Test the origin coordinates step."""
-    hass.config.units = unit_system
     menu_result = await hass.config_entries.flow.async_configure(
         origin_step_result["flow_id"], {"next_step_id": "destination_entity"}
     )
@@ -264,7 +241,6 @@ async def test_step_destination_entity(
         CONF_MODE: TRAVEL_MODE_CAR,
     }
     assert entry.options == {
-        CONF_UNIT_SYSTEM: expected_unit_option,
         CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
         CONF_ARRIVAL_TIME: None,
         CONF_DEPARTURE_TIME: None,
@@ -340,7 +316,6 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         result["flow_id"],
         user_input={
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
-            CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
         },
     )
 
@@ -366,7 +341,6 @@ async def test_options_flow_arrival_time_step(
     assert time_selector_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.options == {
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
         CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
         CONF_ARRIVAL_TIME: "08:00:00",
     }
@@ -391,7 +365,6 @@ async def test_options_flow_departure_time_step(
     assert time_selector_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.options == {
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
         CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
         CONF_DEPARTURE_TIME: "08:00:00",
     }
@@ -409,6 +382,5 @@ async def test_options_flow_no_time_step(
     assert menu_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.options == {
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
         CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
     }

--- a/tests/components/here_travel_time/test_init.py
+++ b/tests/components/here_travel_time/test_init.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from homeassistant.components.here_travel_time.config_flow import default_options
+from homeassistant.components.here_travel_time.config_flow import DEFAULT_OPTIONS
 from homeassistant.components.here_travel_time.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
@@ -18,7 +18,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         unique_id="0123456789",
         data=DEFAULT_CONFIG,
-        options=default_options(hass),
+        options=DEFAULT_OPTIONS,
     )
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The unit system is no longer controlled by an options setting of the HERE Traveltime integration but uses the built in custom units configurable per entity. The distance sensor now uses kilometers as a default and must be manually configured if it was previously using the imperial system.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use SensorDeviceClass.DISTANCE for the distance sensor and remove the `unit` OptionsFlow setting.

Equivalent to https://github.com/home-assistant/core/pull/79285

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
