### PR TITLE
Revert "Improve device_automation trigger validation"

### DIFF
--- a/homeassistant/components/device_automation/action.py
+++ b/homeassistant/components/device_automation/action.py
@@ -7,7 +7,6 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DOMAIN
 from homeassistant.core import Context, HomeAssistant
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from . import DeviceAutomationType, async_get_device_automation_platform
@@ -52,15 +51,14 @@ async def async_validate_action_config(
 ) -> ConfigType:
     """Validate config."""
     try:
-        config = cv.DEVICE_ACTION_SCHEMA(config)
         platform = await async_get_device_automation_platform(
             hass, config[CONF_DOMAIN], DeviceAutomationType.ACTION
         )
         if hasattr(platform, "async_validate_action_config"):
             return await platform.async_validate_action_config(hass, config)
         return cast(ConfigType, platform.ACTION_SCHEMA(config))
-    except (vol.Invalid, InvalidDeviceAutomationConfig) as err:
-        raise vol.Invalid("invalid action configuration: " + str(err)) from err
+    except InvalidDeviceAutomationConfig as err:
+        raise vol.Invalid(str(err) or "Invalid action configuration") from err
 
 
 async def async_call_action_from_config(

--- a/homeassistant/components/device_automation/condition.py
+++ b/homeassistant/components/device_automation/condition.py
@@ -58,8 +58,8 @@ async def async_validate_condition_config(
         if hasattr(platform, "async_validate_condition_config"):
             return await platform.async_validate_condition_config(hass, config)
         return cast(ConfigType, platform.CONDITION_SCHEMA(config))
-    except (vol.Invalid, InvalidDeviceAutomationConfig) as err:
-        raise vol.Invalid("invalid condition configuration: " + str(err)) from err
+    except InvalidDeviceAutomationConfig as err:
+        raise vol.Invalid(str(err) or "Invalid condition configuration") from err
 
 
 async def async_condition_from_config(

--- a/homeassistant/components/device_automation/trigger.py
+++ b/homeassistant/components/device_automation/trigger.py
@@ -58,15 +58,14 @@ async def async_validate_trigger_config(
 ) -> ConfigType:
     """Validate config."""
     try:
-        config = TRIGGER_SCHEMA(config)
         platform = await async_get_device_automation_platform(
             hass, config[CONF_DOMAIN], DeviceAutomationType.TRIGGER
         )
         if not hasattr(platform, "async_validate_trigger_config"):
             return cast(ConfigType, platform.TRIGGER_SCHEMA(config))
         return await platform.async_validate_trigger_config(hass, config)
-    except (vol.Invalid, InvalidDeviceAutomationConfig) as err:
-        raise InvalidDeviceAutomationConfig("invalid trigger configuration") from err
+    except InvalidDeviceAutomationConfig as err:
+        raise vol.Invalid(str(err) or "Invalid trigger configuration") from err
 
 
 async def async_attach_trigger(

--- a/homeassistant/components/rfxtrx/device_action.py
+++ b/homeassistant/components/rfxtrx/device_action.py
@@ -80,6 +80,7 @@ async def async_validate_action_config(
     hass: HomeAssistant, config: ConfigType
 ) -> ConfigType:
     """Validate config."""
+    config = ACTION_SCHEMA(config)
     commands, _ = _get_commands(hass, config[CONF_DEVICE_ID], config[CONF_TYPE])
     sub_type = config[CONF_SUBTYPE]
 

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -720,28 +720,7 @@ async def test_automation_with_bad_condition_action(hass, caplog):
     assert "required key not provided" in caplog.text
 
 
-async def test_automation_with_bad_condition_missing_domain(hass, caplog):
-    """Test automation with bad device condition."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "alias": "hello",
-                "trigger": {"platform": "event", "event_type": "test_event1"},
-                "condition": {"condition": "device", "device_id": "hello.device"},
-                "action": {"service": "test.automation", "entity_id": "hello.world"},
-            }
-        },
-    )
-
-    assert (
-        "Invalid config for [automation]: required key not provided @ data['condition'][0]['domain']"
-        in caplog.text
-    )
-
-
-async def test_automation_with_bad_condition_missing_device_id(hass, caplog):
+async def test_automation_with_bad_condition(hass, caplog):
     """Test automation with bad device condition."""
     assert await async_setup_component(
         hass,
@@ -756,10 +735,7 @@ async def test_automation_with_bad_condition_missing_device_id(hass, caplog):
         },
     )
 
-    assert (
-        "Invalid config for [automation]: required key not provided @ data['condition'][0]['device_id']"
-        in caplog.text
-    )
+    assert "required key not provided" in caplog.text
 
 
 @pytest.fixture
@@ -900,25 +876,8 @@ async def test_automation_with_bad_sub_condition(hass, caplog):
     assert "required key not provided" in caplog.text
 
 
-async def test_automation_with_bad_trigger_missing_domain(hass, caplog):
-    """Test automation with device trigger this is missing domain."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "alias": "hello",
-                "trigger": {"platform": "device", "device_id": "hello.device"},
-                "action": {"service": "test.automation", "entity_id": "hello.world"},
-            }
-        },
-    )
-
-    assert "required key not provided @ data['domain']" in caplog.text
-
-
-async def test_automation_with_bad_trigger_missing_device_id(hass, caplog):
-    """Test automation with device trigger that is missing device_id."""
+async def test_automation_with_bad_trigger(hass, caplog):
+    """Test automation with bad device trigger."""
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -931,7 +890,7 @@ async def test_automation_with_bad_trigger_missing_device_id(hass, caplog):
         },
     )
 
-    assert "required key not provided @ data['device_id']" in caplog.text
+    assert "required key not provided" in caplog.text
 
 
 async def test_websocket_device_not_found(hass, hass_ws_client):

--- a/tests/components/webostv/test_device_trigger.py
+++ b/tests/components/webostv/test_device_trigger.py
@@ -128,7 +128,8 @@ async def test_get_triggers_for_invalid_device_id(hass, caplog):
     await hass.async_block_till_done()
 
     assert (
-        "Invalid config for [automation]: invalid trigger configuration" in caplog.text
+        "Invalid config for [automation]: Device invalid_device_id is not a valid webostv device"
+        in caplog.text
     )
 
 


### PR DESCRIPTION
Reverts home-assistant/core#75044

This PR breaks automation validation: https://github.com/home-assistant/core/issues/79578, and prevents the `automation` integration from loading instead of dropping single automations when there are issues.