### PR TITLE
Code quality update for Subaru sensors

### DIFF
--- a/homeassistant/components/subaru/sensor.py
+++ b/homeassistant/components/subaru/sensor.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from typing import Any
 
 import subarulink.const as sc
@@ -298,13 +297,10 @@ async def _async_migrate_entries(
 
     @callback
     def update_unique_id(entry: er.RegistryEntry) -> dict[str, Any] | None:
-        id_suffix_match = re.match(r".*?_(.+)", entry.unique_id)
-        id_suffix = id_suffix_match.group(1) if id_suffix_match else ""
+        id_split = entry.unique_id.split("_")
 
-        if id_suffix.upper() in replacements:
-            new_unique_id = entry.unique_id.replace(
-                id_suffix, replacements[id_suffix.upper()]
-            )
+        if len(id_split) == 2 and (key := id_split[1].upper()) in replacements:
+            new_unique_id = entry.unique_id.replace(id_split[1], replacements[key])
             _LOGGER.debug(
                 "Migrating entity '%s' unique_id from '%s' to '%s'",
                 entry.entity_id,

--- a/homeassistant/components/subaru/sensor.py
+++ b/homeassistant/components/subaru/sensor.py
@@ -72,7 +72,7 @@ API_GEN_2_SENSORS = [
     SensorEntityDescription(
         key=sc.AVG_FUEL_CONSUMPTION,
         icon="mdi:leaf",
-        name="Avg Fuel Consumption",
+        name="Avg fuel consumption",
         native_unit_of_measurement=FUEL_CONSUMPTION_LITERS_PER_HUNDRED_KILOMETERS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -87,42 +87,42 @@ API_GEN_2_SENSORS = [
     SensorEntityDescription(
         key=sc.TIRE_PRESSURE_FL,
         device_class=SensorDeviceClass.PRESSURE,
-        name="Tire Pressure FL",
+        name="Tire pressure FL",
         native_unit_of_measurement=PRESSURE_HPA,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key=sc.TIRE_PRESSURE_FR,
         device_class=SensorDeviceClass.PRESSURE,
-        name="Tire Pressure FR",
+        name="Tire pressure FR",
         native_unit_of_measurement=PRESSURE_HPA,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key=sc.TIRE_PRESSURE_RL,
         device_class=SensorDeviceClass.PRESSURE,
-        name="Tire Pressure RL",
+        name="Tire pressure RL",
         native_unit_of_measurement=PRESSURE_HPA,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key=sc.TIRE_PRESSURE_RR,
         device_class=SensorDeviceClass.PRESSURE,
-        name="Tire Pressure RR",
+        name="Tire pressure RR",
         native_unit_of_measurement=PRESSURE_HPA,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key=sc.EXTERNAL_TEMP,
         device_class=SensorDeviceClass.TEMPERATURE,
-        name="External Temp",
+        name="External temp",
         native_unit_of_measurement=TEMP_CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key=sc.BATTERY_VOLTAGE,
         device_class=SensorDeviceClass.VOLTAGE,
-        name="12V Battery Voltage",
+        name="12V battery voltage",
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -134,21 +134,21 @@ EV_SENSORS = [
         key=sc.EV_DISTANCE_TO_EMPTY,
         device_class=SensorDeviceClass.DISTANCE,
         icon="mdi:ev-station",
-        name="EV Range",
+        name="EV range",
         native_unit_of_measurement=LENGTH_MILES,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key=sc.EV_STATE_OF_CHARGE_PERCENT,
         device_class=SensorDeviceClass.BATTERY,
-        name="EV Battery Level",
+        name="EV battery level",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key=sc.EV_TIME_TO_FULLY_CHARGED_UTC,
         device_class=SensorDeviceClass.TIMESTAMP,
-        name="EV Time to Full Charge",
+        name="EV time to full charge",
         state_class=SensorStateClass.MEASUREMENT,
     ),
 ]
@@ -211,7 +211,7 @@ class SubaruSensor(
         self.vin = vehicle_info[VEHICLE_VIN]
         self.entity_description = description
         self._attr_device_info = get_device_info(vehicle_info)
-        self._attr_unique_id = f"{self.vin}_{description.name}"
+        self._attr_unique_id = f"{self.vin}_{description.key}"
 
     @property
     def native_value(self) -> None | int | float:

--- a/homeassistant/components/subaru/sensor.py
+++ b/homeassistant/components/subaru/sensor.py
@@ -300,7 +300,7 @@ async def _async_migrate_entries(
         id_split = entry.unique_id.split("_")
         key = id_split[1].upper() if len(id_split) == 2 else None
 
-        if key not in replacements:
+        if key not in replacements or id_split[1] == replacements[key]:
             return None
 
         new_unique_id = entry.unique_id.replace(id_split[1], replacements[key])

--- a/homeassistant/components/subaru/sensor.py
+++ b/homeassistant/components/subaru/sensor.py
@@ -1,7 +1,6 @@
 """Support for Subaru sensors."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import subarulink.const as sc
@@ -49,8 +48,6 @@ from .const import (
     VEHICLE_VIN,
 )
 
-_LOGGER = logging.getLogger(__name__)
-
 # Fuel consumption units
 FUEL_CONSUMPTION_LITERS_PER_HUNDRED_KILOMETERS = "L/100km"
 FUEL_CONSUMPTION_MILES_PER_GALLON = "mi/gal"
@@ -62,6 +59,7 @@ KM_PER_MI = DistanceConverter.convert(1, LENGTH_MILES, LENGTH_KILOMETERS)
 SAFETY_SENSORS = [
     SensorEntityDescription(
         key=sc.ODOMETER,
+        device_class=SensorDeviceClass.DISTANCE,
         icon="mdi:road-variant",
         name="Odometer",
         native_unit_of_measurement=LENGTH_KILOMETERS,
@@ -80,6 +78,7 @@ API_GEN_2_SENSORS = [
     ),
     SensorEntityDescription(
         key=sc.DIST_TO_EMPTY,
+        device_class=SensorDeviceClass.DISTANCE,
         icon="mdi:gas-station",
         name="Range",
         native_unit_of_measurement=LENGTH_KILOMETERS,
@@ -133,6 +132,7 @@ API_GEN_2_SENSORS = [
 EV_SENSORS = [
     SensorEntityDescription(
         key=sc.EV_DISTANCE_TO_EMPTY,
+        device_class=SensorDeviceClass.DISTANCE,
         icon="mdi:ev-station",
         name="EV Range",
         native_unit_of_measurement=LENGTH_MILES,

--- a/tests/components/subaru/conftest.py
+++ b/tests/components/subaru/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from subarulink.const import COUNTRY_USA
 
+from homeassistant import config_entries
 from homeassistant.components.homeassistant import DOMAIN as HA_DOMAIN
 from homeassistant.components.subaru.const import (
     CONF_COUNTRY,
@@ -71,6 +72,15 @@ TEST_OPTIONS = {
     CONF_UPDATE_ENABLED: True,
 }
 
+TEST_CONFIG_ENTRY = {
+    "entry_id": "1",
+    "domain": DOMAIN,
+    "title": TEST_CONFIG[CONF_USERNAME],
+    "data": TEST_CONFIG,
+    "options": TEST_OPTIONS,
+    "source": config_entries.SOURCE_USER,
+}
+
 TEST_DEVICE_NAME = "test_vehicle_2"
 TEST_ENTITY_ID = f"sensor.{TEST_DEVICE_NAME}_odometer"
 
@@ -83,6 +93,7 @@ def advance_time_to_next_fetch(hass):
 
 async def setup_subaru_integration(
     hass,
+    mock_config_entry=None,
     vehicle_list=None,
     vehicle_data=None,
     vehicle_status=None,
@@ -90,16 +101,13 @@ async def setup_subaru_integration(
     fetch_effect=None,
 ):
     """Create Subaru entry."""
-    assert await async_setup_component(hass, HA_DOMAIN, {})
-    assert await async_setup_component(hass, DOMAIN, {})
-
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=TEST_CONFIG,
-        options=TEST_OPTIONS,
-        entry_id=1,
-    )
-    config_entry.add_to_hass(hass)
+    if mock_config_entry:
+        config_entry = mock_config_entry
+    else:
+        assert await async_setup_component(hass, HA_DOMAIN, {})
+        assert await async_setup_component(hass, DOMAIN, {})
+        config_entry = MockConfigEntry(**TEST_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
 
     with patch(
         MOCK_API_CONNECT,

--- a/tests/components/subaru/conftest.py
+++ b/tests/components/subaru/conftest.py
@@ -91,24 +91,16 @@ def advance_time_to_next_fetch(hass):
     async_fire_time_changed(hass, future)
 
 
-async def setup_subaru_integration(
+async def setup_subaru_config_entry(
     hass,
-    mock_config_entry=None,
-    vehicle_list=None,
-    vehicle_data=None,
-    vehicle_status=None,
+    config_entry,
+    vehicle_list=[TEST_VIN_2_EV],
+    vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
+    vehicle_status=VEHICLE_STATUS_EV,
     connect_effect=None,
     fetch_effect=None,
 ):
-    """Create Subaru entry."""
-    if mock_config_entry:
-        config_entry = mock_config_entry
-    else:
-        assert await async_setup_component(hass, HA_DOMAIN, {})
-        assert await async_setup_component(hass, DOMAIN, {})
-        config_entry = MockConfigEntry(**TEST_CONFIG_ENTRY)
-        config_entry.add_to_hass(hass)
-
+    """Run async_setup with API mocks in place."""
     with patch(
         MOCK_API_CONNECT,
         return_value=connect_effect is None,
@@ -142,20 +134,22 @@ async def setup_subaru_integration(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
+
+@pytest.fixture
+async def subaru_config_entry(hass):
+    """Create a Subaru config entry prior to setup."""
+    await async_setup_component(hass, HA_DOMAIN, {})
+    config_entry = MockConfigEntry(**TEST_CONFIG_ENTRY)
+    config_entry.add_to_hass(hass)
     return config_entry
 
 
 @pytest.fixture
-async def ev_entry(hass):
+async def ev_entry(hass, subaru_config_entry):
     """Create a Subaru entry representing an EV vehicle with full STARLINK subscription."""
-    entry = await setup_subaru_integration(
-        hass,
-        vehicle_list=[TEST_VIN_2_EV],
-        vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
-        vehicle_status=VEHICLE_STATUS_EV,
-    )
+    await setup_subaru_config_entry(hass, subaru_config_entry)
     assert DOMAIN in hass.config_entries.async_domains()
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert hass.config_entries.async_get_entry(entry.entry_id)
-    assert entry.state is ConfigEntryState.LOADED
-    return entry
+    assert hass.config_entries.async_get_entry(subaru_config_entry.entry_id)
+    assert subaru_config_entry.state is ConfigEntryState.LOADED
+    return subaru_config_entry

--- a/tests/components/subaru/test_init.py
+++ b/tests/components/subaru/test_init.py
@@ -24,7 +24,7 @@ from .conftest import (
     MOCK_API_FETCH,
     MOCK_API_UPDATE,
     TEST_ENTITY_ID,
-    setup_subaru_integration,
+    setup_subaru_config_entry,
 )
 
 
@@ -42,61 +42,70 @@ async def test_setup_ev(hass, ev_entry):
     assert check_entry.state is ConfigEntryState.LOADED
 
 
-async def test_setup_g2(hass):
+async def test_setup_g2(hass, subaru_config_entry):
     """Test setup with a G2 vehcile ."""
-    entry = await setup_subaru_integration(
+    await setup_subaru_config_entry(
         hass,
+        subaru_config_entry,
         vehicle_list=[TEST_VIN_3_G2],
         vehicle_data=VEHICLE_DATA[TEST_VIN_3_G2],
         vehicle_status=VEHICLE_STATUS_G2,
     )
-    check_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    check_entry = hass.config_entries.async_get_entry(subaru_config_entry.entry_id)
     assert check_entry
     assert check_entry.state is ConfigEntryState.LOADED
 
 
-async def test_setup_g1(hass):
+async def test_setup_g1(hass, subaru_config_entry):
     """Test setup with a G1 vehicle."""
-    entry = await setup_subaru_integration(
-        hass, vehicle_list=[TEST_VIN_1_G1], vehicle_data=VEHICLE_DATA[TEST_VIN_1_G1]
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_1_G1],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_1_G1],
     )
-    check_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    check_entry = hass.config_entries.async_get_entry(subaru_config_entry.entry_id)
     assert check_entry
     assert check_entry.state is ConfigEntryState.LOADED
 
 
-async def test_unsuccessful_connect(hass):
+async def test_unsuccessful_connect(hass, subaru_config_entry):
     """Test unsuccessful connect due to connectivity."""
-    entry = await setup_subaru_integration(
+    await setup_subaru_config_entry(
         hass,
+        subaru_config_entry,
         connect_effect=SubaruException("Service Unavailable"),
         vehicle_list=[TEST_VIN_2_EV],
         vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
         vehicle_status=VEHICLE_STATUS_EV,
     )
-    check_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    check_entry = hass.config_entries.async_get_entry(subaru_config_entry.entry_id)
     assert check_entry
     assert check_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_invalid_credentials(hass):
+async def test_invalid_credentials(hass, subaru_config_entry):
     """Test invalid credentials."""
-    entry = await setup_subaru_integration(
+    await setup_subaru_config_entry(
         hass,
+        subaru_config_entry,
         connect_effect=InvalidCredentials("Invalid Credentials"),
         vehicle_list=[TEST_VIN_2_EV],
         vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
         vehicle_status=VEHICLE_STATUS_EV,
     )
-    check_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    check_entry = hass.config_entries.async_get_entry(subaru_config_entry.entry_id)
     assert check_entry
     assert check_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_update_skip_unsubscribed(hass):
+async def test_update_skip_unsubscribed(hass, subaru_config_entry):
     """Test update function skips vehicles without subscription."""
-    await setup_subaru_integration(
-        hass, vehicle_list=[TEST_VIN_1_G1], vehicle_data=VEHICLE_DATA[TEST_VIN_1_G1]
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_1_G1],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_1_G1],
     )
 
     with patch(MOCK_API_FETCH) as mock_fetch:
@@ -126,10 +135,11 @@ async def test_update_disabled(hass, ev_entry):
         mock_update.assert_not_called()
 
 
-async def test_fetch_failed(hass):
+async def test_fetch_failed(hass, subaru_config_entry):
     """Tests when fetch fails."""
-    await setup_subaru_integration(
+    await setup_subaru_config_entry(
         hass,
+        subaru_config_entry,
         vehicle_list=[TEST_VIN_2_EV],
         vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
         vehicle_status=VEHICLE_STATUS_EV,

--- a/tests/components/subaru/test_sensor.py
+++ b/tests/components/subaru/test_sensor.py
@@ -19,19 +19,15 @@ from .api_responses import (
     EXPECTED_STATE_EV_METRIC,
     EXPECTED_STATE_EV_UNAVAILABLE,
     TEST_VIN_2_EV,
-    VEHICLE_DATA,
     VEHICLE_STATUS_EV,
 )
 from .conftest import (
     MOCK_API_FETCH,
     MOCK_API_GET_DATA,
-    TEST_CONFIG_ENTRY,
     TEST_DEVICE_NAME,
     advance_time_to_next_fetch,
-    setup_subaru_integration,
+    setup_subaru_config_entry,
 )
-
-from tests.common import MockConfigEntry
 
 
 async def test_sensors_ev_imperial(hass, ev_entry):
@@ -76,29 +72,17 @@ async def test_sensors_missing_vin_data(hass, ev_entry):
     ],
 )
 async def test_sensor_migrate_unique_ids(
-    hass,
-    entitydata,
-    old_unique_id,
-    new_unique_id,
+    hass, entitydata, old_unique_id, new_unique_id, subaru_config_entry
 ) -> None:
     """Test successful migration of entity unique_ids."""
-    mock_config_entry = MockConfigEntry(**TEST_CONFIG_ENTRY)
-    mock_config_entry.add_to_hass(hass)
-
     entity_registry = er.async_get(hass)
     entity: er.RegistryEntry = entity_registry.async_get_or_create(
         **entitydata,
-        config_entry=mock_config_entry,
+        config_entry=subaru_config_entry,
     )
     assert entity.unique_id == old_unique_id
 
-    await setup_subaru_integration(
-        hass,
-        mock_config_entry=mock_config_entry,
-        vehicle_list=[TEST_VIN_2_EV],
-        vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
-        vehicle_status=VEHICLE_STATUS_EV,
-    )
+    await setup_subaru_config_entry(hass, subaru_config_entry)
 
     entity_migrated = entity_registry.async_get(entity.entity_id)
     assert entity_migrated
@@ -120,19 +104,13 @@ async def test_sensor_migrate_unique_ids(
     ],
 )
 async def test_sensor_migrate_unique_ids_duplicate(
-    hass,
-    entitydata,
-    old_unique_id,
-    new_unique_id,
+    hass, entitydata, old_unique_id, new_unique_id, subaru_config_entry
 ) -> None:
     """Test unsuccessful migration of entity unique_ids due to duplicate."""
-    mock_config_entry = MockConfigEntry(**TEST_CONFIG_ENTRY)
-    mock_config_entry.add_to_hass(hass)
-
     entity_registry = er.async_get(hass)
     entity: er.RegistryEntry = entity_registry.async_get_or_create(
         **entitydata,
-        config_entry=mock_config_entry,
+        config_entry=subaru_config_entry,
     )
     assert entity.unique_id == old_unique_id
 
@@ -141,16 +119,10 @@ async def test_sensor_migrate_unique_ids_duplicate(
         SENSOR_DOMAIN,
         SUBARU_DOMAIN,
         unique_id=new_unique_id,
-        config_entry=mock_config_entry,
+        config_entry=subaru_config_entry,
     )
 
-    await setup_subaru_integration(
-        hass,
-        mock_config_entry=mock_config_entry,
-        vehicle_list=[TEST_VIN_2_EV],
-        vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
-        vehicle_status=VEHICLE_STATUS_EV,
-    )
+    await setup_subaru_config_entry(hass, subaru_config_entry)
 
     entity_migrated = entity_registry.async_get(entity.entity_id)
     assert entity_migrated

--- a/tests/components/subaru/test_sensor.py
+++ b/tests/components/subaru/test_sensor.py
@@ -1,11 +1,16 @@
 """Test Subaru sensors."""
 from unittest.mock import patch
 
+import pytest
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.subaru.sensor import (
     API_GEN_2_SENSORS,
+    DOMAIN as SUBARU_DOMAIN,
     EV_SENSORS,
     SAFETY_SENSORS,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
@@ -13,14 +18,20 @@ from .api_responses import (
     EXPECTED_STATE_EV_IMPERIAL,
     EXPECTED_STATE_EV_METRIC,
     EXPECTED_STATE_EV_UNAVAILABLE,
+    TEST_VIN_2_EV,
+    VEHICLE_DATA,
     VEHICLE_STATUS_EV,
 )
 from .conftest import (
     MOCK_API_FETCH,
     MOCK_API_GET_DATA,
+    TEST_CONFIG_ENTRY,
     TEST_DEVICE_NAME,
     advance_time_to_next_fetch,
+    setup_subaru_integration,
 )
+
+from tests.common import MockConfigEntry
 
 
 async def test_sensors_ev_imperial(hass, ev_entry):
@@ -48,6 +59,108 @@ async def test_sensors_missing_vin_data(hass, ev_entry):
         await hass.async_block_till_done()
 
     _assert_data(hass, EXPECTED_STATE_EV_UNAVAILABLE)
+
+
+@pytest.mark.parametrize(
+    "entitydata,old_unique_id,new_unique_id",
+    [
+        (
+            {
+                "domain": SENSOR_DOMAIN,
+                "platform": SUBARU_DOMAIN,
+                "unique_id": f"{TEST_VIN_2_EV}_{API_GEN_2_SENSORS[0].name}",
+            },
+            f"{TEST_VIN_2_EV}_{API_GEN_2_SENSORS[0].name}",
+            f"{TEST_VIN_2_EV}_{API_GEN_2_SENSORS[0].key}",
+        ),
+    ],
+)
+async def test_sensor_migrate_unique_ids(
+    hass,
+    entitydata,
+    old_unique_id,
+    new_unique_id,
+) -> None:
+    """Test successful migration of entity unique_ids."""
+    mock_config_entry = MockConfigEntry(**TEST_CONFIG_ENTRY)
+    mock_config_entry.add_to_hass(hass)
+
+    entity_registry = er.async_get(hass)
+    entity: er.RegistryEntry = entity_registry.async_get_or_create(
+        **entitydata,
+        config_entry=mock_config_entry,
+    )
+    assert entity.unique_id == old_unique_id
+
+    await setup_subaru_integration(
+        hass,
+        mock_config_entry=mock_config_entry,
+        vehicle_list=[TEST_VIN_2_EV],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
+        vehicle_status=VEHICLE_STATUS_EV,
+    )
+
+    entity_migrated = entity_registry.async_get(entity.entity_id)
+    assert entity_migrated
+    assert entity_migrated.unique_id == new_unique_id
+
+
+@pytest.mark.parametrize(
+    "entitydata,old_unique_id,new_unique_id",
+    [
+        (
+            {
+                "domain": SENSOR_DOMAIN,
+                "platform": SUBARU_DOMAIN,
+                "unique_id": f"{TEST_VIN_2_EV}_{API_GEN_2_SENSORS[0].name}",
+            },
+            f"{TEST_VIN_2_EV}_{API_GEN_2_SENSORS[0].name}",
+            f"{TEST_VIN_2_EV}_{API_GEN_2_SENSORS[0].key}",
+        )
+    ],
+)
+async def test_sensor_migrate_unique_ids_duplicate(
+    hass,
+    entitydata,
+    old_unique_id,
+    new_unique_id,
+) -> None:
+    """Test unsuccessful migration of entity unique_ids due to duplicate."""
+    mock_config_entry = MockConfigEntry(**TEST_CONFIG_ENTRY)
+    mock_config_entry.add_to_hass(hass)
+
+    entity_registry = er.async_get(hass)
+    entity: er.RegistryEntry = entity_registry.async_get_or_create(
+        **entitydata,
+        config_entry=mock_config_entry,
+    )
+    assert entity.unique_id == old_unique_id
+
+    # create existing entry with new_unique_id that conflicts with migrate
+    existing_entity = entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        SUBARU_DOMAIN,
+        unique_id=new_unique_id,
+        config_entry=mock_config_entry,
+    )
+
+    await setup_subaru_integration(
+        hass,
+        mock_config_entry=mock_config_entry,
+        vehicle_list=[TEST_VIN_2_EV],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
+        vehicle_status=VEHICLE_STATUS_EV,
+    )
+
+    entity_migrated = entity_registry.async_get(entity.entity_id)
+    assert entity_migrated
+    assert entity_migrated.unique_id == old_unique_id
+
+    entity_not_changed = entity_registry.async_get(existing_entity.entity_id)
+    assert entity_not_changed
+    assert entity_not_changed.unique_id == new_unique_id
+
+    assert entity_migrated != entity_not_changed
 
 
 def _assert_data(hass, expected_state):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Code quality updates recommended during review of #66996
  * Use `SensorDeviceClass.DISTANCE` for appropriate sensors
  * Apply sentence casing to sensor names
  * Migrate sensor entity unique_id to use Subaru JSON data dict keys
    * No longer a breaking change
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #66996
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
