### PR TITLE
Add Shelly support for sleeping Gen2 devices

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -38,7 +38,13 @@ from .coordinator import (
     ShellyRpcPollingCoordinator,
     get_entry_data,
 )
-from .utils import get_block_device_sleep_period, get_coap_context, get_device_entry_gen
+from .utils import (
+    get_block_device_sleep_period,
+    get_coap_context,
+    get_device_entry_gen,
+    get_rpc_device_sleep_period,
+    get_ws_context,
+)
 
 BLOCK_PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
@@ -64,7 +70,10 @@ RPC_PLATFORMS: Final = [
     Platform.SWITCH,
     Platform.UPDATE,
 ]
-
+RPC_SLEEPING_PLATFORMS: Final = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+]
 
 COAP_SCHEMA: Final = vol.Schema(
     {
@@ -214,26 +223,87 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> boo
         entry.data.get(CONF_PASSWORD),
     )
 
-    LOGGER.debug("Setting up online RPC device %s", entry.title)
-    try:
-        async with async_timeout.timeout(AIOSHELLY_DEVICE_TIMEOUT_SEC):
-            device = await RpcDevice.create(
-                aiohttp_client.async_get_clientsession(hass), options
-            )
-    except asyncio.TimeoutError as err:
-        raise ConfigEntryNotReady(str(err) or "Timeout during device setup") from err
-    except OSError as err:
-        raise ConfigEntryNotReady(str(err) or "Error during device setup") from err
-    except (AuthRequired, InvalidAuthError) as err:
-        raise ConfigEntryAuthFailed from err
+    ws_context = await get_ws_context(hass)
 
+    device = await RpcDevice.create(
+        aiohttp_client.async_get_clientsession(hass),
+        ws_context,
+        options,
+        False,
+    )
+
+    dev_reg = device_registry.async_get(hass)
+    device_entry = None
+    if entry.unique_id is not None:
+        device_entry = dev_reg.async_get_device(
+            identifiers=set(),
+            connections={
+                (
+                    device_registry.CONNECTION_NETWORK_MAC,
+                    device_registry.format_mac(entry.unique_id),
+                )
+            },
+        )
+    if device_entry and entry.entry_id not in device_entry.config_entries:
+        device_entry = None
+
+    sleep_period = entry.data.get(CONF_SLEEP_PERIOD)
     shelly_entry_data = get_entry_data(hass)[entry.entry_id]
-    shelly_entry_data.rpc = ShellyRpcCoordinator(hass, entry, device)
-    shelly_entry_data.rpc.async_setup()
 
-    shelly_entry_data.rpc_poll = ShellyRpcPollingCoordinator(hass, entry, device)
+    @callback
+    def _async_rpc_device_setup() -> None:
+        """Set up a RPC based device that is online."""
+        shelly_entry_data.rpc = ShellyRpcCoordinator(hass, entry, device)
+        shelly_entry_data.rpc.async_setup()
 
-    hass.config_entries.async_setup_platforms(entry, RPC_PLATFORMS)
+        platforms = RPC_SLEEPING_PLATFORMS
+
+        if not entry.data.get(CONF_SLEEP_PERIOD):
+            shelly_entry_data.rpc_poll = ShellyRpcPollingCoordinator(
+                hass, entry, device
+            )
+            platforms = RPC_PLATFORMS
+
+        hass.config_entries.async_setup_platforms(entry, platforms)
+
+    @callback
+    def _async_device_online(_: Any) -> None:
+        LOGGER.debug("Device %s is online, resuming setup", entry.title)
+        shelly_entry_data.device = None
+
+        if sleep_period is None:
+            data = {**entry.data}
+            data[CONF_SLEEP_PERIOD] = get_rpc_device_sleep_period(device.config)
+            hass.config_entries.async_update_entry(entry, data=data)
+
+        _async_rpc_device_setup()
+
+    if sleep_period == 0:
+        # Not a sleeping device, finish setup
+        LOGGER.debug("Setting up online RPC device %s", entry.title)
+        try:
+            async with async_timeout.timeout(AIOSHELLY_DEVICE_TIMEOUT_SEC):
+                await device.initialize()
+        except asyncio.TimeoutError as err:
+            raise ConfigEntryNotReady(
+                str(err) or "Timeout during device setup"
+            ) from err
+        except OSError as err:
+            raise ConfigEntryNotReady(str(err) or "Error during device setup") from err
+        except (AuthRequired, InvalidAuthError) as err:
+            raise ConfigEntryAuthFailed from err
+        _async_rpc_device_setup()
+    elif sleep_period is None or device_entry is None:
+        # Need to get sleep info or first time sleeping device setup, wait for device
+        shelly_entry_data.device = device
+        LOGGER.debug(
+            "Setup for device %s will resume when device is online", entry.title
+        )
+        device.subscribe_updates(_async_device_online)
+    else:
+        # Restore sensors for sleeping device
+        LOGGER.debug("Setting up offline block device %s", entry.title)
+        _async_rpc_device_setup()
 
     return True
 
@@ -242,20 +312,24 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     shelly_entry_data = get_entry_data(hass)[entry.entry_id]
 
+    if shelly_entry_data.device is not None:
+        # If device is present, block/rpc coordinator is not setup yet
+        shelly_entry_data.device.shutdown()
+        return True
+
+    platforms = RPC_SLEEPING_PLATFORMS
+    if not entry.data.get(CONF_SLEEP_PERIOD):
+        platforms = RPC_PLATFORMS
+
     if get_device_entry_gen(entry) == 2:
         if unload_ok := await hass.config_entries.async_unload_platforms(
-            entry, RPC_PLATFORMS
+            entry, platforms
         ):
             if shelly_entry_data.rpc:
                 await shelly_entry_data.rpc.shutdown()
             get_entry_data(hass).pop(entry.entry_id)
 
         return unload_ok
-
-    if shelly_entry_data.device is not None:
-        # If device is present, block coordinator is not setup yet
-        shelly_entry_data.device.shutdown()
-        return True
 
     platforms = BLOCK_SLEEPING_PLATFORMS
 

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -25,6 +25,7 @@ from .entity import (
     ShellyRestAttributeEntity,
     ShellyRpcAttributeEntity,
     ShellySleepingBlockAttributeEntity,
+    ShellySleepingRpcAttributeEntity,
     async_setup_entry_attribute_entities,
     async_setup_entry_rest,
     async_setup_entry_rpc,
@@ -209,9 +210,19 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors for device."""
     if get_device_entry_gen(config_entry) == 2:
-        return async_setup_entry_rpc(
-            hass, config_entry, async_add_entities, RPC_SENSORS, RpcBinarySensor
-        )
+        if config_entry.data[CONF_SLEEP_PERIOD]:
+            async_setup_entry_rpc(
+                hass,
+                config_entry,
+                async_add_entities,
+                RPC_SENSORS,
+                RpcSleepingBinarySensor,
+            )
+        else:
+            async_setup_entry_rpc(
+                hass, config_entry, async_add_entities, RPC_SENSORS, RpcBinarySensor
+            )
+        return
 
     if config_entry.data[CONF_SLEEP_PERIOD]:
         async_setup_entry_attribute_entities(
@@ -286,6 +297,20 @@ class BlockSleepingBinarySensor(ShellySleepingBlockAttributeEntity, BinarySensor
     def is_on(self) -> bool:
         """Return true if sensor state is on."""
         if self.block is not None:
+            return bool(self.attribute_value)
+
+        return self.last_state == STATE_ON
+
+
+class RpcSleepingBinarySensor(ShellySleepingRpcAttributeEntity, BinarySensorEntity):
+    """Represent a RPC sleeping binary sensor entity."""
+
+    entity_description: RpcBinarySensorDescription
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if RPC sensor state is on."""
+        if self.coordinator.device.initialized:
             return bool(self.attribute_value)
 
         return self.last_state == STATE_ON

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -29,6 +29,8 @@ from .utils import (
     get_info_gen,
     get_model_name,
     get_rpc_device_name,
+    get_rpc_device_sleep_period,
+    get_ws_context,
 )
 
 HOST_SCHEMA: Final = vol.Schema({vol.Required(CONF_HOST): str})
@@ -54,8 +56,10 @@ async def validate_input(
 
     async with async_timeout.timeout(AIOSHELLY_DEVICE_TIMEOUT_SEC):
         if get_info_gen(info) == 2:
+            ws_context = await get_ws_context(hass)
             rpc_device = await RpcDevice.create(
                 aiohttp_client.async_get_clientsession(hass),
+                ws_context,
                 options,
             )
             await rpc_device.shutdown()
@@ -63,7 +67,7 @@ async def validate_input(
 
             return {
                 "title": get_rpc_device_name(rpc_device),
-                CONF_SLEEP_PERIOD: 0,
+                CONF_SLEEP_PERIOD: get_rpc_device_sleep_period(rpc_device.config),
                 "model": rpc_device.shelly.get("model"),
                 "gen": 2,
             }

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,8 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "requirements": ["aioshelly==2.0.2"],
+  "requirements": ["aioshelly==3.0.0"],
+  "dependencies": ["http"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -42,6 +42,7 @@ from .entity import (
     ShellyRestAttributeEntity,
     ShellyRpcAttributeEntity,
     ShellySleepingBlockAttributeEntity,
+    ShellySleepingRpcAttributeEntity,
     async_setup_entry_attribute_entities,
     async_setup_entry_rest,
     async_setup_entry_rpc,
@@ -431,9 +432,19 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors for device."""
     if get_device_entry_gen(config_entry) == 2:
-        return async_setup_entry_rpc(
-            hass, config_entry, async_add_entities, RPC_SENSORS, RpcSensor
-        )
+        if config_entry.data[CONF_SLEEP_PERIOD]:
+            async_setup_entry_rpc(
+                hass,
+                config_entry,
+                async_add_entities,
+                RPC_SENSORS,
+                RpcSleepingSensor,
+            )
+        else:
+            async_setup_entry_rpc(
+                hass, config_entry, async_add_entities, RPC_SENSORS, RpcSensor
+            )
+        return
 
     if config_entry.data[CONF_SLEEP_PERIOD]:
         async_setup_entry_attribute_entities(
@@ -530,6 +541,20 @@ class BlockSleepingSensor(ShellySleepingBlockAttributeEntity, SensorEntity):
     def native_value(self) -> StateType:
         """Return value of sensor."""
         if self.block is not None:
+            return self.attribute_value
+
+        return self.last_state
+
+
+class RpcSleepingSensor(ShellySleepingRpcAttributeEntity, SensorEntity):
+    """Represent a RPC sleeping sensor."""
+
+    entity_description: RpcSensorDescription
+
+    @property
+    def native_value(self) -> StateType:
+        """Return value of sensor."""
+        if self.coordinator.device.initialized:
             return self.attribute_value
 
         return self.last_state

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, cast
 
+from aiohttp.web import Request, WebSocketResponse
 from aioshelly.block_device import BLOCK_VALUE_UNIT, COAP, Block, BlockDevice
 from aioshelly.const import MODEL_NAMES
-from aioshelly.rpc_device import RpcDevice
+from aioshelly.rpc_device import RpcDevice, WsServer
 
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant, callback
@@ -213,7 +215,7 @@ def get_shbtn_input_triggers() -> list[tuple[str, str]]:
 
 @singleton.singleton("shelly_coap")
 async def get_coap_context(hass: HomeAssistant) -> COAP:
-    """Get CoAP context to be used in all Shelly devices."""
+    """Get CoAP context to be used in all Shelly Gen1 devices."""
     context = COAP()
     if DOMAIN in hass.data:
         port = hass.data[DOMAIN].get(CONF_COAP_PORT, DEFAULT_COAP_PORT)
@@ -227,8 +229,31 @@ async def get_coap_context(hass: HomeAssistant) -> COAP:
         context.close()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown_listener)
-
     return context
+
+
+class ShellyReceiver(HomeAssistantView):
+    """Handle pushes from Shelly Gen2 devices."""
+
+    requires_auth = False
+    url = "/api/shelly/ws"
+    name = "api:shelly:ws"
+
+    def __init__(self, ws_server: WsServer) -> None:
+        """Initialize the Shelly receiver view."""
+        self._ws_server = ws_server
+
+    async def get(self, request: Request) -> WebSocketResponse:
+        """Start a get request."""
+        return await self._ws_server.websocket_handler(request)
+
+
+@singleton.singleton("shelly_ws_server")
+async def get_ws_context(hass: HomeAssistant) -> WsServer:
+    """Get websocket server context to be used in all Shelly Gen2 devices."""
+    ws_server = WsServer()
+    hass.http.register_view(ShellyReceiver(ws_server))
+    return ws_server
 
 
 def get_block_device_sleep_period(settings: dict[str, Any]) -> int:
@@ -241,6 +266,11 @@ def get_block_device_sleep_period(settings: dict[str, Any]) -> int:
             sleep_period *= 60  # hours to minutes
 
     return sleep_period * 60  # minutes to seconds
+
+
+def get_rpc_device_sleep_period(config: dict[str, Any]) -> int:
+    """Return the device sleep period in seconds or 0 for non sleeping devices."""
+    return cast(int, config["sys"].get("sleep", {}).get("wakeup_period", 0))
 
 
 def get_info_auth(info: dict[str, Any]) -> bool:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -255,7 +255,7 @@ aiosenseme==0.6.1
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==2.0.2
+aioshelly==3.0.0
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -230,7 +230,7 @@ aiosenseme==0.6.1
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==2.0.2
+aioshelly==3.0.0
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -107,6 +107,13 @@ def mock_coap():
         yield
 
 
+@pytest.fixture(autouse=True)
+def mock_ws_server():
+    """Mock out ws_server."""
+    with patch("homeassistant.components.shelly.utils.get_ws_context"):
+        yield
+
+
 @pytest.fixture
 def device_reg(hass):
     """Return an empty, loaded, registry."""
@@ -172,6 +179,7 @@ async def mock_rpc_device():
             update=AsyncMock(),
             trigger_ota_update=AsyncMock(),
             trigger_reboot=AsyncMock(),
+            initialize=AsyncMock(),
             initialized=True,
             shutdown=AsyncMock(),
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
### Add support for sleeping Gen2 devices (e.g., Shelly Plus H&T)
Remake of https://github.com/home-assistant/core/pull/76424 which required too many changes to work on the same PR.
This PR does not spin a webserver and uses HA webserver for sleeping devices to connect and send push notifications under `/api/shelly/ws`

Bump `aioshelly` to 3.0.0: https://github.com/home-assistant-libs/aioshelly/releases/tag/3.0.0

Diff: https://github.com/home-assistant-libs/aioshelly/compare/2.0.1...3.0.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/76062
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24476

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
