### PR TITLE
Improve support for LIFX multizone devices

### DIFF
--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -57,7 +57,13 @@ CONFIG_SCHEMA = vol.All(
 )
 
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.LIGHT, Platform.SELECT]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.LIGHT,
+    Platform.SELECT,
+    Platform.SENSOR,
+]
 DISCOVERY_INTERVAL = timedelta(minutes=15)
 MIGRATION_INTERVAL = timedelta(minutes=5)
 

--- a/homeassistant/components/lifx/const.py
+++ b/homeassistant/components/lifx/const.py
@@ -46,4 +46,7 @@ INFRARED_BRIGHTNESS_VALUES_MAP = {
 }
 DATA_LIFX_MANAGER = "lifx_manager"
 
+MULTIZONE_COLOR_ZONES = "color_zones"
+
+
 _LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/lifx/manifest.json
+++ b/homeassistant/components/lifx/manifest.json
@@ -3,7 +3,7 @@
   "name": "LIFX",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/lifx",
-  "requirements": ["aiolifx==0.8.5", "aiolifx_effects==0.2.2"],
+  "requirements": ["aiolifx==0.8.6", "aiolifx_effects==0.2.2"],
   "quality_scale": "platinum",
   "dependencies": ["network"],
   "homekit": {

--- a/homeassistant/components/lifx/sensor.py
+++ b/homeassistant/components/lifx/sensor.py
@@ -1,0 +1,97 @@
+"""Sensor entities for LIFX integration."""
+from __future__ import annotations
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT,
+    ATTR_COLOR_MODE,
+    ATTR_COLOR_TEMP,
+    ATTR_HS_COLOR,
+    ColorMode,
+)
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.color import color_temperature_kelvin_to_mired
+
+from .const import ATTR_ZONES, DOMAIN
+from .coordinator import LIFXUpdateCoordinator
+from .entity import LIFXEntity
+from .util import lifx_features
+
+MULTIZONE_ZONES_DESCRIPTION = SensorEntityDescription(
+    key=ATTR_ZONES,
+    name="Zones",
+    icon="mdi:led-strip-variant",
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up LIFX from a config entry."""
+    coordinator: LIFXUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    if lifx_features(coordinator.device)["multizone"]:
+        async_add_entities(
+            [LIFXMultiZoneZonesSensorEntity(coordinator, MULTIZONE_ZONES_DESCRIPTION)]
+        )
+
+
+class LIFXMultiZoneZonesSensorEntity(LIFXEntity, SensorEntity):
+    """LIFX MultiZone zones sensor entity."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        coordinator: LIFXUpdateCoordinator,
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialise the zone count sensor."""
+        super().__init__(coordinator)
+
+        self.entity_description = description
+        self._attr_name = description.name
+        self._attr_unique_id = f"{coordinator.serial_number}_{description.key}"
+        self._async_update_attrs()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update attribute values."""
+        self._attr_native_value = int(self.coordinator.device.zones_count)
+
+        zones = {}
+        for index, color in enumerate(self.coordinator.device.color_zones):
+            hue = round(color[0] / 65535 * 360)
+            saturation = round(color[1] / 65535 * 100)
+            brightness = round(color[2] / 65535 * 255)
+            brightness_pct = round(brightness / 255 * 100)
+            color_temp = color_temperature_kelvin_to_mired(color[3])
+
+            if saturation == 0:
+                zones[f"Zone {index}"] = {
+                    ATTR_COLOR_MODE: ColorMode.COLOR_TEMP,
+                    ATTR_BRIGHTNESS: brightness,
+                    ATTR_BRIGHTNESS_PCT: brightness_pct,
+                    ATTR_COLOR_TEMP: color_temp,
+                }
+            else:
+                zones[f"Zone {index}"] = {
+                    ATTR_COLOR_MODE: ColorMode.HS,
+                    ATTR_HS_COLOR: f"({hue}, {saturation})",
+                    ATTR_BRIGHTNESS: brightness,
+                    ATTR_BRIGHTNESS_PCT: brightness_pct,
+                }
+
+        self._attr_extra_state_attributes = zones

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -193,7 +193,7 @@ aiokafka==0.7.2
 aiokef==0.2.16
 
 # homeassistant.components.lifx
-aiolifx==0.8.5
+aiolifx==0.8.6
 
 # homeassistant.components.lifx
 aiolifx_effects==0.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -171,7 +171,7 @@ aiohue==4.5.0
 aiokafka==0.7.2
 
 # homeassistant.components.lifx
-aiolifx==0.8.5
+aiolifx==0.8.6
 
 # homeassistant.components.lifx
 aiolifx_effects==0.2.2

--- a/tests/components/lifx/__init__.py
+++ b/tests/components/lifx/__init__.py
@@ -151,7 +151,61 @@ def _mocked_light_strip() -> Light:
     bulb.set_color_zones = MockLifxCommand(bulb)
     bulb.get_multizone_effect = MockLifxCommand(bulb)
     bulb.set_multizone_effect = MockLifxCommand(bulb)
+    bulb.get_extended_color_zones = MockLifxCommand(
+        bulb,
+        zones_count=8,
+        zone_index=0,
+        colors_count=8,
+        colors=[
+            (0, 0, 65535, 3500),
+            (0, 0, 65535, 3500),
+            (0, 0, 65535, 3500),
+            (0, 0, 65535, 3500),
+            (0, 0, 65535, 3500),
+            (0, 0, 65535, 3500),
+            (0, 0, 65535, 3500),
+            (0, 0, 65535, 3500),
+        ],
+    )
+    bulb.set_extended_color_zones = MockLifxCommand(bulb)
+    return bulb
 
+
+def _mocked_extended_multizone_strip() -> Light:
+    bulb = _mocked_bulb()
+    bulb.product = 38  # LIFX Z
+    bulb.color_zones = [
+        (0, 0, 65535, 3500),
+        (0, 0, 65535, 3500),
+        (0, 0, 65535, 3500),
+        (0, 0, 65535, 3500),
+        (0, 0, 65535, 3500),
+        (0, 0, 65535, 3500),
+        (0, 0, 65535, 3500),
+        (0, 0, 65535, 3500),
+    ]
+    bulb.effect = {"effect": "MOVE", "speed": 3, "duration": 0, "direction": "RIGHT"}
+    bulb.get_color_zones = MockLifxCommand(bulb)
+    bulb.set_color_zones = MockLifxCommand(bulb)
+    bulb.get_multizone_effect = MockLifxCommand(bulb)
+    bulb.set_multizone_effect = MockLifxCommand(bulb)
+    bulb.get_extended_color_zones = MockLifxCommand(
+        bulb,
+        zones_count=8,
+        zone_index=0,
+        colors_count=8,
+        colors=[
+            (10, 20, 65535, 3500),
+            (10, 20, 65535, 3500),
+            (10, 20, 65535, 3500),
+            (10, 20, 65535, 3500),
+            (10, 20, 65535, 3500),
+            (10, 20, 65535, 3500),
+            (10, 20, 65535, 3500),
+            (10, 20, 65535, 3500),
+        ],
+    )
+    bulb.set_extended_color_zones = MockLifxCommand(bulb)
     return bulb
 
 

--- a/tests/components/lifx/test_sensor.py
+++ b/tests/components/lifx/test_sensor.py
@@ -1,0 +1,54 @@
+"""Tests for the LIFX sensor platform."""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components import lifx
+from homeassistant.components.lifx import DOMAIN
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from . import (
+    SERIAL,
+    _mocked_extended_multizone_strip,
+    _patch_config_flow_try_connect,
+    _patch_device,
+    _patch_discovery,
+)
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+@pytest.fixture(autouse=True)
+def patch_lifx_state_settle_delay():
+    """Set asyncio.sleep for state settles to zero."""
+    with patch("homeassistant.components.lifx.light.LIFX_STATE_SETTLE_DELAY", 0):
+        yield
+
+
+async def test_multizone_zones_sensor(hass: HomeAssistant) -> None:
+    """Test the multizone zones sensor."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=SERIAL
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_extended_multizone_strip()
+
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    entity_id = "sensor.my_bulb_zones"
+    assert bulb.zones_count == 8
+    assert len(bulb.color_zones) == 8
+    assert hass.states.get(entity_id).state == "8"


### PR DESCRIPTION
## Proposed change

Detect compatibility with and use the LIFX `get_extended_color_zones` and `set_extended_color_zones` messages to reduce the round-trip traffic required to update multizone devices. This can have a significant impact on long Beams, for example, by reducing the number of messages to update the state of the zones on my longest Beam from over 10 to only 1.

This also introduces a new Zones sensor that displays the amount of zones as its state with the state of each zone as an extra state attribute. I know this is not recommended, but individual zones aren't really controllable independently, so they can't all be Light entities and I figured creating up to 328 sensor entities for the hue, saturation, brightness and kelvin values of as many as 82 zones would be a bad user experience. This seemed like the best balance of making the information available but not overwhelming.

Note that there is no new functionality in this PR: the existing services work exactly the same way, they're just more efficient for multizone devices.

This requires a version bump in the underlying `aiolifx` library to 0.8.6. The updated library version also includes new Tile related messages which will be used in an upcoming update that adds support for Tile/Candle effects.


Release: https://github.com/frawau/aiolifx/releases/tag/0.8.6
Full changelog: https://github.com/frawau/aiolifx/compare/0.8.5...0.8.6

Signed-off-by: Avi Miller <me@dje.li>


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
