### PR TITLE
Improve naming of units used in statistics

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -485,11 +485,13 @@ class Recorder(threading.Thread):
         statistic_id: str,
         start_time: datetime,
         sum_adjustment: float,
-        display_unit: str,
+        adjustment_unit: str,
     ) -> None:
         """Adjust statistics."""
         self.queue_task(
-            AdjustStatisticsTask(statistic_id, start_time, sum_adjustment, display_unit)
+            AdjustStatisticsTask(
+                statistic_id, start_time, sum_adjustment, adjustment_unit
+            )
         )
 
     @callback

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -899,7 +899,7 @@ def list_statistic_ids(
 
         result = {
             meta["statistic_id"]: {
-                "display_unit_of_measurement": meta["state_unit_of_measurement"],
+                "state_unit_of_measurement": meta["state_unit_of_measurement"],
                 "has_mean": meta["has_mean"],
                 "has_sum": meta["has_sum"],
                 "name": meta["name"],
@@ -926,7 +926,7 @@ def list_statistic_ids(
                 "has_sum": meta["has_sum"],
                 "name": meta["name"],
                 "source": meta["source"],
-                "display_unit_of_measurement": meta["state_unit_of_measurement"],
+                "state_unit_of_measurement": meta["state_unit_of_measurement"],
                 "unit_class": _get_unit_class(meta["unit_of_measurement"]),
                 "unit_of_measurement": meta["unit_of_measurement"],
             }
@@ -939,7 +939,7 @@ def list_statistic_ids(
             "has_sum": info["has_sum"],
             "name": info.get("name"),
             "source": info["source"],
-            "display_unit_of_measurement": info["display_unit_of_measurement"],
+            "state_unit_of_measurement": info["state_unit_of_measurement"],
             "statistics_unit_of_measurement": info["unit_of_measurement"],
             "unit_class": info["unit_class"],
         }
@@ -1605,7 +1605,7 @@ def adjust_statistics(
     statistic_id: str,
     start_time: datetime,
     sum_adjustment: float,
-    display_unit: str,
+    adjustment_unit: str,
 ) -> bool:
     """Process an add_statistics job."""
 
@@ -1617,7 +1617,9 @@ def adjust_statistics(
             return True
 
         statistic_unit = metadata[statistic_id][1]["unit_of_measurement"]
-        convert = _get_display_to_statistic_unit_converter(display_unit, statistic_unit)
+        convert = _get_display_to_statistic_unit_converter(
+            adjustment_unit, statistic_unit
+        )
         sum_adjustment = convert(sum_adjustment)
 
         _adjust_sum_statistics(

--- a/homeassistant/components/recorder/tasks.py
+++ b/homeassistant/components/recorder/tasks.py
@@ -163,7 +163,7 @@ class AdjustStatisticsTask(RecorderTask):
     statistic_id: str
     start_time: datetime
     sum_adjustment: float
-    display_unit: str
+    adjustment_unit: str
 
     def run(self, instance: Recorder) -> None:
         """Run statistics task."""
@@ -172,7 +172,7 @@ class AdjustStatisticsTask(RecorderTask):
             self.statistic_id,
             self.start_time,
             self.sum_adjustment,
-            self.display_unit,
+            self.adjustment_unit,
         ):
             return
         # Schedule a new adjust statistics task if this one didn't finish
@@ -181,7 +181,7 @@ class AdjustStatisticsTask(RecorderTask):
                 self.statistic_id,
                 self.start_time,
                 self.sum_adjustment,
-                self.display_unit,
+                self.adjustment_unit,
             )
         )
 

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -291,7 +291,7 @@ def ws_change_statistics_unit(
         vol.Required("statistic_id"): str,
         vol.Required("start_time"): str,
         vol.Required("adjustment"): vol.Any(float, int),
-        vol.Required("display_unit"): vol.Any(str, None),
+        vol.Required("adjustment_unit_of_measurement"): vol.Any(str, None),
     }
 )
 @websocket_api.async_response
@@ -320,25 +320,26 @@ async def ws_adjust_sum_statistics(
         return
     metadata = metadatas[0]
 
-    def valid_units(statistics_unit: str | None, display_unit: str | None) -> bool:
-        if statistics_unit == display_unit:
+    def valid_units(statistics_unit: str | None, adjustment_unit: str | None) -> bool:
+        if statistics_unit == adjustment_unit:
             return True
         converter = STATISTIC_UNIT_TO_UNIT_CONVERTER.get(statistics_unit)
-        if converter is not None and display_unit in converter.VALID_UNITS:
+        if converter is not None and adjustment_unit in converter.VALID_UNITS:
             return True
         return False
 
     stat_unit = metadata["statistics_unit_of_measurement"]
-    if not valid_units(stat_unit, msg["display_unit"]):
+    adjustment_unit = msg["adjustment_unit_of_measurement"]
+    if not valid_units(stat_unit, adjustment_unit):
         connection.send_error(
             msg["id"],
             "invalid_units",
-            f"Can't convert {stat_unit} to {msg['display_unit']}",
+            f"Can't convert {stat_unit} to {adjustment_unit}",
         )
         return
 
     get_instance(hass).async_adjust_statistics(
-        msg["statistic_id"], start_time, msg["adjustment"], msg["display_unit"]
+        msg["statistic_id"], start_time, msg["adjustment"], adjustment_unit
     )
     connection.send_result(msg["id"])
 

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -63,21 +63,21 @@ async def test_demo_statistics(hass, recorder_mock):
         list_statistic_ids, hass
     )
     assert {
-        "display_unit_of_measurement": "°C",
         "has_mean": True,
         "has_sum": False,
         "name": "Outdoor temperature",
         "source": "demo",
+        "state_unit_of_measurement": "°C",
         "statistic_id": "demo:temperature_outdoor",
         "statistics_unit_of_measurement": "°C",
         "unit_class": "temperature",
     } in statistic_ids
     assert {
-        "display_unit_of_measurement": "kWh",
         "has_mean": False,
         "has_sum": True,
         "name": "Energy consumption 1",
         "source": "demo",
+        "state_unit_of_measurement": "kWh",
         "statistic_id": "demo:energy_consumption_kwh",
         "statistics_unit_of_measurement": "kWh",
         "unit_class": "energy",

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -525,12 +525,12 @@ async def test_import_statistics(
     statistic_ids = list_statistic_ids(hass)
     assert statistic_ids == [
         {
-            "display_unit_of_measurement": "kWh",
             "has_mean": False,
             "has_sum": True,
             "statistic_id": statistic_id,
             "name": "Total imported energy",
             "source": source,
+            "state_unit_of_measurement": "kWh",
             "statistics_unit_of_measurement": "kWh",
             "unit_class": "energy",
         }
@@ -621,12 +621,12 @@ async def test_import_statistics(
     statistic_ids = list_statistic_ids(hass)
     assert statistic_ids == [
         {
-            "display_unit_of_measurement": "MWh",
             "has_mean": False,
             "has_sum": True,
             "statistic_id": statistic_id,
             "name": "Total imported energy renamed",
             "source": source,
+            "state_unit_of_measurement": "MWh",
             "statistics_unit_of_measurement": "kWh",
             "unit_class": "energy",
         }
@@ -682,7 +682,7 @@ async def test_import_statistics(
             "statistic_id": statistic_id,
             "start_time": period2.isoformat(),
             "adjustment": 1000.0,
-            "display_unit": "MWh",
+            "adjustment_unit_of_measurement": "MWh",
         }
     )
     response = await client.receive_json()

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -651,7 +651,7 @@ async def test_list_statistic_ids(
             "has_sum": has_sum,
             "name": None,
             "source": "recorder",
-            "display_unit_of_measurement": display_unit,
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -673,7 +673,7 @@ async def test_list_statistic_ids(
             "has_sum": has_sum,
             "name": None,
             "source": "recorder",
-            "display_unit_of_measurement": display_unit,
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -698,7 +698,7 @@ async def test_list_statistic_ids(
                 "has_sum": has_sum,
                 "name": None,
                 "source": "recorder",
-                "display_unit_of_measurement": display_unit,
+                "state_unit_of_measurement": display_unit,
                 "statistics_unit_of_measurement": statistics_unit,
                 "unit_class": unit_class,
             }
@@ -719,7 +719,7 @@ async def test_list_statistic_ids(
                 "has_sum": has_sum,
                 "name": None,
                 "source": "recorder",
-                "display_unit_of_measurement": display_unit,
+                "state_unit_of_measurement": display_unit,
                 "statistics_unit_of_measurement": statistics_unit,
                 "unit_class": unit_class,
             }
@@ -903,11 +903,11 @@ async def test_update_statistics_metadata(
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
-            "display_unit_of_measurement": "kW",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "kW",
             "statistics_unit_of_measurement": "kW",
             "unit_class": None,
         }
@@ -931,11 +931,11 @@ async def test_update_statistics_metadata(
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
-            "display_unit_of_measurement": "kW",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "kW",
             "statistics_unit_of_measurement": new_unit,
             "unit_class": new_unit_class,
         }
@@ -995,11 +995,11 @@ async def test_change_statistics_unit(hass, hass_ws_client, recorder_mock):
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
-            "display_unit_of_measurement": "kW",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "kW",
             "statistics_unit_of_measurement": "kW",
             "unit_class": None,
         }
@@ -1051,11 +1051,11 @@ async def test_change_statistics_unit(hass, hass_ws_client, recorder_mock):
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
-            "display_unit_of_measurement": "kW",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "kW",
             "statistics_unit_of_measurement": "W",
             "unit_class": "power",
         }
@@ -1104,11 +1104,11 @@ async def test_change_statistics_unit_errors(
     expected_statistic_ids = [
         {
             "statistic_id": "sensor.test",
-            "display_unit_of_measurement": "kW",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "kW",
             "statistics_unit_of_measurement": "kW",
             "unit_class": None,
         }
@@ -1483,11 +1483,11 @@ async def test_get_statistics_metadata(
     assert response["result"] == [
         {
             "statistic_id": "test:total_gas",
-            "display_unit_of_measurement": unit,
             "has_mean": has_mean,
             "has_sum": has_sum,
             "name": "Total imported energy",
             "source": "test",
+            "state_unit_of_measurement": unit,
             "statistics_unit_of_measurement": unit,
             "unit_class": unit_class,
         }
@@ -1511,11 +1511,11 @@ async def test_get_statistics_metadata(
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
-            "display_unit_of_measurement": attributes["unit_of_measurement"],
             "has_mean": has_mean,
             "has_sum": has_sum,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": attributes["unit_of_measurement"],
             "statistics_unit_of_measurement": unit,
             "unit_class": unit_class,
         }
@@ -1539,11 +1539,11 @@ async def test_get_statistics_metadata(
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
-            "display_unit_of_measurement": attributes["unit_of_measurement"],
             "has_mean": has_mean,
             "has_sum": has_sum,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": attributes["unit_of_measurement"],
             "statistics_unit_of_measurement": unit,
             "unit_class": unit_class,
         }
@@ -1635,12 +1635,12 @@ async def test_import_statistics(
     statistic_ids = list_statistic_ids(hass)  # TODO
     assert statistic_ids == [
         {
-            "display_unit_of_measurement": "kWh",
             "has_mean": False,
             "has_sum": True,
             "statistic_id": statistic_id,
             "name": "Total imported energy",
             "source": source,
+            "state_unit_of_measurement": "kWh",
             "statistics_unit_of_measurement": "kWh",
             "unit_class": "energy",
         }
@@ -1864,12 +1864,12 @@ async def test_adjust_sum_statistics_energy(
     statistic_ids = list_statistic_ids(hass)  # TODO
     assert statistic_ids == [
         {
-            "display_unit_of_measurement": "kWh",
             "has_mean": False,
             "has_sum": True,
             "statistic_id": statistic_id,
             "name": "Total imported energy",
             "source": source,
+            "state_unit_of_measurement": "kWh",
             "statistics_unit_of_measurement": "kWh",
             "unit_class": "energy",
         }
@@ -1898,7 +1898,7 @@ async def test_adjust_sum_statistics_energy(
             "statistic_id": statistic_id,
             "start_time": period2.isoformat(),
             "adjustment": 1000.0,
-            "display_unit": "kWh",
+            "adjustment_unit_of_measurement": "kWh",
         }
     )
     response = await client.receive_json()
@@ -1941,7 +1941,7 @@ async def test_adjust_sum_statistics_energy(
             "statistic_id": statistic_id,
             "start_time": period2.isoformat(),
             "adjustment": 2.0,
-            "display_unit": "MWh",
+            "adjustment_unit_of_measurement": "MWh",
         }
     )
     response = await client.receive_json()
@@ -2062,12 +2062,12 @@ async def test_adjust_sum_statistics_gas(
     statistic_ids = list_statistic_ids(hass)  # TODO
     assert statistic_ids == [
         {
-            "display_unit_of_measurement": "m³",
             "has_mean": False,
             "has_sum": True,
             "statistic_id": statistic_id,
             "name": "Total imported energy",
             "source": source,
+            "state_unit_of_measurement": "m³",
             "statistics_unit_of_measurement": "m³",
             "unit_class": "volume",
         }
@@ -2096,7 +2096,7 @@ async def test_adjust_sum_statistics_gas(
             "statistic_id": statistic_id,
             "start_time": period2.isoformat(),
             "adjustment": 1000.0,
-            "display_unit": "m³",
+            "adjustment_unit_of_measurement": "m³",
         }
     )
     response = await client.receive_json()
@@ -2139,7 +2139,7 @@ async def test_adjust_sum_statistics_gas(
             "statistic_id": statistic_id,
             "start_time": period2.isoformat(),
             "adjustment": 35.3147,  # ~1 m³
-            "display_unit": "ft³",
+            "adjustment_unit_of_measurement": "ft³",
         }
     )
     response = await client.receive_json()
@@ -2276,12 +2276,12 @@ async def test_adjust_sum_statistics_errors(
     statistic_ids = list_statistic_ids(hass)
     assert statistic_ids == [
         {
-            "display_unit_of_measurement": state_unit,
             "has_mean": False,
             "has_sum": True,
             "statistic_id": statistic_id,
             "name": "Total imported energy",
             "source": source,
+            "state_unit_of_measurement": state_unit,
             "statistics_unit_of_measurement": statistic_unit,
             "unit_class": unit_class,
         }
@@ -2311,7 +2311,7 @@ async def test_adjust_sum_statistics_errors(
             "statistic_id": "sensor.does_not_exist",
             "start_time": period2.isoformat(),
             "adjustment": 1000.0,
-            "display_unit": statistic_unit,
+            "adjustment_unit_of_measurement": statistic_unit,
         }
     )
     response = await client.receive_json()
@@ -2331,7 +2331,7 @@ async def test_adjust_sum_statistics_errors(
                 "statistic_id": statistic_id,
                 "start_time": period2.isoformat(),
                 "adjustment": 1000.0,
-                "display_unit": unit,
+                "adjustment_unit_of_measurement": unit,
             }
         )
         response = await client.receive_json()
@@ -2351,7 +2351,7 @@ async def test_adjust_sum_statistics_errors(
                 "statistic_id": statistic_id,
                 "start_time": period2.isoformat(),
                 "adjustment": 1000.0,
-                "display_unit": unit,
+                "adjustment_unit_of_measurement": unit,
             }
         )
         response = await client.receive_json()

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -136,11 +136,11 @@ def test_compile_hourly_statistics(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -210,12 +210,12 @@ def test_compile_hourly_statistics_purged_state_changes(
     statistic_ids = list_statistic_ids(hass)
     assert statistic_ids == [
         {
-            "display_unit_of_measurement": display_unit,
             "statistic_id": "sensor.test1",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -281,31 +281,31 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": "°C",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "°C",
             "statistics_unit_of_measurement": "°C",
             "unit_class": "temperature",
         },
         {
             "statistic_id": "sensor.test6",
-            "display_unit_of_measurement": "°C",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "°C",
             "statistics_unit_of_measurement": "°C",
             "unit_class": "temperature",
         },
         {
             "statistic_id": "sensor.test7",
-            "display_unit_of_measurement": "°C",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "°C",
             "statistics_unit_of_measurement": "°C",
             "unit_class": "temperature",
         },
@@ -436,11 +436,11 @@ async def test_compile_hourly_sum_statistics_amount(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -516,7 +516,7 @@ async def test_compile_hourly_sum_statistics_amount(
             "statistic_id": "sensor.test1",
             "start_time": period1.isoformat(),
             "adjustment": 100.0,
-            "display_unit": display_unit,
+            "adjustment_unit_of_measurement": display_unit,
         }
     )
     response = await client.receive_json()
@@ -536,7 +536,7 @@ async def test_compile_hourly_sum_statistics_amount(
             "statistic_id": "sensor.test1",
             "start_time": period2.isoformat(),
             "adjustment": -400.0,
-            "display_unit": display_unit,
+            "adjustment_unit_of_measurement": display_unit,
         }
     )
     response = await client.receive_json()
@@ -629,11 +629,11 @@ def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -730,11 +730,11 @@ def test_compile_hourly_sum_statistics_amount_invalid_last_reset(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -815,11 +815,11 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -929,11 +929,11 @@ def test_compile_hourly_sum_statistics_negative_state(
     wait_recording_done(hass)
     statistic_ids = list_statistic_ids(hass)
     assert {
-        "name": None,
-        "display_unit_of_measurement": display_unit,
         "has_mean": False,
         "has_sum": True,
+        "name": None,
         "source": "recorder",
+        "state_unit_of_measurement": display_unit,
         "statistic_id": entity_id,
         "statistics_unit_of_measurement": statistics_unit,
         "unit_class": unit_class,
@@ -1018,11 +1018,11 @@ def test_compile_hourly_sum_statistics_total_no_reset(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -1121,11 +1121,11 @@ def test_compile_hourly_sum_statistics_total_increasing(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -1235,11 +1235,11 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         }
@@ -1330,11 +1330,11 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": "kWh",
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "kWh",
             "statistics_unit_of_measurement": "kWh",
             "unit_class": "energy",
         }
@@ -1423,31 +1423,31 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": "kWh",
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "kWh",
             "statistics_unit_of_measurement": "kWh",
             "unit_class": "energy",
         },
         {
             "statistic_id": "sensor.test2",
-            "display_unit_of_measurement": "kWh",
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "kWh",
             "statistics_unit_of_measurement": "kWh",
             "unit_class": "energy",
         },
         {
             "statistic_id": "sensor.test3",
-            "display_unit_of_measurement": "Wh",
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "Wh",
             "statistics_unit_of_measurement": "kWh",
             "unit_class": "energy",
         },
@@ -1807,11 +1807,11 @@ def test_list_statistic_ids(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": statistic_type == "mean",
             "has_sum": statistic_type == "sum",
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         },
@@ -1822,11 +1822,11 @@ def test_list_statistic_ids(
             assert statistic_ids == [
                 {
                     "statistic_id": "sensor.test1",
-                    "display_unit_of_measurement": display_unit,
                     "has_mean": statistic_type == "mean",
                     "has_sum": statistic_type == "sum",
                     "name": None,
                     "source": "recorder",
+                    "state_unit_of_measurement": display_unit,
                     "statistics_unit_of_measurement": statistics_unit,
                     "unit_class": unit_class,
                 },
@@ -1913,11 +1913,11 @@ def test_compile_hourly_statistics_changing_units_1(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         },
@@ -1949,11 +1949,11 @@ def test_compile_hourly_statistics_changing_units_1(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         },
@@ -2025,11 +2025,11 @@ def test_compile_hourly_statistics_changing_units_2(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": "cats",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "cats",
             "statistics_unit_of_measurement": "cats",
             "unit_class": unit_class,
         },
@@ -2091,11 +2091,11 @@ def test_compile_hourly_statistics_changing_units_3(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         },
@@ -2127,11 +2127,11 @@ def test_compile_hourly_statistics_changing_units_3(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistics_unit,
             "unit_class": unit_class,
         },
@@ -2193,11 +2193,11 @@ def test_compile_hourly_statistics_changing_device_class_1(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": state_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": state_unit,
             "statistics_unit_of_measurement": state_unit,
             "unit_class": unit_class,
         },
@@ -2239,11 +2239,11 @@ def test_compile_hourly_statistics_changing_device_class_1(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": state_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": state_unit,
             "statistics_unit_of_measurement": state_unit,
             "unit_class": unit_class,
         },
@@ -2302,11 +2302,11 @@ def test_compile_hourly_statistics_changing_device_class_1(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": state_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": state_unit,
             "statistics_unit_of_measurement": state_unit,
             "unit_class": unit_class,
         },
@@ -2382,11 +2382,11 @@ def test_compile_hourly_statistics_changing_device_class_2(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistic_unit,
             "unit_class": unit_class,
         },
@@ -2432,11 +2432,11 @@ def test_compile_hourly_statistics_changing_device_class_2(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": display_unit,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": display_unit,
             "statistics_unit_of_measurement": statistic_unit,
             "unit_class": unit_class,
         },
@@ -2502,11 +2502,11 @@ def test_compile_hourly_statistics_changing_statistics(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": None,
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": None,
             "statistics_unit_of_measurement": None,
             "unit_class": None,
         },
@@ -2539,11 +2539,11 @@ def test_compile_hourly_statistics_changing_statistics(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": None,
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": None,
             "statistics_unit_of_measurement": None,
             "unit_class": None,
         },
@@ -2734,41 +2734,41 @@ def test_compile_statistics_hourly_daily_monthly_summary(hass_recorder, caplog):
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
-            "display_unit_of_measurement": "%",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "%",
             "statistics_unit_of_measurement": "%",
             "unit_class": None,
         },
         {
             "statistic_id": "sensor.test2",
-            "display_unit_of_measurement": "%",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "%",
             "statistics_unit_of_measurement": "%",
             "unit_class": None,
         },
         {
             "statistic_id": "sensor.test3",
-            "display_unit_of_measurement": "%",
             "has_mean": True,
             "has_sum": False,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "%",
             "statistics_unit_of_measurement": "%",
             "unit_class": None,
         },
         {
             "statistic_id": "sensor.test4",
-            "display_unit_of_measurement": "EUR",
             "has_mean": False,
             "has_sum": True,
             "name": None,
             "source": "recorder",
+            "state_unit_of_measurement": "EUR",
             "statistics_unit_of_measurement": "EUR",
             "unit_class": None,
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve naming of units used in statistics WS APIs:
 - Rename `display_unit_of_measurement` to `state_unit_of_measurement` in responses to `recorder/get_statistics_metadata` and `recorder/list_statistic_ids`
 - Rename `display_unit` to `adjustment_unit_of_measurement` in `recorder/adjust_sum_statistics`

Frontend PR: https://github.com/home-assistant/frontend/pull/13913
Blog post updated: https://github.com/home-assistant/developers.home-assistant/pull/1473

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
