### PR TITLE
Add at_started helper

### DIFF
--- a/homeassistant/helpers/start.py
+++ b/homeassistant/helpers/start.py
@@ -4,21 +4,31 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 from typing import Any
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START
-from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
+from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    CoreState,
+    Event,
+    HassJob,
+    HomeAssistant,
+    callback,
+)
 
 
 @callback
-def async_at_start(
+def _async_at_core_state(
     hass: HomeAssistant,
     at_start_cb: Callable[[HomeAssistant], Coroutine[Any, Any, None] | None],
+    event_type: str,
+    check_state: Callable[[HomeAssistant], bool],
 ) -> CALLBACK_TYPE:
-    """Execute something when Home Assistant is started.
+    """Execute a job at_start_cb when Home Assistant has the wanted state.
 
-    Will execute it now if Home Assistant is already started.
+    The job is executed immediately if Home Assistant is in the wanted state.
+    Will wait for event specified by event_type if it isn't.
     """
     at_start_job = HassJob(at_start_cb)
-    if hass.is_running:
+    if check_state(hass):
         hass.async_run_hass_job(at_start_job, hass)
         return lambda: None
 
@@ -36,5 +46,43 @@ def async_at_start(
         if unsub:
             unsub()
 
-    unsub = hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _matched_event)
+    unsub = hass.bus.async_listen_once(event_type, _matched_event)
     return cancel
+
+
+@callback
+def async_at_start(
+    hass: HomeAssistant,
+    at_start_cb: Callable[[HomeAssistant], Coroutine[Any, Any, None] | None],
+) -> CALLBACK_TYPE:
+    """Execute a job at_start_cb when Home Assistant is starting.
+
+    The job is executed immediately if Home Assistant is already starting or started.
+    Will wait for EVENT_HOMEASSISTANT_START if it isn't.
+    """
+
+    def _is_running(hass: HomeAssistant) -> bool:
+        return hass.is_running
+
+    return _async_at_core_state(
+        hass, at_start_cb, EVENT_HOMEASSISTANT_START, _is_running
+    )
+
+
+@callback
+def async_at_started(
+    hass: HomeAssistant,
+    at_start_cb: Callable[[HomeAssistant], Coroutine[Any, Any, None] | None],
+) -> CALLBACK_TYPE:
+    """Execute a job at_start_cb when Home Assistant has started.
+
+    The job is executed immediately if Home Assistant is already started.
+    Will wait for EVENT_HOMEASSISTANT_STARTED if it isn't.
+    """
+
+    def _is_started(hass: HomeAssistant) -> bool:
+        return hass.state == CoreState.running
+
+    return _async_at_core_state(
+        hass, at_start_cb, EVENT_HOMEASSISTANT_STARTED, _is_started
+    )

--- a/tests/helpers/test_start.py
+++ b/tests/helpers/test_start.py
@@ -1,6 +1,6 @@
 """Test starting HA helpers."""
 from homeassistant import core
-from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.helpers import start
 
 
@@ -100,7 +100,7 @@ async def test_at_start_when_starting_callback(hass, caplog):
         assert record.levelname in ("DEBUG", "INFO")
 
 
-async def test_cancelling_when_running(hass, caplog):
+async def test_cancelling_at_start_when_running(hass, caplog):
     """Test cancelling at start when already running."""
     assert hass.state == core.CoreState.running
     assert hass.is_running
@@ -120,7 +120,7 @@ async def test_cancelling_when_running(hass, caplog):
         assert record.levelname in ("DEBUG", "INFO")
 
 
-async def test_cancelling_when_starting(hass):
+async def test_cancelling_at_start_when_starting(hass):
     """Test cancelling at start when yet to start."""
     hass.state = core.CoreState.not_running
     assert not hass.is_running
@@ -137,5 +137,150 @@ async def test_cancelling_when_starting(hass):
     assert len(calls) == 0
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+
+async def test_at_started_when_running_awaitable(hass):
+    """Test at started when already started."""
+    assert hass.state == core.CoreState.running
+
+    calls = []
+
+    async def cb_at_start(hass):
+        """Home Assistant is started."""
+        calls.append(1)
+
+    start.async_at_started(hass, cb_at_start)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # Test the job is not run if state is CoreState.starting
+    hass.state = core.CoreState.starting
+
+    start.async_at_started(hass, cb_at_start)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+async def test_at_started_when_running_callback(hass, caplog):
+    """Test at started when already running."""
+    assert hass.state == core.CoreState.running
+
+    calls = []
+
+    @core.callback
+    def cb_at_start(hass):
+        """Home Assistant is started."""
+        calls.append(1)
+
+    start.async_at_started(hass, cb_at_start)()
+    assert len(calls) == 1
+
+    # Test the job is not run if state is CoreState.starting
+    hass.state = core.CoreState.starting
+
+    start.async_at_started(hass, cb_at_start)()
+    assert len(calls) == 1
+
+    # Check the unnecessary cancel did not generate warnings or errors
+    for record in caplog.records:
+        assert record.levelname in ("DEBUG", "INFO")
+
+
+async def test_at_started_when_starting_awaitable(hass):
+    """Test at started when yet to start."""
+    hass.state = core.CoreState.not_running
+
+    calls = []
+
+    async def cb_at_start(hass):
+        """Home Assistant is started."""
+        calls.append(1)
+
+    start.async_at_started(hass, cb_at_start)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+async def test_at_started_when_starting_callback(hass, caplog):
+    """Test at started when yet to start."""
+    hass.state = core.CoreState.not_running
+
+    calls = []
+
+    @core.callback
+    def cb_at_start(hass):
+        """Home Assistant is started."""
+        calls.append(1)
+
+    cancel = start.async_at_started(hass, cb_at_start)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    cancel()
+
+    # Check the unnecessary cancel did not generate warnings or errors
+    for record in caplog.records:
+        assert record.levelname in ("DEBUG", "INFO")
+
+
+async def test_cancelling_at_started_when_running(hass, caplog):
+    """Test cancelling at start when already running."""
+    assert hass.state == core.CoreState.running
+    assert hass.is_running
+
+    calls = []
+
+    async def cb_at_start(hass):
+        """Home Assistant is started."""
+        calls.append(1)
+
+    start.async_at_started(hass, cb_at_start)()
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # Check the unnecessary cancel did not generate warnings or errors
+    for record in caplog.records:
+        assert record.levelname in ("DEBUG", "INFO")
+
+
+async def test_cancelling_at_started_when_starting(hass):
+    """Test cancelling at start when yet to start."""
+    hass.state = core.CoreState.not_running
+    assert not hass.is_running
+
+    calls = []
+
+    @core.callback
+    def cb_at_start(hass):
+        """Home Assistant is started."""
+        calls.append(1)
+
+    start.async_at_started(hass, cb_at_start)()
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
     assert len(calls) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `homeassistant.helpers.at_started`:
- The job is executed immediately if `hass.state` is `CoreState.running`
- Will wait for `EVENT_HOMEASSISTANT_STARTED` if it isn't.

In comparison, `homeassistant.helpers.at_start`:
- The job is executed immediately if `hass.state` is `CoreState.running` or `CoreState.starting`
- Will wait for `EVENT_HOMEASSISTANT_START` if it isn't.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
