### PR TITLE
Adjust icons with new device classes

### DIFF
--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -130,6 +130,7 @@ SENSORS: Final[tuple[SensorEntityDescription, ...]] = (
         key="total_liter_m3",
         name="Total water usage",
         native_unit_of_measurement=VOLUME_CUBIC_METERS,
+        icon="mdi:gauge",
         device_class=SensorDeviceClass.VOLUME,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -109,7 +109,6 @@ ROBOT_SENSOR_MAP: dict[type[Robot], list[RobotSensorEntityDescription]] = {
         RobotSensorEntityDescription[LitterRobot4](
             key="pet_weight",
             name="Pet weight",
-            icon="mdi:scale",
             native_unit_of_measurement=MASS_POUNDS,
             device_class=SensorDeviceClass.WEIGHT,
         ),

--- a/homeassistant/components/mysensors/sensor.py
+++ b/homeassistant/components/mysensors/sensor.py
@@ -95,13 +95,11 @@ SENSORS: dict[str, SensorEntityDescription] = {
         key="V_WEIGHT",
         native_unit_of_measurement=MASS_KILOGRAMS,
         device_class=SensorDeviceClass.WEIGHT,
-        icon="mdi:weight-kilogram",
     ),
     "V_DISTANCE": SensorEntityDescription(
         key="V_DISTANCE",
         native_unit_of_measurement=LENGTH_METERS,
         device_class=SensorDeviceClass.DISTANCE,
-        icon="mdi:ruler",
     ),
     "V_IMPEDANCE": SensorEntityDescription(
         key="V_IMPEDANCE",

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -610,7 +610,7 @@ async def test_sensor_entity_total_liters(
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL_INCREASING
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == VOLUME_CUBIC_METERS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.VOLUME
-    assert state.attributes.get(ATTR_ICON) is None
+    assert state.attributes.get(ATTR_ICON) == "mdi:gauge"
 
 
 async def test_sensor_entity_disabled_when_null(

--- a/tests/components/mysensors/test_sensor.py
+++ b/tests/components/mysensors/test_sensor.py
@@ -118,7 +118,7 @@ async def test_distance_sensor(
     assert state
     assert state.state == "15"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DISTANCE
-    assert state.attributes[ATTR_ICON] is None
+    assert ATTR_ICON not in state.attributes
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "cm"
 
 

--- a/tests/components/mysensors/test_sensor.py
+++ b/tests/components/mysensors/test_sensor.py
@@ -117,7 +117,8 @@ async def test_distance_sensor(
 
     assert state
     assert state.state == "15"
-    assert state.attributes[ATTR_ICON] == "mdi:ruler"
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DISTANCE
+    assert state.attributes[ATTR_ICON] is None
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "cm"
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
> Icon to use in the frontend. Icons start with mdi: plus an identifier. You probably don't need this since Home Assistant already provides default icons for all entities according to its device_class. This should be used only in the case where there either is no matching device_class or where the icon used for the device_class would be confusing or misleading.

https://developers.home-assistant.io/docs/core/entity/

From @bdraco: if the icon provided by the device class is not confusing or misleading it should be removed. If there is no icon provided by the device class it should likely still be set.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
