### PR TITLE
Add helper - Attribute as Sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -103,6 +103,7 @@ build.json @home-assistant/supervisor
 /tests/components/atag/ @MatsNL
 /homeassistant/components/aten_pe/ @mtdcr
 /homeassistant/components/atome/ @baqs
+/homeassistant/components/attribute_as_sensor/ @gjohansson-ST
 /homeassistant/components/august/ @bdraco
 /tests/components/august/ @bdraco
 /homeassistant/components/aurora/ @djtimca

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -104,6 +104,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/aten_pe/ @mtdcr
 /homeassistant/components/atome/ @baqs
 /homeassistant/components/attribute_as_sensor/ @gjohansson-ST
+/tests/components/attribute_as_sensor/ @gjohansson-ST
 /homeassistant/components/august/ @bdraco
 /tests/components/august/ @bdraco
 /homeassistant/components/aurora/ @djtimca

--- a/homeassistant/components/attribute_as_sensor/__init__.py
+++ b/homeassistant/components/attribute_as_sensor/__init__.py
@@ -1,0 +1,26 @@
+"""The Attribute as Sensor component."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+PLATFORMS = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Min/Max from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
+
+    return True
+
+
+async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update listener, called when the config entry options are changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/attribute_as_sensor/config_flow.py
+++ b/homeassistant/components/attribute_as_sensor/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     CONF_ATTRIBUTE,
     CONF_DEVICE_CLASS,
+    CONF_ENTITY_ID,
     CONF_ICON,
     CONF_NAME,
     TEMP_CELSIUS,
@@ -27,7 +28,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowMenuStep,
 )
 
-from .const import CONF_ENTITY_ID, DOMAIN
+from .const import DOMAIN
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/attribute_as_sensor/config_flow.py
+++ b/homeassistant/components/attribute_as_sensor/config_flow.py
@@ -1,0 +1,90 @@
+"""Config flow for Attribute as Sensor integration."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import (
+    CONF_STATE_CLASS,
+    CONF_UNIT_OF_MEASUREMENT,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    CONF_ATTRIBUTE,
+    CONF_DEVICE_CLASS,
+    CONF_ICON,
+    CONF_NAME,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
+from homeassistant.helpers import selector
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaConfigFlowHandler,
+    SchemaFlowFormStep,
+    SchemaFlowMenuStep,
+)
+
+from .const import CONF_ENTITY_ID, DOMAIN
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): selector.TextSelector(),
+        vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
+            selector.EntitySelectorConfig(multiple=False),
+        ),
+        vol.Optional(CONF_ICON): selector.IconSelector(),
+    }
+)
+
+
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
+            selector.SelectSelectorConfig(options=[e.value for e in SensorDeviceClass])
+        ),
+        vol.Optional(CONF_STATE_CLASS): selector.SelectSelector(
+            selector.SelectSelectorConfig(options=[e.value for e in SensorStateClass])
+        ),
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.SelectSelectorConfig(
+            options=[TEMP_CELSIUS, TEMP_FAHRENHEIT],
+            custom_value=True,
+            mode=selector.SelectSelectorMode.DROPDOWN,
+        ),
+    }
+)
+
+
+def attribute_schema(
+    handler: SchemaConfigFlowHandler, user_input: dict[str, Any]
+) -> vol.Schema:
+    """Return schema for selecting attribute for entity."""
+    return vol.Schema(
+        {
+            vol.Optional(CONF_ATTRIBUTE): selector.AttributeSelector(
+                selector.AttributeSelectorConfig(entity_id=user_input[CONF_ENTITY_ID])
+            ),
+        }
+    ).extend(OPTIONS_SCHEMA.schema)
+
+
+CONFIG_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
+    "user": SchemaFlowFormStep(CONFIG_SCHEMA, next_step=lambda _: "attr"),
+    "attr": SchemaFlowFormStep(attribute_schema),
+}
+OPTIONS_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
+    "init": SchemaFlowFormStep(OPTIONS_SCHEMA)
+}
+
+
+class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config or options flow for Attribute as Entity."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return cast(str, options["name"]) if "name" in options else ""

--- a/homeassistant/components/attribute_as_sensor/config_flow.py
+++ b/homeassistant/components/attribute_as_sensor/config_flow.py
@@ -9,8 +9,8 @@ import voluptuous as vol
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
     CONF_UNIT_OF_MEASUREMENT,
-    SensorDeviceClass,
-    SensorStateClass,
+    DEVICE_CLASSES,
+    STATE_CLASSES,
 )
 from homeassistant.const import (
     CONF_ATTRIBUTE,
@@ -39,19 +39,23 @@ CONFIG_SCHEMA = vol.Schema(
     }
 )
 
-
 OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
-            selector.SelectSelectorConfig(options=[e.value for e in SensorDeviceClass])
+            selector.SelectSelectorConfig(
+                options=DEVICE_CLASSES, mode=selector.SelectSelectorMode.DROPDOWN
+            )
         ),
         vol.Optional(CONF_STATE_CLASS): selector.SelectSelector(
-            selector.SelectSelectorConfig(options=[e.value for e in SensorStateClass])
+            selector.SelectSelectorConfig(
+                options=STATE_CLASSES, mode=selector.SelectSelectorMode.DROPDOWN
+            )
         ),
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.SelectSelectorConfig(
-            options=[TEMP_CELSIUS, TEMP_FAHRENHEIT],
-            custom_value=True,
-            mode=selector.SelectSelectorMode.DROPDOWN,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[TEMP_CELSIUS, TEMP_FAHRENHEIT],
+                custom_value=True,
+            )
         ),
     }
 )

--- a/homeassistant/components/attribute_as_sensor/const.py
+++ b/homeassistant/components/attribute_as_sensor/const.py
@@ -1,5 +1,3 @@
 """Constants for the Attribute as Sensor integration."""
 
 DOMAIN = "attribute_as_sensor"
-
-CONF_ENTITY_ID = "entity_id"

--- a/homeassistant/components/attribute_as_sensor/const.py
+++ b/homeassistant/components/attribute_as_sensor/const.py
@@ -1,0 +1,5 @@
+"""Constants for the Attribute as Sensor integration."""
+
+DOMAIN = "attribute_as_sensor"
+
+CONF_ENTITY_ID = "entity_id"

--- a/homeassistant/components/attribute_as_sensor/manifest.json
+++ b/homeassistant/components/attribute_as_sensor/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "attribute_as_sensor",
+  "integration_type": "helper",
+  "name": "Attribute as Sensor",
+  "documentation": "https://www.home-assistant.io/integrations/attribute_as_sensor",
+  "codeowners": ["@gjohansson-ST"],
+  "quality_scale": "internal",
+  "iot_class": "local_push",
+  "config_flow": true
+}

--- a/homeassistant/components/attribute_as_sensor/sensor.py
+++ b/homeassistant/components/attribute_as_sensor/sensor.py
@@ -90,14 +90,14 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the sensor."""
-    entity_id = config[CONF_ENTITY_ID]
-    name = config[CONF_NAME]
-    attribute = config[CONF_ATTRIBUTE]
-    unique_id = config.get(CONF_UNIQUE_ID)
-    icon = config.get(CONF_ICON)
-    device_class = config.get(CONF_DEVICE_CLASS)
-    state_class = config.get(CONF_STATE_CLASS)
-    uom = config.get(CONF_UNIT_OF_MEASUREMENT)
+    entity_id: str = config[CONF_ENTITY_ID]
+    name: str = config[CONF_NAME]
+    attribute: str = config[CONF_ATTRIBUTE]
+    unique_id: str | None = config.get(CONF_UNIQUE_ID)
+    icon: str | None = config.get(CONF_ICON)
+    device_class: str | None = config.get(CONF_DEVICE_CLASS)
+    state_class: str | None = config.get(CONF_STATE_CLASS)
+    uom: str | None = config.get(CONF_UNIT_OF_MEASUREMENT)
 
     await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
 
@@ -105,7 +105,7 @@ async def async_setup_platform(
         [
             AttributeSensor(
                 entity_id,
-                attribute,
+                attribute.lower(),
                 icon,
                 device_class,
                 state_class,

--- a/homeassistant/components/attribute_as_sensor/sensor.py
+++ b/homeassistant/components/attribute_as_sensor/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ATTRIBUTE,
     CONF_DEVICE_CLASS,
+    CONF_ENTITY_ID,
     CONF_ICON,
     CONF_NAME,
     CONF_UNIQUE_ID,
@@ -33,7 +34,7 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import PLATFORMS
-from .const import CONF_ENTITY_ID, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
-        vol.Required(CONF_ATTRIBUTE, "attribute"): cv.string,
+        vol.Required(CONF_ATTRIBUTE): cv.string,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Optional(CONF_ICON): cv.icon,
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,

--- a/homeassistant/components/attribute_as_sensor/sensor.py
+++ b/homeassistant/components/attribute_as_sensor/sensor.py
@@ -1,0 +1,192 @@
+"""Support for displaying attributes as Sensor."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import (
+    CONF_STATE_CLASS,
+    DEVICE_CLASSES_SCHEMA,
+    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
+    STATE_CLASSES_SCHEMA,
+    SensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ATTRIBUTE,
+    CONF_DEVICE_CLASS,
+    CONF_ICON,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    CONF_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import Event, HomeAssistant, State, callback
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.reload import async_setup_reload_service
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from . import PLATFORMS
+from .const import CONF_ENTITY_ID, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ATTRIBUTE, "attribute"): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_ICON): cv.icon,
+        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+    }
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize config entry."""
+    registry = er.async_get(hass)
+    entity_id = er.async_validate_entity_id(
+        registry, config_entry.options[CONF_ENTITY_ID]
+    )
+    attribute = config_entry.options[CONF_ATTRIBUTE]
+    icon = config_entry.options.get(CONF_ICON)
+    device_class = config_entry.options.get(CONF_DEVICE_CLASS)
+    state_class = config_entry.options.get(CONF_STATE_CLASS)
+    uom = config_entry.options.get(CONF_UNIT_OF_MEASUREMENT)
+
+    async_add_entities(
+        [
+            AttributeSensor(
+                entity_id,
+                attribute,
+                icon,
+                device_class,
+                state_class,
+                uom,
+                config_entry.title,
+                config_entry.entry_id,
+            )
+        ]
+    )
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the sensor."""
+    entity_id = config[CONF_ENTITY_ID]
+    name = config[CONF_NAME]
+    attribute = config[CONF_ATTRIBUTE]
+    unique_id = config.get(CONF_UNIQUE_ID)
+    icon = config.get(CONF_ICON)
+    device_class = config.get(CONF_DEVICE_CLASS)
+    state_class = config.get(CONF_STATE_CLASS)
+    uom = config.get(CONF_UNIT_OF_MEASUREMENT)
+
+    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
+
+    async_add_entities(
+        [
+            AttributeSensor(
+                entity_id,
+                attribute,
+                icon,
+                device_class,
+                state_class,
+                uom,
+                name,
+                unique_id,
+            )
+        ]
+    )
+
+
+class AttributeSensor(SensorEntity):
+    """Representation of an Attribute as Sensor sensor."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        entity_id: str,
+        attribute: str,
+        icon: str | None,
+        device_class: str | None,
+        state_class: str | None,
+        uom: str | None,
+        name: str,
+        unique_id: str | None,
+    ) -> None:
+        """Initialize the sensor."""
+        self._attr_unique_id = unique_id
+        self._entity_id = entity_id
+        self._attribute = attribute
+        self._attr_name = name
+
+        self._attr_device_class = device_class
+        self._attr_icon = icon
+        self._attr_native_unit_of_measurement = uom
+        self._attr_state_class = state_class
+
+    async def async_added_to_hass(self) -> None:
+        """Handle added to Hass."""
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, self._entity_id, self._async_attribute_sensor_state_listener
+            )
+        )
+
+        # Replay current state of source entities
+        state = self.hass.states.get(self._entity_id)
+        state_event = Event("", {"entity_id": self._entity_id, "new_state": state})
+        self._async_attribute_sensor_state_listener(state_event, update_state=False)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes of the sensor."""
+        return {ATTR_ENTITY_ID: self._entity_id}
+
+    @callback
+    def _async_attribute_sensor_state_listener(
+        self, event: Event, update_state: bool = True
+    ) -> None:
+        """Handle the sensor state changes."""
+        new_state: State | None = event.data.get("new_state")
+        # entity: str | None = event.data["entity_id"]
+
+        if (
+            new_state is None
+            or new_state.state is None
+            or new_state.state == STATE_UNAVAILABLE
+        ):
+            self._attr_native_value = STATE_UNKNOWN
+            if not update_state:
+                return
+
+        self._attr_native_value = STATE_UNKNOWN
+
+        if (
+            new_state
+            and new_state.attributes
+            and (value := new_state.attributes.get(self._attribute))
+        ):
+            self._attr_native_value = value
+
+        self.async_write_ha_state()
+        return

--- a/homeassistant/components/attribute_as_sensor/services.yaml
+++ b/homeassistant/components/attribute_as_sensor/services.yaml
@@ -1,0 +1,3 @@
+reload:
+  name: Reload
+  description: Reload all attribute as Sensor entities.

--- a/homeassistant/components/attribute_as_sensor/strings.json
+++ b/homeassistant/components/attribute_as_sensor/strings.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Add Attribute as Sensor",
-        "description": "Create a sensor that derive it's value from an attribute of another entity.",
+        "description": "Create a sensor that derives its value from an attribute of another entity.",
         "data": {
           "entity_id": "Input entities",
           "name": "Name",

--- a/homeassistant/components/attribute_as_sensor/strings.json
+++ b/homeassistant/components/attribute_as_sensor/strings.json
@@ -1,0 +1,42 @@
+{
+  "title": "Attribute as Sensor",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Add Attribute as Sensor",
+        "description": "Create a sensor that derives it's value from an attribute from another entity.",
+        "data": {
+          "entity_id": "Input entities",
+          "name": "Name",
+          "icon": "Icon"
+        }
+      },
+      "attr": {
+        "data": {
+          "attribute": "Attribute",
+          "device_class": "Device Class",
+          "state_class": "State Class",
+          "unit_of_measurement": "Unit of Measurement"
+        },
+        "data_description": {
+          "attribute": "Select the Attribute from the entity that you like to get as sensor.",
+          "unit_of_measurement": "Select an unit of measurement or add your own custom UoM"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "device_class": "[%key:component::attribute_as_sensor::config::step::attr::data::device_class%]",
+          "state_class": "[%key:component::attribute_as_sensor::config::step::attr::data::state_class%]",
+          "unit_of_measurement": "[%key:component::attribute_as_sensor::config::step::attr::data::unit_of_measurement%]"
+        },
+        "data_description": {
+          "unit_of_measurement": "[%key:component::attribute_as_sensor::config::step::attr::data_description::unit_of_measurement%]"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/attribute_as_sensor/strings.json
+++ b/homeassistant/components/attribute_as_sensor/strings.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Add Attribute as Sensor",
-        "description": "Create a sensor that derives it's value from an attribute from another entity.",
+        "description": "Create a sensor that derive it's value from an attribute of another entity.",
         "data": {
           "entity_id": "Input entities",
           "name": "Name",
@@ -19,8 +19,8 @@
           "unit_of_measurement": "Unit of Measurement"
         },
         "data_description": {
-          "attribute": "Select the Attribute from the entity that you like to get as sensor.",
-          "unit_of_measurement": "Select an unit of measurement or add your own custom UoM"
+          "attribute": "Select the attribute that you would like to use as a sensor.",
+          "unit_of_measurement": "Select a pre-defined unit of measurement or customize your own."
         }
       }
     }

--- a/homeassistant/components/attribute_as_sensor/translations/en.json
+++ b/homeassistant/components/attribute_as_sensor/translations/en.json
@@ -1,0 +1,42 @@
+{
+    "config": {
+        "step": {
+            "attr": {
+                "data": {
+                    "attribute": "Attribute",
+                    "device_class": "Device Class",
+                    "state_class": "State Class",
+                    "unit_of_measurement": "Unit of Measurement"
+                },
+                "data_description": {
+                    "attribute": "Select the Attribute from the entity that you like to get as sensor.",
+                    "unit_of_measurement": "Select an unit of measurement or add your own custom UoM"
+                }
+            },
+            "user": {
+                "data": {
+                    "entity_id": "Input entities",
+                    "icon": "Icon",
+                    "name": "Name"
+                },
+                "description": "Create a sensor that derives it's value from an attribute from another entity.",
+                "title": "Add Attribute as Sensor"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "device_class": "Device Class",
+                    "state_class": "State Class",
+                    "unit_of_measurement": "Unit of Measurement"
+                },
+                "data_description": {
+                    "unit_of_measurement": "Select an unit of measurement or add your own custom UoM"
+                }
+            }
+        }
+    },
+    "title": "Attribute as Sensor"
+}

--- a/homeassistant/components/attribute_as_sensor/translations/en.json
+++ b/homeassistant/components/attribute_as_sensor/translations/en.json
@@ -9,8 +9,8 @@
                     "unit_of_measurement": "Unit of Measurement"
                 },
                 "data_description": {
-                    "attribute": "Select the Attribute from the entity that you like to get as sensor.",
-                    "unit_of_measurement": "Select an unit of measurement or add your own custom UoM"
+                    "attribute": "Select the attribute that you would like to use as a sensor.",
+                    "unit_of_measurement": "Select a pre-defined unit of measurement or customize your own."
                 }
             },
             "user": {
@@ -19,7 +19,7 @@
                     "icon": "Icon",
                     "name": "Name"
                 },
-                "description": "Create a sensor that derives it's value from an attribute from another entity.",
+                "description": "Create a sensor that derive it's value from an attribute of another entity.",
                 "title": "Add Attribute as Sensor"
             }
         }
@@ -33,7 +33,7 @@
                     "unit_of_measurement": "Unit of Measurement"
                 },
                 "data_description": {
-                    "unit_of_measurement": "Select an unit of measurement or add your own custom UoM"
+                    "unit_of_measurement": "Select a pre-defined unit of measurement or customize your own."
                 }
             }
         }

--- a/homeassistant/components/attribute_as_sensor/translations/en.json
+++ b/homeassistant/components/attribute_as_sensor/translations/en.json
@@ -19,7 +19,7 @@
                     "icon": "Icon",
                     "name": "Name"
                 },
-                "description": "Create a sensor that derive it's value from an attribute of another entity.",
+                "description": "Create a sensor that derives its value from an attribute of another entity.",
                 "title": "Add Attribute as Sensor"
             }
         }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -465,6 +465,7 @@ FLOWS = {
         "zwave_me",
     ],
     "helper": [
+        "attribute_as_sensor",
         "derivative",
         "group",
         "integration",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5117,6 +5117,10 @@
     }
   },
   "helper": {
+    "attribute_as_sensor": {
+      "config_flow": true,
+      "iot_class": "local_push"
+    },
     "counter": {
       "config_flow": false,
       "iot_class": null,
@@ -5190,6 +5194,7 @@
     }
   },
   "translated_name": [
+    "attribute_as_sensor",
     "aurora",
     "cert_expiry",
     "cpuspeed",

--- a/tests/components/attribute_as_sensor/__init__.py
+++ b/tests/components/attribute_as_sensor/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Attribute as Sensor component."""

--- a/tests/components/attribute_as_sensor/fixtures/configuration.yaml
+++ b/tests/components/attribute_as_sensor/fixtures/configuration.yaml
@@ -1,0 +1,10 @@
+sensor:
+  - platform: attribute_as_sensor
+    entity_id: sensor.test_1
+    name: second_test
+    icon: mdi:test-icon
+    attribute: test_attribute
+    device_class: temperature
+    state_class: measurement
+    unit_of_measurement: °C
+    unique_id: very_unique_id

--- a/tests/components/attribute_as_sensor/test_config_flow.py
+++ b/tests/components/attribute_as_sensor/test_config_flow.py
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize("platform", ("sensor",))
-async def test_config_flow(hass: HomeAssistant, platform) -> None:
+async def test_config_flow(hass: HomeAssistant, platform: str) -> None:
     """Test the config flow."""
     input_sensor = "sensor.input_one"
 
@@ -80,19 +80,8 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
     assert config_entry.title == "My attribute_as_sensor"
 
 
-def get_suggested(schema, key):
-    """Get suggested value for key in voluptuous schema."""
-    for k in schema.keys():
-        if k == key:
-            if k.description is None or "suggested_value" not in k.description:
-                return None
-            return k.description["suggested_value"]
-    # Wanted key absent from schema
-    raise Exception
-
-
 @pytest.mark.parametrize("platform", ("sensor",))
-async def test_options(hass: HomeAssistant, platform) -> None:
+async def test_options(hass: HomeAssistant, platform: str) -> None:
     """Test reconfiguring."""
     hass.states.async_set("sensor.input_one", "10", attributes={"test_attribute": 20})
 

--- a/tests/components/attribute_as_sensor/test_config_flow.py
+++ b/tests/components/attribute_as_sensor/test_config_flow.py
@@ -1,0 +1,164 @@
+"""Test the Attribute as Sensor config flow."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.attribute_as_sensor.const import DOMAIN
+from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.util.unit_conversion import TemperatureConverter
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize("platform", ("sensor",))
+async def test_config_flow(hass: HomeAssistant, platform) -> None:
+    """Test the config flow."""
+    input_sensor = "sensor.input_one"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.attribute_as_sensor.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "name": "My attribute_as_sensor",
+                "entity_id": input_sensor,
+                "icon": "mdi:test-icon",
+            },
+        )
+
+        await hass.async_block_till_done()
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "attr"
+        assert result["errors"] is None
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "attribute": "test_attribute",
+                "device_class": "speed",
+                "state_class": "measurement",
+                "unit_of_measurement": "m/s",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "My attribute_as_sensor"
+    assert result2["data"] == {}
+    assert result2["options"] == {
+        "entity_id": input_sensor,
+        "name": "My attribute_as_sensor",
+        "icon": "mdi:test-icon",
+        "attribute": "test_attribute",
+        "device_class": "speed",
+        "state_class": "measurement",
+        "unit_of_measurement": "m/s",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        "entity_id": input_sensor,
+        "name": "My attribute_as_sensor",
+        "icon": "mdi:test-icon",
+        "attribute": "test_attribute",
+        "device_class": "speed",
+        "state_class": "measurement",
+        "unit_of_measurement": "m/s",
+    }
+    assert config_entry.title == "My attribute_as_sensor"
+
+
+def get_suggested(schema, key):
+    """Get suggested value for key in voluptuous schema."""
+    for k in schema.keys():
+        if k == key:
+            if k.description is None or "suggested_value" not in k.description:
+                return None
+            return k.description["suggested_value"]
+    # Wanted key absent from schema
+    raise Exception
+
+
+@pytest.mark.parametrize("platform", ("sensor",))
+async def test_options(hass: HomeAssistant, platform) -> None:
+    """Test reconfiguring."""
+    hass.states.async_set("sensor.input_one", "10", attributes={"test_attribute": 20})
+
+    input_sensor = "sensor.input_one"
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "entity_id": input_sensor,
+            "name": "My attribute_as_sensor",
+            "icon": "mdi:test-icon",
+            "attribute": "test_attribute",
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "unit_of_measurement": "°C",
+        },
+        title="My attribute_as_sensor",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "unit_of_measurement": "°F",
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        "entity_id": input_sensor,
+        "name": "My attribute_as_sensor",
+        "icon": "mdi:test-icon",
+        "attribute": "test_attribute",
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "unit_of_measurement": "°F",
+    }
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        "entity_id": input_sensor,
+        "name": "My attribute_as_sensor",
+        "icon": "mdi:test-icon",
+        "attribute": "test_attribute",
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "unit_of_measurement": "°F",
+    }
+    assert config_entry.title == "My attribute_as_sensor"
+
+    # Check config entry is reloaded with new options
+    await hass.async_block_till_done()
+
+    # Check the entity was updated, no new entity was created
+    assert len(hass.states.async_all()) == 2
+
+    # Check the state of the entity has changed as expected
+    state = hass.states.get(f"{platform}.my_attribute_as_sensor")
+    metric_state = TemperatureConverter.convert(20, TEMP_FAHRENHEIT, TEMP_CELSIUS)
+    assert state.state == str(round(metric_state))
+    assert state.attributes["entity_id"] == "sensor.input_one"

--- a/tests/components/attribute_as_sensor/test_sensor.py
+++ b/tests/components/attribute_as_sensor/test_sensor.py
@@ -1,0 +1,135 @@
+"""The test for the Attribute as Sensor sensor platform."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant import config as hass_config
+from homeassistant.components.attribute_as_sensor.const import DOMAIN
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
+    SERVICE_RELOAD,
+    STATE_UNKNOWN,
+    TEMP_CELSIUS,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import get_fixture_path
+
+
+async def test_attribute_as_sensor(hass: HomeAssistant):
+    """Test the sensor."""
+    config = {
+        "sensor": {
+            "platform": "attribute_as_sensor",
+            "name": "test_sensor",
+            "entity_id": "sensor.test_1",
+            "icon": "mdi:test-icon",
+            "attribute": "test_attribute",
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "unit_of_measurement": "°C",
+            "unique_id": "very_unique_id",
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    entity_id = config["sensor"]["entity_id"]
+    hass.states.async_set(entity_id, 10, {"test_attribute": 20})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_sensor")
+
+    assert state.state == "20"
+    assert state.attributes.get("entity_id") == "sensor.test_1"
+    assert state.attributes.get(ATTR_ICON) == "mdi:test-icon"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
+
+
+async def test_attribute_as_sensor_missing_attribute(hass: HomeAssistant):
+    """Test the sensor with faulty attribute."""
+    config = {
+        "sensor": {
+            "platform": "attribute_as_sensor",
+            "name": "test_sensor",
+            "entity_id": "sensor.test_1",
+            "icon": "mdi:test-icon",
+            "attribute": "wrong_attribute",
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "unit_of_measurement": "°C",
+            "unique_id": "very_unique_id",
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    entity_id = config["sensor"]["entity_id"]
+    hass.states.async_set(entity_id, 10, {"test_attribute": 20})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_sensor")
+
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get("entity_id") == "sensor.test_1"
+    assert state.attributes.get(ATTR_ICON) == "mdi:test-icon"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
+
+
+async def test_reload(hass: HomeAssistant):
+    """Verify we can reload filter sensors."""
+    hass.states.async_set("sensor.test_1", 10, {"test_attribute": 20})
+
+    await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": {
+                "platform": "attribute_as_sensor",
+                "name": "test_sensor",
+                "entity_id": "sensor.test_1",
+                "icon": "mdi:test-icon",
+                "attribute": "test_attribute",
+                "device_class": "temperature",
+                "state_class": "measurement",
+                "unit_of_measurement": "°C",
+                "unique_id": "very_unique_id",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 2
+
+    assert hass.states.get("sensor.test_sensor")
+
+    yaml_path = get_fixture_path("configuration.yaml", "attribute_as_sensor")
+
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 2
+
+    state = hass.states.get("sensor.test_sensor")
+    assert state
+    assert state.state == "20"

--- a/tests/components/attribute_as_sensor/test_sensor.py
+++ b/tests/components/attribute_as_sensor/test_sensor.py
@@ -24,7 +24,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import get_fixture_path
 
 
-async def test_attribute_as_sensor(hass: HomeAssistant):
+async def test_attribute_as_sensor(hass: HomeAssistant) -> None:
     """Test the sensor."""
     config = {
         "sensor": {
@@ -57,7 +57,7 @@ async def test_attribute_as_sensor(hass: HomeAssistant):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
 
 
-async def test_attribute_as_sensor_missing_attribute(hass: HomeAssistant):
+async def test_attribute_as_sensor_missing_attribute(hass: HomeAssistant) -> None:
     """Test the sensor with faulty attribute."""
     config = {
         "sensor": {
@@ -90,7 +90,7 @@ async def test_attribute_as_sensor_missing_attribute(hass: HomeAssistant):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
 
 
-async def test_reload(hass: HomeAssistant):
+async def test_reload(hass: HomeAssistant) -> None:
     """Verify we can reload filter sensors."""
     hass.states.async_set("sensor.test_1", 10, {"test_attribute": 20})
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a very simple helper to set another entities attribute as sensor.
Could potentially expand this in second step to also support binary_sensor

Also mentioned here in the community forums https://community.home-assistant.io/t/wth-are-attributes-such-a-pain-to-work-with/467837 and https://community.home-assistant.io/t/new-helper-entity-from-attribute/461078/5

Would like acceptance on this before proceeding to make PR's in the other repo's.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24583

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
