### PR TITLE
Add additional integration_type options for integration manifests

### DIFF
--- a/homeassistant/components/air_quality/manifest.json
+++ b/homeassistant/components/air_quality/manifest.json
@@ -3,5 +3,6 @@
   "name": "Air Quality",
   "documentation": "https://www.home-assistant.io/integrations/air_quality",
   "codeowners": ["@home-assistant/core"],
-  "quality_scale": "internal"
+  "quality_scale": "internal",
+  "integration_type": "entity"
 }

--- a/homeassistant/components/analytics/manifest.json
+++ b/homeassistant/components/analytics/manifest.json
@@ -7,5 +7,5 @@
   "after_dependencies": ["energy"],
   "quality_scale": "internal",
   "iot_class": "cloud_push",
-  "integration_type": "internal"
+  "integration_type": "system"
 }

--- a/homeassistant/components/analytics/manifest.json
+++ b/homeassistant/components/analytics/manifest.json
@@ -6,5 +6,6 @@
   "dependencies": ["api", "websocket_api"],
   "after_dependencies": ["energy"],
   "quality_scale": "internal",
-  "iot_class": "cloud_push"
+  "iot_class": "cloud_push",
+  "integration_type": "internal"
 }

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -129,7 +129,7 @@ class Manifest(TypedDict, total=False):
     name: str
     disabled: str
     domain: str
-    integration_type: Literal["integration", "hardware", "helper"]
+    integration_type: Literal["entity", "integration", "hardware", "helper", "system"]
     dependencies: list[str]
     after_dependencies: list[str]
     requirements: list[str]
@@ -558,7 +558,9 @@ class Integration:
         return self.manifest.get("iot_class")
 
     @property
-    def integration_type(self) -> Literal["integration", "hardware", "helper"]:
+    def integration_type(
+        self,
+    ) -> Literal["entity", "integration", "hardware", "helper", "system"]:
         """Return the integration type."""
         return self.manifest.get("integration_type", "integration")
 

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -163,7 +163,7 @@ MANIFEST_SCHEMA = vol.Schema(
         vol.Required("domain"): str,
         vol.Required("name"): str,
         vol.Optional("integration_type"): vol.In(
-            ["entity", "hardware", "helper", "internal"]
+            ["entity", "hardware", "helper", "system"]
         ),
         vol.Optional("config_flow"): bool,
         vol.Optional("mqtt"): [str],

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -162,7 +162,9 @@ MANIFEST_SCHEMA = vol.Schema(
     {
         vol.Required("domain"): str,
         vol.Required("name"): str,
-        vol.Optional("integration_type"): vol.In(["hardware", "helper"]),
+        vol.Optional("integration_type"): vol.In(
+            ["entity", "hardware", "helper", "internal"]
+        ),
         vol.Optional("config_flow"): bool,
         vol.Optional("mqtt"): [str],
         vol.Optional("zeroconf"): [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add additional `integration_type` options for integration manifests:
- `entity` for integrations providing entity domains
- `system` for integrations which are typically not user facing, but are instead automatically setup by other integrations

This PR marks `air_quality` as `entity` and `api` as `system`

Other integrations' manifests should be updated in follow-up PRs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
