### PR TITLE
Convert darksky unittest tests to pytest

### DIFF
--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -150,7 +150,6 @@ async def test_setup(hass, requests_mock):
         assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
         await hass.async_block_till_done()
 
-        assert mock_get_forecast.called
         assert mock_get_forecast.call_count == 1
         assert len(hass.states.async_entity_ids()) == 13
 

--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -1,17 +1,13 @@
 """The tests for the Dark Sky platform."""
 from datetime import timedelta
 import re
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import forecastio
-from requests.exceptions import HTTPError
-import requests_mock
 
-from homeassistant.components.darksky import sensor as darksky
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant, load_fixture
+from tests.common import load_fixture
 
 VALID_CONFIG_MINIMAL = {
     "sensor": {
@@ -86,123 +82,100 @@ def load_forecastMock(key, lat, lon, units, lang):  # pylint: disable=invalid-na
     return ""
 
 
-class TestDarkSkySetup(unittest.TestCase):
-    """Test the Dark Sky platform."""
+async def test_setup_with_config(hass, requests_mock):
+    """Test the platform setup with configuration."""
+    with patch("homeassistant.components.darksky.sensor.forecastio.load_forecast"):
+        assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
+        await hass.async_block_till_done()
 
-    def add_entities(self, new_entities, update_before_add=False):
-        """Mock add entities."""
-        if update_before_add:
-            for entity in new_entities:
-                entity.update()
-
-        for entity in new_entities:
-            self.entities.append(entity)
-
-    def setUp(self):
-        """Initialize values for this testcase class."""
-        self.hass = get_test_home_assistant()
-        self.key = "foo"
-        self.lat = self.hass.config.latitude = 37.8267
-        self.lon = self.hass.config.longitude = -122.423
-        self.entities = []
-        self.addCleanup(self.tear_down_cleanup)
-
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    @patch(
-        "homeassistant.components.darksky.sensor.forecastio.load_forecast",
-        new=load_forecastMock,
-    )
-    def test_setup_with_config(self):
-        """Test the platform setup with configuration."""
-        setup_component(self.hass, "sensor", VALID_CONFIG_MINIMAL)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("sensor.dark_sky_summary")
+        state = hass.states.get("sensor.dark_sky_summary")
         assert state is not None
 
-    def test_setup_with_invalid_config(self):
-        """Test the platform setup with invalid configuration."""
-        setup_component(self.hass, "sensor", INVALID_CONFIG_MINIMAL)
-        self.hass.block_till_done()
 
-        state = self.hass.states.get("sensor.dark_sky_summary")
-        assert state is None
+async def test_setup_with_invalid_config(hass):
+    """Test the platform setup with invalid configuration."""
+    assert await async_setup_component(hass, "sensor", INVALID_CONFIG_MINIMAL)
+    await hass.async_block_till_done()
 
-    @patch(
-        "homeassistant.components.darksky.sensor.forecastio.load_forecast",
-        new=load_forecastMock,
-    )
-    def test_setup_with_language_config(self):
-        """Test the platform setup with language configuration."""
-        setup_component(self.hass, "sensor", VALID_CONFIG_LANG_DE)
-        self.hass.block_till_done()
+    state = hass.states.get("sensor.dark_sky_summary")
+    assert state is None
 
-        state = self.hass.states.get("sensor.dark_sky_summary")
+
+async def test_setup_with_language_config(hass):
+    """Test the platform setup with language configuration."""
+    with patch("homeassistant.components.darksky.sensor.forecastio.load_forecast"):
+        assert await async_setup_component(hass, "sensor", VALID_CONFIG_LANG_DE)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.dark_sky_summary")
         assert state is not None
 
-    def test_setup_with_invalid_language_config(self):
-        """Test the platform setup with language configuration."""
-        setup_component(self.hass, "sensor", INVALID_CONFIG_LANG)
-        self.hass.block_till_done()
 
-        state = self.hass.states.get("sensor.dark_sky_summary")
-        assert state is None
+async def test_setup_with_invalid_language_config(hass):
+    """Test the platform setup with language configuration."""
+    assert await async_setup_component(hass, "sensor", INVALID_CONFIG_LANG)
+    await hass.async_block_till_done()
 
-    @patch("forecastio.api.get_forecast")
-    def test_setup_bad_api_key(self, mock_get_forecast):
-        """Test for handling a bad API key."""
-        # The Dark Sky API wrapper that we use raises an HTTP error
-        # when you try to use a bad (or no) API key.
-        url = "https://api.darksky.net/forecast/{}/{},{}?units=auto".format(
-            self.key, str(self.lat), str(self.lon)
-        )
-        msg = f"400 Client Error: Bad Request for url: {url}"
-        mock_get_forecast.side_effect = HTTPError(msg)
+    state = hass.states.get("sensor.dark_sky_summary")
+    assert state is None
 
-        response = darksky.setup_platform(
-            self.hass, VALID_CONFIG_MINIMAL["sensor"], MagicMock()
-        )
-        assert not response
 
-    @patch(
+async def test_setup_bad_api_key(hass, requests_mock):
+    """Test for handling a bad API key."""
+    # The Dark Sky API wrapper that we use raises an HTTP error
+    # when you try to use a bad (or no) API key.
+    url = "https://api.darksky.net/forecast/{}/{},{}?units=auto".format(
+        "foo", str(hass.config.latitude), str(hass.config.longitude)
+    )
+    msg = f"400 Client Error: Bad Request for url: {url}"
+    requests_mock.get(url, text=msg, status_code=400)
+
+    assert await async_setup_component(
+        hass, "sensor", {"sensor": {"platform": "darksky", "api_key": "foo"}}
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.dark_sky_summary") is None
+
+
+async def test_setup_with_alerts_config(hass):
+    """Test the platform setup with configuration."""
+    with patch(
         "homeassistant.components.darksky.sensor.forecastio.load_forecast",
         new=load_forecastMock,
-    )
-    def test_setup_with_alerts_config(self):
-        """Test the platform setup with alert configuration."""
-        setup_component(self.hass, "sensor", VALID_CONFIG_ALERTS)
-        self.hass.block_till_done()
+    ):
+        await async_setup_component(hass, "sensor", VALID_CONFIG_ALERTS)
+        await hass.async_block_till_done()
 
-        state = self.hass.states.get("sensor.dark_sky_alerts")
-        assert state.state == "0"
+        state = hass.states.get("sensor.dark_sky_alerts")
+        assert state is not None
 
-    @requests_mock.Mocker()
-    @patch("forecastio.api.get_forecast", wraps=forecastio.api.get_forecast)
-    def test_setup(self, mock_req, mock_get_forecast):
-        """Test for successfully setting up the forecast.io platform."""
+
+async def test_setup(hass, requests_mock):
+    """Test for successfully setting up the forecast.io platform."""
+    with patch(
+        "forecastio.api.get_forecast", wraps=forecastio.api.get_forecast
+    ) as mock_get_forecast:
         uri = (
             r"https://api.(darksky.net|forecast.io)\/forecast\/(\w+)\/"
             r"(-?\d+\.?\d*),(-?\d+\.?\d*)"
         )
-        mock_req.get(re.compile(uri), text=load_fixture("darksky.json"))
+        requests_mock.get(re.compile(uri), text=load_fixture("darksky.json"))
 
-        assert setup_component(self.hass, "sensor", VALID_CONFIG_MINIMAL)
-        self.hass.block_till_done()
+        assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
+        await hass.async_block_till_done()
 
         assert mock_get_forecast.called
         assert mock_get_forecast.call_count == 1
-        assert len(self.hass.states.entity_ids()) == 13
+        assert len(hass.states.async_entity_ids()) == 13
 
-        state = self.hass.states.get("sensor.dark_sky_summary")
+        state = hass.states.get("sensor.dark_sky_summary")
         assert state is not None
         assert state.state == "Clear"
         assert state.attributes.get("friendly_name") == "Dark Sky Summary"
-        state = self.hass.states.get("sensor.dark_sky_alerts")
+        state = hass.states.get("sensor.dark_sky_alerts")
         assert state.state == "2"
 
-        state = self.hass.states.get("sensor.dark_sky_daytime_high_temperature_1d")
+        state = hass.states.get("sensor.dark_sky_daytime_high_temperature_1d")
         assert state is not None
         assert state.attributes.get("device_class") == "temperature"

--- a/tests/components/darksky/test_weather.py
+++ b/tests/components/darksky/test_weather.py
@@ -1,67 +1,47 @@
 """The tests for the Dark Sky weather component."""
 import re
-import unittest
 from unittest.mock import patch
 
 import forecastio
 from requests.exceptions import ConnectionError
-import requests_mock
 
 from homeassistant.components import weather
-from homeassistant.setup import setup_component
-from homeassistant.util.unit_system import METRIC_SYSTEM
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant, load_fixture
+from tests.common import load_fixture
 
 
-class TestDarkSky(unittest.TestCase):
-    """Test the Dark Sky weather component."""
-
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.hass.config.units = METRIC_SYSTEM
-        self.lat = self.hass.config.latitude = 37.8267
-        self.lon = self.hass.config.longitude = -122.423
-        self.addCleanup(self.tear_down_cleanup)
-
-    def tear_down_cleanup(self):
-        """Stop down everything that was started."""
-        self.hass.stop()
-
-    @requests_mock.Mocker()
-    @patch("forecastio.api.get_forecast", wraps=forecastio.api.get_forecast)
-    def test_setup(self, mock_req, mock_get_forecast):
-        """Test for successfully setting up the forecast.io platform."""
-        uri = (
-            r"https://api.(darksky.net|forecast.io)\/forecast\/(\w+)\/"
-            r"(-?\d+\.?\d*),(-?\d+\.?\d*)"
+async def test_setup(hass, requests_mock):
+    """Test for successfully setting up the forecast.io platform."""
+    with patch("forecastio.api.get_forecast", wraps=forecastio.api.get_forecast):
+        requests_mock.get(
+            re.compile(
+                r"https://api.(darksky.net|forecast.io)\/forecast\/(\w+)\/"
+                r"(-?\d+\.?\d*),(-?\d+\.?\d*)"
+            ),
+            text=load_fixture("darksky.json"),
         )
-        mock_req.get(re.compile(uri), text=load_fixture("darksky.json"))
 
-        assert setup_component(
-            self.hass,
+        assert await async_setup_component(
+            hass,
             weather.DOMAIN,
             {"weather": {"name": "test", "platform": "darksky", "api_key": "foo"}},
         )
-        self.hass.block_till_done()
+        await hass.async_block_till_done()
 
-        assert mock_get_forecast.called
-        assert mock_get_forecast.call_count == 1
-
-        state = self.hass.states.get("weather.test")
+        state = hass.states.get("weather.test")
         assert state.state == "sunny"
 
-    @patch("forecastio.load_forecast", side_effect=ConnectionError())
-    def test_failed_setup(self, mock_load_forecast):
-        """Test to ensure that a network error does not break component state."""
 
-        assert setup_component(
-            self.hass,
+async def test_failed_setup(hass):
+    """Test to ensure that a network error does not break component state."""
+    with patch("forecastio.load_forecast", side_effect=ConnectionError()):
+        assert await async_setup_component(
+            hass,
             weather.DOMAIN,
             {"weather": {"name": "test", "platform": "darksky", "api_key": "foo"}},
         )
-        self.hass.block_till_done()
+        await hass.async_block_till_done()
 
-        state = self.hass.states.get("weather.test")
+        state = hass.states.get("weather.test")
         assert state.state == "unavailable"

--- a/tests/components/darksky/test_weather.py
+++ b/tests/components/darksky/test_weather.py
@@ -13,7 +13,9 @@ from tests.common import load_fixture
 
 async def test_setup(hass, requests_mock):
     """Test for successfully setting up the forecast.io platform."""
-    with patch("forecastio.api.get_forecast", wraps=forecastio.api.get_forecast):
+    with patch(
+        "forecastio.api.get_forecast", wraps=forecastio.api.get_forecast
+    ) as mock_get_forecast:
         requests_mock.get(
             re.compile(
                 r"https://api.(darksky.net|forecast.io)\/forecast\/(\w+)\/"
@@ -29,6 +31,7 @@ async def test_setup(hass, requests_mock):
         )
         await hass.async_block_till_done()
 
+        assert mock_get_forecast.call_count == 1
         state = hass.states.get("weather.test")
         assert state.state == "sunny"
 

--- a/tests/components/darksky/test_weather.py
+++ b/tests/components/darksky/test_weather.py
@@ -3,7 +3,7 @@ import re
 from unittest.mock import patch
 
 import forecastio
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError as ConnectError
 
 from homeassistant.components import weather
 from homeassistant.setup import async_setup_component
@@ -35,7 +35,7 @@ async def test_setup(hass, requests_mock):
 
 async def test_failed_setup(hass):
     """Test to ensure that a network error does not break component state."""
-    with patch("forecastio.load_forecast", side_effect=ConnectionError()):
+    with patch("forecastio.load_forecast", side_effect=ConnectError()):
         assert await async_setup_component(
             hass,
             weather.DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Convert the `unittest.TestCase` based unit tests for the darksky integration into pytest based tests.
- Closes #79890

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40831
- This PR is related to issue:  #40831
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
