### PR TITLE
Add presence duration number

### DIFF
--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -1,11 +1,15 @@
-"""Support for configuring different deCONZ sensors."""
+"""Support for configuring different deCONZ numbers."""
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
 
+from pydeconz.gateway import DeconzSession
+from pydeconz.interfaces.sensors import SensorResources
 from pydeconz.models.event import EventType
+from pydeconz.models.sensor import SensorBase as PydeconzSensorBase
 from pydeconz.models.sensor.presence import Presence
 
 from homeassistant.components.number import (
@@ -17,39 +21,76 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+import homeassistant.helpers.entity_registry as er
 
+from .const import DOMAIN as DECONZ_DOMAIN
 from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
 
+T = TypeVar("T", Presence, PydeconzSensorBase)
+
 
 @dataclass
-class DeconzNumberDescriptionMixin:
+class DeconzNumberDescriptionMixin(Generic[T]):
     """Required values when describing deCONZ number entities."""
 
-    suffix: str
+    instance_check: type[T]
+    name_suffix: str
+    set_fn: Callable[[DeconzSession, str, int], Coroutine[Any, Any, dict[str, Any]]]
     update_key: str
-    value_fn: Callable[[Presence], float | None]
+    value_fn: Callable[[T], float | None]
 
 
 @dataclass
-class DeconzNumberDescription(NumberEntityDescription, DeconzNumberDescriptionMixin):
+class DeconzNumberDescription(NumberEntityDescription, DeconzNumberDescriptionMixin[T]):
     """Class describing deCONZ number entities."""
 
 
-ENTITY_DESCRIPTIONS = {
-    Presence: [
-        DeconzNumberDescription(
-            key="delay",
-            value_fn=lambda device: device.delay,
-            suffix="Delay",
-            update_key="delay",
-            native_max_value=65535,
-            native_min_value=0,
-            native_step=1,
-            entity_category=EntityCategory.CONFIG,
-        )
-    ]
-}
+ENTITY_DESCRIPTIONS: tuple[DeconzNumberDescription, ...] = (
+    DeconzNumberDescription[Presence](
+        key="delay",
+        instance_check=Presence,
+        name_suffix="Delay",
+        set_fn=lambda api, id, v: api.sensors.presence.set_config(id=id, delay=v),
+        update_key="delay",
+        value_fn=lambda device: device.delay,
+        native_max_value=65535,
+        native_min_value=0,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    DeconzNumberDescription[Presence](
+        key="duration",
+        instance_check=Presence,
+        name_suffix="Duration",
+        set_fn=lambda api, id, v: api.sensors.presence.set_config(id=id, duration=v),
+        update_key="duration",
+        value_fn=lambda device: device.duration,
+        native_max_value=65535,
+        native_min_value=0,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
+@callback
+def async_update_unique_id(
+    hass: HomeAssistant, unique_id: str, description: DeconzNumberDescription
+) -> None:
+    """Update unique ID base to be on full unique ID rather than device serial.
+
+    Introduced with release 2022.11.
+    """
+    ent_reg = er.async_get(hass)
+
+    new_unique_id = f"{unique_id}-{description.key}"
+    if ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, new_unique_id):
+        return
+
+    unique_id = f'{unique_id.split("-", 1)[0]}-{description.key}'
+    if entity_id := ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, unique_id):
+        ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
 
 
 async def async_setup_entry(
@@ -66,12 +107,14 @@ async def async_setup_entry(
         """Add sensor from deCONZ."""
         sensor = gateway.api.sensors.presence[sensor_id]
 
-        for description in ENTITY_DESCRIPTIONS.get(type(sensor), []):
+        for description in ENTITY_DESCRIPTIONS:
             if (
-                not hasattr(sensor, description.key)
+                not isinstance(sensor, description.instance_check)
                 or description.value_fn(sensor) is None
             ):
                 continue
+            if description.key == "delay":
+                async_update_unique_id(hass, sensor.unique_id, description)
             async_add_entities([DeconzNumber(sensor, gateway, description)])
 
     gateway.register_platform_add_device_callback(
@@ -81,21 +124,23 @@ async def async_setup_entry(
     )
 
 
-class DeconzNumber(DeconzDevice[Presence], NumberEntity):
+class DeconzNumber(DeconzDevice[SensorResources], NumberEntity):
     """Representation of a deCONZ number entity."""
 
     TYPE = DOMAIN
+    entity_description: DeconzNumberDescription
 
     def __init__(
         self,
-        device: Presence,
+        device: SensorResources,
         gateway: DeconzGateway,
         description: DeconzNumberDescription,
     ) -> None:
         """Initialize deCONZ number entity."""
-        self.entity_description: DeconzNumberDescription = description
-        self._update_key = self.entity_description.update_key
-        self._name_suffix = description.suffix
+        self.entity_description = description
+        self.unique_id_suffix = description.key
+        self._name_suffix = description.name_suffix
+        self._update_key = description.update_key
         super().__init__(device, gateway)
 
     @property
@@ -105,12 +150,8 @@ class DeconzNumber(DeconzDevice[Presence], NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set sensor config."""
-        await self.gateway.api.sensors.presence.set_config(
-            id=self._device.resource_id,
-            delay=int(value),
+        await self.entity_description.set_fn(
+            self.gateway.api,
+            self._device.resource_id,
+            int(value),
         )
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique identifier for this entity."""
-        return f"{self.serial}-{self.entity_description.suffix.lower()}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on https://github.com/home-assistant/core/pull/62777 by @scop 
Expose duration setting for devices reporting "duration"
Migrates unique ID of delay number entities to be normalised as with all other sensor based entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
