### PR TITLE
Cleanup unit conversion

### DIFF
--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -26,6 +26,7 @@ from homeassistant.util.unit_conversion import (
 
 from .const import MAX_QUEUE_BACKLOG
 from .statistics import (
+    STATISTIC_UNIT_TO_UNIT_CONVERTER,
     async_add_external_statistics,
     async_change_statistics_unit,
     async_import_statistics,
@@ -322,17 +323,9 @@ async def ws_adjust_sum_statistics(
     def valid_units(statistics_unit: str | None, display_unit: str | None) -> bool:
         if statistics_unit == display_unit:
             return True
-        for converter in (
-            DistanceConverter,
-            EnergyConverter,
-            MassConverter,
-            VolumeConverter,
-        ):
-            if (
-                statistics_unit == converter.NORMALIZED_UNIT
-                and display_unit in converter.VALID_UNITS
-            ):
-                return True
+        converter = STATISTIC_UNIT_TO_UNIT_CONVERTER.get(statistics_unit)
+        if converter is not None and display_unit in converter.VALID_UNITS:
+            return True
         return False
 
     stat_unit = metadata["statistics_unit_of_measurement"]

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -9,11 +9,6 @@ import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api import messages
-from homeassistant.const import (
-    ENERGY_KILO_WATT_HOUR,
-    ENERGY_MEGA_WATT_HOUR,
-    ENERGY_WATT_HOUR,
-)
 from homeassistant.core import HomeAssistant, callback, valid_entity_id
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.json import JSON_DUMP
@@ -327,26 +322,17 @@ async def ws_adjust_sum_statistics(
     def valid_units(statistics_unit: str | None, display_unit: str | None) -> bool:
         if statistics_unit == display_unit:
             return True
-        if (
-            statistics_unit == DistanceConverter.NORMALIZED_UNIT
-            and display_unit in DistanceConverter.VALID_UNITS
+        for converter in (
+            DistanceConverter,
+            EnergyConverter,
+            MassConverter,
+            VolumeConverter,
         ):
-            return True
-        if statistics_unit == ENERGY_KILO_WATT_HOUR and display_unit in (
-            ENERGY_MEGA_WATT_HOUR,
-            ENERGY_WATT_HOUR,
-        ):
-            return True
-        if (
-            statistics_unit == MassConverter.NORMALIZED_UNIT
-            and display_unit in MassConverter.VALID_UNITS
-        ):
-            return True
-        if (
-            statistics_unit == VolumeConverter.NORMALIZED_UNIT
-            and display_unit in VolumeConverter.VALID_UNITS
-        ):
-            return True
+            if (
+                statistics_unit == converter.NORMALIZED_UNIT
+                and display_unit in converter.VALID_UNITS
+            ):
+                return True
         return False
 
     stat_unit = metadata["statistics_unit_of_measurement"]

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -234,19 +234,6 @@ UNIT_CONVERTERS: dict[str, type[BaseUnitConverter]] = {
     SensorDeviceClass.WEIGHT: MassConverter,
 }
 
-UNIT_RATIOS: dict[str, dict[str, float]] = {
-    SensorDeviceClass.DISTANCE: DistanceConverter.UNIT_CONVERSION,
-    SensorDeviceClass.PRESSURE: PressureConverter.UNIT_CONVERSION,
-    SensorDeviceClass.SPEED: SpeedConverter.UNIT_CONVERSION,
-    SensorDeviceClass.TEMPERATURE: {
-        TEMP_CELSIUS: 1.0,
-        TEMP_FAHRENHEIT: 1.8,
-        TEMP_KELVIN: 1.0,
-    },
-    SensorDeviceClass.VOLUME: VolumeConverter.UNIT_CONVERSION,
-    SensorDeviceClass.WEIGHT: MassConverter.UNIT_CONVERSION,
-}
-
 # mypy: disallow-any-generics
 
 
@@ -456,6 +443,7 @@ class SensorEntity(Entity):
         ):
             assert unit_of_measurement
             assert native_unit_of_measurement
+            converter = UNIT_CONVERTERS[device_class]
 
             value_s = str(value)
             prec = len(value_s) - value_s.index(".") - 1 if "." in value_s else 0
@@ -465,8 +453,9 @@ class SensorEntity(Entity):
             ratio_log = max(
                 0,
                 log10(
-                    UNIT_RATIOS[device_class][native_unit_of_measurement]
-                    / UNIT_RATIOS[device_class][unit_of_measurement]
+                    converter.get_unit_ratio(
+                        native_unit_of_measurement, unit_of_measurement
+                    )
                 ),
             )
             prec = prec + floor(ratio_log)
@@ -474,7 +463,7 @@ class SensorEntity(Entity):
             # Suppress ValueError (Could not convert sensor_value to float)
             with suppress(ValueError):
                 value_f = float(value)  # type: ignore[arg-type]
-                value_f_new = UNIT_CONVERTERS[device_class].convert(
+                value_f_new = converter.convert(
                     value_f,
                     native_unit_of_measurement,
                     unit_of_measurement,

--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -17,7 +17,8 @@ from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
 
 from .unit_conversion import PressureConverter
 
-UNIT_CONVERSION: dict[str, float] = PressureConverter.UNIT_CONVERSION
+# pylint: disable-next=protected-access
+UNIT_CONVERSION: dict[str, float] = PressureConverter._UNIT_CONVERSION
 VALID_UNITS = PressureConverter.VALID_UNITS
 
 

--- a/homeassistant/util/speed.py
+++ b/homeassistant/util/speed.py
@@ -24,7 +24,8 @@ from .unit_conversion import (  # pylint: disable=unused-import # noqa: F401
     SpeedConverter,
 )
 
-UNIT_CONVERSION = SpeedConverter.UNIT_CONVERSION
+# pylint: disable-next=protected-access
+UNIT_CONVERSION = SpeedConverter._UNIT_CONVERSION
 VALID_UNITS = SpeedConverter.VALID_UNITS
 
 

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -102,7 +102,7 @@ class BaseUnitConverter:
 class BaseUnitConverterWithUnitConversion(BaseUnitConverter):
     """Define the format of a conversion utility."""
 
-    UNIT_CONVERSION: dict[str, float]
+    _UNIT_CONVERSION: dict[str, float]
 
     @classmethod
     def convert(cls, value: float, from_unit: str, to_unit: str) -> float:
@@ -111,14 +111,14 @@ class BaseUnitConverterWithUnitConversion(BaseUnitConverter):
             return value
 
         try:
-            from_ratio = cls.UNIT_CONVERSION[from_unit]
+            from_ratio = cls._UNIT_CONVERSION[from_unit]
         except KeyError as err:
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(from_unit, cls.UNIT_CLASS)
             ) from err
 
         try:
-            to_ratio = cls.UNIT_CONVERSION[to_unit]
+            to_ratio = cls._UNIT_CONVERSION[to_unit]
         except KeyError as err:
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(to_unit, cls.UNIT_CLASS)
@@ -130,7 +130,7 @@ class BaseUnitConverterWithUnitConversion(BaseUnitConverter):
     @classmethod
     def get_unit_ratio(cls, from_unit: str, to_unit: str) -> float:
         """Get unit ratio between units of measurement."""
-        return cls.UNIT_CONVERSION[from_unit] / cls.UNIT_CONVERSION[to_unit]
+        return cls._UNIT_CONVERSION[from_unit] / cls._UNIT_CONVERSION[to_unit]
 
 
 class DistanceConverter(BaseUnitConverterWithUnitConversion):
@@ -138,7 +138,7 @@ class DistanceConverter(BaseUnitConverterWithUnitConversion):
 
     UNIT_CLASS = "distance"
     NORMALIZED_UNIT = LENGTH_METERS
-    UNIT_CONVERSION: dict[str, float] = {
+    _UNIT_CONVERSION: dict[str, float] = {
         LENGTH_METERS: 1,
         LENGTH_MILLIMETERS: 1 / _MM_TO_M,
         LENGTH_CENTIMETERS: 1 / _CM_TO_M,
@@ -165,7 +165,7 @@ class EnergyConverter(BaseUnitConverterWithUnitConversion):
 
     UNIT_CLASS = "energy"
     NORMALIZED_UNIT = ENERGY_KILO_WATT_HOUR
-    UNIT_CONVERSION: dict[str, float] = {
+    _UNIT_CONVERSION: dict[str, float] = {
         ENERGY_WATT_HOUR: 1 * 1000,
         ENERGY_KILO_WATT_HOUR: 1,
         ENERGY_MEGA_WATT_HOUR: 1 / 1000,
@@ -182,7 +182,7 @@ class MassConverter(BaseUnitConverterWithUnitConversion):
 
     UNIT_CLASS = "mass"
     NORMALIZED_UNIT = MASS_GRAMS
-    UNIT_CONVERSION: dict[str, float] = {
+    _UNIT_CONVERSION: dict[str, float] = {
         MASS_MICROGRAMS: 1 * 1000 * 1000,
         MASS_MILLIGRAMS: 1 * 1000,
         MASS_GRAMS: 1,
@@ -205,7 +205,7 @@ class PowerConverter(BaseUnitConverterWithUnitConversion):
 
     UNIT_CLASS = "power"
     NORMALIZED_UNIT = POWER_WATT
-    UNIT_CONVERSION: dict[str, float] = {
+    _UNIT_CONVERSION: dict[str, float] = {
         POWER_WATT: 1,
         POWER_KILO_WATT: 1 / 1000,
     }
@@ -220,7 +220,7 @@ class PressureConverter(BaseUnitConverterWithUnitConversion):
 
     UNIT_CLASS = "pressure"
     NORMALIZED_UNIT = PRESSURE_PA
-    UNIT_CONVERSION: dict[str, float] = {
+    _UNIT_CONVERSION: dict[str, float] = {
         PRESSURE_PA: 1,
         PRESSURE_HPA: 1 / 100,
         PRESSURE_KPA: 1 / 1000,
@@ -249,7 +249,7 @@ class SpeedConverter(BaseUnitConverterWithUnitConversion):
 
     UNIT_CLASS = "speed"
     NORMALIZED_UNIT = SPEED_METERS_PER_SECOND
-    UNIT_CONVERSION: dict[str, float] = {
+    _UNIT_CONVERSION: dict[str, float] = {
         SPEED_FEET_PER_SECOND: 1 / _FOOT_TO_M,
         SPEED_INCHES_PER_DAY: _DAYS_TO_SECS / _IN_TO_M,
         SPEED_INCHES_PER_HOUR: _HRS_TO_SECS / _IN_TO_M,
@@ -369,7 +369,7 @@ class VolumeConverter(BaseUnitConverterWithUnitConversion):
     UNIT_CLASS = "volume"
     NORMALIZED_UNIT = VOLUME_CUBIC_METERS
     # Units in terms of m³
-    UNIT_CONVERSION: dict[str, float] = {
+    _UNIT_CONVERSION: dict[str, float] = {
         VOLUME_LITERS: 1 / _L_TO_CUBIC_METER,
         VOLUME_MILLILITERS: 1 / _ML_TO_CUBIC_METER,
         VOLUME_GALLONS: 1 / _GALLON_TO_CUBIC_METER,

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -93,6 +93,11 @@ class BaseUnitConverter:
     def convert(cls, value: float, from_unit: str, to_unit: str) -> float:
         """Convert one unit of measurement to another."""
 
+    @classmethod
+    @abstractmethod
+    def get_unit_ratio(cls, from_unit: str, to_unit: str) -> float:
+        """Get unit ratio between units of measurement."""
+
 
 class BaseUnitConverterWithUnitConversion(BaseUnitConverter):
     """Define the format of a conversion utility."""
@@ -121,6 +126,11 @@ class BaseUnitConverterWithUnitConversion(BaseUnitConverter):
 
         new_value = value / from_ratio
         return new_value * to_ratio
+
+    @classmethod
+    def get_unit_ratio(cls, from_unit: str, to_unit: str) -> float:
+        """Get unit ratio between units of measurement."""
+        return cls.UNIT_CONVERSION[from_unit] / cls.UNIT_CONVERSION[to_unit]
 
 
 class DistanceConverter(BaseUnitConverterWithUnitConversion):
@@ -271,6 +281,11 @@ class TemperatureConverter(BaseUnitConverter):
         TEMP_FAHRENHEIT,
         TEMP_KELVIN,
     }
+    _UNIT_RATIO = {
+        TEMP_CELSIUS: 1.0,
+        TEMP_FAHRENHEIT: 1.8,
+        TEMP_KELVIN: 1.0,
+    }
 
     @classmethod
     def convert(
@@ -341,6 +356,11 @@ class TemperatureConverter(BaseUnitConverter):
         if interval:
             return celsius
         return celsius + 273.15
+
+    @classmethod
+    def get_unit_ratio(cls, from_unit: str, to_unit: str) -> float:
+        """Get unit ratio between units of measurement."""
+        return cls._UNIT_RATIO[from_unit] / cls._UNIT_RATIO[to_unit]
 
 
 class VolumeConverter(BaseUnitConverterWithUnitConversion):

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -14,7 +14,8 @@ from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
 
 from .unit_conversion import VolumeConverter
 
-UNIT_CONVERSION = VolumeConverter.UNIT_CONVERSION
+# pylint: disable-next=protected-access
+UNIT_CONVERSION = VolumeConverter._UNIT_CONVERSION
 VALID_UNITS = VolumeConverter.VALID_UNITS
 
 

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -163,6 +163,30 @@ def test_convert_nonnumeric_value(
 
 
 @pytest.mark.parametrize(
+    "converter,from_unit,to_unit,expected",
+    [
+        (DistanceConverter, LENGTH_KILOMETERS, LENGTH_METERS, 1 / 1000),
+        (EnergyConverter, ENERGY_WATT_HOUR, ENERGY_KILO_WATT_HOUR, 1000),
+        (PowerConverter, POWER_WATT, POWER_KILO_WATT, 1000),
+        (PressureConverter, PRESSURE_HPA, PRESSURE_INHG, pytest.approx(33.86389)),
+        (
+            SpeedConverter,
+            SPEED_KILOMETERS_PER_HOUR,
+            SPEED_MILES_PER_HOUR,
+            pytest.approx(1.609343),
+        ),
+        (TemperatureConverter, TEMP_CELSIUS, TEMP_FAHRENHEIT, 1 / 1.8),
+        (VolumeConverter, VOLUME_GALLONS, VOLUME_LITERS, pytest.approx(0.264172)),
+    ],
+)
+def test_get_unit_ratio(
+    converter: type[BaseUnitConverter], from_unit: str, to_unit: str, expected: float
+) -> None:
+    """Test unit ratio."""
+    assert converter.get_unit_ratio(from_unit, to_unit) == expected
+
+
+@pytest.mark.parametrize(
     "value,from_unit,expected,to_unit",
     [
         (5, LENGTH_MILES, pytest.approx(8.04672), LENGTH_KILOMETERS),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup unit conversion now that all device classes are in:
- [x] Move UNIT_RATIO to BaseUnitConverter
- [x] Make UNIT_CONVERSION private
- [x] Remove STATISTIC_UNIT_TO_UNIT_CLASS constant from recorder
- [x] Cleanup websocket_api in recorder
- [x] allow adjustment from any unit which is part of a unit_class known by recorder

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
