### PR TITLE
Streamline calendar dataclass API/attribute conversions

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -122,18 +122,16 @@ def _event_dict_factory(obj: Iterable[tuple[str, Any]]) -> dict[str, str]:
     return result
 
 
-def _api_event_dict_factory(
-    obj: Iterable[tuple[str, Any]]
-) -> dict[str, str | dict[str, str]]:
+def _api_event_dict_factory(obj: Iterable[tuple[str, Any]]) -> dict[str, Any]:
     """Convert CalendarEvent dataclass items to the API format."""
-    result: dict[str, str | dict[str, str]] = {}
+    result: dict[str, Any] = {}
     for name, value in obj:
         if isinstance(value, datetime.datetime):
             result[name] = {"dateTime": dt.as_local(value).isoformat()}
         elif isinstance(value, datetime.date):
             result[name] = {"date": value.isoformat()}
         else:
-            result[name] = str(value)
+            result[name] = value
     return result
 
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -1,7 +1,8 @@
 """Support for Google Calendar event device sensors."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Iterable
+import dataclasses
 import datetime
 from http import HTTPStatus
 import logging
@@ -77,7 +78,7 @@ def get_date(date: dict[str, Any]) -> datetime.datetime:
     return dt.as_local(parsed_datetime)
 
 
-@dataclass
+@dataclasses.dataclass
 class CalendarEvent:
     """An event on a calendar."""
 
@@ -104,17 +105,36 @@ class CalendarEvent:
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dict representation of the event."""
-        data = {
-            "start": self.start.isoformat(),
-            "end": self.end.isoformat(),
-            "summary": self.summary,
+        return {
+            **dataclasses.asdict(self, dict_factory=_event_dict_factory),
             "all_day": self.all_day,
         }
-        if self.description:
-            data["description"] = self.description
-        if self.location:
-            data["location"] = self.location
-        return data
+
+
+def _event_dict_factory(obj: Iterable[tuple[str, Any]]) -> dict[str, str]:
+    """Convert CalendarEvent dataclass items to dictionary of attributes."""
+    result: dict[str, str] = {}
+    for name, value in obj:
+        if isinstance(value, (datetime.datetime, datetime.date)):
+            result[name] = value.isoformat()
+        elif value is not None:
+            result[name] = str(value)
+    return result
+
+
+def _api_event_dict_factory(
+    obj: Iterable[tuple[str, Any]]
+) -> dict[str, str | dict[str, str]]:
+    """Convert CalendarEvent dataclass items to the API format."""
+    result: dict[str, str | dict[str, str]] = {}
+    for name, value in obj:
+        if isinstance(value, datetime.datetime):
+            result[name] = {"dateTime": dt.as_local(value).isoformat()}
+        elif isinstance(value, datetime.date):
+            result[name] = {"date": value.isoformat()}
+        else:
+            result[name] = str(value)
+    return result
 
 
 def _get_datetime_local(
@@ -250,15 +270,10 @@ class CalendarEventView(http.HomeAssistantView):
             return self.json_message(
                 f"Error reading events: {err}", HTTPStatus.INTERNAL_SERVER_ERROR
             )
+
         return self.json(
             [
-                {
-                    "summary": event.summary,
-                    "description": event.description,
-                    "location": event.location,
-                    "start": _get_api_date(event.start),
-                    "end": _get_api_date(event.end),
-                }
+                dataclasses.asdict(event, dict_factory=_api_event_dict_factory)
                 for event in calendar_event_list
             ]
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Streamline calendar dataclass API/attribute conversions using `dataclasses.dict` to convert the dataclass to a dict using a function. It is now easier to compare the differences between the two dataclasses easily since the functions are next to each other.

The motivation is for adding new attributes to help ensure they don't diverge, in preparation for adding local calendar, and other new attributes in the future. (pending PR to add status)

Note that entity attribute building is left unchanged for now: Adding a new attribute to `CalendarEvent` does not add it a `CalendarEntity` attribute to make that extra step more intentional.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
