### PR TITLE
Bump aioswitcher to 3.0.2

### DIFF
--- a/homeassistant/components/switcher_kis/manifest.json
+++ b/homeassistant/components/switcher_kis/manifest.json
@@ -3,7 +3,7 @@
   "name": "Switcher",
   "documentation": "https://www.home-assistant.io/integrations/switcher_kis/",
   "codeowners": ["@tomerfi", "@thecode"],
-  "requirements": ["aioswitcher==3.0.0"],
+  "requirements": ["aioswitcher==3.0.2"],
   "quality_scale": "platinum",
   "iot_class": "local_push",
   "config_flow": true,

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from aioswitcher.api import Command, SwitcherApi, SwitcherBaseResponse
+from aioswitcher.api import Command, SwitcherBaseResponse, SwitcherType1Api
 from aioswitcher.device import DeviceCategory, DeviceState
 import voluptuous as vol
 
@@ -110,7 +110,7 @@ class SwitcherBaseSwitchEntity(
         error = None
 
         try:
-            async with SwitcherApi(
+            async with SwitcherType1Api(
                 self.coordinator.data.ip_address, self.coordinator.data.device_id
             ) as swapi:
                 response = await getattr(swapi, api)(*args)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -267,7 +267,7 @@ aioslimproto==2.1.1
 aiosteamist==0.3.2
 
 # homeassistant.components.switcher_kis
-aioswitcher==3.0.0
+aioswitcher==3.0.2
 
 # homeassistant.components.syncthing
 aiosyncthing==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -242,7 +242,7 @@ aioslimproto==2.1.1
 aiosteamist==0.3.2
 
 # homeassistant.components.switcher_kis
-aioswitcher==3.0.0
+aioswitcher==3.0.2
 
 # homeassistant.components.syncthing
 aiosyncthing==0.5.1

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -43,11 +43,11 @@ def mock_api():
 
     patchers = [
         patch(
-            "homeassistant.components.switcher_kis.switch.SwitcherApi.connect",
+            "homeassistant.components.switcher_kis.switch.SwitcherType1Api.connect",
             new=api_mock,
         ),
         patch(
-            "homeassistant.components.switcher_kis.switch.SwitcherApi.disconnect",
+            "homeassistant.components.switcher_kis.switch.SwitcherType1Api.disconnect",
             new=api_mock,
         ),
     ]

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -44,7 +44,7 @@ async def test_turn_on_with_timer_service(hass, mock_bridge, mock_api, monkeypat
     assert state.state == STATE_OFF
 
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device"
+        "homeassistant.components.switcher_kis.switch.SwitcherType1Api.control_device"
     ) as mock_control_device:
         await hass.services.async_call(
             DOMAIN,
@@ -74,7 +74,7 @@ async def test_set_auto_off_service(hass, mock_bridge, mock_api):
     entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
 
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_auto_shutdown"
+        "homeassistant.components.switcher_kis.switch.SwitcherType1Api.set_auto_shutdown"
     ) as mock_set_auto_shutdown:
         await hass.services.async_call(
             DOMAIN,
@@ -99,7 +99,7 @@ async def test_set_auto_off_service_fail(hass, mock_bridge, mock_api, caplog):
     entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
 
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_auto_shutdown",
+        "homeassistant.components.switcher_kis.switch.SwitcherType1Api.set_auto_shutdown",
         return_value=None,
     ) as mock_set_auto_shutdown:
         await hass.services.async_call(

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -43,7 +43,7 @@ async def test_switch(hass, mock_bridge, mock_api, monkeypatch):
 
     # Test turning on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device",
+        "homeassistant.components.switcher_kis.switch.SwitcherType1Api.control_device",
     ) as mock_control_device:
         await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -56,7 +56,7 @@ async def test_switch(hass, mock_bridge, mock_api, monkeypatch):
 
     # Test turning off
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device"
+        "homeassistant.components.switcher_kis.switch.SwitcherType1Api.control_device"
     ) as mock_control_device:
         await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -87,7 +87,7 @@ async def test_switch_control_fail(hass, mock_bridge, mock_api, monkeypatch, cap
 
     # Test exception during turn on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device",
+        "homeassistant.components.switcher_kis.switch.SwitcherType1Api.control_device",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
         await hass.services.async_call(
@@ -111,7 +111,7 @@ async def test_switch_control_fail(hass, mock_bridge, mock_api, monkeypatch, cap
 
     # Test error response during turn on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device",
+        "homeassistant.components.switcher_kis.switch.SwitcherType1Api.control_device",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
         await hass.services.async_call(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Bump `aioswitcher` to 3.0.2**

Changelog: https://github.com/TomerFi/aioswitcher/compare/3.0.0...3.0.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
