### PR TITLE
Add diagnostics to LaMetric

### DIFF
--- a/homeassistant/components/lametric/diagnostics.py
+++ b/homeassistant/components/lametric/diagnostics.py
@@ -1,0 +1,29 @@
+"""Diagnostics support for LaMetric."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import LaMetricDataUpdateCoordinator
+
+TO_REDACT = {
+    "device_id",
+    "name",
+    "serial_number",
+    "ssid",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: LaMetricDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    # Round-trip via JSON to trigger serialization
+    data = json.loads(coordinator.data.json())
+    return async_redact_data(data, TO_REDACT)

--- a/tests/components/lametric/test_diagnostics.py
+++ b/tests/components/lametric/test_diagnostics.py
@@ -12,7 +12,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSession,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/lametric/test_diagnostics.py
+++ b/tests/components/lametric/test_diagnostics.py
@@ -1,0 +1,57 @@
+"""Tests for the diagnostics data provided by the LaMetric integration."""
+from aiohttp import ClientSession
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+    init_integration: MockConfigEntry,
+):
+    """Test diagnostics."""
+    assert await get_diagnostics_for_config_entry(
+        hass, hass_client, init_integration
+    ) == {
+        "device_id": REDACTED,
+        "name": REDACTED,
+        "serial_number": REDACTED,
+        "os_version": "2.2.2",
+        "mode": "auto",
+        "model": "LM 37X8",
+        "audio": {
+            "volume": 100,
+            "volume_range": {"range_min": 0, "range_max": 100},
+            "volume_limit": {"range_min": 0, "range_max": 100},
+        },
+        "bluetooth": {
+            "available": True,
+            "name": REDACTED,
+            "active": False,
+            "discoverable": True,
+            "pairable": True,
+            "address": "AA:BB:CC:DD:EE:FF",
+        },
+        "display": {
+            "brightness": 100,
+            "brightness_mode": "auto",
+            "width": 37,
+            "height": 8,
+            "display_type": "mixed",
+        },
+        "wifi": {
+            "active": True,
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "available": True,
+            "encryption": "WPA",
+            "ssid": REDACTED,
+            "ip": "127.0.0.1",
+            "mode": "dhcp",
+            "netmask": "255.255.255.0",
+            "rssi": 21,
+        },
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds support for downloading diagnostics to the LaMetric integration.

Here is the result on how it looks for one of my LaMetric devices:

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Core",
    "version": "2022.11.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": true,
    "python_version": "3.9.9",
    "docker": false,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.10.0-11-amd64",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "lametric",
    "name": "LaMetric",
    "documentation": "https://www.home-assistant.io/integrations/lametric",
    "requirements": [
      "demetriek==0.2.4"
    ],
    "codeowners": [
      "@robbiet480",
      "@frenck"
    ],
    "iot_class": "local_polling",
    "dependencies": [
      "application_credentials"
    ],
    "loggers": [
      "demetriek"
    ],
    "config_flow": true,
    "ssdp": [
      {
        "deviceType": "urn:schemas-upnp-org:device:LaMetric:1"
      }
    ],
    "dhcp": [
      {
        "registered_devices": true
      }
    ],
    "is_built_in": true
  },
  "data": {
    "device_id": "**REDACTED**",
    "name": "**REDACTED**",
    "serial_number": "**REDACTED**",
    "os_version": "2.2.4",
    "mode": "kiosk",
    "model": "LM 37X8",
    "audio": {
      "volume": 84,
      "volume_range": {
        "range_min": 0,
        "range_max": 100
      },
      "volume_limit": {
        "range_min": 0,
        "range_max": 100
      }
    },
    "bluetooth": {
      "available": true,
      "name": "**REDACTED**",
      "active": false,
      "discoverable": true,
      "pairable": true,
      "address": "24:18:C6:19:68:0A"
    },
    "display": {
      "brightness": 62,
      "brightness_mode": "manual",
      "width": 37,
      "height": 8,
      "display_type": "mixed"
    },
    "wifi": {
      "active": true,
      "mac": "24:18:C6:19:00:0E",
      "available": true,
      "encryption": "WPA",
      "ssid": "**REDACTED**",
      "ip": "10.10.11.105",
      "mode": "dhcp",
      "netmask": "255.255.254.0",
      "rssi": 26
    }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
