### PR TITLE
Convert network mode from sensor to select for huawei_lte

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -129,6 +129,7 @@ PLATFORMS = [
     Platform.DEVICE_TRACKER,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.SELECT,
 ]
 
 

--- a/homeassistant/components/huawei_lte/const.py
+++ b/homeassistant/components/huawei_lte/const.py
@@ -1,5 +1,7 @@
 """Huawei LTE constants."""
 
+from huawei_lte_api.enums.net import NetworkModeEnum
+
 DOMAIN = "huawei_lte"
 
 ATTR_CONFIG_ENTRY_ID = "config_entry_id"
@@ -79,3 +81,13 @@ ALL_KEYS = (
     | SWITCH_KEYS
     | {KEY_DEVICE_BASIC_INFORMATION}
 )
+
+NETWORKMODE_TO_STRING = {
+    NetworkModeEnum.MODE_AUTO.value: "4G/3G/2G",
+    NetworkModeEnum.MODE_4G_3G_AUTO.value: "4G/3G",
+    NetworkModeEnum.MODE_4G_2G_AUTO.value: "4G/2G",
+    NetworkModeEnum.MODE_4G_ONLY.value: "4G",
+    NetworkModeEnum.MODE_3G_2G_AUTO.value: "3G/2G",
+    NetworkModeEnum.MODE_3G_ONLY.value: "3G",
+    NetworkModeEnum.MODE_2G_ONLY.value: "2G",
+}

--- a/homeassistant/components/huawei_lte/select.py
+++ b/homeassistant/components/huawei_lte/select.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up from config entry."""
-    router = hass.data[DOMAIN].routers[config_entry.unique_id]
+    router = hass.data[DOMAIN].routers[config_entry.entry_id]
     selects: list[Entity] = []
 
     desc = SelectEntityDescription(

--- a/homeassistant/components/huawei_lte/select.py
+++ b/homeassistant/components/huawei_lte/select.py
@@ -1,10 +1,10 @@
 """Support for Huawei LTE selects."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import partial
 import logging
-from typing import Callable
 
 from huawei_lte_api.enums.net import LTEBandEnum, NetworkBandEnum
 
@@ -19,7 +19,7 @@ from homeassistant.helpers.entity import Entity, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HuaweiLteBaseEntityWithDevice
-from .const import DOMAIN, KEY_NET_NET_MODE
+from .const import DOMAIN, KEY_NET_NET_MODE, NETWORKMODE_TO_STRING
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,16 +42,8 @@ async def async_setup_entry(
             description=desc,
             key=KEY_NET_NET_MODE,
             item="NetworkMode",
-            choices={
-                "00": "4G/3G/2G",
-                "01": "2G",
-                "02": "3G",
-                "03": "4G",
-                "0301": "4G/2G",
-                "0302": "4G/3G",
-                "0201": "3G/2G",
-            },
-            setter_method=partial(
+            choices=NETWORKMODE_TO_STRING,
+            setter_fn=partial(
                 router.client.net.set_net_mode,
                 LTEBandEnum.ALL,
                 NetworkBandEnum.ALL,
@@ -70,14 +62,14 @@ class HuaweiLteBaseSelect(HuaweiLteBaseEntityWithDevice, SelectEntity):
     key: str
     item: str
     choices: dict[str, str]
-    setter_method: Callable
+    setter_fn: Callable
 
     _raw_state: str | None = field(default=None, init=False)
 
     def select_option(self, option: str) -> None:
         """Change the selected option."""
         choices_reverse = {v: k for k, v in self.choices.items()}
-        self.setter_method(choices_reverse.get(option))
+        self.setter_fn(choices_reverse.get(option))
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/huawei_lte/select.py
+++ b/homeassistant/components/huawei_lte/select.py
@@ -31,15 +31,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up from config entry."""
     router = hass.data[DOMAIN].routers[config_entry.unique_id]
-    switches: list[Entity] = []
+    selects: list[Entity] = []
 
     desc = SelectEntityDescription(
         key="network_mode", name="Preferred mode", entity_category=EntityCategory.CONFIG
     )
-    switches.append(
+    selects.append(
         HuaweiLteBaseSelect(
             router,
-            description=desc,
+            entity_description=desc,
             key=KEY_NET_NET_MODE,
             item="NetworkMode",
             choices=NETWORKMODE_TO_STRING,
@@ -51,20 +51,24 @@ async def async_setup_entry(
         )
     )
 
-    async_add_entities(switches, True)
+    async_add_entities(selects, True)
 
 
 @dataclass
 class HuaweiLteBaseSelect(HuaweiLteBaseEntityWithDevice, SelectEntity):
     """Huawei LTE select base class."""
 
-    description: SelectEntityDescription
+    entity_description: SelectEntityDescription
     key: str
     item: str
     choices: dict[str, str]
     setter_fn: Callable
 
     _raw_state: str | None = field(default=None, init=False)
+
+    def __post_init__(self) -> None:
+        """Initialize remaining attributes."""
+        self._attr_name = self.entity_description.name or self.item
 
     def select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -74,7 +78,7 @@ class HuaweiLteBaseSelect(HuaweiLteBaseEntityWithDevice, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return current option."""
-        state_str = self.choices.get(self._raw_state)  # type: ignore[arg-type]
+        state_str = self.choices.get(self._raw_state)
         if state_str is None:
             _LOGGER.warning("Unknown state: %s", self._raw_state)
 

--- a/homeassistant/components/huawei_lte/select.py
+++ b/homeassistant/components/huawei_lte/select.py
@@ -1,0 +1,119 @@
+"""Support for Huawei LTE selects."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import partial
+import logging
+from typing import Callable
+
+from huawei_lte_api.enums.net import LTEBandEnum, NetworkBandEnum
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SelectEntity,
+    SelectEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import HuaweiLteBaseEntityWithDevice
+from .const import DOMAIN, KEY_NET_NET_MODE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up from config entry."""
+    router = hass.data[DOMAIN].routers[config_entry.unique_id]
+    switches: list[Entity] = []
+
+    desc = SelectEntityDescription(
+        key="network_mode", name="Preferred mode", entity_category=EntityCategory.CONFIG
+    )
+    switches.append(
+        HuaweiLteBaseSelect(
+            router,
+            description=desc,
+            key=KEY_NET_NET_MODE,
+            item="NetworkMode",
+            choices={
+                "00": "4G/3G/2G",
+                "01": "2G",
+                "02": "3G",
+                "03": "4G",
+                "0301": "4G/2G",
+                "0302": "4G/3G",
+                "0201": "3G/2G",
+            },
+            setter_method=partial(
+                router.client.net.set_net_mode,
+                LTEBandEnum.ALL,
+                NetworkBandEnum.ALL,
+            ),
+        )
+    )
+
+    async_add_entities(switches, True)
+
+
+@dataclass
+class HuaweiLteBaseSelect(HuaweiLteBaseEntityWithDevice, SelectEntity):
+    """Huawei LTE select base class."""
+
+    description: SelectEntityDescription
+    key: str
+    item: str
+    choices: dict[str, str]
+    setter_method: Callable
+
+    _raw_state: str | None = field(default=None, init=False)
+
+    def select_option(self, option: str) -> None:
+        """Change the selected option."""
+        choices_reverse = {v: k for k, v in self.choices.items()}
+        self.setter_method(choices_reverse.get(option))
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current option."""
+        state_str = self.choices.get(self._raw_state)  # type: ignore[arg-type]
+        if state_str is None:
+            _LOGGER.warning("Unknown state: %s", self._raw_state)
+
+        return state_str
+
+    @property
+    def options(self) -> list[str]:
+        """Return available options."""
+        return list(self.choices.values())
+
+    @property
+    def _device_unique_id(self) -> str:
+        return f"{self.key}.{self.item}"
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to needed data on add."""
+        await super().async_added_to_hass()
+        self.router.subscriptions[self.key].add(f"{SELECT_DOMAIN}/{self.item}")
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from needed data on remove."""
+        await super().async_will_remove_from_hass()
+        self.router.subscriptions[self.key].remove(f"{SELECT_DOMAIN}/{self.item}")
+
+    async def async_update(self) -> None:
+        """Update state."""
+        try:
+            value = self.router.data[self.key][self.item]
+        except KeyError:
+            _LOGGER.debug("%s[%s] not in data", self.key, self.item)
+            self._available = False
+            return
+        self._available = True
+        self._raw_state = str(value)

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -8,8 +8,6 @@ from datetime import datetime, timedelta
 import logging
 import re
 
-from huawei_lte_api.enums.net import NetworkModeEnum
-
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
@@ -42,6 +40,7 @@ from .const import (
     KEY_NET_CURRENT_PLMN,
     KEY_NET_NET_MODE,
     KEY_SMS_SMS_COUNT,
+    NETWORKMODE_TO_STRING,
     SENSOR_KEYS,
 )
 
@@ -573,15 +572,7 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
                 key="NetworkMode",
                 name="Preferred mode",
                 format_fn=lambda x: (
-                    {
-                        NetworkModeEnum.MODE_AUTO.value: "4G/3G/2G",
-                        NetworkModeEnum.MODE_4G_3G_AUTO.value: "4G/3G",
-                        NetworkModeEnum.MODE_4G_2G_AUTO.value: "4G/2G",
-                        NetworkModeEnum.MODE_4G_ONLY.value: "4G",
-                        NetworkModeEnum.MODE_3G_2G_AUTO.value: "3G/2G",
-                        NetworkModeEnum.MODE_3G_ONLY.value: "3G",
-                        NetworkModeEnum.MODE_2G_ONLY.value: "2G",
-                    }.get(x),
+                    NETWORKMODE_TO_STRING.get(x),
                     None,
                 ),
                 entity_category=EntityCategory.CONFIG,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR converts an already existing network mode sensor into a select to allow changing preferred network mode (Auto, 3G-only, 4G-only etc.) the router should use.

This is rather a PoC than a polished PR that is ready to be merged, so I'll mark this as draft to get some input from the codeowner.
I have tested this with B715s-23c, but I have no access to that device again until next year so I cannot provide a screenshot how it looks like :-(


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
