### PR TITLE
Fitbit: Create a device for the Fitbit user, to group Fitbit sensors and generate nicer names and entity IDs

### DIFF
--- a/homeassistant/components/fitbit/const.py
+++ b/homeassistant/components/fitbit/const.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
 ATTR_ACCESS_TOKEN: Final = "access_token"
 ATTR_REFRESH_TOKEN: Final = "refresh_token"
 ATTR_LAST_SAVED_AT: Final = "last_saved_at"
+ATTR_INCLUDE_DEVICE: Final = "include_device"
 
 ATTR_DURATION: Final = "duration"
 ATTR_DISTANCE: Final = "distance"

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -364,11 +364,11 @@ class FitbitSensor(SensorEntity):
         self.extra = extra
         if self.extra is not None:
             self._attr_name = f"{self.extra.get('deviceVersion')} Battery"
-            self._attr_unique_id = f"fitbit_{user_profile['encodedId']}_{self.extra.get('deviceVersion')}_battery"
-        else:
             self._attr_unique_id = (
-                f"fitbit_{user_profile['encodedId']}_{description.key}"
+                f"{user_profile['encodedId']}_{self.extra.get('deviceVersion')}_battery"
             )
+        else:
+            self._attr_unique_id = f"{user_profile['encodedId']}_{description.key}"
         if (unit_type := description.unit_type) == "":
             split_resource = description.key.rsplit("/", maxsplit=1)[-1]
             try:

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -348,7 +348,7 @@ class FitbitSensor(SensorEntity):
     def __init__(
         self,
         client: Fitbit,
-        user_profile: dict,
+        user_profile: dict[str, Any],
         config_path: str,
         description: FitbitSensorEntityDescription,
         is_metric: bool,

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -362,13 +362,14 @@ class FitbitSensor(SensorEntity):
         self.is_metric = is_metric
         self.clock_format = clock_format
         self.extra = extra
+
+        self._attr_unique_id = f"{user_profile['encodedId']}_{description.key}"
         if self.extra is not None:
             self._attr_name = f"{self.extra.get('deviceVersion')} Battery"
             self._attr_unique_id = (
-                f"{user_profile['encodedId']}_{self.extra.get('deviceVersion')}_battery"
+                f"{self._attr_unique_id}_{self.extra.get('id')}_battery"
             )
-        else:
-            self._attr_unique_id = f"{user_profile['encodedId']}_{description.key}"
+
         if (unit_type := description.unit_type) == "":
             split_resource = description.key.rsplit("/", maxsplit=1)[-1]
             try:

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -366,9 +366,7 @@ class FitbitSensor(SensorEntity):
         self._attr_unique_id = f"{user_profile['encodedId']}_{description.key}"
         if self.extra is not None:
             self._attr_name = f"{self.extra.get('deviceVersion')} Battery"
-            self._attr_unique_id = (
-                f"{self._attr_unique_id}_{self.extra.get('id')}_battery"
-            )
+            self._attr_unique_id = f"{self._attr_unique_id}_{self.extra.get('id')}"
 
         if (unit_type := description.unit_type) == "":
             split_resource = description.key.rsplit("/", maxsplit=1)[-1]

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -195,8 +195,9 @@ def setup_platform(
         if int(time.time()) - expires_at > 3600:
             authd_client.client.refresh_token()
 
+        user_profile = authd_client.user_profile_get()["user"]
         if (unit_system := config[CONF_UNIT_SYSTEM]) == "default":
-            authd_client.system = authd_client.user_profile_get()["user"]["locale"]
+            authd_client.system = user_profile["locale"]
             if authd_client.system != "en_GB":
                 if hass.config.units.is_metric:
                     authd_client.system = "metric"
@@ -211,6 +212,7 @@ def setup_platform(
         entities = [
             FitbitSensor(
                 authd_client,
+                user_profile,
                 config_path,
                 description,
                 hass.config.units.is_metric,
@@ -224,6 +226,7 @@ def setup_platform(
                 [
                     FitbitSensor(
                         authd_client,
+                        user_profile,
                         config_path,
                         FITBIT_RESOURCE_BATTERY,
                         hass.config.units.is_metric,
@@ -345,6 +348,7 @@ class FitbitSensor(SensorEntity):
     def __init__(
         self,
         client: Fitbit,
+        user_profile: dict,
         config_path: str,
         description: FitbitSensorEntityDescription,
         is_metric: bool,
@@ -360,6 +364,11 @@ class FitbitSensor(SensorEntity):
         self.extra = extra
         if self.extra is not None:
             self._attr_name = f"{self.extra.get('deviceVersion')} Battery"
+            self._attr_unique_id = f"fitbit_{user_profile['encodedId']}_{self.extra.get('deviceVersion')}_battery"
+        else:
+            self._attr_unique_id = (
+                f"fitbit_{user_profile['encodedId']}_{description.key}"
+            )
         if (unit_type := description.unit_type) == "":
             split_resource = description.key.rsplit("/", maxsplit=1)[-1]
             try:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change improves the entity IDs and names for Fitbit sensors. I didn't like how the sensors had no prefix or context. For example, it just adds a "Weight" sensor with the ID "sensor.weight". I also thought it was a bit annoying that I couldn't type "fitbit" in the search bar to show a list of entities from the Fitbit integration.

I added a "Fitbit" prefix to the names, and a `sensor.fitbit_` prefix to the IDs. I am also now setting the `unique_id` for entities, which was previously omitted. This means that their settings can be managed from the UI.

This change is backwards compatible and does not affect any existing integrations that already have a `fitbit.conf` file. I achieved this by adding a new `entity_id_version` property to `fitbit.conf`. If this is undefined or set to `1`, then the original names are used. If this is set to `2` (the new default value), then the new unique IDs and names are used. Users can opt-in to the new IDs and names by updating their `fitbit.conf`. Any newly configured integrations will use the new names and IDs by default.

#### Before:

| Entity Name | Entity ID |
|-------|---------|
| Weight | `sensor.weight` |
| BMI | `sensor.bmi` |
| Aria 2 Battery | `sensor.aria_2_battery` |
| Sleep Minutes Asleep | `sensor.sleep_minutes_asleep` |

#### After:

| Entity Name | Entity ID |
|-------|---------|
| Fitbit Weight | `sensor.fitbit_weight` |
| Fitbit BMI | `sensor.fitbit_bmi`
| Fitbit Aria 2 Battery | `sensor.fitbit_aria_2_battery` |
| Fitbit Sleep Minutes Asleep | `sensor.fitbit_sleep_minutes_asleep` |

## Screenshots

I was able to get the dev container running, and I set up an [Ngrok secure tunnel](https://ngrok.com/docs/secure-tunnels) to fully test the OAuth flow and make sure everything is working. Here are the new entities:

<img width="1486" alt="Screen Shot 2022-10-04 at 5 27 20 PM" src="https://user-images.githubusercontent.com/139536/193739373-6d4619ab-b885-4eb3-824c-71164df3ae8c.png">

Their settings can now be managed from the UI:

<img width="581" alt="Screen Shot 2022-10-04 at 6 12 44 PM" src="https://user-images.githubusercontent.com/139536/193739613-ff44a2be-6345-4bcb-a0a1-658a04c0132c.png">

I'm already using these changes in my real Home Assistant instance, by copying the `fitbit` folder into `/custom_components` and adding `"version": "2.0.0"` to `manifest.json`. 

I can confirm that `entity_id_version` was set to `1` in my `fitbit.conf` when I initially installed the custom component, and no changes were made to my existing Fitbit entities. After I manually updated `entity_id_version` to `2` and restarted HA, the integration started using the new entity IDs and names:

<img width="1314" alt="Screen Shot 2022-10-04 at 6 25 57 PM" src="https://user-images.githubusercontent.com/139536/193741141-77d8b555-a888-4928-aa9e-faa12f9b2e0b.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: n/a (no change needed)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
  - The fitbit integration did not have any existing tests

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
