### PR TITLE
Add configuration URL to IPP (Printer)

### DIFF
--- a/homeassistant/components/ipp/entity.py
+++ b/homeassistant/components/ipp/entity.py
@@ -41,4 +41,5 @@ class IPPEntity(CoordinatorEntity[IPPDataUpdateCoordinator]):
             model=self.coordinator.data.info.model,
             name=self.coordinator.data.info.name,
             sw_version=self.coordinator.data.info.version,
+            configuration_url=self.coordinator.data.info.more_info,
         )

--- a/homeassistant/components/ipp/manifest.json
+++ b/homeassistant/components/ipp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ipp",
   "name": "Internet Printing Protocol (IPP)",
   "documentation": "https://www.home-assistant.io/integrations/ipp",
-  "requirements": ["pyipp==0.11.0"],
+  "requirements": ["pyipp==0.12.0"],
   "codeowners": ["@ctalkington"],
   "config_flow": true,
   "quality_scale": "platinum",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1628,7 +1628,7 @@ pyintesishome==1.8.0
 pyipma==3.0.5
 
 # homeassistant.components.ipp
-pyipp==0.11.0
+pyipp==0.12.0
 
 # homeassistant.components.iqvia
 pyiqvia==2022.04.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1144,7 +1144,7 @@ pyinsteon==1.2.0
 pyipma==3.0.5
 
 # homeassistant.components.ipp
-pyipp==0.11.0
+pyipp==0.12.0
 
 # homeassistant.components.iqvia
 pyiqvia==2022.04.0


### PR DESCRIPTION
## Proposed change

Adding a configuration URL link to IPP Printer integration. This has only been tested with HP Printers so I can't guarantee it works with everything - ideally somebody with another brand would be able to test this.


<img width="323" alt="image" src="https://user-images.githubusercontent.com/6491743/193066138-c53dd943-d199-41f3-b78e-d30797297787.png">

Made a commit to parent lib -> as seen here to enable `more_info` into ha
https://github.com/ctalkington/python-ipp/compare/0.11.0...0.12.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
