### PR TITLE
Implement sync time button for moehlenhoff_alpha2 

### DIFF
--- a/homeassistant/components/moehlenhoff_alpha2/__init__.py
+++ b/homeassistant/components/moehlenhoff_alpha2/__init__.py
@@ -17,7 +17,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.BUTTON]
 
 UPDATE_INTERVAL = timedelta(seconds=60)
 

--- a/homeassistant/components/moehlenhoff_alpha2/button.py
+++ b/homeassistant/components/moehlenhoff_alpha2/button.py
@@ -1,4 +1,4 @@
-"""Support for Alpha2 IO device battery sensors."""
+"""Button entity to set the time of the Alpha2 base."""
 
 from datetime import datetime
 

--- a/homeassistant/components/moehlenhoff_alpha2/button.py
+++ b/homeassistant/components/moehlenhoff_alpha2/button.py
@@ -1,0 +1,42 @@
+"""Support for Alpha2 IO device battery sensors."""
+
+from datetime import datetime
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import Alpha2BaseCoordinator
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add Alpha2 button entities."""
+
+    coordinator: Alpha2BaseCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities([Alpha2TimeSyncButton(coordinator, config_entry.entry_id)])
+
+
+class Alpha2TimeSyncButton(CoordinatorEntity[Alpha2BaseCoordinator], ButtonEntity):
+    """Alpha2 virtual time sync button."""
+
+    _attr_name = "Sync Time"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: Alpha2BaseCoordinator, entry_id: str) -> None:
+        """Initialize Alpha2TimeSyncButton."""
+        super().__init__(coordinator)
+
+        self._attr_unique_id = f"{entry_id}:sync_time_button"
+
+    async def async_press(self) -> None:
+        """Synchronize current local time from HA instance to base station."""
+        await self.coordinator.base.set_datetime(datetime.now())

--- a/homeassistant/components/moehlenhoff_alpha2/manifest.json
+++ b/homeassistant/components/moehlenhoff_alpha2/manifest.json
@@ -3,7 +3,7 @@
   "name": "Möhlenhoff Alpha 2",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/moehlenhoff_alpha2",
-  "requirements": ["moehlenhoff-alpha2==1.2.1"],
+  "requirements": ["moehlenhoff-alpha2==1.3.0"],
   "iot_class": "local_push",
   "codeowners": ["@j-a-n"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1087,7 +1087,7 @@ minio==5.0.10
 moat-ble==0.1.1
 
 # homeassistant.components.moehlenhoff_alpha2
-moehlenhoff-alpha2==1.2.1
+moehlenhoff-alpha2==1.3.0
 
 # homeassistant.components.motion_blinds
 motionblinds==0.6.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -789,7 +789,7 @@ minio==5.0.10
 moat-ble==0.1.1
 
 # homeassistant.components.moehlenhoff_alpha2
-moehlenhoff-alpha2==1.2.1
+moehlenhoff-alpha2==1.3.0
 
 # homeassistant.components.motion_blinds
 motionblinds==0.6.13


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This implements a sync time button for the moehlenhoff_alpha2 integration. When the button is pressed, the current local time of the HA instance is set for the internal clock of the alpha 2 base station.

https://community.home-assistant.io/t/integration-moehlenhoff-alpha2-keep-date-and-time-up-to-date/462153

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to dependency changes in this pull request: 
https://github.com/j-a-n/python-moehlenhoff-alpha2/commit/b36ca421a6c5eeefddb61c97ee310ad062442ea0

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
