### PR TITLE
Realign util constants with 2022.9.7

### DIFF
--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -1,6 +1,8 @@
 """Distance util functions."""
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
     LENGTH,
     LENGTH_CENTIMETERS,
@@ -18,6 +20,28 @@ from homeassistant.helpers.frame import report
 from .unit_conversion import DistanceConverter
 
 VALID_UNITS = DistanceConverter.VALID_UNITS
+
+TO_METERS: dict[str, Callable[[float], float]] = {
+    LENGTH_METERS: lambda meters: meters,
+    LENGTH_MILES: lambda miles: miles * 1609.344,
+    LENGTH_YARD: lambda yards: yards * 0.9144,
+    LENGTH_FEET: lambda feet: feet * 0.3048,
+    LENGTH_INCHES: lambda inches: inches * 0.0254,
+    LENGTH_KILOMETERS: lambda kilometers: kilometers * 1000,
+    LENGTH_CENTIMETERS: lambda centimeters: centimeters * 0.01,
+    LENGTH_MILLIMETERS: lambda millimeters: millimeters * 0.001,
+}
+
+METERS_TO: dict[str, Callable[[float], float]] = {
+    LENGTH_METERS: lambda meters: meters,
+    LENGTH_MILES: lambda meters: meters * 0.000621371,
+    LENGTH_YARD: lambda meters: meters * 1.09361,
+    LENGTH_FEET: lambda meters: meters * 3.28084,
+    LENGTH_INCHES: lambda meters: meters * 39.3701,
+    LENGTH_KILOMETERS: lambda meters: meters * 0.001,
+    LENGTH_CENTIMETERS: lambda meters: meters * 100,
+    LENGTH_MILLIMETERS: lambda meters: meters * 1000,
+}
 
 
 def convert(value: float, from_unit: str, to_unit: str) -> float:

--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -18,18 +18,9 @@ from homeassistant.helpers.frame import report
 
 from .unit_conversion import PressureConverter
 
+# pylint: disable-next=protected-access
+UNIT_CONVERSION: dict[str, float] = PressureConverter._UNIT_CONVERSION
 VALID_UNITS = PressureConverter.VALID_UNITS
-UNIT_CONVERSION: dict[str, float] = {
-    PRESSURE_PA: 1,
-    PRESSURE_HPA: 1 / 100,
-    PRESSURE_KPA: 1 / 1000,
-    PRESSURE_BAR: 1 / 100000,
-    PRESSURE_CBAR: 1 / 1000,
-    PRESSURE_MBAR: 1 / 100,
-    PRESSURE_INHG: 1 / 3386.389,
-    PRESSURE_PSI: 1 / 6894.757,
-    PRESSURE_MMHG: 1 / 133.322,
-}
 
 
 def convert(value: float, from_unit: str, to_unit: str) -> float:

--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -18,9 +18,18 @@ from homeassistant.helpers.frame import report
 
 from .unit_conversion import PressureConverter
 
-# pylint: disable-next=protected-access
-UNIT_CONVERSION: dict[str, float] = PressureConverter._UNIT_CONVERSION
 VALID_UNITS = PressureConverter.VALID_UNITS
+UNIT_CONVERSION: dict[str, float] = {
+    PRESSURE_PA: 1,
+    PRESSURE_HPA: 1 / 100,
+    PRESSURE_KPA: 1 / 1000,
+    PRESSURE_BAR: 1 / 100000,
+    PRESSURE_CBAR: 1 / 1000,
+    PRESSURE_MBAR: 1 / 100,
+    PRESSURE_INHG: 1 / 3386.389,
+    PRESSURE_PSI: 1 / 6894.757,
+    PRESSURE_MMHG: 1 / 133.322,
+}
 
 
 def convert(value: float, from_unit: str, to_unit: str) -> float:

--- a/homeassistant/util/speed.py
+++ b/homeassistant/util/speed.py
@@ -15,7 +15,7 @@ from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
 )
 from homeassistant.helpers.frame import report
 
-from .unit_conversion import (
+from .unit_conversion import (  # pylint: disable=unused-import # noqa: F401
     _FOOT_TO_M as FOOT_TO_M,
     _HRS_TO_SECS as HRS_TO_SECS,
     _IN_TO_M as IN_TO_M,
@@ -25,17 +25,9 @@ from .unit_conversion import (
     SpeedConverter,
 )
 
+# pylint: disable-next=protected-access
+UNIT_CONVERSION: dict[str, float] = SpeedConverter._UNIT_CONVERSION
 VALID_UNITS = SpeedConverter.VALID_UNITS
-UNIT_CONVERSION: dict[str, float] = {
-    SPEED_FEET_PER_SECOND: 1 / FOOT_TO_M,
-    SPEED_INCHES_PER_DAY: (24 * HRS_TO_SECS) / IN_TO_M,
-    SPEED_INCHES_PER_HOUR: HRS_TO_SECS / IN_TO_M,
-    SPEED_KILOMETERS_PER_HOUR: HRS_TO_SECS / KM_TO_M,
-    SPEED_KNOTS: HRS_TO_SECS / NAUTICAL_MILE_TO_M,
-    SPEED_METERS_PER_SECOND: 1,
-    SPEED_MILES_PER_HOUR: HRS_TO_SECS / MILE_TO_M,
-    SPEED_MILLIMETERS_PER_DAY: (24 * HRS_TO_SECS) * 1000,
-}
 
 
 def convert(value: float, from_unit: str, to_unit: str) -> float:

--- a/homeassistant/util/speed.py
+++ b/homeassistant/util/speed.py
@@ -15,7 +15,7 @@ from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
 )
 from homeassistant.helpers.frame import report
 
-from .unit_conversion import (  # pylint: disable=unused-import # noqa: F401
+from .unit_conversion import (
     _FOOT_TO_M as FOOT_TO_M,
     _HRS_TO_SECS as HRS_TO_SECS,
     _IN_TO_M as IN_TO_M,
@@ -25,9 +25,17 @@ from .unit_conversion import (  # pylint: disable=unused-import # noqa: F401
     SpeedConverter,
 )
 
-# pylint: disable-next=protected-access
-UNIT_CONVERSION = SpeedConverter._UNIT_CONVERSION
 VALID_UNITS = SpeedConverter.VALID_UNITS
+UNIT_CONVERSION: dict[str, float] = {
+    SPEED_FEET_PER_SECOND: 1 / FOOT_TO_M,
+    SPEED_INCHES_PER_DAY: (24 * HRS_TO_SECS) / IN_TO_M,
+    SPEED_INCHES_PER_HOUR: HRS_TO_SECS / IN_TO_M,
+    SPEED_KILOMETERS_PER_HOUR: HRS_TO_SECS / KM_TO_M,
+    SPEED_KNOTS: HRS_TO_SECS / NAUTICAL_MILE_TO_M,
+    SPEED_METERS_PER_SECOND: 1,
+    SPEED_MILES_PER_HOUR: HRS_TO_SECS / MILE_TO_M,
+    SPEED_MILLIMETERS_PER_DAY: (24 * HRS_TO_SECS) * 1000,
+}
 
 
 def convert(value: float, from_unit: str, to_unit: str) -> float:

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -15,8 +15,6 @@ from homeassistant.helpers.frame import report
 
 from .unit_conversion import VolumeConverter
 
-# pylint: disable-next=protected-access
-UNIT_CONVERSION = VolumeConverter._UNIT_CONVERSION
 VALID_UNITS = VolumeConverter.VALID_UNITS
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reinstate/Realign util constants with 2022.9.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
