### PR TITLE
Improve iterable typing (2)

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -489,7 +489,7 @@ class HomeKit:
         advertise_ip: str | None,
         entry_id: str,
         entry_title: str,
-        devices: Iterable[str] | None = None,
+        devices: list[str] | None = None,
     ) -> None:
         """Initialize a HomeKit object."""
         self.hass = hass

--- a/homeassistant/components/lifx/discovery.py
+++ b/homeassistant/components/lifx/discovery.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Iterable, ValuesView
 
 from aiolifx.aiolifx import LifxDiscovery, Light, ScanManager
 
@@ -17,7 +17,7 @@ from .const import CONF_SERIAL, DOMAIN
 DEFAULT_TIMEOUT = 8.5
 
 
-async def async_discover_devices(hass: HomeAssistant) -> Iterable[Light]:
+async def async_discover_devices(hass: HomeAssistant) -> ValuesView[Light]:
     """Discover lifx devices."""
     all_lights: dict[str, Light] = {}
     broadcast_addrs = await network.async_get_ipv4_broadcast_addresses(hass)

--- a/homeassistant/components/lifx/discovery.py
+++ b/homeassistant/components/lifx/discovery.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, ValuesView
+from collections.abc import Collection, Iterable
 
 from aiolifx.aiolifx import LifxDiscovery, Light, ScanManager
 
@@ -17,7 +17,7 @@ from .const import CONF_SERIAL, DOMAIN
 DEFAULT_TIMEOUT = 8.5
 
 
-async def async_discover_devices(hass: HomeAssistant) -> ValuesView[Light]:
+async def async_discover_devices(hass: HomeAssistant) -> Collection[Light]:
     """Discover lifx devices."""
     all_lights: dict[str, Light] = {}
     broadcast_addrs = await network.async_get_ipv4_broadcast_addresses(hass)


### PR DESCRIPTION
## Proposed change
`Iterable` doesn't have a `__len__` method. This could lead to cases where a variable typed as `Iterable` is always true.
```py
def func(var: Iterable[str]) -> None:
    if var:
        ...
```
If `func` would be called with a `Generator`, a valid input, the if-clause would always be true. In practice, most often `func` is only called with things like `list`, `tuple`, or `set`. For these `Collection` is a better base type as it includes `__len__`.

Mypy will soon be able to emit a specific warning: https://github.com/python/mypy/pull/13762

Ref: https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
