### PR TITLE
Use value_fn in WLED number

### DIFF
--- a/homeassistant/components/wled/number.py
+++ b/homeassistant/components/wled/number.py
@@ -1,7 +1,11 @@
 """Support for LED numbers."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from functools import partial
+
+from wled import Segment
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -35,8 +39,20 @@ async def async_setup_entry(
     update_segments()
 
 
+@dataclass
+class WLEDNumberDescriptionMixin:
+    """Mixin for WLED number."""
+
+    value_fn: Callable[[Segment], float | None]
+
+
+@dataclass
+class WLEDNumberEntityDescription(NumberEntityDescription, WLEDNumberDescriptionMixin):
+    """Class describing WLED number entities."""
+
+
 NUMBERS = [
-    NumberEntityDescription(
+    WLEDNumberEntityDescription(
         key=ATTR_SPEED,
         name="Speed",
         icon="mdi:speedometer",
@@ -44,14 +60,16 @@ NUMBERS = [
         native_step=1,
         native_min_value=0,
         native_max_value=255,
+        value_fn=lambda segment: segment.speed,
     ),
-    NumberEntityDescription(
+    WLEDNumberEntityDescription(
         key=ATTR_INTENSITY,
         name="Intensity",
         entity_category=EntityCategory.CONFIG,
         native_step=1,
         native_min_value=0,
         native_max_value=255,
+        value_fn=lambda segment: segment.intensity,
     ),
 ]
 
@@ -59,11 +77,13 @@ NUMBERS = [
 class WLEDNumber(WLEDEntity, NumberEntity):
     """Defines a WLED speed number."""
 
+    entity_description: WLEDNumberEntityDescription
+
     def __init__(
         self,
         coordinator: WLEDDataUpdateCoordinator,
         segment: int,
-        description: NumberEntityDescription,
+        description: WLEDNumberEntityDescription,
     ) -> None:
         """Initialize WLED ."""
         super().__init__(coordinator=coordinator)
@@ -92,9 +112,8 @@ class WLEDNumber(WLEDEntity, NumberEntity):
     @property
     def native_value(self) -> float | None:
         """Return the current WLED segment number value."""
-        return getattr(  # type: ignore[no-any-return]
-            self.coordinator.data.state.segments[self._segment],
-            self.entity_description.key,
+        return self.entity_description.value_fn(
+            self.coordinator.data.state.segments[self._segment]
         )
 
     @wled_exception_handler


### PR DESCRIPTION
## Proposed change
Replace `getattr` with a custom `value_fn` to enable better type checking.
Followup to: https://github.com/home-assistant/core/pull/79822#pullrequestreview-1135207224

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
