### PR TITLE
Add sum-differences characteristics to statistics component

### DIFF
--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -78,6 +78,9 @@ STAT_MEDIAN = "median"
 STAT_NOISINESS = "noisiness"
 STAT_QUANTILES = "quantiles"
 STAT_STANDARD_DEVIATION = "standard_deviation"
+STAT_SUM = "sum"
+STAT_SUM_DIFFERENCES = "sum_differences"
+STAT_SUM_DIFFERENCES_NONNEGATIVE = "sum_differences_nonnegative"
 STAT_TOTAL = "total"
 STAT_VALUE_MAX = "value_max"
 STAT_VALUE_MIN = "value_min"
@@ -113,6 +116,9 @@ STATS_NUMERIC_SUPPORT = {
     STAT_NOISINESS,
     STAT_QUANTILES,
     STAT_STANDARD_DEVIATION,
+    STAT_SUM,
+    STAT_SUM_DIFFERENCES,
+    STAT_SUM_DIFFERENCES_NONNEGATIVE,
     STAT_TOTAL,
     STAT_VALUE_MAX,
     STAT_VALUE_MIN,
@@ -159,6 +165,9 @@ STAT_NUMERIC_RETAIN_UNIT = {
     STAT_MEDIAN,
     STAT_NOISINESS,
     STAT_STANDARD_DEVIATION,
+    STAT_SUM,
+    STAT_SUM_DIFFERENCES,
+    STAT_SUM_DIFFERENCES_NONNEGATIVE,
     STAT_TOTAL,
     STAT_VALUE_MAX,
     STAT_VALUE_MIN,
@@ -669,10 +678,7 @@ class StatisticsSensor(SensorEntity):
 
     def _stat_noisiness(self) -> StateType:
         if len(self.states) >= 2:
-            diff_sum = sum(
-                abs(j - i) for i, j in zip(list(self.states), list(self.states)[1:])
-            )
-            return diff_sum / (len(self.states) - 1)
+            return cast(float, self._stat_sum_differences()) / (len(self.states) - 1)
         return None
 
     def _stat_quantiles(self) -> StateType:
@@ -694,10 +700,30 @@ class StatisticsSensor(SensorEntity):
             return statistics.stdev(self.states)
         return None
 
-    def _stat_total(self) -> StateType:
+    def _stat_sum(self) -> StateType:
         if len(self.states) > 0:
             return sum(self.states)
         return None
+
+    def _stat_sum_differences(self) -> StateType:
+        if len(self.states) >= 2:
+            diff_sum = sum(
+                abs(j - i) for i, j in zip(list(self.states), list(self.states)[1:])
+            )
+            return diff_sum
+        return None
+
+    def _stat_sum_differences_nonnegative(self) -> StateType:
+        if len(self.states) >= 2:
+            diff_sum_nn = sum(
+                (j - i if j >= i else j - 0)
+                for i, j in zip(list(self.states), list(self.states)[1:])
+            )
+            return diff_sum_nn
+        return None
+
+    def _stat_total(self) -> StateType:
+        return self._stat_sum()
 
     def _stat_value_max(self) -> StateType:
         if len(self.states) > 0:

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -771,6 +771,56 @@ async def test_state_characteristics(hass: HomeAssistant):
         },
         {
             "source_sensor_domain": "sensor",
+            "name": "sum",
+            "value_0": STATE_UNKNOWN,
+            "value_1": float(VALUES_NUMERIC[-1]),
+            "value_9": float(sum(VALUES_NUMERIC)),
+            "unit": "°C",
+        },
+        {
+            "source_sensor_domain": "sensor",
+            "name": "sum_differences",
+            "value_0": STATE_UNKNOWN,
+            "value_1": STATE_UNKNOWN,
+            "value_9": float(
+                sum(
+                    [
+                        abs(20 - 17),
+                        abs(15.2 - 20),
+                        abs(5 - 15.2),
+                        abs(3.8 - 5),
+                        abs(9.2 - 3.8),
+                        abs(6.7 - 9.2),
+                        abs(14 - 6.7),
+                        abs(6 - 14),
+                    ]
+                )
+            ),
+            "unit": "°C",
+        },
+        {
+            "source_sensor_domain": "sensor",
+            "name": "sum_differences_nonnegative",
+            "value_0": STATE_UNKNOWN,
+            "value_1": STATE_UNKNOWN,
+            "value_9": float(
+                sum(
+                    [
+                        20 - 17,
+                        15.2 - 0,
+                        5 - 0,
+                        3.8 - 0,
+                        9.2 - 3.8,
+                        6.7 - 0,
+                        14 - 6.7,
+                        6 - 0,
+                    ]
+                )
+            ),
+            "unit": "°C",
+        },
+        {
+            "source_sensor_domain": "sensor",
             "name": "total",
             "value_0": STATE_UNKNOWN,
             "value_1": float(VALUES_NUMERIC[-1]),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Minor addition to the statistics component.

This PR adds two very relevant characteristics to the statistics component. Compare https://docs.influxdata.com/flux/v0.x/stdlib/universe/difference (`sum(difference())` and `sum(difference(nonNegative: true))`):

* `sum_differences`: sum up all the value-to-value differences (e.g. to evaluate absolute activity of a production process) 
* `sum_differences_nonnegative`: same as above, but handling the occasional reset to zero correctly. (e.g. to sum up recent solar energy production from a 'daily' meter)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes community discussion https://community.home-assistant.io/t/help-with-statistics-sensor-calculate-increase-in-the-last-48-hours/466326
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24329

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
