### PR TITLE
Bump zwave_js lib to 0.43.0 and fix multi-file firmware updates

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import dataclasses
 from functools import partial, wraps
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from aiohttp import web, web_exceptions, web_request
 import voluptuous as vol
@@ -27,7 +27,7 @@ from zwave_js_server.exceptions import (
     NotFoundError,
     SetValueFailed,
 )
-from zwave_js_server.firmware import begin_firmware_update
+from zwave_js_server.firmware import update_firmware
 from zwave_js_server.model.controller import (
     ControllerStatistics,
     InclusionGrant,
@@ -36,8 +36,9 @@ from zwave_js_server.model.controller import (
 )
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.firmware import (
-    FirmwareUpdateFinished,
+    FirmwareUpdateData,
     FirmwareUpdateProgress,
+    FirmwareUpdateResult,
 )
 from zwave_js_server.model.log_config import LogConfig
 from zwave_js_server.model.log_message import LogMessage
@@ -1897,11 +1898,14 @@ async def websocket_is_node_firmware_update_in_progress(
 
 def _get_firmware_update_progress_dict(
     progress: FirmwareUpdateProgress,
-) -> dict[str, int]:
+) -> dict[str, int | float]:
     """Get a dictionary of firmware update progress."""
     return {
+        "current_file": progress.current_file,
+        "total_files": progress.total_files,
         "sent_fragments": progress.sent_fragments,
         "total_fragments": progress.total_fragments,
+        "progress": progress.progress,
     }
 
 
@@ -1943,14 +1947,16 @@ async def websocket_subscribe_firmware_update_status(
 
     @callback
     def forward_finished(event: dict) -> None:
-        finished: FirmwareUpdateFinished = event["firmware_update_finished"]
+        finished: FirmwareUpdateResult = event["firmware_update_finished"]
         connection.send_message(
             websocket_api.event_message(
                 msg[ID],
                 {
                     "event": event["event"],
                     "status": finished.status,
+                    "success": finished.success,
                     "wait_time": finished.wait_time,
+                    "reinterview": finished.reinterview,
                 },
             )
         )
@@ -2052,21 +2058,20 @@ class FirmwareUploadView(HomeAssistantView):
         if "file" not in data or not isinstance(data["file"], web_request.FileField):
             raise web_exceptions.HTTPBadRequest
 
-        target = None
-        if "target" in data:
-            target = int(cast(str, data["target"]))
-
         uploaded_file: web_request.FileField = data["file"]
 
         try:
-            await begin_firmware_update(
+            await update_firmware(
                 node.client.ws_server_url,
                 node,
-                uploaded_file.filename,
-                await hass.async_add_executor_job(uploaded_file.file.read),
+                [
+                    FirmwareUpdateData(
+                        uploaded_file.filename,
+                        await hass.async_add_executor_job(uploaded_file.file.read),
+                    )
+                ],
                 async_get_clientsession(hass),
                 additional_user_agent_components=USER_AGENT,
-                target=target,
             )
         except BaseZwaveJSServerError as err:
             raise web_exceptions.HTTPBadRequest(reason=str(err)) from err

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.42.0"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.43.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["usb", "http", "websocket_api"],
   "iot_class": "local_push",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2622,7 +2622,7 @@ zigpy==0.50.3
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.42.0
+zwave-js-server-python==0.43.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.2.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1814,7 +1814,7 @@ zigpy-znp==0.8.2
 zigpy==0.50.3
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.42.0
+zwave-js-server-python==0.43.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.2.6

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -324,7 +324,7 @@ async def test_update_entity_progress(
     assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
 
     client.async_send_command.reset_mock()
-    client.async_send_command.return_value = None
+    client.async_send_command.return_value = {"success": False}
 
     # Test successful install call without a version
     install_task = hass.async_create_task(
@@ -352,8 +352,13 @@ async def test_update_entity_progress(
             "source": "node",
             "event": "firmware update progress",
             "nodeId": node.node_id,
-            "sentFragments": 1,
-            "totalFragments": 20,
+            "progress": {
+                "currentFile": 1,
+                "totalFiles": 1,
+                "sentFragments": 1,
+                "totalFragments": 20,
+                "progress": 5.0,
+            },
         },
     )
     node.receive_event(event)
@@ -370,7 +375,11 @@ async def test_update_entity_progress(
             "source": "node",
             "event": "firmware update finished",
             "nodeId": node.node_id,
-            "status": FirmwareUpdateStatus.OK_NO_RESTART,
+            "result": {
+                "status": FirmwareUpdateStatus.OK_NO_RESTART,
+                "success": True,
+                "reInterview": False,
+            },
         },
     )
 
@@ -381,142 +390,7 @@ async def test_update_entity_progress(
     state = hass.states.get(UPDATE_ENTITY)
     assert state
     attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] == 0
-    assert attrs[ATTR_INSTALLED_VERSION] == "11.2.4"
-    assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
-    assert state.state == STATE_OFF
-
-    await install_task
-
-
-async def test_update_entity_progress_multiple(
-    hass,
-    client,
-    climate_radio_thermostat_ct100_plus_different_endpoints,
-    integration,
-):
-    """Test update entity progress with multiple files."""
-    node = climate_radio_thermostat_ct100_plus_different_endpoints
-    client.async_send_command.return_value = FIRMWARE_UPDATE_MULTIPLE_FILES
-
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
-    await hass.async_block_till_done()
-
-    state = hass.states.get(UPDATE_ENTITY)
-    assert state
-    assert state.state == STATE_ON
-    attrs = state.attributes
-    assert attrs[ATTR_INSTALLED_VERSION] == "10.7"
-    assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
-
-    client.async_send_command.reset_mock()
-    client.async_send_command.return_value = None
-
-    # Test successful install call without a version
-    install_task = hass.async_create_task(
-        hass.services.async_call(
-            UPDATE_DOMAIN,
-            SERVICE_INSTALL,
-            {
-                ATTR_ENTITY_ID: UPDATE_ENTITY,
-            },
-            blocking=True,
-        )
-    )
-
-    # Sleep so that task starts
-    await asyncio.sleep(0.1)
-
-    state = hass.states.get(UPDATE_ENTITY)
-    assert state
-    attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] is True
-
-    node.receive_event(
-        Event(
-            type="firmware update progress",
-            data={
-                "source": "node",
-                "event": "firmware update progress",
-                "nodeId": node.node_id,
-                "sentFragments": 1,
-                "totalFragments": 20,
-            },
-        )
-    )
-
-    # Block so HA can do its thing
-    await asyncio.sleep(0)
-
-    # Validate that the progress is updated (two files means progress is 50% of 5)
-    state = hass.states.get(UPDATE_ENTITY)
-    assert state
-    attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] == 2
-
-    node.receive_event(
-        Event(
-            type="firmware update finished",
-            data={
-                "source": "node",
-                "event": "firmware update finished",
-                "nodeId": node.node_id,
-                "status": FirmwareUpdateStatus.OK_NO_RESTART,
-            },
-        )
-    )
-
-    # Block so HA can do its thing
-    await asyncio.sleep(0)
-
-    # One file done, progress should be 50%
-    state = hass.states.get(UPDATE_ENTITY)
-    assert state
-    attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] == 50
-
-    node.receive_event(
-        Event(
-            type="firmware update progress",
-            data={
-                "source": "node",
-                "event": "firmware update progress",
-                "nodeId": node.node_id,
-                "sentFragments": 1,
-                "totalFragments": 20,
-            },
-        )
-    )
-
-    # Block so HA can do its thing
-    await asyncio.sleep(0)
-
-    # Validate that the progress is updated (50% + 50% of 5)
-    state = hass.states.get(UPDATE_ENTITY)
-    assert state
-    attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] == 52
-
-    node.receive_event(
-        Event(
-            type="firmware update finished",
-            data={
-                "source": "node",
-                "event": "firmware update finished",
-                "nodeId": node.node_id,
-                "status": FirmwareUpdateStatus.OK_NO_RESTART,
-            },
-        )
-    )
-
-    # Block so HA can do its thing
-    await asyncio.sleep(0)
-
-    # Validate that progress is reset and entity reflects new version
-    state = hass.states.get(UPDATE_ENTITY)
-    assert state
-    attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] == 0
+    assert attrs[ATTR_IN_PROGRESS] is False
     assert attrs[ATTR_INSTALLED_VERSION] == "11.2.4"
     assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
     assert state.state == STATE_OFF
@@ -546,7 +420,7 @@ async def test_update_entity_install_failed(
     assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
 
     client.async_send_command.reset_mock()
-    client.async_send_command.return_value = None
+    client.async_send_command.return_value = {"success": False}
 
     async def call_install():
         await hass.services.async_call(
@@ -558,8 +432,18 @@ async def test_update_entity_install_failed(
             blocking=True,
         )
 
-    # Test install call - we expect it to raise
-    install_task = hass.async_create_task(call_install())
+    # Test install call - we expect it to finish fail
+    # install_task = hass.async_create_task(call_install())
+    install_task = hass.async_create_task(
+        hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {
+                ATTR_ENTITY_ID: UPDATE_ENTITY,
+            },
+            blocking=True,
+        )
+    )
 
     # Sleep so that task starts
     await asyncio.sleep(0.1)
@@ -570,8 +454,13 @@ async def test_update_entity_install_failed(
             "source": "node",
             "event": "firmware update progress",
             "nodeId": node.node_id,
-            "sentFragments": 1,
-            "totalFragments": 20,
+            "progress": {
+                "currentFile": 1,
+                "totalFiles": 1,
+                "sentFragments": 1,
+                "totalFragments": 20,
+                "progress": 5.0,
+            },
         },
     )
     node.receive_event(event)
@@ -588,7 +477,11 @@ async def test_update_entity_install_failed(
             "source": "node",
             "event": "firmware update finished",
             "nodeId": node.node_id,
-            "status": FirmwareUpdateStatus.ERROR_TIMEOUT,
+            "result": {
+                "status": FirmwareUpdateStatus.ERROR_TIMEOUT,
+                "success": False,
+                "reInterview": False,
+            },
         },
     )
 
@@ -599,7 +492,7 @@ async def test_update_entity_install_failed(
     state = hass.states.get(UPDATE_ENTITY)
     assert state
     attrs = state.attributes
-    assert attrs[ATTR_IN_PROGRESS] == 0
+    assert attrs[ATTR_IN_PROGRESS] is False
     assert attrs[ATTR_INSTALLED_VERSION] == "10.7"
     assert attrs[ATTR_LATEST_VERSION] == "11.2.4"
     assert state.state == STATE_ON

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -422,18 +422,7 @@ async def test_update_entity_install_failed(
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = {"success": False}
 
-    async def call_install():
-        await hass.services.async_call(
-            UPDATE_DOMAIN,
-            SERVICE_INSTALL,
-            {
-                ATTR_ENTITY_ID: UPDATE_ENTITY,
-            },
-            blocking=True,
-        )
-
     # Test install call - we expect it to finish fail
-    # install_task = hass.async_create_task(call_install())
     install_task = hass.async_create_task(
         hass.services.async_call(
             UPDATE_DOMAIN,


### PR DESCRIPTION
## Breaking change
You must use `zwave-js-server` 1.24.0 or greater (schema 24).

With this release, you will need to update your `zwave-js-server` instance.

- If you use the `Z-Wave JS` addon, you need to have at least version 0.1.74.
- If you use the `Z-Wave JS UI` addon, you need to have at least version 1.1.0.
- If you use the `Z-Wave JS UI` Docker container, you need to have at least version 8.1.0.
- If you run your own Docker container, or some other installation method, you will need to update your `zwave-js-server` instance to at least 1.24.0.

## Proposed change
Part of the problems we dealt with for the original implementation of the firmware update service is that we had to install each file individually. This turned out to be a problem for the way some manufacturers released updates so zwave-js has added multiple file support in 10.3. This simplifies the logic required on our end significantly and improves the overall firmware update experience. As a bonus, we can now show more accurate progress across all files rather than assuming all files are the same size because zwave-js calculates that for us.

Requires a lib version bump.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
