### PR TITLE
Add support for parent_device field so entities are nested within Keypad Devices

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -366,9 +366,7 @@ class LutronCasetaDevice(Entity):
             )
         ):
             # Append the child device name to the end of the parent keypad name to create the entity name
-            self._attr_name = " ".join(
-                (parent_device_info["name"], device["device_name"])
-            )
+            self._attr_name = f'{parent_device_info["name"]} {device["device_name"]}'
             # Set the device_info to the same as the Parent Keypad
             # The entities will be nested inside the keypad device
             self._attr_device_info = parent_device_info

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -363,10 +363,11 @@ class LutronCasetaDevice(Entity):
         if "parent_device" in device:
             # Check if this entity will be a child of an existing device
             if device_info_by_device_id is not None:
-                parent_device_info = device_info_by_device_id.get(
-                    device["parent_device"], None
-                )
-                if parent_device_info is not None:
+                if (
+                    parent_device_info := device_info_by_device_id.get(
+                        device["parent_device"], None
+                    )
+                ) is not None:
                     # Append the child device name to the end of the parent keypad name to create the entity name
                     self._attr_name = " ".join(
                         (parent_device_info["name"], device["device_name"])

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -242,7 +242,7 @@ def _async_register_button_devices(
             "manufacturer": MANUFACTURER,
             "config_entry_id": config_entry_id,
             "identifiers": {(DOMAIN, ha_device["serial"])},
-            "model": f"{device['model']} ({ha_device['type']})",
+            "model": f"{ha_device['model']} ({ha_device['type']})",
             "via_device": (DOMAIN, bridge_device["serial"]),
         }
         if area != UNASSIGNED_AREA:

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -221,7 +221,7 @@ def _async_register_button_devices(
     device_registry = dr.async_get(hass)
     button_devices_by_dr_id: dict[str, dict] = {}
     device_info_by_device_id: dict[int, dict[str, Any]] = {}
-    seen = set()
+    seen: set[str] = set()
     bridge_devices = bridge.get_devices()
 
     for device in button_devices_by_id.values():
@@ -360,22 +360,23 @@ class LutronCasetaDevice(Entity):
         if "serial" not in self._device:
             return
 
-        if "parent_device" in device:
-            # Check if this entity will be a child of an existing device
-            if device_info_by_device_id is not None:
-                if (
-                    parent_device_info := device_info_by_device_id.get(
-                        device["parent_device"], None
-                    )
-                ) is not None:
-                    # Append the child device name to the end of the parent keypad name to create the entity name
-                    self._attr_name = " ".join(
-                        (parent_device_info["name"], device["device_name"])
-                    )
-                    # Set the device_info to the same as the Parent Keypad
-                    # The entities will be nested inside the keypad device
-                    self._attr_device_info = parent_device_info
-                    return
+        if (
+            "parent_device" in device
+            and device_info_by_device_id is not None
+            and (
+                parent_device_info := device_info_by_device_id.get(
+                    device["parent_device"]
+                )
+            )
+        ):
+            # Append the child device name to the end of the parent keypad name to create the entity name
+            self._attr_name = " ".join(
+                (parent_device_info["name"], device["device_name"])
+            )
+            # Set the device_info to the same as the Parent Keypad
+            # The entities will be nested inside the keypad device
+            self._attr_device_info = parent_device_info
+            return
 
         area, name = _area_and_name_from_name(device["name"])
         self._attr_name = full_name = f"{area} {name}"

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -346,7 +346,7 @@ class LutronCasetaDevice(Entity):
 
     _attr_should_poll = False
 
-    def __init__(self, device, bridge, bridge_device, device_info_by_device_id=None):
+    def __init__(self, device, data):
         """Set up the base class.
 
         [:param]device the device metadata
@@ -354,19 +354,15 @@ class LutronCasetaDevice(Entity):
         [:param]bridge_device a dict with the details of the bridge
         """
         self._device = device
-        self._smartbridge = bridge
-        self._bridge_device = bridge_device
-        self._bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
+        self._smartbridge = data.bridge
+        self._bridge_device = data.bridge_device
+        self._bridge_unique_id = serial_to_unique_id(data.bridge_device["serial"])
         if "serial" not in self._device:
             return
 
-        if (
-            "parent_device" in device
-            and device_info_by_device_id is not None
-            and (
-                parent_device_info := device_info_by_device_id.get(
-                    device["parent_device"]
-                )
+        if "parent_device" in device and (
+            parent_device_info := data.device_info_by_device_id.get(
+                device["parent_device"]
             )
         ):
             # Append the child device name to the end of the parent keypad name to create the entity name

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -177,15 +177,15 @@ async def async_setup_entry(
 
     buttons = bridge.buttons
     _async_register_bridge_device(hass, entry_id, bridge_device)
-    button_devices = _async_register_button_devices(
-        hass, entry_id, bridge_device, buttons
+    button_devices, device_info_by_device_id = _async_register_button_devices(
+        hass, entry_id, bridge, bridge_device, buttons
     )
     _async_subscribe_pico_remote_events(hass, bridge, buttons)
 
     # Store this bridge (keyed by entry_id) so it can be retrieved by the
     # platforms we're setting up.
     hass.data[DOMAIN][entry_id] = LutronCasetaData(
-        bridge, bridge_device, button_devices
+        bridge, bridge_device, button_devices, device_info_by_device_id
     )
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
@@ -213,34 +213,46 @@ def _async_register_bridge_device(
 def _async_register_button_devices(
     hass: HomeAssistant,
     config_entry_id: str,
+    bridge,
     bridge_device,
     button_devices_by_id: dict[int, dict],
-) -> dict[str, dict]:
+) -> tuple[dict[str, dict], dict[int, dict[str, Any]]]:
     """Register button devices (Pico Remotes) in the device registry."""
     device_registry = dr.async_get(hass)
     button_devices_by_dr_id: dict[str, dict] = {}
+    device_info_by_device_id: dict[int, dict[str, Any]] = {}
     seen = set()
+    bridge_devices = bridge.get_devices()
 
     for device in button_devices_by_id.values():
-        if "serial" not in device or device["serial"] in seen:
+
+        ha_device = device
+        if "parent_device" in device and device["parent_device"] is not None:
+            # Device is a child of parent_device
+            # use the parent_device for HA device info
+            ha_device = bridge_devices[device["parent_device"]]
+
+        if "serial" not in ha_device or ha_device["serial"] in seen:
             continue
-        seen.add(device["serial"])
-        area, name = _area_and_name_from_name(device["name"])
+        seen.add(ha_device["serial"])
+
+        area, name = _area_and_name_from_name(ha_device["name"])
         device_args: dict[str, Any] = {
             "name": f"{area} {name}",
             "manufacturer": MANUFACTURER,
             "config_entry_id": config_entry_id,
-            "identifiers": {(DOMAIN, device["serial"])},
-            "model": f"{device['model']} ({device['type']})",
+            "identifiers": {(DOMAIN, ha_device["serial"])},
+            "model": f"{device['model']} ({ha_device['type']})",
             "via_device": (DOMAIN, bridge_device["serial"]),
         }
         if area != UNASSIGNED_AREA:
             device_args["suggested_area"] = area
 
         dr_device = device_registry.async_get_or_create(**device_args)
-        button_devices_by_dr_id[dr_device.id] = device
+        button_devices_by_dr_id[dr_device.id] = ha_device
+        device_info_by_device_id.setdefault(ha_device["device_id"], device_args)
 
-    return button_devices_by_dr_id
+    return button_devices_by_dr_id, device_info_by_device_id
 
 
 def _area_and_name_from_name(device_name: str) -> tuple[str, str]:
@@ -282,16 +294,23 @@ def _async_subscribe_pico_remote_events(
         else:
             action = ACTION_RELEASE
 
-        type_ = _lutron_model_to_device_type(device["model"], device["type"])
-        area, name = _area_and_name_from_name(device["name"])
+        bridge_devices = bridge_device.get_devices()
+        ha_device = device
+        if "parent_device" in device and device["parent_device"] is not None:
+            # Device is a child of parent_device
+            # use the parent_device for HA device info
+            ha_device = bridge_devices[device["parent_device"]]
+
+        type_ = _lutron_model_to_device_type(ha_device["model"], ha_device["type"])
+        area, name = _area_and_name_from_name(ha_device["name"])
         leap_button_number = device["button_number"]
         lip_button_number = async_get_lip_button(type_, leap_button_number)
-        hass_device = dev_reg.async_get_device({(DOMAIN, device["serial"])})
+        hass_device = dev_reg.async_get_device({(DOMAIN, ha_device["serial"])})
 
         hass.bus.async_fire(
             LUTRON_CASETA_BUTTON_EVENT,
             {
-                ATTR_SERIAL: device["serial"],
+                ATTR_SERIAL: ha_device["serial"],
                 ATTR_TYPE: type_,
                 ATTR_BUTTON_NUMBER: lip_button_number,
                 ATTR_LEAP_BUTTON_NUMBER: leap_button_number,
@@ -327,7 +346,7 @@ class LutronCasetaDevice(Entity):
 
     _attr_should_poll = False
 
-    def __init__(self, device, bridge, bridge_device):
+    def __init__(self, device, bridge, bridge_device, device_info_by_device_id=None):
         """Set up the base class.
 
         [:param]device the device metadata
@@ -340,6 +359,23 @@ class LutronCasetaDevice(Entity):
         self._bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
         if "serial" not in self._device:
             return
+
+        if "parent_device" in device:
+            # Check if this entity will be a child of an existing device
+            if device_info_by_device_id is not None:
+                parent_device_info = device_info_by_device_id.get(
+                    device["parent_device"], None
+                )
+                if parent_device_info is not None:
+                    # Append the child device name to the end of the parent keypad name to create the entity name
+                    self._attr_name = " ".join(
+                        (parent_device_info["name"], device["device_name"])
+                    )
+                    # Set the device_info to the same as the Parent Keypad
+                    # The entities will be nested inside the keypad device
+                    self._attr_device_info = parent_device_info
+                    return
+
         area, name = _area_and_name_from_name(device["name"])
         self._attr_name = full_name = f"{area} {name}"
         info = DeviceInfo(

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -28,10 +28,9 @@ async def async_setup_entry(
     """
     data: LutronCasetaData = hass.data[CASETA_DOMAIN][config_entry.entry_id]
     bridge = data.bridge
-    bridge_device = data.bridge_device
     occupancy_groups = bridge.occupancy_groups
     async_add_entities(
-        LutronOccupancySensor(occupancy_group, bridge, bridge_device)
+        LutronOccupancySensor(occupancy_group, data)
         for occupancy_group in occupancy_groups.values()
     )
 
@@ -41,9 +40,9 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.OCCUPANCY
 
-    def __init__(self, device, bridge, bridge_device):
+    def __init__(self, device, data):
         """Init an occupancy sensor."""
-        super().__init__(device, bridge, bridge_device)
+        super().__init__(device, data)
         _, name = _area_and_name_from_name(device["name"])
         self._attr_name = name
         self._attr_device_info = DeviceInfo(

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -30,11 +30,9 @@ async def async_setup_entry(
     """
     data: LutronCasetaData = hass.data[CASETA_DOMAIN][config_entry.entry_id]
     bridge = data.bridge
-    bridge_device = data.bridge_device
     cover_devices = bridge.get_devices_by_domain(DOMAIN)
     async_add_entities(
-        LutronCasetaCover(cover_device, bridge, bridge_device)
-        for cover_device in cover_devices
+        LutronCasetaCover(cover_device, data) for cover_device in cover_devices
     )
 
 

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -34,11 +34,8 @@ async def async_setup_entry(
     """
     data: LutronCasetaData = hass.data[CASETA_DOMAIN][config_entry.entry_id]
     bridge = data.bridge
-    bridge_device = data.bridge_device
     fan_devices = bridge.get_devices_by_domain(DOMAIN)
-    async_add_entities(
-        LutronCasetaFan(fan_device, bridge, bridge_device) for fan_device in fan_devices
-    )
+    async_add_entities(LutronCasetaFan(fan_device, data) for fan_device in fan_devices)
 
 
 class LutronCasetaFan(LutronCasetaDeviceUpdatableEntity, FanEntity):

--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -41,11 +41,9 @@ async def async_setup_entry(
     """
     data: LutronCasetaData = hass.data[CASETA_DOMAIN][config_entry.entry_id]
     bridge = data.bridge
-    bridge_device = data.bridge_device
     light_devices = bridge.get_devices_by_domain(DOMAIN)
     async_add_entities(
-        LutronCasetaLight(light_device, bridge, bridge_device)
-        for light_device in light_devices
+        LutronCasetaLight(light_device, data) for light_device in light_devices
     )
 
 

--- a/homeassistant/components/lutron_caseta/models.py
+++ b/homeassistant/components/lutron_caseta/models.py
@@ -14,3 +14,4 @@ class LutronCasetaData:
     bridge: Smartbridge
     bridge_device: dict[str, Any]
     button_devices: dict[str, dict]
+    device_info_by_device_id: dict[int, dict[str, Any]]

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -27,23 +27,20 @@ async def async_setup_entry(
     """
     data: LutronCasetaData = hass.data[CASETA_DOMAIN][config_entry.entry_id]
     bridge = data.bridge
-    bridge_device = data.bridge_device
     scenes = bridge.get_scenes()
-    async_add_entities(
-        LutronCasetaScene(scenes[scene], bridge, bridge_device) for scene in scenes
-    )
+    async_add_entities(LutronCasetaScene(scenes[scene], data) for scene in scenes)
 
 
 class LutronCasetaScene(Scene):
     """Representation of a Lutron Caseta scene."""
 
-    def __init__(self, scene, bridge, bridge_device):
+    def __init__(self, scene, data):
         """Initialize the Lutron Caseta scene."""
         self._scene_id = scene["scene_id"]
-        self._bridge: Smartbridge = bridge
-        bridge_unique_id = serial_to_unique_id(bridge_device["serial"])
+        self._bridge: Smartbridge = data.bridge
+        bridge_unique_id = serial_to_unique_id(data.bridge_device["serial"])
         self._attr_device_info = DeviceInfo(
-            identifiers={(CASETA_DOMAIN, bridge_device["serial"])},
+            identifiers={(CASETA_DOMAIN, data.bridge_device["serial"])},
         )
         self._attr_name = _area_and_name_from_name(scene["name"])[1]
         self._attr_unique_id = f"scene_{bridge_unique_id}_{self._scene_id}"

--- a/homeassistant/components/lutron_caseta/switch.py
+++ b/homeassistant/components/lutron_caseta/switch.py
@@ -24,14 +24,9 @@ async def async_setup_entry(
     """
     data: LutronCasetaData = hass.data[CASETA_DOMAIN][config_entry.entry_id]
     bridge = data.bridge
-    bridge_device = data.bridge_device
-    device_info_by_device_id = data.device_info_by_device_id
     switch_devices = bridge.get_devices_by_domain(DOMAIN)
     async_add_entities(
-        LutronCasetaLight(
-            switch_device, bridge, bridge_device, device_info_by_device_id
-        )
-        for switch_device in switch_devices
+        LutronCasetaLight(switch_device, data) for switch_device in switch_devices
     )
 
 

--- a/homeassistant/components/lutron_caseta/switch.py
+++ b/homeassistant/components/lutron_caseta/switch.py
@@ -25,9 +25,12 @@ async def async_setup_entry(
     data: LutronCasetaData = hass.data[CASETA_DOMAIN][config_entry.entry_id]
     bridge = data.bridge
     bridge_device = data.bridge_device
+    device_info_by_device_id = data.device_info_by_device_id
     switch_devices = bridge.get_devices_by_domain(DOMAIN)
     async_add_entities(
-        LutronCasetaLight(switch_device, bridge, bridge_device)
+        LutronCasetaLight(
+            switch_device, bridge, bridge_device, device_info_by_device_id
+        )
         for switch_device in switch_devices
     )
 

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -34,6 +34,7 @@ from tests.common import (
 
 MOCK_BUTTON_DEVICES = [
     {
+        "device_id": "710",
         "Name": "Back Hall Pico",
         "ID": 2,
         "Area": {"Name": "Back Hall"},
@@ -50,6 +51,7 @@ MOCK_BUTTON_DEVICES = [
         "serial": 43845548,
     },
     {
+        "device_id": "742",
         "Name": "Front Steps Sunnata Keypad",
         "ID": 3,
         "Area": {"Name": "Front Steps"},
@@ -87,19 +89,22 @@ async def _async_setup_lutron_with_picos(hass, device_reg):
     config_entry = MockConfigEntry(domain=DOMAIN, data={})
     config_entry.add_to_hass(hass)
     dr_button_devices = {}
+    device_info_by_device_id = {}
 
     for device in MOCK_BUTTON_DEVICES:
-        dr_device = device_reg.async_get_or_create(
-            name=device["leap_name"],
-            manufacturer=MANUFACTURER,
-            config_entry_id=config_entry.entry_id,
-            identifiers={(DOMAIN, device["serial"])},
-            model=f"{device['model']} ({device[CONF_TYPE]})",
-        )
+        device_args = {
+            "name": device["leap_name"],
+            "manufacturer": MANUFACTURER,
+            "config_entry_id": config_entry.entry_id,
+            "identifiers": {(DOMAIN, device["serial"])},
+            "model": f"{device['model']} ({device[CONF_TYPE]})",
+        }
+        dr_device = device_reg.async_get_or_create(**device_args)
         dr_button_devices[dr_device.id] = device
+        device_info_by_device_id.setdefault(device["device_id"], device_args)
 
     hass.data[DOMAIN][config_entry.entry_id] = LutronCasetaData(
-        MagicMock(), MagicMock(), dr_button_devices
+        MagicMock(), MagicMock(), dr_button_devices, device_info_by_device_id
     )
     return config_entry.entry_id
 


### PR DESCRIPTION
## Proposed change
This update adds support for the parent_device field added to pylutron-caseta 0.16.0

When entity devices are created, we now check for a parent device, and use the parent's device_info, instead of generating a new device_info for each entity.

This allows LEDs and button entities, which are part of Keypads and Picos (button only), to show as nested within the Keypad Device.

A future PR will add support for button entities, and depends on this change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
