### PR TITLE
Add unique ID to fitbit

### DIFF
--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -364,11 +364,11 @@ class FitbitSensor(SensorEntity):
         self.extra = extra
         if self.extra is not None:
             self._attr_name = f"{self.extra.get('deviceVersion')} Battery"
-            self._attr_unique_id = f"fitbit_{user_profile['encodedId']}_{self.extra.get('deviceVersion')}_battery"
-        else:
             self._attr_unique_id = (
-                f"fitbit_{user_profile['encodedId']}_{description.key}"
+                f"{user_profile['encodedId']}_{self.extra.get('deviceVersion')}_battery"
             )
+        else:
+            self._attr_unique_id = f"{user_profile['encodedId']}_{description.key}"
         if (unit_type := description.unit_type) == "":
             split_resource = description.key.rsplit("/", maxsplit=1)[-1]
             try:

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -348,7 +348,7 @@ class FitbitSensor(SensorEntity):
     def __init__(
         self,
         client: Fitbit,
-        user_profile: dict,
+        user_profile: dict[str, Any],
         config_path: str,
         description: FitbitSensorEntityDescription,
         is_metric: bool,

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -362,13 +362,14 @@ class FitbitSensor(SensorEntity):
         self.is_metric = is_metric
         self.clock_format = clock_format
         self.extra = extra
+
+        self._attr_unique_id = f"{user_profile['encodedId']}_{description.key}"
         if self.extra is not None:
             self._attr_name = f"{self.extra.get('deviceVersion')} Battery"
             self._attr_unique_id = (
-                f"{user_profile['encodedId']}_{self.extra.get('deviceVersion')}_battery"
+                f"{self._attr_unique_id}_{self.extra.get('id')}_battery"
             )
-        else:
-            self._attr_unique_id = f"{user_profile['encodedId']}_{description.key}"
+
         if (unit_type := description.unit_type) == "":
             split_resource = description.key.rsplit("/", maxsplit=1)[-1]
             try:

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -366,9 +366,7 @@ class FitbitSensor(SensorEntity):
         self._attr_unique_id = f"{user_profile['encodedId']}_{description.key}"
         if self.extra is not None:
             self._attr_name = f"{self.extra.get('deviceVersion')} Battery"
-            self._attr_unique_id = (
-                f"{self._attr_unique_id}_{self.extra.get('id')}_battery"
-            )
+            self._attr_unique_id = f"{self._attr_unique_id}_{self.extra.get('id')}"
 
         if (unit_type := description.unit_type) == "":
             split_resource = description.key.rsplit("/", maxsplit=1)[-1]

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -195,8 +195,9 @@ def setup_platform(
         if int(time.time()) - expires_at > 3600:
             authd_client.client.refresh_token()
 
+        user_profile = authd_client.user_profile_get()["user"]
         if (unit_system := config[CONF_UNIT_SYSTEM]) == "default":
-            authd_client.system = authd_client.user_profile_get()["user"]["locale"]
+            authd_client.system = user_profile["locale"]
             if authd_client.system != "en_GB":
                 if hass.config.units.is_metric:
                     authd_client.system = "metric"
@@ -211,6 +212,7 @@ def setup_platform(
         entities = [
             FitbitSensor(
                 authd_client,
+                user_profile,
                 config_path,
                 description,
                 hass.config.units.is_metric,
@@ -224,6 +226,7 @@ def setup_platform(
                 [
                     FitbitSensor(
                         authd_client,
+                        user_profile,
                         config_path,
                         FITBIT_RESOURCE_BATTERY,
                         hass.config.units.is_metric,
@@ -345,6 +348,7 @@ class FitbitSensor(SensorEntity):
     def __init__(
         self,
         client: Fitbit,
+        user_profile: dict,
         config_path: str,
         description: FitbitSensorEntityDescription,
         is_metric: bool,
@@ -360,6 +364,11 @@ class FitbitSensor(SensorEntity):
         self.extra = extra
         if self.extra is not None:
             self._attr_name = f"{self.extra.get('deviceVersion')} Battery"
+            self._attr_unique_id = f"fitbit_{user_profile['encodedId']}_{self.extra.get('deviceVersion')}_battery"
+        else:
+            self._attr_unique_id = (
+                f"fitbit_{user_profile['encodedId']}_{description.key}"
+            )
         if (unit_type := description.unit_type) == "":
             split_resource = description.key.rsplit("/", maxsplit=1)[-1]
             try:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a preliminary PR for improving the fitbit sensor names and IDs: https://github.com/home-assistant/core/pull/79572

Adds a unique ID for all fitbit sensors. Here is the full list of unique_ids that are generated:

```
7NHXM8_activities/activityCalories
7NHXM8_activities/calories
7NHXM8_activities/caloriesBMR
7NHXM8_activities/distance
7NHXM8_activities/elevation
7NHXM8_activities/floors
7NHXM8_activities/heart
7NHXM8_activities/minutesFairlyActive
7NHXM8_activities/minutesLightlyActive
7NHXM8_activities/minutesSedentary
7NHXM8_activities/minutesVeryActive
7NHXM8_activities/steps
7NHXM8_activities/tracker/activityCalories
7NHXM8_activities/tracker/calories
7NHXM8_activities/tracker/distance
7NHXM8_activities/tracker/elevation
7NHXM8_activities/tracker/floors
7NHXM8_activities/tracker/minutesFairlyActive
7NHXM8_activities/tracker/minutesLightlyActive
7NHXM8_activities/tracker/minutesSedentary
7NHXM8_activities/tracker/minutesVeryActive
7NHXM8_activities/tracker/steps
7NHXM8_body/bmi
7NHXM8_body/fat
7NHXM8_body/weight
7NHXM8_sleep/awakeningsCount
7NHXM8_sleep/efficiency
7NHXM8_sleep/minutesAfterWakeup
7NHXM8_sleep/minutesAsleep
7NHXM8_sleep/minutesAwake
7NHXM8_sleep/minutesToFallAsleep
7NHXM8_sleep/startTime
7NHXM8_sleep/timeInBed
7NHXM8_devices/battery_1472464222
7NHXM8_devices/battery_FX0081613702081719090664204C925A17
```

I got confused with some of the duplicate entities that were being created (ending in `_2`), but the new entities with a unique_id actually take over the original entity_id, so all automations, scripts, dashboards, etc. that refer to the original entities will continue working, and the old entities can be deleted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
