### PR TITLE
Powerview refactor prep for all shade types

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -19,7 +19,6 @@ from aiopvapi.resources.shade import (
     MAX_POSITION,
     MIN_POSITION,
     BaseShade,
-    ShadeTopDownBottomUp,
     factory as PvShade,
 )
 import async_timeout
@@ -117,16 +116,20 @@ def create_powerview_shade_entity(
     """Create a PowerViewShade entity."""
 
     classes: list[BaseShade] = []
-    if isinstance(shade, ShadeTopDownBottomUp):
+
+    if shade.capability.type == 1:
+        classes.append(PowerViewShadeWithTiltOnClosed)
+    elif shade.capability.type == 2:
+        classes.append(PowerViewShadeWithTiltAnywhere)
+    elif shade.capability.type == 4:
+        classes.append(PowerViewShadeWithTiltAnywhere)
+    elif shade.capability.type == 7:
         classes.extend([PowerViewShadeTDBUTop, PowerViewShadeTDBUBottom])
-    elif (  # this will be extended further in next release for more defined control
-        shade.capability.capabilities.tiltOnClosed
-        or shade.capability.capabilities.tiltAnywhere
-    ):
-        classes.append(PowerViewShadeWithTilt)
     else:
         classes.append(PowerViewShade)
+
     _LOGGER.debug("%s (%s) detected as %a", shade.name, shade.capability.type, classes)
+
     return [
         cls(coordinator, device_info, room_name, shade, name_before_refresh)
         for cls in classes
@@ -392,6 +395,185 @@ class PowerViewShade(PowerViewShadeBase):
         )
 
 
+class PowerViewShadeWithTiltBase(PowerViewShade):
+    """Representation for PowerView shades with tilt capabilities."""
+
+    def __init__(
+        self,
+        coordinator: PowerviewShadeUpdateCoordinator,
+        device_info: PowerviewDeviceInfo,
+        room_name: str,
+        shade: BaseShade,
+        name: str,
+    ) -> None:
+        """Initialize the shade."""
+        super().__init__(coordinator, device_info, room_name, shade, name)
+        self._attr_supported_features |= (
+            CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.SET_TILT_POSITION
+        )
+        if self._device_info.model != LEGACY_DEVICE_MODEL:
+            self._attr_supported_features |= CoverEntityFeature.STOP_TILT
+        self._max_tilt = self._shade.shade_limits.tilt_max
+
+    @property
+    def current_cover_tilt_position(self) -> int:
+        """Return the current cover tile position."""
+        return hd_position_to_hass(self.positions.vane, self._max_tilt)
+
+    @property
+    def transition_steps(self):
+        """Return the steps to make a move."""
+        return hd_position_to_hass(
+            self.positions.primary, MAX_POSITION
+        ) + hd_position_to_hass(self.positions.vane, self._max_tilt)
+
+    @property
+    def open_tilt_position(self) -> PowerviewShadeMove:
+        """Return the open tilt position and required additional positions."""
+        return PowerviewShadeMove(self._shade.open_position_tilt, {})
+
+    @property
+    def close_tilt_position(self) -> PowerviewShadeMove:
+        """Return the close tilt position and required additional positions."""
+        return PowerviewShadeMove(self._shade.close_position_tilt, {})
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        """Close the cover tilt."""
+        self._async_schedule_update_for_transition(self.transition_steps)
+        await self._async_execute_move(self.close_tilt_position)
+        self.async_write_ha_state()
+
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        """Open the cover tilt."""
+        self._async_schedule_update_for_transition(100 - self.transition_steps)
+        await self._async_execute_move(self.open_tilt_position)
+        self.async_write_ha_state()
+
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        """Move the vane to a specific position."""
+        await self._async_set_cover_tilt_position(kwargs[ATTR_TILT_POSITION])
+
+    async def _async_set_cover_tilt_position(
+        self, target_hass_tilt_position: int
+    ) -> None:
+        """Move the vane to a specific position."""
+        final_position = self.current_cover_position + target_hass_tilt_position
+        self._async_schedule_update_for_transition(
+            abs(self.transition_steps - final_position)
+        )
+        await self._async_execute_move(self._get_shade_tilt(target_hass_tilt_position))
+        self.async_write_ha_state()
+
+    @callback
+    def _get_shade_tilt(self, target_hass_tilt_position: int) -> PowerviewShadeMove:
+        """Return a PowerviewShadeMove."""
+        position_vane = hass_position_to_hd(target_hass_tilt_position, self._max_tilt)
+        return PowerviewShadeMove(
+            {ATTR_POSITION1: position_vane, ATTR_POSKIND1: POS_KIND_VANE}, {}
+        )
+
+    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+        """Stop the cover tilting."""
+        await self.async_stop_cover()
+
+
+class PowerViewShadeWithTiltOnClosed(PowerViewShadeWithTiltBase):
+    """Representation of a PowerView shade with tilt when closed capabilities.
+
+    API Class: ShadeBottomUpTiltOnClosed + ShadeBottomUpTiltOnClosed90
+
+    Type 1 - Bottom Up w/ 90° Tilt
+    Shade 44 - a shade thought to have been a firmware issue (type 0 usually dont tilt)
+    """
+
+    @property
+    def open_position(self) -> PowerviewShadeMove:
+        """Return the open position and required additional positions."""
+        return PowerviewShadeMove(
+            self._shade.open_position, {POS_KIND_VANE: MIN_POSITION}
+        )
+
+    @property
+    def close_position(self) -> PowerviewShadeMove:
+        """Return the close position and required additional positions."""
+        return PowerviewShadeMove(
+            self._shade.close_position, {POS_KIND_VANE: MIN_POSITION}
+        )
+
+    @property
+    def open_tilt_position(self) -> PowerviewShadeMove:
+        """Return the open tilt position and required additional positions."""
+        return PowerviewShadeMove(
+            self._shade.open_position_tilt, {POS_KIND_PRIMARY: MIN_POSITION}
+        )
+
+    @property
+    def close_tilt_position(self) -> PowerviewShadeMove:
+        """Return the close tilt position and required additional positions."""
+        return PowerviewShadeMove(
+            self._shade.close_position_tilt, {POS_KIND_PRIMARY: MIN_POSITION}
+        )
+
+    @callback
+    def _get_shade_move(self, target_hass_position: int) -> PowerviewShadeMove:
+        """Return a PowerviewShadeMove."""
+        position_shade = hass_position_to_hd(target_hass_position)
+        return PowerviewShadeMove(
+            {ATTR_POSITION1: position_shade, ATTR_POSKIND1: POS_KIND_PRIMARY},
+            {POS_KIND_VANE: MIN_POSITION},
+        )
+
+    @callback
+    def _get_shade_tilt(self, target_hass_tilt_position: int) -> PowerviewShadeMove:
+        """Return a PowerviewShadeMove."""
+        position_vane = hass_position_to_hd(target_hass_tilt_position, self._max_tilt)
+        return PowerviewShadeMove(
+            {ATTR_POSITION1: position_vane, ATTR_POSKIND1: POS_KIND_VANE},
+            {POS_KIND_PRIMARY: MIN_POSITION},
+        )
+
+
+class PowerViewShadeWithTiltAnywhere(PowerViewShadeWithTiltBase):
+    """Representation of a PowerView shade with tilt anywhere capabilities.
+
+    API Class: ShadeBottomUpTiltAnywhere, ShadeVerticalTiltAnywhere
+
+    Type 2 - Bottom Up w/ 180° Tilt
+    Type 4 - Vertical (Traversing) w/ 180° Tilt
+    """
+
+    @callback
+    def _get_shade_move(self, target_hass_position: int) -> PowerviewShadeMove:
+        position_shade = hass_position_to_hd(target_hass_position, MAX_POSITION)
+        position_vane = self.positions.vane
+        return PowerviewShadeMove(
+            {
+                ATTR_POSITION1: position_shade,
+                ATTR_POSITION2: position_vane,
+                ATTR_POSKIND1: POS_KIND_PRIMARY,
+                ATTR_POSKIND2: POS_KIND_VANE,
+            },
+            {},
+        )
+
+    @callback
+    def _get_shade_tilt(self, target_hass_tilt_position: int) -> PowerviewShadeMove:
+        """Return a PowerviewShadeMove."""
+        position_shade = self.positions.primary
+        position_vane = hass_position_to_hd(target_hass_tilt_position, self._max_tilt)
+        return PowerviewShadeMove(
+            {
+                ATTR_POSITION1: position_shade,
+                ATTR_POSITION2: position_vane,
+                ATTR_POSKIND1: POS_KIND_PRIMARY,
+                ATTR_POSKIND2: POS_KIND_VANE,
+            },
+            {},
+        )
+
+
 class PowerViewShadeDualRailBase(PowerViewShade):
     """Representation of a shade with top/down bottom/up capabilities.
 
@@ -526,119 +708,3 @@ class PowerViewShadeTDBUTop(PowerViewShadeDualRailBase):
             },
             {},
         )
-
-
-class PowerViewShadeWithTilt(PowerViewShade):
-    """Representation of a PowerView shade with tilt capabilities."""
-
-    def __init__(
-        self,
-        coordinator: PowerviewShadeUpdateCoordinator,
-        device_info: PowerviewDeviceInfo,
-        room_name: str,
-        shade: BaseShade,
-        name: str,
-    ) -> None:
-        """Initialize the shade."""
-        super().__init__(coordinator, device_info, room_name, shade, name)
-        self._attr_supported_features |= (
-            CoverEntityFeature.OPEN_TILT
-            | CoverEntityFeature.CLOSE_TILT
-            | CoverEntityFeature.SET_TILT_POSITION
-        )
-        if self._device_info.model != LEGACY_DEVICE_MODEL:
-            self._attr_supported_features |= CoverEntityFeature.STOP_TILT
-        self._max_tilt = self._shade.shade_limits.tilt_max
-
-    @property
-    def current_cover_tilt_position(self) -> int:
-        """Return the current cover tile position."""
-        return hd_position_to_hass(self.positions.vane, self._max_tilt)
-
-    @property
-    def transition_steps(self):
-        """Return the steps to make a move."""
-        return hd_position_to_hass(
-            self.positions.primary, MAX_POSITION
-        ) + hd_position_to_hass(self.positions.vane, self._max_tilt)
-
-    @property
-    def open_position(self) -> PowerviewShadeMove:
-        """Return the open position and required additional positions."""
-        return PowerviewShadeMove(
-            self._shade.open_position, {POS_KIND_VANE: MIN_POSITION}
-        )
-
-    @property
-    def close_position(self) -> PowerviewShadeMove:
-        """Return the close position and required additional positions."""
-        return PowerviewShadeMove(
-            self._shade.close_position, {POS_KIND_VANE: MIN_POSITION}
-        )
-
-    @property
-    def open_tilt_position(self) -> PowerviewShadeMove:
-        """Return the open tilt position and required additional positions."""
-        # next upstream api release to include self._shade.open_tilt_position
-        return PowerviewShadeMove(
-            {ATTR_POSKIND1: POS_KIND_VANE, ATTR_POSITION1: self._max_tilt},
-            {POS_KIND_PRIMARY: MIN_POSITION},
-        )
-
-    @property
-    def close_tilt_position(self) -> PowerviewShadeMove:
-        """Return the close tilt position and required additional positions."""
-        # next upstream api release to include self._shade.close_tilt_position
-        return PowerviewShadeMove(
-            {ATTR_POSKIND1: POS_KIND_VANE, ATTR_POSITION1: MIN_POSITION},
-            {POS_KIND_PRIMARY: MIN_POSITION},
-        )
-
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
-        """Close the cover tilt."""
-        self._async_schedule_update_for_transition(self.transition_steps)
-        await self._async_execute_move(self.close_tilt_position)
-        self.async_write_ha_state()
-
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
-        """Open the cover tilt."""
-        self._async_schedule_update_for_transition(100 - self.transition_steps)
-        await self._async_execute_move(self.open_tilt_position)
-        self.async_write_ha_state()
-
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
-        """Move the vane to a specific position."""
-        await self._async_set_cover_tilt_position(kwargs[ATTR_TILT_POSITION])
-
-    async def _async_set_cover_tilt_position(
-        self, target_hass_tilt_position: int
-    ) -> None:
-        """Move the vane to a specific position."""
-        final_position = self.current_cover_position + target_hass_tilt_position
-        self._async_schedule_update_for_transition(
-            abs(self.transition_steps - final_position)
-        )
-        await self._async_execute_move(self._get_shade_tilt(target_hass_tilt_position))
-        self.async_write_ha_state()
-
-    @callback
-    def _get_shade_move(self, target_hass_position: int) -> PowerviewShadeMove:
-        """Return a PowerviewShadeMove."""
-        position_shade = hass_position_to_hd(target_hass_position)
-        return PowerviewShadeMove(
-            {ATTR_POSITION1: position_shade, ATTR_POSKIND1: POS_KIND_PRIMARY},
-            {POS_KIND_VANE: MIN_POSITION},
-        )
-
-    @callback
-    def _get_shade_tilt(self, target_hass_tilt_position: int) -> PowerviewShadeMove:
-        """Return a PowerviewShadeMove."""
-        position_vane = hass_position_to_hd(target_hass_tilt_position, self._max_tilt)
-        return PowerviewShadeMove(
-            {ATTR_POSITION1: position_vane, ATTR_POSKIND1: POS_KIND_VANE},
-            {POS_KIND_PRIMARY: MIN_POSITION},
-        )
-
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
-        """Stop the cover tilting."""
-        await self.async_stop_cover()

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -12,15 +12,12 @@ from aiopvapi.helpers.constants import (
     ATTR_POSITION1,
     ATTR_POSITION2,
     ATTR_POSITION_DATA,
-)
-from aiopvapi.resources.shade import (
     ATTR_POSKIND1,
     ATTR_POSKIND2,
     MAX_POSITION,
     MIN_POSITION,
-    BaseShade,
-    factory as PvShade,
 )
+from aiopvapi.resources.shade import BaseShade, factory as PvShade
 import async_timeout
 
 from homeassistant.components.cover import (

--- a/homeassistant/components/hunterdouglas_powerview/manifest.json
+++ b/homeassistant/components/hunterdouglas_powerview/manifest.json
@@ -2,7 +2,7 @@
   "domain": "hunterdouglas_powerview",
   "name": "Hunter Douglas PowerView",
   "documentation": "https://www.home-assistant.io/integrations/hunterdouglas_powerview",
-  "requirements": ["aiopvapi==2.0.2"],
+  "requirements": ["aiopvapi==2.0.3"],
   "codeowners": ["@bdraco", "@kingy444", "@trullock"],
   "config_flow": true,
   "homekit": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -229,7 +229,7 @@ aioopenexchangerates==0.4.0
 aiopulse==0.4.3
 
 # homeassistant.components.hunterdouglas_powerview
-aiopvapi==2.0.2
+aiopvapi==2.0.3
 
 # homeassistant.components.pvpc_hourly_pricing
 aiopvpc==3.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -204,7 +204,7 @@ aioopenexchangerates==0.4.0
 aiopulse==0.4.3
 
 # homeassistant.components.hunterdouglas_powerview
-aiopvapi==2.0.2
+aiopvapi==2.0.3
 
 # homeassistant.components.pvpc_hourly_pricing
 aiopvpc==3.0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Breaking out the TiltOnClosed and TiltAnywhere functionality for more streamlined control.
This also lays the groundwork for adding all shade types to the plugin (incoming PR 😄 )
Bump to api to support this groundwork included (this PR needs the updated API to function correctly)
https://github.com/sander76/aio-powerview-api/releases/tag/v2.0.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
