### PR TITLE
Proper handling of authentication errors in AVM Fritz!Tools

### DIFF
--- a/homeassistant/components/fritz/__init__.py
+++ b/homeassistant/components/fritz/__init__.py
@@ -1,15 +1,19 @@
 """Support for AVM Fritz!Box functions."""
 import logging
 
-from fritzconnection.core.exceptions import FritzConnectionException
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from .common import AvmWrapper, FritzData
-from .const import DATA_FRITZ, DOMAIN, FRITZ_EXCEPTIONS, PLATFORMS
+from .const import (
+    DATA_FRITZ,
+    DOMAIN,
+    FRITZ_AUTH_EXCEPTIONS,
+    FRITZ_EXCEPTIONS,
+    PLATFORMS,
+)
 from .services import async_setup_services, async_unload_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,10 +32,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await avm_wrapper.async_setup(entry.options)
+    except FRITZ_AUTH_EXCEPTIONS as ex:
+        raise ConfigEntryAuthFailed from ex
     except FRITZ_EXCEPTIONS as ex:
         raise ConfigEntryNotReady from ex
-    except FritzConnectionException as ex:
-        raise ConfigEntryAuthFailed from ex
 
     if (
         "X_AVM-DE_UPnP1" in avm_wrapper.connection.services

--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -9,7 +9,7 @@ from typing import Any
 from urllib.parse import ParseResult, urlparse
 
 from fritzconnection import FritzConnection
-from fritzconnection.core.exceptions import FritzConnectionException, FritzSecurityError
+from fritzconnection.core.exceptions import FritzConnectionException
 import voluptuous as vol
 
 from homeassistant.components import ssdp
@@ -32,6 +32,7 @@ from .const import (
     ERROR_CANNOT_CONNECT,
     ERROR_UNKNOWN,
     ERROR_UPNP_NOT_CONFIGURED,
+    FRITZ_AUTH_EXCEPTIONS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,7 +71,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
                 timeout=60.0,
                 pool_maxsize=30,
             )
-        except FritzSecurityError:
+        except FRITZ_AUTH_EXCEPTIONS:
             return ERROR_AUTH_INVALID
         except FritzConnectionException:
             return ERROR_CANNOT_CONNECT

--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -5,8 +5,11 @@ from typing import Literal
 from fritzconnection.core.exceptions import (
     FritzActionError,
     FritzActionFailedError,
+    FritzAuthorizationError,
+    FritzConnectionException,
     FritzInternalError,
     FritzLookUpError,
+    FritzSecurityError,
     FritzServiceError,
 )
 
@@ -66,9 +69,12 @@ UPTIME_DEVIATION = 5
 FRITZ_EXCEPTIONS = (
     FritzActionError,
     FritzActionFailedError,
+    FritzConnectionException,
     FritzInternalError,
     FritzServiceError,
     FritzLookUpError,
 )
+
+FRITZ_AUTH_EXCEPTIONS = (FritzAuthorizationError, FritzSecurityError)
 
 WIFI_STANDARD = {1: "2.4Ghz", 2: "5Ghz", 3: "5Ghz", 4: "Guest"}

--- a/homeassistant/components/fritz/manifest.json
+++ b/homeassistant/components/fritz/manifest.json
@@ -2,7 +2,7 @@
   "domain": "fritz",
   "name": "AVM FRITZ!Box Tools",
   "documentation": "https://www.home-assistant.io/integrations/fritz",
-  "requirements": ["fritzconnection==1.10.3", "xmltodict==0.13.0"],
+  "requirements": ["fritzconnection==1.11.0", "xmltodict==0.13.0"],
   "dependencies": ["network"],
   "codeowners": ["@mammuth", "@AaronDavidSchneider", "@chemelli74", "@mib1185"],
   "config_flow": true,

--- a/homeassistant/components/fritzbox_callmonitor/manifest.json
+++ b/homeassistant/components/fritzbox_callmonitor/manifest.json
@@ -4,7 +4,7 @@
   "integration_type": "device",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/fritzbox_callmonitor",
-  "requirements": ["fritzconnection==1.10.3"],
+  "requirements": ["fritzconnection==1.11.0"],
   "codeowners": ["@cdce8p"],
   "iot_class": "local_polling",
   "loggers": ["fritzconnection"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -748,7 +748,7 @@ freesms==0.2.0
 
 # homeassistant.components.fritz
 # homeassistant.components.fritzbox_callmonitor
-fritzconnection==1.10.3
+fritzconnection==1.11.0
 
 # homeassistant.components.google_translate
 gTTS==2.2.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -567,7 +567,7 @@ freebox-api==1.0.1
 
 # homeassistant.components.fritz
 # homeassistant.components.fritzbox_callmonitor
-fritzconnection==1.10.3
+fritzconnection==1.11.0
 
 # homeassistant.components.google_translate
 gTTS==2.2.4

--- a/tests/components/fritz/test_init.py
+++ b/tests/components/fritz/test_init.py
@@ -1,14 +1,17 @@
 """Tests for Fritz!Tools."""
 from unittest.mock import patch
 
-from fritzconnection.core.exceptions import FritzSecurityError
 import pytest
 
 from homeassistant.components.device_tracker import (
     CONF_CONSIDER_HOME,
     DEFAULT_CONSIDER_HOME,
 )
-from homeassistant.components.fritz.const import DOMAIN, FRITZ_EXCEPTIONS
+from homeassistant.components.fritz.const import (
+    DOMAIN,
+    FRITZ_AUTH_EXCEPTIONS,
+    FRITZ_EXCEPTIONS,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -60,7 +63,11 @@ async def test_options_reload(hass: HomeAssistant, fc_class_mock, fh_class_mock)
         mock_reload.assert_called_once()
 
 
-async def test_setup_auth_fail(hass: HomeAssistant):
+@pytest.mark.parametrize(
+    "error",
+    FRITZ_AUTH_EXCEPTIONS,
+)
+async def test_setup_auth_fail(hass: HomeAssistant, error):
     """Test starting a flow by user with an already configured device."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -68,7 +75,7 @@ async def test_setup_auth_fail(hass: HomeAssistant):
 
     with patch(
         "homeassistant.components.fritz.common.FritzConnection",
-        side_effect=FritzSecurityError,
+        side_effect=error,
     ):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- needs https://github.com/kbr/fritzconnection/pull/170 to be merged and new release of the lib

With this, we can distinguish between a connection (_e.g. timeout_) and authentication issue, so we can proper handle the config entry init (_see https://github.com/home-assistant/core/issues/71822#issuecomment-1139686592_)

Bumps [`fritzconnection`](https://github.com/kbr/fritzconnection/) to [1.11.0](https://github.com/kbr/fritzconnection/releases/tag/1.11.0)
diff: https://github.com/kbr/fritzconnection/compare/1.10.3...1.11.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #71822
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
