### PR TITLE
Fix empty default ZHA configuration

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1053,6 +1053,22 @@ async def websocket_update_zha_configuration(
     options = zha_gateway.config_entry.options
     data_to_save = {**options, **{CUSTOM_CONFIGURATION: msg["data"]}}
 
+    for section, schema in ZHA_CONFIG_SCHEMAS.items():
+        for entry in schema.schema:
+            # remove options that match defaults
+            if (
+                data_to_save[CUSTOM_CONFIGURATION].get(section, {}).get(entry)
+                == entry.default()
+            ):
+                data_to_save[CUSTOM_CONFIGURATION][section].pop(entry)
+            # remove entire section block if empty
+            if not data_to_save[CUSTOM_CONFIGURATION][section]:
+                data_to_save[CUSTOM_CONFIGURATION].pop(section)
+
+    # remove entire custom_configuration block if empty
+    if not data_to_save[CUSTOM_CONFIGURATION]:
+        data_to_save.pop(CUSTOM_CONFIGURATION)
+
     _LOGGER.info(
         "Updating ZHA custom configuration options from %s to %s",
         options,

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1028,6 +1028,12 @@ async def websocket_get_configuration(
         data["data"][section] = zha_gateway.config_entry.options.get(
             CUSTOM_CONFIGURATION, {}
         ).get(section, {})
+
+        # send default values for unconfigured options
+        for entry in data["schemas"][section]:
+            if data["data"][section].get(entry["name"]) is None:
+                data["data"][section][entry["name"]] = entry["default"]
+
     connection.send_result(msg[ID], data)
 
 

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -146,7 +146,7 @@ CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY = 60 * 60 * 6  # 6 hours
 
 CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
+        vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION, default=0): cv.positive_int,
         vol.Required(CONF_ENABLE_ENHANCED_LIGHT_TRANSITION, default=False): cv.boolean,
         vol.Required(CONF_ENABLE_LIGHT_TRANSITIONING_FLAG, default=True): cv.boolean,
         vol.Required(CONF_ALWAYS_PREFER_XY_COLOR_MODE, default=True): cv.boolean,


### PR DESCRIPTION
## Proposed change
**Background:**
Currently there's an issue where the ZHA configuration shows as empty until the "Update configuration" button is clicked at least once (and the page reloaded):
<img width="300" alt="Bildschirm­foto 2022-10-02 um 16 17 29" src="https://user-images.githubusercontent.com/6409465/193461050-bf919772-1133-4955-8cd0-fd3f0a5d8c31.png">
Especially for new users, this can be very confusing, For example, the checkboxes are all unselected:
This doesn't reflect the settings ZHA uses in this situation though, as default config values are used.

Example: It's not easy for a new user to just disable the "Enable identify effect when devices join the network" (on by default) setting, as the user could think that setting is already off. Just clicking "Update configuration" and reloading the page then reveal the default settings after the integration is reloaded.
After that, the option can actually be disabled and the settings saved again.

**Changes:**
This PR changes the behavior of the ``zha/configuration`` API to populate non-existent data fields with the default values. These default values are the ones currently used by ZHA when the options aren't explicitly set in the config.

How I've done it might not be the best way to do it though, so feel free to suggest changes.
I've also played around with just showing the default value in the frontend (so leaving hass-core untouched), but that kind of leaves backend/frontend "out-of-sync", as the API stays the same then and doesn't return "any data" (and the frontend needs to "check whether to show the default value or the actual value").

**After the changes:**
<img width="300" alt="Bildschirm­foto 2022-10-02 um 16 23 00" src="https://user-images.githubusercontent.com/6409465/193461562-a399771a-dc20-4715-9953-47e269137cf1.png">


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
