### PR TITLE
Add to issue registry if user has mirrored entries for breaking in #67631

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -259,9 +259,7 @@ class BayesianBinarySensor(BinarySensorEntity):
             raise_mirrored_entries(
                 self.hass,
                 all_template_observations,
-                text=f"{self._attr_name}/{all_template_observations[0]['value_template']}"
-                + "/"
-                + str(all_template_observations[0]["value_template"]),
+                text=f"{self._attr_name}/{all_template_observations[0]['value_template']}",
             )
 
     @callback

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -34,6 +34,7 @@ from homeassistant.helpers.template import result_as_boolean
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import DOMAIN, PLATFORMS
+from .repairs import raise_mirrored_entries
 
 ATTR_OBSERVATIONS = "observations"
 ATTR_OCCURRED_OBSERVATION_ENTITIES = "occurred_observation_entities"
@@ -244,6 +245,24 @@ class BayesianBinarySensor(BinarySensorEntity):
         self.current_observations.update(self._initialize_current_observations())
         self.probability = self._calculate_new_probability()
         self._attr_is_on = bool(self.probability >= self._probability_threshold)
+
+        # detect mirrored entries
+        for entity, observations in self.observations_by_entity.items():
+            raise_mirrored_entries(
+                self.hass, observations, text=str(self._attr_name) + "/" + str(entity)
+            )
+
+        all_template_observations = []
+        for value in self.observations_by_template.values():
+            all_template_observations.append(value[0])
+        if len(all_template_observations) == 2:
+            raise_mirrored_entries(
+                self.hass,
+                all_template_observations,
+                text=str(self._attr_name)
+                + "/"
+                + str(all_template_observations[0]["value_template"]),
+            )
 
     @callback
     def _recalculate_and_write_state(self):

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -259,7 +259,7 @@ class BayesianBinarySensor(BinarySensorEntity):
             raise_mirrored_entries(
                 self.hass,
                 all_template_observations,
-                text=f"{self._attr_name}/{all_template_observations[0]["value_template"]}"
+                text=f"{self._attr_name}/{all_template_observations[0]['value_template']}"
                 + "/"
                 + str(all_template_observations[0]["value_template"]),
             )

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -259,7 +259,7 @@ class BayesianBinarySensor(BinarySensorEntity):
             raise_mirrored_entries(
                 self.hass,
                 all_template_observations,
-                text=str(self._attr_name)
+                text=f"{self._attr_name}/{all_template_observations[0]["value_template"]}"
                 + "/"
                 + str(all_template_observations[0]["value_template"]),
             )

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -249,7 +249,7 @@ class BayesianBinarySensor(BinarySensorEntity):
         # detect mirrored entries
         for entity, observations in self.observations_by_entity.items():
             raise_mirrored_entries(
-                self.hass, observations, text=str(self._attr_name) + "/" + str(entity)
+                self.hass, observations, text=f"{self._attr_name}/{entity}"
             )
 
         all_template_observations = []

--- a/homeassistant/components/bayesian/repairs.py
+++ b/homeassistant/components/bayesian/repairs.py
@@ -1,0 +1,39 @@
+"""Helpers for generating repairs."""
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry
+
+from . import DOMAIN
+
+
+def raise_mirrored_entries(hass: HomeAssistant, observations, text: str = "") -> None:
+    """If there are mirrored entries, the user is probably using a workaround for a patched bug."""
+    if len(observations) != 2:
+        return
+    true_sums_1: bool = (
+        round(
+            observations[0]["prob_given_true"] + observations[1]["prob_given_true"], 1
+        )
+        == 1.0
+    )
+    false_sums_1: bool = (
+        round(
+            observations[0]["prob_given_false"] + observations[1]["prob_given_false"], 1
+        )
+        == 1.0
+    )
+    same_states: bool = observations[0]["platform"] == observations[1]["platform"]
+    if true_sums_1 & false_sums_1 & same_states:
+        issue_registry.async_create_issue(
+            hass,
+            DOMAIN,
+            "mirrored_entry/" + text,
+            breaks_in_ha_version="2022.10.0",
+            is_fixable=False,
+            is_persistent=False,
+            severity=issue_registry.IssueSeverity.WARNING,
+            translation_key="manual_migration",
+            translation_placeholders={"entity": text},
+            learn_more_url="https://github.com/home-assistant/core/pull/67631",
+        )

--- a/homeassistant/components/bayesian/translations/en.json
+++ b/homeassistant/components/bayesian/translations/en.json
@@ -1,0 +1,8 @@
+{
+  "issues": {
+    "manual_migration": {
+      "description": "The Bayesian integration now also updates the probability if the observed `to_state`, `above`, `below`, or `value_template` evaluates to `False` rather than only `True`. So it is no longer required to have duplicate, complementary entries for each binary state. Please remove the mirrored entry for `{entity}`",
+      "title": "Manual YAML fix required for Bayesian"
+    }
+  }
+}

--- a/homeassistant/components/bayesian/translations/en.json
+++ b/homeassistant/components/bayesian/translations/en.json
@@ -1,7 +1,7 @@
 {
   "issues": {
     "manual_migration": {
-      "description": "The Bayesian integration now also updates the probability if the observed `to_state`, `above`, `below`, or `value_template` evaluates to `False` rather than only `True`. So it is no longer required to have duplicate, complementary entries for each binary state. Please remove the mirrored entry for `{entity}`",
+      "description": "The Bayesian integration now also updates the probability if the observed `to_state`, `above`, `below`, or `value_template` evaluates to `False` rather than only `True`. So it is no longer required to have duplicate, complementary entries for each binary state. Please remove the mirrored entry for `{entity}`.",
       "title": "Manual YAML fix required for Bayesian"
     }
   }

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, callback
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.issue_registry import async_get
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_fixture_path
@@ -184,6 +185,8 @@ async def test_sensor_numeric_state(hass):
 
     assert state.state == "off"
 
+    assert len(async_get(hass).issues) == 0
+
 
 async def test_sensor_state(hass):
     """Test sensor on state platform observations."""
@@ -341,6 +344,7 @@ async def test_threshold(hass):
     assert round(abs(1.0 - state.attributes.get("probability")), 7) == 0
 
     assert state.state == "on"
+    assert len(async_get(hass).issues) == 0
 
 
 async def test_multiple_observations(hass):
@@ -493,6 +497,94 @@ async def test_multiple_numeric_observations(hass):
     assert state.state == "on"
     assert state.attributes.get("observations")[0]["platform"] == "numeric_state"
     assert state.attributes.get("observations")[1]["platform"] == "numeric_state"
+
+
+async def test_mirrored_observations(hass):
+    """Test whether mirrored entries are detected and appropriate issues are created."""
+
+    config = {
+        "binary_sensor": {
+            "platform": "bayesian",
+            "name": "Test_Binary",
+            "observations": [
+                {
+                    "platform": "state",
+                    "entity_id": "binary_sensor.test_monitored",
+                    "to_state": "on",
+                    "prob_given_true": 0.8,
+                    "prob_given_false": 0.4,
+                },
+                {
+                    "platform": "state",
+                    "entity_id": "binary_sensor.test_monitored",
+                    "to_state": "off",
+                    "prob_given_true": 0.2,
+                    "prob_given_false": 0.59,
+                },
+                {
+                    "platform": "numeric_state",
+                    "entity_id": "sensor.test_monitored1",
+                    "above": 5,
+                    "prob_given_true": 0.7,
+                    "prob_given_false": 0.4,
+                },
+                {
+                    "platform": "numeric_state",
+                    "entity_id": "sensor.test_monitored1",
+                    "below": 5,
+                    "prob_given_true": 0.3,
+                    "prob_given_false": 0.6,
+                },
+                {
+                    "platform": "template",
+                    "value_template": "{{states('sensor.test_monitored2') == 'off'}}",
+                    "prob_given_true": 0.79,
+                    "prob_given_false": 0.4,
+                },
+                {
+                    "platform": "template",
+                    "value_template": "{{states('sensor.test_monitored2') == 'on'}}",
+                    "prob_given_true": 0.2,
+                    "prob_given_false": 0.6,
+                },
+                {
+                    "platform": "state",
+                    "entity_id": "sensor.colour",
+                    "to_state": "blue",
+                    "prob_given_true": 0.33,
+                    "prob_given_false": 0.8,
+                },
+                {
+                    "platform": "state",
+                    "entity_id": "sensor.colour",
+                    "to_state": "green",
+                    "prob_given_true": 0.3,
+                    "prob_given_false": 0.15,
+                },
+                {
+                    "platform": "state",
+                    "entity_id": "sensor.colour",
+                    "to_state": "red",
+                    "prob_given_true": 0.4,
+                    "prob_given_false": 0.05,
+                },
+            ],
+            "prior": 0.1,
+        }
+    }
+    assert len(async_get(hass).issues) == 0
+    assert await async_setup_component(hass, "binary_sensor", config)
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.test_monitored2", "on")
+    await hass.async_block_till_done()
+
+    assert len(async_get(hass).issues) == 3
+    assert (
+        async_get(hass).issues[
+            ("bayesian", "mirrored_entry/Test_Binary/sensor.test_monitored1")
+        ]
+        is not None
+    )
 
 
 async def test_probability_updates(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is part of a wider project to improve the Bayesian integration. Which can be seen in more detail on the [community forum](https://community.home-assistant.io/t/the-future-of-the-bayesian-integration-thoughts-wanted/465476). 

This PR does the following:
1. Adds an issue registry item for the breaking change in #67631 so perhaps it should target the same release? https://github.com/home-assistant/core/blob/a0e2af9582e87922dd9d3fd8bb637b840c25c127/homeassistant/components/bayesian/repairs.py#L11
2. Adds a test for the issue registry creation: https://github.com/home-assistant/core/blob/a0e2af9582e87922dd9d3fd8bb637b840c25c127/tests/components/bayesian/test_binary_sensor.py#L502
3. And tests for false positives https://github.com/home-assistant/core/blob/a0e2af9582e87922dd9d3fd8bb637b840c25c127/tests/components/bayesian/test_binary_sensor.py#L188


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to community post discussing changes: https://community.home-assistant.io/t/the-future-of-the-bayesian-integration-thoughts-wanted/465476

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
