### PR TITLE
Update huisbaasje-client 0.1.0 to energyflip-client 0.2.0

### DIFF
--- a/homeassistant/components/huisbaasje/config_flow.py
+++ b/homeassistant/components/huisbaasje/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Huisbaasje integration."""
 import logging
 
-from huisbaasje import Huisbaasje, HuisbaasjeConnectionException, HuisbaasjeException
+from energyflip import EnergyFlip, EnergyFlipConnectionException, EnergyFlipException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -31,10 +31,10 @@ class HuisbaasjeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             user_id = await self._validate_input(user_input)
-        except HuisbaasjeConnectionException as exception:
+        except EnergyFlipConnectionException as exception:
             _LOGGER.warning(exception)
             errors["base"] = "cannot_connect"
-        except HuisbaasjeException as exception:
+        except EnergyFlipException as exception:
             _LOGGER.warning(exception)
             errors["base"] = "invalid_auth"
         except AbortFlow:
@@ -72,9 +72,12 @@ class HuisbaasjeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
 
-        huisbaasje = Huisbaasje(username, password)
+        energyflip = EnergyFlip(username, password)
 
-        # Attempt authentication. If this fails, an HuisbaasjeException will be thrown
-        await huisbaasje.authenticate()
+        # Attempt authentication. If this fails, an EnergyFlipException will be thrown
+        await energyflip.authenticate()
 
-        return huisbaasje.get_user_id()
+        # Request customer overview. This also sets the user id on the client
+        await energyflip.customer_overview()
+
+        return energyflip.get_user_id()

--- a/homeassistant/components/huisbaasje/const.py
+++ b/homeassistant/components/huisbaasje/const.py
@@ -1,5 +1,5 @@
 """Constants for the Huisbaasje integration."""
-from huisbaasje.const import (
+from energyflip.const import (
     SOURCE_TYPE_ELECTRICITY,
     SOURCE_TYPE_ELECTRICITY_IN,
     SOURCE_TYPE_ELECTRICITY_IN_LOW,

--- a/homeassistant/components/huisbaasje/manifest.json
+++ b/homeassistant/components/huisbaasje/manifest.json
@@ -3,7 +3,7 @@
   "name": "Huisbaasje",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/huisbaasje",
-  "requirements": ["huisbaasje-client==0.1.0"],
+  "requirements": ["energyflip-client==0.2.0"],
   "codeowners": ["@dennisschroer"],
   "iot_class": "cloud_polling",
   "loggers": ["huisbaasje"]

--- a/homeassistant/components/huisbaasje/manifest.json
+++ b/homeassistant/components/huisbaasje/manifest.json
@@ -3,7 +3,7 @@
   "name": "Huisbaasje",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/huisbaasje",
-  "requirements": ["energyflip-client==0.2.0"],
+  "requirements": ["energyflip-client==0.2.1"],
   "codeowners": ["@dennisschroer"],
   "iot_class": "cloud_polling",
   "loggers": ["huisbaasje"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -623,7 +623,7 @@ elmax_api==0.0.2
 emulated_roku==0.2.1
 
 # homeassistant.components.huisbaasje
-energyflip-client==0.2.0
+energyflip-client==0.2.1
 
 # homeassistant.components.enocean
 enocean==0.50

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -622,6 +622,9 @@ elmax_api==0.0.2
 # homeassistant.components.emulated_roku
 emulated_roku==0.2.1
 
+# homeassistant.components.huisbaasje
+energyflip-client==0.2.0
+
 # homeassistant.components.enocean
 enocean==0.50
 
@@ -881,9 +884,6 @@ httplib2==0.20.4
 
 # homeassistant.components.huawei_lte
 huawei-lte-api==1.6.1
-
-# homeassistant.components.huisbaasje
-huisbaasje-client==0.1.0
 
 # homeassistant.components.hydrawise
 hydrawiser==0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -475,6 +475,9 @@ elmax_api==0.0.2
 # homeassistant.components.emulated_roku
 emulated_roku==0.2.1
 
+# homeassistant.components.huisbaasje
+energyflip-client==0.2.0
+
 # homeassistant.components.enocean
 enocean==0.50
 
@@ -658,9 +661,6 @@ httplib2==0.20.4
 
 # homeassistant.components.huawei_lte
 huawei-lte-api==1.6.1
-
-# homeassistant.components.huisbaasje
-huisbaasje-client==0.1.0
 
 # homeassistant.components.hyperion
 hyperion-py==0.7.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -476,7 +476,7 @@ elmax_api==0.0.2
 emulated_roku==0.2.1
 
 # homeassistant.components.huisbaasje
-energyflip-client==0.2.0
+energyflip-client==0.2.1
 
 # homeassistant.components.enocean
 enocean==0.50

--- a/tests/components/huisbaasje/test_config_flow.py
+++ b/tests/components/huisbaasje/test_config_flow.py
@@ -3,8 +3,8 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.huisbaasje.config_flow import (
-    HuisbaasjeConnectionException,
-    HuisbaasjeException,
+    EnergyFlipConnectionException,
+    EnergyFlipException,
 )
 from homeassistant.components.huisbaasje.const import DOMAIN
 
@@ -58,7 +58,7 @@ async def test_form_invalid_auth(hass):
 
     with patch(
         "huisbaasje.Huisbaasje.authenticate",
-        side_effect=HuisbaasjeException,
+        side_effect=EnergyFlipException,
     ):
         form_result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -80,7 +80,7 @@ async def test_form_cannot_connect(hass):
 
     with patch(
         "huisbaasje.Huisbaasje.authenticate",
-        side_effect=HuisbaasjeConnectionException,
+        side_effect=EnergyFlipConnectionException,
     ):
         form_result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/huisbaasje/test_config_flow.py
+++ b/tests/components/huisbaasje/test_config_flow.py
@@ -1,13 +1,13 @@
 """Test the Huisbaasje config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, data_entry_flow
 from energyflip import (
-    EnergyFlip,
     EnergyFlipConnectionException,
-    EnergyFlipUnauthenticatedException,
     EnergyFlipException,
+    EnergyFlipUnauthenticatedException,
 )
+
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.huisbaasje.const import DOMAIN
 
 from tests.common import MockConfigEntry

--- a/tests/components/huisbaasje/test_config_flow.py
+++ b/tests/components/huisbaasje/test_config_flow.py
@@ -2,8 +2,10 @@
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.huisbaasje.config_flow import (
+from energyflip import (
+    EnergyFlip,
     EnergyFlipConnectionException,
+    EnergyFlipUnauthenticatedException,
     EnergyFlipException,
 )
 from homeassistant.components.huisbaasje.const import DOMAIN
@@ -21,9 +23,11 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch(
-        "huisbaasje.Huisbaasje.authenticate", return_value=None
+        "energyflip.EnergyFlip.authenticate", return_value=None
     ) as mock_authenticate, patch(
-        "huisbaasje.Huisbaasje.get_user_id",
+        "energyflip.EnergyFlip.customer_overview", return_value=None
+    ) as mock_customer_overview, patch(
+        "energyflip.EnergyFlip.get_user_id",
         return_value="test-id",
     ) as mock_get_user_id, patch(
         "homeassistant.components.huisbaasje.async_setup_entry",
@@ -46,6 +50,7 @@ async def test_form(hass):
         "password": "test-password",
     }
     assert len(mock_authenticate.mock_calls) == 1
+    assert len(mock_customer_overview.mock_calls) == 1
     assert len(mock_get_user_id.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -57,7 +62,7 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-        "huisbaasje.Huisbaasje.authenticate",
+        "energyflip.EnergyFlip.authenticate",
         side_effect=EnergyFlipException,
     ):
         form_result = await hass.config_entries.flow.async_configure(
@@ -72,14 +77,14 @@ async def test_form_invalid_auth(hass):
     assert form_result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
-    """Test we handle cannot connect error."""
+async def test_form_authenticate_cannot_connect(hass):
+    """Test we handle cannot connect error in authenticate."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
-        "huisbaasje.Huisbaasje.authenticate",
+        "energyflip.EnergyFlip.authenticate",
         side_effect=EnergyFlipConnectionException,
     ):
         form_result = await hass.config_entries.flow.async_configure(
@@ -94,14 +99,80 @@ async def test_form_cannot_connect(hass):
     assert form_result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass):
-    """Test we handle an unknown error."""
+async def test_form_authenticate_unknown_error(hass):
+    """Test we handle an unknown error in authenticate."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
-        "huisbaasje.Huisbaasje.authenticate",
+        "energyflip.EnergyFlip.authenticate",
+        side_effect=Exception,
+    ):
+        form_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert form_result["type"] == data_entry_flow.FlowResultType.FORM
+    assert form_result["errors"] == {"base": "unknown"}
+
+
+async def test_form_customer_overview_cannot_connect(hass):
+    """Test we handle cannot connect error in customer_overview."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("energyflip.EnergyFlip.authenticate", return_value=None), patch(
+        "energyflip.EnergyFlip.customer_overview",
+        side_effect=EnergyFlipConnectionException,
+    ):
+        form_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert form_result["type"] == data_entry_flow.FlowResultType.FORM
+    assert form_result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_customer_overview_authentication_error(hass):
+    """Test we handle an unknown error in customer_overview."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("energyflip.EnergyFlip.authenticate", return_value=None), patch(
+        "energyflip.EnergyFlip.customer_overview",
+        side_effect=EnergyFlipUnauthenticatedException,
+    ):
+        form_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert form_result["type"] == data_entry_flow.FlowResultType.FORM
+    assert form_result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_customer_overview_unknown_error(hass):
+    """Test we handle an unknown error in customer_overview."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("energyflip.EnergyFlip.authenticate", return_value=None), patch(
+        "energyflip.EnergyFlip.customer_overview",
         side_effect=Exception,
     ):
         form_result = await hass.config_entries.flow.async_configure(
@@ -133,10 +204,9 @@ async def test_form_entry_exists(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch("huisbaasje.Huisbaasje.authenticate", return_value=None), patch(
-        "huisbaasje.Huisbaasje.get_user_id",
-        return_value="test-id",
-    ), patch(
+    with patch("energyflip.EnergyFlip.authenticate", return_value=None), patch(
+        "energyflip.EnergyFlip.customer_overview", return_value=None
+    ), patch("energyflip.EnergyFlip.get_user_id", return_value="test-id",), patch(
         "homeassistant.components.huisbaasje.async_setup_entry",
         return_value=True,
     ):

--- a/tests/components/huisbaasje/test_init.py
+++ b/tests/components/huisbaasje/test_init.py
@@ -24,11 +24,11 @@ async def test_setup(hass: HomeAssistant):
 async def test_setup_entry(hass: HomeAssistant):
     """Test for successfully setting a config entry."""
     with patch(
-        "huisbaasje.Huisbaasje.authenticate", return_value=None
+        "energyflip.EnergyFlip.authenticate", return_value=None
     ) as mock_authenticate, patch(
-        "huisbaasje.Huisbaasje.is_authenticated", return_value=True
+        "energyflip.EnergyFlip.is_authenticated", return_value=True
     ) as mock_is_authenticated, patch(
-        "huisbaasje.Huisbaasje.current_measurements",
+        "energyflip.EnergyFlip.current_measurements",
         return_value=MOCK_CURRENT_MEASUREMENTS,
     ) as mock_current_measurements:
         hass.config.components.add(huisbaasje.DOMAIN)
@@ -68,7 +68,7 @@ async def test_setup_entry(hass: HomeAssistant):
 async def test_setup_entry_error(hass: HomeAssistant):
     """Test for successfully setting a config entry."""
     with patch(
-        "huisbaasje.Huisbaasje.authenticate", side_effect=EnergyFlipException
+        "energyflip.EnergyFlip.authenticate", side_effect=EnergyFlipException
     ) as mock_authenticate:
         hass.config.components.add(huisbaasje.DOMAIN)
         config_entry = MockConfigEntry(
@@ -103,11 +103,11 @@ async def test_setup_entry_error(hass: HomeAssistant):
 async def test_unload_entry(hass: HomeAssistant):
     """Test for successfully unloading the config entry."""
     with patch(
-        "huisbaasje.Huisbaasje.authenticate", return_value=None
+        "energyflip.EnergyFlip.authenticate", return_value=None
     ) as mock_authenticate, patch(
-        "huisbaasje.Huisbaasje.is_authenticated", return_value=True
+        "energyflip.EnergyFlip.is_authenticated", return_value=True
     ) as mock_is_authenticated, patch(
-        "huisbaasje.Huisbaasje.current_measurements",
+        "energyflip.EnergyFlip.current_measurements",
         return_value=MOCK_CURRENT_MEASUREMENTS,
     ) as mock_current_measurements:
         hass.config.components.add(huisbaasje.DOMAIN)

--- a/tests/components/huisbaasje/test_init.py
+++ b/tests/components/huisbaasje/test_init.py
@@ -1,7 +1,7 @@
 """Test cases for the initialisation of the Huisbaasje integration."""
 from unittest.mock import patch
 
-from huisbaasje import HuisbaasjeException
+from energyflip import EnergyFlipException
 
 from homeassistant.components import huisbaasje
 from homeassistant.config_entries import ConfigEntryState
@@ -68,7 +68,7 @@ async def test_setup_entry(hass: HomeAssistant):
 async def test_setup_entry_error(hass: HomeAssistant):
     """Test for successfully setting a config entry."""
     with patch(
-        "huisbaasje.Huisbaasje.authenticate", side_effect=HuisbaasjeException
+        "huisbaasje.Huisbaasje.authenticate", side_effect=EnergyFlipException
     ) as mock_authenticate:
         hass.config.components.add(huisbaasje.DOMAIN)
         config_entry = MockConfigEntry(

--- a/tests/components/huisbaasje/test_sensor.py
+++ b/tests/components/huisbaasje/test_sensor.py
@@ -29,11 +29,11 @@ from tests.common import MockConfigEntry
 async def test_setup_entry(hass: HomeAssistant):
     """Test for successfully loading sensor states."""
     with patch(
-        "huisbaasje.Huisbaasje.authenticate", return_value=None
+        "energyflip.EnergyFlip.authenticate", return_value=None
     ) as mock_authenticate, patch(
-        "huisbaasje.Huisbaasje.is_authenticated", return_value=True
+        "energyflip.EnergyFlip.is_authenticated", return_value=True
     ) as mock_is_authenticated, patch(
-        "huisbaasje.Huisbaasje.current_measurements",
+        "energyflip.EnergyFlip.current_measurements",
         return_value=MOCK_CURRENT_MEASUREMENTS,
     ) as mock_current_measurements:
 
@@ -344,11 +344,11 @@ async def test_setup_entry(hass: HomeAssistant):
 async def test_setup_entry_absent_measurement(hass: HomeAssistant):
     """Test for successfully loading sensor states when response does not contain all measurements."""
     with patch(
-        "huisbaasje.Huisbaasje.authenticate", return_value=None
+        "energyflip.EnergyFlip.authenticate", return_value=None
     ) as mock_authenticate, patch(
-        "huisbaasje.Huisbaasje.is_authenticated", return_value=True
+        "energyflip.EnergyFlip.is_authenticated", return_value=True
     ) as mock_is_authenticated, patch(
-        "huisbaasje.Huisbaasje.current_measurements",
+        "energyflip.EnergyFlip.current_measurements",
         return_value=MOCK_LIMITED_CURRENT_MEASUREMENTS,
     ) as mock_current_measurements:
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Update `huisbaasje-client 0.1.0` to `energyflip-client 0.2.1`.
- https://github.com/dennisschroer/energyflip-client/compare/v0.1.0...v0.2.1


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: Fixes https://github.com/home-assistant/core/issues/78890
- This PR is only a bugfix; a rename of the integration is also coming in a seperate PR. So the current confusion between Huisbaasje and the library called EnergyFlip is only temporary.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] -Documentation added/updated for [www.home-assistant.io][docs-repository]- 

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
