### PR TITLE
Return 401 status code with invalid login flow

### DIFF
--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -197,8 +197,8 @@ class LoginFlowBaseView(HomeAssistantView):
     ) -> web.Response:
         """Convert the flow result to a response."""
         if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
-            # @log_invalid_auth does not work here since it returns HTTP 200.
-            # We need to manually log failed login attempts.
+            # return HTTP 200 by default, return other HTTP status codes e.g. on bad credentials
+            status_code = HTTPStatus.OK
             if (
                 result["type"] == data_entry_flow.FlowResultType.FORM
                 and (errors := result.get("errors"))
@@ -208,8 +208,9 @@ class LoginFlowBaseView(HomeAssistantView):
                     "invalid_code",
                 )
             ):
+                status_code = HTTPStatus.UNAUTHORIZED
                 await process_wrong_login(request)
-            return self.json(_prepare_result_json(result))
+            return self.json(_prepare_result_json(result), status_code)
 
         hass: HomeAssistant = request.app["hass"]
 

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -66,7 +66,7 @@ async def test_invalid_username_password(hass, aiohttp_client):
             },
         )
 
-    assert resp.status == HTTPStatus.OK
+    assert resp.status == HTTPStatus.UNAUTHORIZED
     step = await resp.json()
     assert len(mock_process_wrong_login.mock_calls) == 1
 
@@ -86,7 +86,7 @@ async def test_invalid_username_password(hass, aiohttp_client):
             },
         )
 
-    assert resp.status == HTTPStatus.OK
+    assert resp.status == HTTPStatus.UNAUTHORIZED
     step = await resp.json()
     assert len(mock_process_wrong_login.mock_calls) == 1
 
@@ -106,7 +106,7 @@ async def test_invalid_username_password(hass, aiohttp_client):
             },
         )
 
-    assert resp.status == HTTPStatus.OK
+    assert resp.status == HTTPStatus.UNAUTHORIZED
     step = await resp.json()
     assert len(mock_process_wrong_login.mock_calls) == 1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
I don't have the complete view about all HA components and their connections, but I don't see this as breaking.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Login requests with invalid credentials are currently returned with HTTP status code 200.
I propose to return the IMO more correct status code 401 Unauthorized on all invalid logins.

This allows the user e.g. to block requests with fail2ban on a network level after too many (=user defined) failed login requests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #79284
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
  - auth tests and others pass, unrelated tests fail (tts, plex)
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. - WIP 😀 

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
