### PR TITLE
Refactor Shelly to use data class for ConfigEntry data

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -146,9 +146,9 @@ async def _async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     @callback
     def _async_block_device_setup() -> None:
         """Set up a block based device that is online."""
-        coordinator = get_entry_data(hass)[
-            entry.entry_id
-        ].block = ShellyBlockCoordinator(hass, entry, device)
+        shelly_entry_data = get_entry_data(hass)[entry.entry_id]
+        shelly_entry_data.block = ShellyBlockCoordinator(hass, entry, device)
+        shelly_entry_data.block.async_setup()
         coordinator.async_setup()
 
         platforms = BLOCK_SLEEPING_PLATFORMS

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -142,14 +142,13 @@ async def _async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         device_entry = None
 
     sleep_period = entry.data.get(CONF_SLEEP_PERIOD)
+    shelly_entry_data = get_entry_data(hass)[entry.entry_id]
 
     @callback
     def _async_block_device_setup() -> None:
         """Set up a block based device that is online."""
-        shelly_entry_data = get_entry_data(hass)[entry.entry_id]
         shelly_entry_data.block = ShellyBlockCoordinator(hass, entry, device)
         shelly_entry_data.block.async_setup()
-        coordinator.async_setup()
 
         platforms = BLOCK_SLEEPING_PLATFORMS
 
@@ -162,7 +161,7 @@ async def _async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     @callback
     def _async_device_online(_: Any) -> None:
         LOGGER.debug("Device %s is online, resuming setup", entry.title)
-        get_entry_data(hass)[entry.entry_id].device = None
+        shelly_entry_data.device = None
 
         if sleep_period is None:
             data = {**entry.data}
@@ -194,7 +193,7 @@ async def _async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         _async_block_device_setup()
     elif sleep_period is None or device_entry is None:
         # Need to get sleep info or first time sleeping device setup, wait for device
-        get_entry_data(hass)[entry.entry_id].device = device
+        shelly_entry_data.device = device
         LOGGER.debug(
             "Setup for device %s will resume when device is online", entry.title
         )

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Final, cast
+from typing import Final
 
 from homeassistant.components.button import (
     ButtonDeviceClass,
@@ -18,8 +18,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
-from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC, SHELLY_GAS_MODELS
-from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
+from .const import SHELLY_GAS_MODELS
+from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .utils import get_block_device_name, get_device_entry_gen, get_rpc_device_name
 
 
@@ -80,15 +80,9 @@ async def async_setup_entry(
     """Set buttons for device."""
     coordinator: ShellyRpcCoordinator | ShellyBlockCoordinator | None = None
     if get_device_entry_gen(config_entry) == 2:
-        if rpc_coordinator := hass.data[DOMAIN][DATA_CONFIG_ENTRY][
-            config_entry.entry_id
-        ].get(RPC):
-            coordinator = cast(ShellyRpcCoordinator, rpc_coordinator)
+        coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
     else:
-        if block_coordinator := hass.data[DOMAIN][DATA_CONFIG_ENTRY][
-            config_entry.entry_id
-        ].get(BLOCK):
-            coordinator = cast(ShellyBlockCoordinator, block_coordinator)
+        coordinator = get_entry_data(hass)[config_entry.entry_id].block
 
     if coordinator is not None:
         entities = []

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -26,15 +26,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    AIOSHELLY_DEVICE_TIMEOUT_SEC,
-    BLOCK,
-    DATA_CONFIG_ENTRY,
-    DOMAIN,
-    LOGGER,
-    SHTRV_01_TEMPERATURE_SETTINGS,
-)
-from .coordinator import ShellyBlockCoordinator
+from .const import AIOSHELLY_DEVICE_TIMEOUT_SEC, LOGGER, SHTRV_01_TEMPERATURE_SETTINGS
+from .coordinator import ShellyBlockCoordinator, get_entry_data
 from .utils import get_device_entry_gen
 
 
@@ -48,10 +41,8 @@ async def async_setup_entry(
     if get_device_entry_gen(config_entry) == 2:
         return
 
-    coordinator: ShellyBlockCoordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][
-        config_entry.entry_id
-    ][BLOCK]
-
+    coordinator = get_entry_data(hass)[config_entry.entry_id].block
+    assert coordinator
     if coordinator.device.initialized:
         async_setup_climate_entities(async_add_entities, coordinator)
     else:

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -9,13 +9,7 @@ DOMAIN: Final = "shelly"
 
 LOGGER: Logger = getLogger(__package__)
 
-BLOCK: Final = "block"
 DATA_CONFIG_ENTRY: Final = "config_entry"
-DEVICE: Final = "device"
-REST: Final = "rest"
-RPC: Final = "rpc"
-RPC_POLL: Final = "rpc_poll"
-
 CONF_COAP_PORT: Final = "coap_port"
 DEFAULT_COAP_PORT: Final = 5683
 FIRMWARE_PATTERN: Final = re.compile(r"^(\d{8})")

--- a/homeassistant/components/shelly/cover.py
+++ b/homeassistant/components/shelly/cover.py
@@ -15,8 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC
-from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
+from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .entity import ShellyBlockEntity, ShellyRpcEntity
 from .utils import get_device_entry_gen, get_rpc_key_ids
 
@@ -40,7 +39,8 @@ def async_setup_block_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up cover for device."""
-    coordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][BLOCK]
+    coordinator = get_entry_data(hass)[config_entry.entry_id].block
+    assert coordinator and coordinator.device.blocks
     blocks = [block for block in coordinator.device.blocks if block.type == "roller"]
 
     if not blocks:
@@ -56,8 +56,8 @@ def async_setup_rpc_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entities for RPC device."""
-    coordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][RPC]
-
+    coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
+    assert coordinator
     cover_key_ids = get_rpc_key_ids(coordinator.device.status, "cover")
 
     if not cover_key_ids:

--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -22,7 +22,6 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
-from . import get_block_device_coordinator, get_rpc_device_coordinator
 from .const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
@@ -33,6 +32,10 @@ from .const import (
     INPUTS_EVENTS_SUBTYPES,
     RPC_INPUTS_EVENTS_TYPES,
     SHBTN_MODELS,
+)
+from .coordinator import (
+    get_block_coordinator_by_device_id,
+    get_rpc_coordinator_by_device_id,
 )
 from .utils import (
     get_block_input_triggers,
@@ -78,7 +81,7 @@ async def async_validate_trigger_config(
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
 
     if config[CONF_TYPE] in RPC_INPUTS_EVENTS_TYPES:
-        rpc_coordinator = get_rpc_device_coordinator(hass, config[CONF_DEVICE_ID])
+        rpc_coordinator = get_rpc_coordinator_by_device_id(hass, config[CONF_DEVICE_ID])
         if not rpc_coordinator or not rpc_coordinator.device.initialized:
             return config
 
@@ -87,7 +90,9 @@ async def async_validate_trigger_config(
             return config
 
     elif config[CONF_TYPE] in BLOCK_INPUTS_EVENTS_TYPES:
-        block_coordinator = get_block_device_coordinator(hass, config[CONF_DEVICE_ID])
+        block_coordinator = get_block_coordinator_by_device_id(
+            hass, config[CONF_DEVICE_ID]
+        )
         if not block_coordinator or not block_coordinator.device.initialized:
             return config
 
@@ -109,12 +114,12 @@ async def async_get_triggers(
     """List device triggers for Shelly devices."""
     triggers: list[dict[str, str]] = []
 
-    if rpc_coordinator := get_rpc_device_coordinator(hass, device_id):
+    if rpc_coordinator := get_rpc_coordinator_by_device_id(hass, device_id):
         input_triggers = get_rpc_input_triggers(rpc_coordinator.device)
         append_input_triggers(triggers, input_triggers, device_id)
         return triggers
 
-    if block_coordinator := get_block_device_coordinator(hass, device_id):
+    if block_coordinator := get_block_coordinator_by_device_id(hass, device_id):
         if block_coordinator.model in SHBTN_MODELS:
             input_triggers = get_shbtn_input_triggers()
             append_input_triggers(triggers, input_triggers, device_id)

--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -6,8 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC
-from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
+from .coordinator import get_entry_data
 
 TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
 
@@ -16,12 +15,13 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict:
     """Return diagnostics for a config entry."""
-    data: dict = hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id]
+    entry_data = get_entry_data(hass)[entry.entry_id]
 
     device_settings: str | dict = "not initialized"
     device_status: str | dict = "not initialized"
-    if BLOCK in data:
-        block_coordinator: ShellyBlockCoordinator = data[BLOCK]
+    if entry_data.block:
+        block_coordinator = entry_data.block
+        assert block_coordinator
         device_info = {
             "name": block_coordinator.name,
             "model": block_coordinator.model,
@@ -51,7 +51,8 @@ async def async_get_config_entry_diagnostics(
                 ]
             }
     else:
-        rpc_coordinator: ShellyRpcCoordinator = data[RPC]
+        rpc_coordinator = entry_data.rpc
+        assert rpc_coordinator
         device_info = {
             "name": rpc_coordinator.name,
             "model": rpc_coordinator.model,

--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -15,12 +15,12 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict:
     """Return diagnostics for a config entry."""
-    entry_data = get_entry_data(hass)[entry.entry_id]
+    shelly_entry_data = get_entry_data(hass)[entry.entry_id]
 
     device_settings: str | dict = "not initialized"
     device_status: str | dict = "not initialized"
-    if entry_data.block:
-        block_coordinator = entry_data.block
+    if shelly_entry_data.block:
+        block_coordinator = shelly_entry_data.block
         assert block_coordinator
         device_info = {
             "name": block_coordinator.name,
@@ -51,7 +51,7 @@ async def async_get_config_entry_diagnostics(
                 ]
             }
     else:
-        rpc_coordinator = entry_data.rpc
+        rpc_coordinator = shelly_entry_data.rpc
         assert rpc_coordinator
         device_info = {
             "name": rpc_coordinator.name,

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -18,21 +18,12 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    AIOSHELLY_DEVICE_TIMEOUT_SEC,
-    BLOCK,
-    DATA_CONFIG_ENTRY,
-    DOMAIN,
-    LOGGER,
-    REST,
-    RPC,
-    RPC_POLL,
-)
+from .const import AIOSHELLY_DEVICE_TIMEOUT_SEC, LOGGER
 from .coordinator import (
     ShellyBlockCoordinator,
-    ShellyRestCoordinator,
     ShellyRpcCoordinator,
     ShellyRpcPollingCoordinator,
+    get_entry_data,
 )
 from .utils import (
     async_remove_shelly_entity,
@@ -54,10 +45,8 @@ def async_setup_entry_attribute_entities(
     ],
 ) -> None:
     """Set up entities for attributes."""
-    coordinator: ShellyBlockCoordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][
-        config_entry.entry_id
-    ][BLOCK]
-
+    coordinator = get_entry_data(hass)[config_entry.entry_id].block
+    assert coordinator
     if coordinator.device.initialized:
         async_setup_block_attribute_entities(
             hass, async_add_entities, coordinator, sensors, sensor_class
@@ -166,13 +155,10 @@ def async_setup_entry_rpc(
     sensor_class: Callable,
 ) -> None:
     """Set up entities for REST sensors."""
-    coordinator: ShellyRpcCoordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][
-        config_entry.entry_id
-    ][RPC]
-
-    polling_coordinator: ShellyRpcPollingCoordinator = hass.data[DOMAIN][
-        DATA_CONFIG_ENTRY
-    ][config_entry.entry_id][RPC_POLL]
+    coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
+    assert coordinator
+    polling_coordinator = get_entry_data(hass)[config_entry.entry_id].rpc_poll
+    assert polling_coordinator
 
     entities = []
     for sensor_id in sensors:
@@ -220,10 +206,8 @@ def async_setup_entry_rest(
     sensor_class: Callable,
 ) -> None:
     """Set up entities for REST sensors."""
-    coordinator: ShellyRestCoordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][
-        config_entry.entry_id
-    ][REST]
-
+    coordinator = get_entry_data(hass)[config_entry.entry_id].rest
+    assert coordinator
     entities = []
     for sensor_id in sensors:
         description = sensors.get(sensor_id)

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -26,9 +26,6 @@ from homeassistant.util.color import (
 )
 
 from .const import (
-    BLOCK,
-    DATA_CONFIG_ENTRY,
-    DOMAIN,
     DUAL_MODE_LIGHT_MODELS,
     FIRMWARE_PATTERN,
     KELVIN_MAX_VALUE,
@@ -39,11 +36,10 @@ from .const import (
     MAX_TRANSITION_TIME,
     MODELS_SUPPORTING_LIGHT_TRANSITION,
     RGBW_MODELS,
-    RPC,
     SHBLB_1_RGB_EFFECTS,
     STANDARD_RGB_EFFECTS,
 )
-from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
+from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .entity import ShellyBlockEntity, ShellyRpcEntity
 from .utils import (
     async_remove_shelly_entity,
@@ -77,8 +73,8 @@ def async_setup_block_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entities for block device."""
-    coordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][BLOCK]
-
+    coordinator = get_entry_data(hass)[config_entry.entry_id].block
+    assert coordinator
     blocks = []
     assert coordinator.device.blocks
     for block in coordinator.device.blocks:
@@ -108,7 +104,8 @@ def async_setup_rpc_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entities for RPC device."""
-    coordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][RPC]
+    coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
+    assert coordinator
     switch_key_ids = get_rpc_key_ids(coordinator.device.status, "switch")
 
     switch_ids = []

--- a/homeassistant/components/shelly/logbook.py
+++ b/homeassistant/components/shelly/logbook.py
@@ -8,7 +8,6 @@ from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.typing import EventType
 
-from . import get_block_device_coordinator, get_rpc_device_coordinator
 from .const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
@@ -17,6 +16,10 @@ from .const import (
     DOMAIN,
     EVENT_SHELLY_CLICK,
     RPC_INPUTS_EVENTS_TYPES,
+)
+from .coordinator import (
+    get_block_coordinator_by_device_id,
+    get_rpc_coordinator_by_device_id,
 )
 from .utils import get_block_device_name, get_rpc_entity_name
 
@@ -37,13 +40,13 @@ def async_describe_events(
         input_name = f"{event.data[ATTR_DEVICE]} channel {channel}"
 
         if click_type in RPC_INPUTS_EVENTS_TYPES:
-            rpc_coordinator = get_rpc_device_coordinator(hass, device_id)
+            rpc_coordinator = get_rpc_coordinator_by_device_id(hass, device_id)
             if rpc_coordinator and rpc_coordinator.device.initialized:
                 key = f"input:{channel-1}"
                 input_name = get_rpc_entity_name(rpc_coordinator.device, key)
 
         elif click_type in BLOCK_INPUTS_EVENTS_TYPES:
-            block_coordinator = get_block_device_coordinator(hass, device_id)
+            block_coordinator = get_block_coordinator_by_device_id(hass, device_id)
             if block_coordinator and block_coordinator.device.initialized:
                 device_name = get_block_device_name(block_coordinator.device)
                 input_name = f"{device_name} channel {channel}"

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -10,8 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC
-from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
+from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .entity import ShellyBlockEntity, ShellyRpcEntity
 from .utils import (
     async_remove_shelly_entity,
@@ -41,7 +40,8 @@ def async_setup_block_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entities for block device."""
-    coordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][BLOCK]
+    coordinator = get_entry_data(hass)[config_entry.entry_id].block
+    assert coordinator
 
     # In roller mode the relay blocks exist but do not contain required info
     if (
@@ -75,8 +75,8 @@ def async_setup_rpc_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entities for RPC device."""
-    coordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][RPC]
-
+    coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
+    assert coordinator
     switch_key_ids = get_rpc_key_ids(coordinator.device.status, "switch")
 
     switch_ids = []

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -17,8 +17,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import BLOCK, CONF_SLEEP_PERIOD, DATA_CONFIG_ENTRY, DOMAIN
-from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
+from .const import CONF_SLEEP_PERIOD
+from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .entity import (
     RestEntityDescription,
     RpcEntityDescription,
@@ -178,11 +178,9 @@ class RestUpdateEntity(ShellyRestAttributeEntity, UpdateEntity):
     ) -> None:
         """Install the latest firmware version."""
         config_entry = self.block_coordinator.entry
-        block_coordinator = self.hass.data[DOMAIN][DATA_CONFIG_ENTRY][
-            config_entry.entry_id
-        ].get(BLOCK)
+        coordinator = get_entry_data(self.hass)[config_entry.entry_id].block
         self._in_progress_old_version = self.installed_version
-        await self.entity_description.install(block_coordinator)
+        await self.entity_description.install(coordinator)
 
 
 class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use data class to access config entry data
Move coordinator related functions to `coordinator.py`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
