### PR TITLE
Refactor bayesian observations using dataclass

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -310,8 +310,8 @@ class BayesianBinarySensor(BinarySensorEntity):
         for observation in self.observations_by_entity[entity]:
             platform = str(observation.platform)
 
-            observation = self.observation_handlers[platform](observation)
-            observation.observed = observation
+            observed = self.observation_handlers[platform](observation)
+            observation.observed = observed
 
             local_observations[observation.id] = observation
 

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -158,17 +158,17 @@ class BayesianBinarySensor(BinarySensorEntity):
         self._attr_name = name
         self._observations = [
             Observation(
-                entity_id=o.get(CONF_ENTITY_ID),
-                platform=o[CONF_PLATFORM],
-                prob_given_false=o[CONF_P_GIVEN_F],
-                prob_given_true=o[CONF_P_GIVEN_T],
+                entity_id=observation.get(CONF_ENTITY_ID),
+                platform=observation[CONF_PLATFORM],
+                prob_given_false=observation[CONF_P_GIVEN_F],
+                prob_given_true=observation[CONF_P_GIVEN_T],
                 observed=None,
-                to_state=o.get(CONF_TO_STATE),
-                above=o.get(CONF_ABOVE),
-                below=o.get(CONF_BELOW),
-                value_template=o.get(CONF_VALUE_TEMPLATE),
+                to_state=observation.get(CONF_TO_STATE),
+                above=observation.get(CONF_ABOVE),
+                below=observation.get(CONF_BELOW),
+                value_template=observation.get(CONF_VALUE_TEMPLATE),
             )
-            for o in observations
+            for observation in observations
         ]
         self._probability_threshold = probability_threshold
         self._attr_device_class = device_class
@@ -243,18 +243,18 @@ class BayesianBinarySensor(BinarySensorEntity):
                     self.entity_id,
                 )
 
-                observation = None
+                observed = None
             else:
-                observation = result_as_boolean(result)
+                observed = result_as_boolean(result)
 
-            for obs in self.observations_by_template[template]:
-                obs.observed = observation
+            for observation in self.observations_by_template[template]:
+                observation.observed = observed
 
                 # in some cases a template may update because of the absence of an entity
                 if entity is not None:
-                    obs.entity_id = str(entity)
+                    observation.entity_id = str(entity)
 
-                self.current_observations[obs.id] = obs
+                self.current_observations[observation.id] = observation
 
             if event:
                 self.async_set_context(event.context)
@@ -308,7 +308,7 @@ class BayesianBinarySensor(BinarySensorEntity):
         local_observations = OrderedDict({})
 
         for entity_obs in self.observations_by_entity[entity]:
-            platform: str = str(entity_obs.platform)
+            platform = str(entity_obs.platform)
 
             observation = self.observation_handlers[platform](entity_obs)
             entity_obs.observed = observation
@@ -320,25 +320,25 @@ class BayesianBinarySensor(BinarySensorEntity):
     def _calculate_new_probability(self):
         prior = self.prior
 
-        for obs in self.current_observations.values():
-            if obs is not None:
-                if obs.observed is True:
+        for observation in self.current_observations.values():
+            if observation is not None:
+                if observation.observed is True:
                     prior = update_probability(
                         prior,
-                        obs.prob_given_true,
-                        obs.prob_given_false,
+                        observation.prob_given_true,
+                        observation.prob_given_false,
                     )
-                elif obs.observed is False:
+                elif observation.observed is False:
                     prior = update_probability(
                         prior,
-                        1 - obs.prob_given_true,
-                        1 - obs.prob_given_false,
+                        1 - observation.prob_given_true,
+                        1 - observation.prob_given_false,
                     )
-                elif obs.observed is None:
-                    if obs.entity_id is not None:
+                elif observation.observed is None:
+                    if observation.entity_id is not None:
                         _LOGGER.debug(
                             "Observation for entity '%s' returned None, it will not be used for Bayesian updating",
-                            obs.entity_id,
+                            observation.entity_id,
                         )
                     else:
                         _LOGGER.debug(

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -153,14 +153,7 @@ class BayesianBinarySensor(BinarySensorEntity):
 
     _attr_should_poll = False
 
-    def __init__(
-        self,
-        name,
-        prior,
-        observations,
-        probability_threshold,
-        device_class,
-    ) -> None:
+    def __init__(self, name, prior, observations, probability_threshold, device_class):
         """Initialize the Bayesian sensor."""
         self._attr_name = name
         self._observations = [
@@ -180,12 +173,12 @@ class BayesianBinarySensor(BinarySensorEntity):
         self._probability_threshold = probability_threshold
         self._attr_device_class = device_class
         self._attr_is_on = False
-        self._callbacks = []  # type: ignore[var-annotated]
+        self._callbacks = []
 
         self.prior = prior
         self.probability = prior
 
-        self.current_observations = OrderedDict({})  # type: ignore[var-annotated]
+        self.current_observations = OrderedDict({})
 
         self.observations_by_entity = self._build_observations_by_entity()
         self.observations_by_template = self._build_observations_by_template()

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -458,6 +458,7 @@ class BayesianBinarySensor(BinarySensorEntity):
         return {
             ATTR_PROBABILITY: round(self.probability, 2),
             ATTR_PROBABILITY_THRESHOLD: self._probability_threshold,
+            # An entity can be in more than one observation so set then list to deduplicate
             ATTR_OCCURRED_OBSERVATION_ENTITIES: list(
                 {
                     observation.entity_id

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -472,7 +472,11 @@ class BayesianBinarySensor(BinarySensorEntity):
                     and observation.observed is not None
                 }
             ),
-            ATTR_OBSERVATIONS: attr_observations_list,
+            ATTR_OBSERVATIONS: [
+                observation.to_dict()
+                for observation in self.current_observations.values()
+                if observation is not None
+            ],
         }
 
     async def async_update(self) -> None:

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -307,13 +307,13 @@ class BayesianBinarySensor(BinarySensorEntity):
     def _record_entity_observations(self, entity):
         local_observations = OrderedDict({})
 
-        for entity_obs in self.observations_by_entity[entity]:
-            platform = str(entity_obs.platform)
+        for observation in self.observations_by_entity[entity]:
+            platform = str(observation.platform)
 
-            observation = self.observation_handlers[platform](entity_obs)
-            entity_obs.observed = observation
+            observation = self.observation_handlers[platform](observation)
+            observation.observed = observation
 
-            local_observations[entity_obs.id] = entity_obs
+            local_observations[observation.id] = observation
 
         return local_observations
 

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -404,7 +404,7 @@ class BayesianBinarySensor(BinarySensorEntity):
 
         return observations_by_template
 
-    def _process_numeric_state(self, entity_observation: Observation):
+    def _process_numeric_state(self, entity_observation):
         """Return True if numeric condition is met, return False if not, return None otherwise."""
         entity = entity_observation.entity_id
 

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -362,18 +362,16 @@ class BayesianBinarySensor(BinarySensorEntity):
         """
 
         observations_by_entity: dict[str, list[Observation]] = {}
-        for _, observation in enumerate(self._observations):
+        for observation in self._observations:
 
-            if observation.entity_id is None:
+            if (key := observation.entity_id) is None:
                 continue
-            observations_by_entity.setdefault(observation.entity_id, []).append(
-                observation
-            )
+            observations_by_entity.setdefault(key, []).append(observation)
 
-        for li_of_obs in observations_by_entity.values():
-            if len(li_of_obs) == 1:
+        for entity_observations in observations_by_entity.values():
+            if len(entity_observations) == 1:
                 continue
-            for observation in li_of_obs:
+            for observation in entity_observations:
                 if observation.platform != "state":
                     continue
                 observation.platform = "multi_state"
@@ -395,7 +393,7 @@ class BayesianBinarySensor(BinarySensorEntity):
         """
 
         observations_by_template = {}
-        for _, observation in enumerate(self._observations):
+        for observation in self._observations:
             if observation.value_template is None:
                 continue
 
@@ -423,7 +421,11 @@ class BayesianBinarySensor(BinarySensorEntity):
             return None
 
     def _process_state(self, entity_observation):
-        """Return True if state conditions are met, return False if they are not. Returns None if the state is unavailable."""
+        """Return True if state conditions are met, return False if they are not.
+
+        Returns None if the state is unavailable.
+        """
+
         entity = entity_observation.entity_id
 
         try:
@@ -435,7 +437,11 @@ class BayesianBinarySensor(BinarySensorEntity):
             return None
 
     def _process_multi_state(self, entity_observation):
-        """Return True if state conditions are met, otherwise return None. Never return False as all other states should have their own probabilities configured."""
+        """Return True if state conditions are met, otherwise return None.
+
+        Never return False as all other states should have their own probabilities configured.
+        """
+
         entity = entity_observation.entity_id
 
         try:
@@ -449,9 +455,9 @@ class BayesianBinarySensor(BinarySensorEntity):
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
         attr_observations_list = [
-            obs.to_dict()
-            for obs in self.current_observations.values()
-            if obs is not None
+            observation.to_dict()
+            for observation in self.current_observations.values()
+            if observation is not None
         ]
 
         return {
@@ -459,11 +465,11 @@ class BayesianBinarySensor(BinarySensorEntity):
             ATTR_PROBABILITY_THRESHOLD: self._probability_threshold,
             ATTR_OCCURRED_OBSERVATION_ENTITIES: list(
                 {
-                    obs.entity_id
-                    for obs in self.current_observations.values()
-                    if obs is not None
-                    and obs.entity_id is not None
-                    and obs.observed is not None
+                    observation.entity_id
+                    for observation in self.current_observations.values()
+                    if observation is not None
+                    and observation.entity_id is not None
+                    and observation.observed is not None
                 }
             ),
             ATTR_OBSERVATIONS: attr_observations_list,

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -308,7 +308,7 @@ class BayesianBinarySensor(BinarySensorEntity):
         local_observations = OrderedDict({})
 
         for observation in self.observations_by_entity[entity]:
-            platform = str(observation.platform)
+            platform = observation.platform
 
             observed = self.observation_handlers[platform](observation)
             observation.observed = observed

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -454,11 +454,6 @@ class BayesianBinarySensor(BinarySensorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
-        attr_observations_list = [
-            observation.to_dict()
-            for observation in self.current_observations.values()
-            if observation is not None
-        ]
 
         return {
             ATTR_PROBABILITY: round(self.probability, 2),

--- a/homeassistant/components/bayesian/const.py
+++ b/homeassistant/components/bayesian/const.py
@@ -1,0 +1,17 @@
+"""Consts for using in modules."""
+
+ATTR_OBSERVATIONS = "observations"
+ATTR_OCCURRED_OBSERVATION_ENTITIES = "occurred_observation_entities"
+ATTR_PROBABILITY = "probability"
+ATTR_PROBABILITY_THRESHOLD = "probability_threshold"
+
+CONF_OBSERVATIONS = "observations"
+CONF_PRIOR = "prior"
+CONF_TEMPLATE = "template"
+CONF_PROBABILITY_THRESHOLD = "probability_threshold"
+CONF_P_GIVEN_F = "prob_given_false"
+CONF_P_GIVEN_T = "prob_given_true"
+CONF_TO_STATE = "to_state"
+
+DEFAULT_NAME = "Bayesian Binary Sensor"
+DEFAULT_PROBABILITY_THRESHOLD = 0.5

--- a/homeassistant/components/bayesian/helpers.py
+++ b/homeassistant/components/bayesian/helpers.py
@@ -34,7 +34,7 @@ class Observation:
     def to_dict(self) -> dict[str, str | float | bool | None]:
         """Represent Class as a Dict for easier serialization."""
 
-        # Sadly necessary because dataclasses asdict() can't serialize Templates and ignores Properties.
+        # Needed because dataclasses asdict() can't serialize Templates and ignores Properties.
         dic = {
             CONF_PLATFORM: self.platform,
             CONF_ENTITY_ID: self.entity_id,

--- a/homeassistant/components/bayesian/helpers.py
+++ b/homeassistant/components/bayesian/helpers.py
@@ -32,8 +32,9 @@ class Observation:
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
 
     def to_dict(self) -> dict[str, str | float | bool | None]:
-        """Represent Class as a Dict for easier serialization. Sadly necessary because dataclasses asdict() can't serialize Templates and ignores Properties."""
+        """Represent Class as a Dict for easier serialization."""
 
+        # Sadly necessary because dataclasses asdict() can't serialize Templates and ignores Properties.
         dic = {
             CONF_PLATFORM: self.platform,
             CONF_ENTITY_ID: self.entity_id,

--- a/homeassistant/components/bayesian/helpers.py
+++ b/homeassistant/components/bayesian/helpers.py
@@ -1,0 +1,71 @@
+"""Helpers to deal with bayesian observations."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import uuid
+
+from homeassistant.const import (
+    CONF_ABOVE,
+    CONF_BELOW,
+    CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_VALUE_TEMPLATE,
+)
+from homeassistant.helpers.template import Template
+
+from .const import CONF_P_GIVEN_F, CONF_P_GIVEN_T, CONF_TO_STATE
+
+
+@dataclass
+class Observation:
+    """Representation of a sensor or template observation."""
+
+    entity_id: str | None
+    platform: str
+    prob_given_true: float
+    prob_given_false: float
+    to_state: str | None
+    above: float | None
+    below: float | None
+    value_template: Template | None
+    observed: bool | None = None
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def to_dict(self) -> dict[str, str | float | bool | None]:
+        """Represent Class as a Dict for easier serialization. Sadly necessary because dataclasses asdict() can't serialize Templates and ignores Properties."""
+
+        dic = {
+            CONF_PLATFORM: self.platform,
+            CONF_ENTITY_ID: self.entity_id,
+            CONF_VALUE_TEMPLATE: self.template,
+            CONF_TO_STATE: self.to_state,
+            CONF_ABOVE: self.above,
+            CONF_BELOW: self.below,
+            CONF_P_GIVEN_T: self.prob_given_true,
+            CONF_P_GIVEN_F: self.prob_given_false,
+            "observed": self.observed,
+        }
+
+        for key, value in dic.copy().items():
+            if value is None:
+                del dic[key]
+
+        return dic
+
+    def is_mirror(self, other: Observation) -> bool:
+        """Dectects whether given observation is a mirror of this one."""
+        true_sums_1: bool = (
+            round(self.prob_given_true + other.prob_given_true, 1) == 1.0
+        )
+        false_sums_1: bool = (
+            round(self.prob_given_false + other.prob_given_false, 1) == 1.0
+        )
+        same_states: bool = self.platform == other.platform
+        return true_sums_1 & false_sums_1 & same_states
+
+    @property
+    def template(self) -> str | None:
+        """Not all observations have templates and we want to get template strings."""
+        if self.value_template is not None:
+            return self.value_template.template
+        return None

--- a/homeassistant/components/bayesian/helpers.py
+++ b/homeassistant/components/bayesian/helpers.py
@@ -55,14 +55,11 @@ class Observation:
 
     def is_mirror(self, other: Observation) -> bool:
         """Dectects whether given observation is a mirror of this one."""
-        true_sums_1: bool = (
-            round(self.prob_given_true + other.prob_given_true, 1) == 1.0
+        return (
+            self.platform == other.platform
+            and round(self.prob_given_true + other.prob_given_true, 1) == 1
+            and round(self.prob_given_false + other.prob_given_false, 1) == 1
         )
-        false_sums_1: bool = (
-            round(self.prob_given_false + other.prob_given_false, 1) == 1.0
-        )
-        same_states: bool = self.platform == other.platform
-        return true_sums_1 & false_sums_1 & same_states
 
     @property
     def template(self) -> str | None:

--- a/homeassistant/components/bayesian/repairs.py
+++ b/homeassistant/components/bayesian/repairs.py
@@ -11,20 +11,7 @@ def raise_mirrored_entries(hass: HomeAssistant, observations, text: str = "") ->
     """If there are mirrored entries, the user is probably using a workaround for a patched bug."""
     if len(observations) != 2:
         return
-    true_sums_1: bool = (
-        round(
-            observations[0]["prob_given_true"] + observations[1]["prob_given_true"], 1
-        )
-        == 1.0
-    )
-    false_sums_1: bool = (
-        round(
-            observations[0]["prob_given_false"] + observations[1]["prob_given_false"], 1
-        )
-        == 1.0
-    )
-    same_states: bool = observations[0]["platform"] == observations[1]["platform"]
-    if true_sums_1 & false_sums_1 & same_states:
+    if observations[0].is_mirror(observations[1]):
         issue_registry.async_create_issue(
             hass,
             DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is part of a wider project to improve the Bayesian integration. Which can be seen in more detail on the [community forum](https://community.home-assistant.io/t/the-future-of-the-bayesian-integration-thoughts-wanted/465476). 

This PR does the following:
1. Refactors 'Observations' to be a dataclass rather than passing around nested Dicts, OrderedDicts and lists
Split out from #79291 on request of @epenet

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to community post discussing changes: https://community.home-assistant.io/t/the-future-of-the-bayesian-integration-thoughts-wanted/465476

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
