### PR TITLE
Reduce missed coverage in zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -188,7 +188,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         )
         self._set_modes_and_presets()
         self._attr_supported_features = 0
-        if len(self._hvac_presets) > 1:
+        if self._current_mode and len(self._hvac_presets) > 1:
             self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
         # If any setpoint value exists, we can assume temperature
         # can be set
@@ -408,9 +408,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        if not self._fan_mode:
-            return
-
+        assert self._fan_mode is not None
         try:
             new_state = int(
                 next(
@@ -464,9 +462,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
-        if self._current_mode is None:
-            # Thermostat(valve) has no support for setting a mode, so we make it a no-op
-            return
+        assert self._current_mode is not None
         if preset_mode == PRESET_NONE:
             # try to restore to the (translated) main hvac mode
             await self.async_set_hvac_mode(self.hvac_mode)

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -27,7 +27,6 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -138,8 +137,7 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
-        if target_value is None:
-            raise HomeAssistantError("Missing target value on device.")
+        assert target_value is not None
         await self.info.node.async_set_value(
             target_value, percent_to_zwave_position(kwargs[ATTR_POSITION])
         )
@@ -147,15 +145,13 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
-        if target_value is None:
-            raise HomeAssistantError("Missing target value on device.")
+        assert target_value is not None
         await self.info.node.async_set_value(target_value, 99)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
-        if target_value is None:
-            raise HomeAssistantError("Missing target value on device.")
+        assert target_value is not None
         await self.info.node.async_set_value(target_value, 0)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/zwave_js/number.py
+++ b/homeassistant/components/zwave_js/number.py
@@ -113,10 +113,7 @@ class ZwaveVolumeNumberEntity(ZWaveBaseEntity, NumberEntity):
         super().__init__(config_entry, driver, info)
         max_value = cast(int, self.info.primary_value.metadata.max)
         min_value = cast(int, self.info.primary_value.metadata.min)
-        self.correction_factor = max_value - min_value
-        # Fallback in case we can't properly calculate correction factor
-        if self.correction_factor == 0:
-            self.correction_factor = 1
+        self.correction_factor = (max_value - min_value) or 1
 
         # Entity class attributes
         self._attr_native_min_value = 0

--- a/homeassistant/components/zwave_js/select.py
+++ b/homeassistant/components/zwave_js/select.py
@@ -11,7 +11,6 @@ from zwave_js_server.model.driver import Driver
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN, SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -173,7 +172,6 @@ class ZwaveMultilevelSwitchSelectEntity(ZWaveBaseEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        if (target_value := self._target_value) is None:
-            raise HomeAssistantError("Missing target value on device.")
+        assert self._target_value is not None
         key = next(key for key, val in self._lookup_map.items() if val == option)
-        await self.info.node.async_set_value(target_value, int(key))
+        await self.info.node.async_set_value(self._target_value, int(key))

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -170,7 +170,7 @@ async def test_only_one_lock(hass, client, lock_home_connect_620, integration):
 
 
 async def test_door_lock_no_value(hass, client, lock_schlage_be469_state, integration):
-    """Test a lock entity with door lock command class."""
+    """Test a lock entity with door lock command class that has no value for mode."""
     node_state = replace_value_of_zwave_value(
         lock_schlage_be469_state,
         [

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -1,7 +1,12 @@
 """Test the Z-Wave JS lock platform."""
-from zwave_js_server.const.command_class.lock import ATTR_CODE_SLOT, ATTR_USERCODE
+from zwave_js_server.const import CommandClass
+from zwave_js_server.const.command_class.lock import (
+    ATTR_CODE_SLOT,
+    ATTR_USERCODE,
+    CURRENT_MODE_PROPERTY,
+)
 from zwave_js_server.event import Event
-from zwave_js_server.model.node import NodeStatus
+from zwave_js_server.model.node import Node, NodeStatus
 
 from homeassistant.components.lock import (
     DOMAIN as LOCK_DOMAIN,
@@ -9,6 +14,7 @@ from homeassistant.components.lock import (
     SERVICE_UNLOCK,
 )
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
+from homeassistant.components.zwave_js.helpers import ZwaveValueMatcher
 from homeassistant.components.zwave_js.lock import (
     SERVICE_CLEAR_LOCK_USERCODE,
     SERVICE_SET_LOCK_USERCODE,
@@ -17,10 +23,11 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_LOCKED,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
 
-from .common import SCHLAGE_BE469_LOCK_ENTITY
+from .common import SCHLAGE_BE469_LOCK_ENTITY, replace_value_of_zwave_value
 
 
 async def test_door_lock(hass, client, lock_schlage_be469, integration):
@@ -160,3 +167,23 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
 async def test_only_one_lock(hass, client, lock_home_connect_620, integration):
     """Test node with both Door Lock and Lock CC values only gets one lock entity."""
     assert len(hass.states.async_entity_ids("lock")) == 1
+
+
+async def test_door_lock_no_value(hass, client, lock_schlage_be469_state, integration):
+    """Test a lock entity with door lock command class."""
+    node_state = replace_value_of_zwave_value(
+        lock_schlage_be469_state,
+        [
+            ZwaveValueMatcher(
+                property_=CURRENT_MODE_PROPERTY,
+                command_class=CommandClass.DOOR_LOCK,
+            )
+        ],
+        None,
+    )
+    node = Node(client, node_state)
+    client.driver.controller.emit("node added", {"node": node})
+    await hass.async_block_till_done()
+    state = hass.states.get(SCHLAGE_BE469_LOCK_ENTITY)
+    assert state
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/zwave_js/test_switch.py
+++ b/tests/components/zwave_js/test_switch.py
@@ -1,11 +1,14 @@
 """Test the Z-Wave JS switch platform."""
 
+from zwave_js_server.const import CURRENT_VALUE_PROPERTY, CommandClass
 from zwave_js_server.event import Event
+from zwave_js_server.model.node import Node
 
 from homeassistant.components.switch import DOMAIN, SERVICE_TURN_OFF, SERVICE_TURN_ON
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.components.zwave_js.helpers import ZwaveValueMatcher
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 
-from .common import SWITCH_ENTITY
+from .common import SWITCH_ENTITY, replace_value_of_zwave_value
 
 
 async def test_switch(hass, hank_binary_switch, integration, client):
@@ -14,7 +17,7 @@ async def test_switch(hass, hank_binary_switch, integration, client):
     node = hank_binary_switch
 
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_OFF
 
     # Test turning on
     await hass.services.async_call(
@@ -178,3 +181,25 @@ async def test_barrier_signaling_switch(hass, gdc_zw062, integration, client):
 
     state = hass.states.get(entity)
     assert state.state == STATE_ON
+
+
+async def test_switch_no_value(hass, hank_binary_switch_state, integration, client):
+    """Test the switch where primary value value is None."""
+    node_data = replace_value_of_zwave_value(
+        hank_binary_switch_state,
+        [
+            ZwaveValueMatcher(
+                property_=CURRENT_VALUE_PROPERTY,
+                command_class=CommandClass.SWITCH_BINARY,
+            )
+        ],
+        None,
+    )
+    node = Node(client, node_data)
+    client.driver.controller.emit("node added", {"node": node})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(SWITCH_ENTITY)
+
+    assert state
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/zwave_js/test_switch.py
+++ b/tests/components/zwave_js/test_switch.py
@@ -185,7 +185,7 @@ async def test_barrier_signaling_switch(hass, gdc_zw062, integration, client):
 
 async def test_switch_no_value(hass, hank_binary_switch_state, integration, client):
     """Test the switch where primary value value is None."""
-    node_data = replace_value_of_zwave_value(
+    node_state = replace_value_of_zwave_value(
         hank_binary_switch_state,
         [
             ZwaveValueMatcher(
@@ -195,7 +195,7 @@ async def test_switch_no_value(hass, hank_binary_switch_state, integration, clie
         ],
         None,
     )
-    node = Node(client, node_data)
+    node = Node(client, node_state)
     client.driver.controller.emit("node added", {"node": node})
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
Just going to be working through platforms. As far as I can tell the climate services are already guarded by feature requirements. For cover/select services, all of the covers/selects I found are discovered based on the `currentValue` property and I *THINK* the only reason why `targetValue` would be missing is if the device needs to be reinterviewed.

If we want I can pop the necessary values out to get the coverage instead of switching to assertions but that seems unnecessarily forced. Then again, I am forcing values to be None, so maybe it's not that unreasonable?


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
