### PR TITLE
ZHA radio migration: reset the old adapter

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -646,8 +646,6 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
 
         if "radio_type" in discovery_info.properties:
             self._radio_type = RadioType[discovery_info.properties["radio_type"]]
-        elif "zigate" in local_name:
-            self._radio_type = RadioType.zigate
         elif "efr32" in local_name:
             self._radio_type = RadioType.ezsp
         else:

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for ZHA."""
 from __future__ import annotations
 
+import asyncio
 import collections
 import contextlib
 import copy
@@ -66,6 +67,8 @@ CHOOSE_AUTOMATIC_BACKUP = "choose_automatic_backup"
 OVERWRITE_COORDINATOR_IEEE = "overwrite_coordinator_ieee"
 
 UPLOADED_BACKUP_FILE = "uploaded_backup_file"
+
+CONNECT_DELAY_S = 1.0
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -159,6 +162,7 @@ class BaseZhaFlow(FlowHandler):
             yield app
         finally:
             await app.disconnect()
+            await asyncio.sleep(CONNECT_DELAY_S)
 
     async def _restore_backup(
         self, backup: zigpy.backups.NetworkBackup, **kwargs: Any

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -641,7 +641,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
         port = discovery_info.port or DEFAULT_ZHA_ZEROCONF_PORT
 
         # Fix incorrect port for older TubesZB devices
-        if "tubeszb" in local_name and port == ESPHOME_API_PORT:
+        if "tube" in local_name and port == ESPHOME_API_PORT:
             port = DEFAULT_ZHA_ZEROCONF_PORT
 
         if "radio_type" in discovery_info.properties:

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -86,7 +86,7 @@
       },
       "intent_migrate": {
         "title": "Migrate to a new radio",
-        "description": "Your current radio will be reset.  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?"
+        "description": "**Your old radio will be factory reset.**  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?"
       },
       "instruct_unplug": {
         "title": "Unplug your old radio",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -76,6 +76,22 @@
         "title": "Reconfigure ZHA",
         "description": "ZHA will be stopped.  Do you wish to continue?"
       },
+      "prompt_migrate_or_reconfigure": {
+        "title": "Migrate or re-configure",
+        "description": "Are you migrating to a new radio or are you re-configuring the existing one?",
+        "menu_options": {
+          "intent_migrate": "Migrate to a new radio",
+          "intent_reconfigure": "Re-configure the current radio"
+        }
+      },
+      "intent_migrate": {
+        "title": "Migrate to a new radio",
+        "description": "Your current radio will be reset.  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?"
+      },
+      "instruct_unplug": {
+        "title": "Unplug your old radio",
+        "description": "Your old radio has been reset.  If the hardware is no longer needed, you can now unplug it."
+      },
       "choose_serial_port": {
         "title": "[%key:component::zha::config::step::choose_serial_port::title%]",
         "data": {

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -78,7 +78,7 @@
       },
       "prompt_migrate_or_reconfigure": {
         "title": "Migrate or re-configure",
-        "description": "Are you migrating to a new radio or are you re-configuring the existing one?",
+        "description": "Are you migrating to a new radio or re-configuring the current radio?",
         "menu_options": {
           "intent_migrate": "Migrate to a new radio",
           "intent_reconfigure": "Re-configure the current radio"
@@ -86,7 +86,7 @@
       },
       "intent_migrate": {
         "title": "Migrate to a new radio",
-        "description": "**Your old radio will be factory reset.**  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?"
+        "description": "Your old radio will be factory reset.  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?"
       },
       "instruct_unplug": {
         "title": "Unplug your old radio",

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -194,7 +194,7 @@
                 "title": "Unplug your old radio"
             },
             "intent_migrate": {
-                "description": "Your current radio will be reset.  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?",
+                "description": "**Your old radio will be factory reset.**  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?",
                 "title": "Migrate to a new radio"
             },
             "manual_pick_radio_type": {

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -194,7 +194,7 @@
                 "title": "Unplug your old radio"
             },
             "intent_migrate": {
-                "description": "**Your old radio will be factory reset.**  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?",
+                "description": "Your old radio will be factory reset.  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?",
                 "title": "Migrate to a new radio"
             },
             "manual_pick_radio_type": {
@@ -221,7 +221,7 @@
                 "title": "Overwrite Radio IEEE Address"
             },
             "prompt_migrate_or_reconfigure": {
-                "description": "Are you migrating to a new radio or are you re-configuring the existing one?",
+                "description": "Are you migrating to a new radio or re-configuring the current radio?",
                 "menu_options": {
                     "intent_migrate": "Migrate to a new radio",
                     "intent_reconfigure": "Re-configure the current radio"

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -64,35 +64,12 @@
                 "description": "Your backup has a different IEEE address than your radio.  For your network to function properly, the IEEE address of your radio should also be changed.\n\nThis is a permanent operation.",
                 "title": "Overwrite Radio IEEE Address"
             },
-            "pick_radio": {
-                "data": {
-                    "radio_type": "Radio Type"
-                },
-                "description": "Pick a type of your Zigbee radio",
-                "title": "Radio Type"
-            },
-            "port_config": {
-                "data": {
-                    "baudrate": "port speed",
-                    "flow_control": "data flow control",
-                    "path": "Serial device path"
-                },
-                "description": "Enter port specific settings",
-                "title": "Settings"
-            },
             "upload_manual_backup": {
                 "data": {
                     "uploaded_backup_file": "Upload a file"
                 },
                 "description": "Restore your network settings from an uploaded backup JSON file. You can download one from a different ZHA installation from **Network Settings**, or use a Zigbee2MQTT `coordinator_backup.json` file.",
                 "title": "Upload a Manual Backup"
-            },
-            "user": {
-                "data": {
-                    "path": "Serial Device Path"
-                },
-                "description": "Select serial port for Zigbee radio",
-                "title": "ZHA"
             }
         }
     },
@@ -212,6 +189,14 @@
                 "description": "ZHA will be stopped.  Do you wish to continue?",
                 "title": "Reconfigure ZHA"
             },
+            "instruct_unplug": {
+                "description": "Your old radio has been reset.  If the hardware is no longer needed, you can now unplug it.",
+                "title": "Unplug your old radio"
+            },
+            "intent_migrate": {
+                "description": "Your current radio will be reset.  If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\nDo you wish to continue?",
+                "title": "Migrate to a new radio"
+            },
             "manual_pick_radio_type": {
                 "data": {
                     "radio_type": "Radio Type"
@@ -234,6 +219,14 @@
                 },
                 "description": "Your backup has a different IEEE address than your radio.  For your network to function properly, the IEEE address of your radio should also be changed.\n\nThis is a permanent operation.",
                 "title": "Overwrite Radio IEEE Address"
+            },
+            "prompt_migrate_or_reconfigure": {
+                "description": "Are you migrating to a new radio or are you re-configuring the existing one?",
+                "menu_options": {
+                    "intent_migrate": "Migrate to a new radio",
+                    "intent_reconfigure": "Re-configure the current radio"
+                },
+                "title": "Migrate or re-configure"
             },
             "upload_manual_backup": {
                 "data": {

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -47,6 +47,13 @@ def disable_platform_only():
 
 
 @pytest.fixture(autouse=True)
+def reduce_reconnect_timeout():
+    """Reduces reconnect timeout to speed up tests."""
+    with patch("homeassistant.components.zha.config_flow.CONNECT_DELAY_S", 0.01):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def mock_app():
     """Mock zigpy app interface."""
     mock_app = AsyncMock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Dual-radio adapters like the HUSBZB-1 cannot be unplugged after migration: this causes two concurrent Zigbee networks with the same settings to be active, causing massive network degradation on the new radio.

With #79565 now merged, this PR adds an extra step to the ZHA migration flow to reset the old radio using the new zigpy reset API:

<img width="569" alt="image" src="https://user-images.githubusercontent.com/32534428/194123928-2213e16e-dbea-4b01-b4fb-803a492d07ac.png">

<img width="704" alt="image" src="https://user-images.githubusercontent.com/32534428/194124649-7f37beb5-7bfb-4484-bf22-6ad412e17405.png">

<img width="674" alt="image" src="https://user-images.githubusercontent.com/32534428/194124675-ae01b33c-7ed3-43f9-8ef8-8553722d79bc.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #79092
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
