### PR TITLE
Update Config Flow to show message about unsupported Overkiz hardware

### DIFF
--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -68,6 +68,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the initial step via config flow."""
         errors = {}
+        description_placeholders = {}
 
         if user_input:
             self._default_user = user_input[CONF_USERNAME]
@@ -83,7 +84,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if user_input[CONF_HUB] == "atlantic_cozytouch" and not isinstance(
                     exception, CozyTouchBadCredentialsException
                 ):
-                    errors["base"] = "cozytouch_unsupported_hardware"
+                    description_placeholders["unsupported_device"] = "CozyTouch"
+                    errors["base"] = "unsupported_hardware"
                 else:
                     errors["base"] = "invalid_auth"
             except (TimeoutError, ClientError):
@@ -137,6 +139,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     ),
                 }
             ),
+            description_placeholders=description_placeholders,
             errors=errors,
         )
 

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -79,8 +79,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except TooManyRequestsException:
                 errors["base"] = "too_many_requests"
             except BadCredentialsException as exception:
-                # If authentication with CozyTouch auth server is valid, but token is invalid for Overkiz
-                # API server, the hardware is not supported.
+                # If authentication with CozyTouch auth server is valid, but token is invalid
+                # for Overkiz API server, the hardware is not supported.
                 if user_input[CONF_HUB] == "atlantic_cozytouch" and not isinstance(
                     exception, CozyTouchBadCredentialsException
                 ):
@@ -95,7 +95,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except TooManyAttemptsBannedException:
                 errors["base"] = "too_many_attempts"
             except UnknownUserException:
-                errors["base"] = "unknown_user"
+                # Somfy Protect accounts are not supported since they don't use
+                # the Overkiz API server. Login will return unknown user.
+                description_placeholders["unsupported_device"] = "Somfy Protect"
+                errors["base"] = "unsupported_hardware"
             except Exception as exception:  # pylint: disable=broad-except
                 errors["base"] = "unknown"
                 LOGGER.exception(exception)

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -14,6 +14,7 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "cozytouch_unsupported_hardware": "Your CozyTouch hardware is not manufactured by Overkiz, and thus not supported by this integration.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "server_in_maintenance": "Server is down for maintenance",
       "too_many_attempts": "Too many attempts with an invalid token, temporarily banned",

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -19,7 +19,6 @@
       "too_many_attempts": "Too many attempts with an invalid token, temporarily banned",
       "too_many_requests": "Too many requests, try again later",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "unknown_user": "Unknown user. Somfy Protect accounts are not supported by this integration.",
       "unsupported_hardware": "Your {unsupported_device} hardware is not supported by this integration."
     },
     "abort": {

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -14,13 +14,13 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "cozytouch_unsupported_hardware": "Your CozyTouch hardware is not manufactured by Overkiz, and thus not supported by this integration.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "server_in_maintenance": "Server is down for maintenance",
       "too_many_attempts": "Too many attempts with an invalid token, temporarily banned",
       "too_many_requests": "Too many requests, try again later",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "unknown_user": "Unknown user. Somfy Protect accounts are not supported by this integration."
+      "unknown_user": "Unknown user. Somfy Protect accounts are not supported by this integration.",
+      "unsupported_hardware": "Your {unsupported_device} hardware is not supported by this integration."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",

--- a/homeassistant/components/overkiz/translations/en.json
+++ b/homeassistant/components/overkiz/translations/en.json
@@ -12,7 +12,6 @@
             "too_many_attempts": "Too many attempts with an invalid token, temporarily banned",
             "too_many_requests": "Too many requests, try again later",
             "unknown": "Unexpected error",
-            "unknown_user": "Unknown user. Somfy Protect accounts are not supported by this integration.",
             "unsupported_hardware": "Your {unsupported_device} hardware is not supported by this integration."
         },
         "flow_title": "Gateway: {gateway_id}",

--- a/homeassistant/components/overkiz/translations/en.json
+++ b/homeassistant/components/overkiz/translations/en.json
@@ -7,13 +7,13 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "cozytouch_unsupported_hardware": "Your CozyTouch hardware is not manufactured by Overkiz, and thus not supported by this integration.",
             "invalid_auth": "Invalid authentication",
             "server_in_maintenance": "Server is down for maintenance",
             "too_many_attempts": "Too many attempts with an invalid token, temporarily banned",
             "too_many_requests": "Too many requests, try again later",
             "unknown": "Unexpected error",
-            "unknown_user": "Unknown user. Somfy Protect accounts are not supported by this integration."
+            "unknown_user": "Unknown user. Somfy Protect accounts are not supported by this integration.",
+            "unsupported_hardware": "Your {unsupported_device} hardware is not supported by this integration."
         },
         "flow_title": "Gateway: {gateway_id}",
         "step": {

--- a/homeassistant/components/overkiz/translations/en.json
+++ b/homeassistant/components/overkiz/translations/en.json
@@ -7,6 +7,7 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
+            "cozytouch_unsupported_hardware": "Your CozyTouch hardware is not manufactured by Overkiz, and thus not supported by this integration.",
             "invalid_auth": "Invalid authentication",
             "server_in_maintenance": "Server is down for maintenance",
             "too_many_attempts": "Too many attempts with an invalid token, temporarily banned",

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -27,6 +27,7 @@ TEST_PASSWORD = "test-password"
 TEST_PASSWORD2 = "test-password2"
 TEST_HUB = "somfy_europe"
 TEST_HUB2 = "hi_kumo_europe"
+TEST_HUB_COZYTOUCH = "atlantic_cozytouch"
 TEST_GATEWAY_ID = "1234-5678-9123"
 TEST_GATEWAY_ID2 = "4321-5678-9123"
 
@@ -105,6 +106,35 @@ async def test_form_invalid_auth(
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"username": TEST_EMAIL, "password": TEST_PASSWORD, "hub": TEST_HUB},
+        )
+
+    assert result["step_id"] == config_entries.SOURCE_USER
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["errors"] == {"base": error}
+
+
+@pytest.mark.parametrize(
+    "side_effect, error",
+    [
+        (BadCredentialsException, "unsupported_hardware"),
+    ],
+)
+async def test_form_invalid_cozytouch_auth(
+    hass: HomeAssistant, side_effect: Exception, error: str
+) -> None:
+    """Test we handle invalid auth from CozyTouch."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("pyoverkiz.client.OverkizClient.login", side_effect=side_effect):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": TEST_EMAIL,
+                "password": TEST_PASSWORD,
+                "hub": TEST_HUB_COZYTOUCH,
+            },
         )
 
     assert result["step_id"] == config_entries.SOURCE_USER

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -89,7 +89,7 @@ async def test_form(hass: HomeAssistant) -> None:
         (ClientError, "cannot_connect"),
         (MaintenanceException, "server_in_maintenance"),
         (TooManyAttemptsBannedException, "too_many_attempts"),
-        (UnknownUserException, "unknown_user"),
+        (UnknownUserException, "unsupported_hardware"),
         (Exception, "unknown"),
     ],
 )


### PR DESCRIPTION
## Proposed change

Fixes https://github.com/home-assistant/core/issues/75394. Show a clear error message for CozyTouch users that do not have Overkiz supported hardware. Recently CozyTouch started rolling out more hardware, which is supported by the CozyTouch API directly and not the Overkiz API. This is a totally different platform and can thus not be supported.


This will change the error message from 
<img width="561" alt="Screen Shot 2022-10-02 at 22 34 10" src="https://user-images.githubusercontent.com/1424596/193475109-6667e89e-2382-46ff-a517-fc46ce514d3b.png">
to
<img width="564" alt="Screen Shot 2022-10-02 at 22 34 00" src="https://user-images.githubusercontent.com/1424596/193475104-4d7a7695-16cd-45d4-8057-604f4611fde3.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/75394
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
