### PR TITLE
Adjust automatic temperature conversions

### DIFF
--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -379,9 +379,20 @@ class NumberEntity(Entity):
         native_unit_of_measurement = self.native_unit_of_measurement
 
         if (
+            unit_conversion := self.hass.config.unit_conversions.get(self.device_class)
+        ) and (to_unit := unit_conversion.get(native_unit_of_measurement)):
+            return to_unit
+
+        if (
             self.device_class == NumberDeviceClass.TEMPERATURE
+            and native_unit_of_measurement != self.hass.config.units.temperature_unit
             and native_unit_of_measurement in (TEMP_CELSIUS, TEMP_FAHRENHEIT)
         ):
+            # Automatic conversion based on UnitSystem will stop working in XXXX.XX.
+            # To keep existing behavior, please add a mapping for
+            # {native_unit_of_measurement} > {self.hass.config.units.temperature_unit}
+            # To cancel automatic temperature conversion, please add a mapping for
+            # {native_unit_of_measurement} > {native_unit_of_measurement}
             return self.hass.config.units.temperature_unit
 
         return native_unit_of_measurement

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -388,9 +388,20 @@ class SensorEntity(Entity):
         native_unit_of_measurement = self.native_unit_of_measurement
 
         if (
-            self.device_class == DEVICE_CLASS_TEMPERATURE
+            unit_conversion := self.hass.config.unit_conversions.get(self.device_class)
+        ) and (to_unit := unit_conversion.get(native_unit_of_measurement)):
+            return to_unit
+
+        if (
+            self.device_class == SensorDeviceClass.TEMPERATURE
+            and native_unit_of_measurement != self.hass.config.units.temperature_unit
             and native_unit_of_measurement in (TEMP_CELSIUS, TEMP_FAHRENHEIT)
         ):
+            # Automatic conversion based on UnitSystem will stop working in XXXX.XX.
+            # To keep existing behavior, please add a mapping for
+            # {native_unit_of_measurement} > {self.hass.config.units.temperature_unit}
+            # To cancel automatic temperature conversion, please add a mapping for
+            # {native_unit_of_measurement} > {native_unit_of_measurement}
             return self.hass.config.units.temperature_unit
 
         return native_unit_of_measurement

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1795,6 +1795,11 @@ class Config:
         self.elevation: int = 0
         self.location_name: str = "Home"
         self.time_zone: str = "UTC"
+        # self.unit_conversions = {
+        #     "distance": {LENGTH_KILOMETERS: LENGTH_MILES},
+        #     "temperature": {TEMP_CELSIUS: TEMP_FAHRENHEIT},
+        # }
+        self.unit_conversions: dict[str | None, dict[str | None, str]] = {}
         self.units: UnitSystem = METRIC_SYSTEM
         self.internal_url: str | None = None
         self.external_url: str | None = None

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -1,6 +1,8 @@
 """Typing Helpers for Home Assistant."""
 from __future__ import annotations
 
+from typing import Final
+
 from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     ENERGY_MEGA_WATT_HOUR,
@@ -50,6 +52,9 @@ from homeassistant.const import (
     VOLUME_MILLILITERS,
 )
 from homeassistant.exceptions import HomeAssistantError
+
+# Do not convert flag
+DO_NOT_CONVERT: Final = "**DO_NOT_CONVERT**"
 
 # Distance conversion constants
 _MM_TO_M = 0.001  # 1 mm = 0.001 m


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add ability to enable/disable automatic temperature conversions

Stop relying on UnitSystem for this, and add a specific setting to enable/disable for specific units.

It would need an adjustement on the frontend so users can set it, at least for temperature to begin with.

```python
# Sample for someone who wants to use always FAHRENHEIT (replicates current imperial behavior)
override_units = {
    "temperature": {
        TEMP_CELSIUS: TEMP_FAHRENHEIT,
        TEMP_FAHRENHEIT: None,
        TEMP_KELVIN: None,
    },
}
# Sample for someone who wants to use always CELSIUS (replicates current metric behavior)
override_units = {
    "temperature": {
        TEMP_CELSIUS: None,
        TEMP_FAHRENHEIT: TEMP_CELSIUS,
        TEMP_KELVIN: None,
    },
}
# Sample for someone who wants to disable conversions (during the migration period)
override_units = {
    "temperature": {
        TEMP_CELSIUS: TEMP_CELSIUS,
        TEMP_FAHRENHEIT: TEMP_FAHRENHEIT,
        TEMP_KELVIN: None,
    },
}
# Sample for someone who wants to disable conversions (after the migration period)
override_units = {
    "temperature": {
        TEMP_CELSIUS: None,
        TEMP_FAHRENHEIT: None,
        TEMP_KELVIN: None,
    },
}

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
