### PR TITLE
Improve robustness of linking homekit yaml to config entries

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -193,14 +193,21 @@ def _async_all_homekit_instances(hass: HomeAssistant) -> list[HomeKit]:
     ]
 
 
-def _async_get_entries_by_name(
+def _async_get_imported_entries_indices(
     current_entries: list[ConfigEntry],
-) -> dict[str, ConfigEntry]:
+) -> tuple[dict[str, ConfigEntry], dict[int, ConfigEntry]]:
     """Return a dict of the entries by name."""
 
     # For backwards compat, its possible the first bridge is using the default
     # name.
-    return {entry.data.get(CONF_NAME, BRIDGE_NAME): entry for entry in current_entries}
+    entries_by_name: dict[str, ConfigEntry] = {}
+    entries_by_port: dict[int, ConfigEntry] = {}
+    for entry in current_entries:
+        if entry.source != SOURCE_IMPORT:
+            continue
+        entries_by_name[entry.data.get(CONF_NAME, BRIDGE_NAME)] = entry
+        entries_by_port[entry.data.get(CONF_PORT, DEFAULT_PORT)] = entry
+    return entries_by_name, entries_by_port
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -218,10 +225,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         return True
 
     current_entries = hass.config_entries.async_entries(DOMAIN)
-    entries_by_name = _async_get_entries_by_name(current_entries)
+    entries_by_name, entries_by_port = _async_get_imported_entries_indices(
+        current_entries
+    )
 
     for index, conf in enumerate(config[DOMAIN]):
-        if _async_update_config_entry_if_from_yaml(hass, entries_by_name, conf):
+        if _async_update_config_entry_from_yaml(
+            hass, entries_by_name, entries_by_port, conf
+        ):
             continue
 
         conf[CONF_ENTRY_INDEX] = index
@@ -237,8 +248,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 
 @callback
-def _async_update_config_entry_if_from_yaml(
-    hass: HomeAssistant, entries_by_name: dict[str, ConfigEntry], conf: ConfigType
+def _async_update_config_entry_from_yaml(
+    hass: HomeAssistant,
+    entries_by_name: dict[str, ConfigEntry],
+    entries_by_port: dict[int, ConfigEntry],
+    conf: ConfigType,
 ) -> bool:
     """Update a config entry with the latest yaml.
 
@@ -246,27 +260,24 @@ def _async_update_config_entry_if_from_yaml(
 
     Returns False if there is no matching config entry
     """
-    bridge_name = conf[CONF_NAME]
-
-    if (
-        bridge_name in entries_by_name
-        and entries_by_name[bridge_name].source == SOURCE_IMPORT
+    if not (
+        matching_entry := entries_by_name.get(conf.get(CONF_NAME, BRIDGE_NAME))
+        or entries_by_port.get(conf.get(CONF_PORT, DEFAULT_PORT))
     ):
-        entry = entries_by_name[bridge_name]
-        # If they alter the yaml config we import the changes
-        # since there currently is no practical way to support
-        # all the options in the UI at this time.
-        data = conf.copy()
-        options = {}
-        for key in CONFIG_OPTIONS:
-            if key in data:
-                options[key] = data[key]
-                del data[key]
+        return False
 
-        hass.config_entries.async_update_entry(entry, data=data, options=options)
-        return True
+    # If they alter the yaml config we import the changes
+    # since there currently is no practical way to support
+    # all the options in the UI at this time.
+    data = conf.copy()
+    options = {}
+    for key in CONFIG_OPTIONS:
+        if key in data:
+            options[key] = data[key]
+            del data[key]
 
-    return False
+    hass.config_entries.async_update_entry(matching_entry, data=data, options=options)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -451,10 +462,14 @@ def _async_register_events_and_services(hass: HomeAssistant) -> None:
             return
 
         current_entries = hass.config_entries.async_entries(DOMAIN)
-        entries_by_name = _async_get_entries_by_name(current_entries)
+        entries_by_name, entries_by_port = _async_get_imported_entries_indices(
+            current_entries
+        )
 
         for conf in config[DOMAIN]:
-            _async_update_config_entry_if_from_yaml(hass, entries_by_name, conf)
+            _async_update_config_entry_from_yaml(
+                hass, entries_by_name, entries_by_port, conf
+            )
 
         reload_tasks = [
             hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -196,7 +196,7 @@ def _async_all_homekit_instances(hass: HomeAssistant) -> list[HomeKit]:
 def _async_get_imported_entries_indices(
     current_entries: list[ConfigEntry],
 ) -> tuple[dict[str, ConfigEntry], dict[int, ConfigEntry]]:
-    """Return a dict of the entries by name."""
+    """Return a dicts of the entries by name and port."""
 
     # For backwards compat, its possible the first bridge is using the default
     # name.


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes #79330

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
