### PR TITLE
Home Connect: Operation state translations

### DIFF
--- a/homeassistant/components/home_connect/api.py
+++ b/homeassistant/components/home_connect/api.py
@@ -33,6 +33,7 @@ from .const import (
     BSH_OPERATION_STATE,
     BSH_POWER_OFF,
     BSH_POWER_STANDBY,
+    OPERATION_STATE_DEVICE_CLASS,
     SIGNAL_UPDATE_ENTITIES,
 )
 
@@ -197,7 +198,7 @@ class DeviceWithOpState(HomeConnectDevice):
                 ATTR_UNIT: None,
                 ATTR_KEY: BSH_OPERATION_STATE,
                 ATTR_ICON: "mdi:state-machine",
-                ATTR_DEVICE_CLASS: None,
+                ATTR_DEVICE_CLASS: OPERATION_STATE_DEVICE_CLASS,
                 ATTR_SIGN: 1,
             }
         ]

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -53,7 +53,7 @@ ATTR_SIGN = "sign"
 ATTR_UNIT = "unit"
 ATTR_VALUE = "value"
 
-OPERATION_STATE_DEVICE_CLASS = "operation__state"
+OPERATION_STATE_DEVICE_CLASS = "home_connect__operation_state"
 
 OPERATION_STATE_TRANSLATION: dict[str, str] = {
     "BSH.Common.EnumType.OperationState.Inactive": "inactive",

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -2,8 +2,8 @@
 
 DOMAIN = "home_connect"
 
-OAUTH2_AUTHORIZE = "https://simulator.home-connect.com/security/oauth/authorize"
-OAUTH2_TOKEN = "https://simulator.home-connect.com/security/oauth/token"
+OAUTH2_AUTHORIZE = "https://api.home-connect.com/security/oauth/authorize"
+OAUTH2_TOKEN = "https://api.home-connect.com/security/oauth/token"
 
 BSH_POWER_STATE = "BSH.Common.Setting.PowerState"
 BSH_POWER_ON = "BSH.Common.EnumType.PowerState.On"

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -54,15 +54,3 @@ ATTR_UNIT = "unit"
 ATTR_VALUE = "value"
 
 OPERATION_STATE_DEVICE_CLASS = "home_connect__operation_state"
-
-OPERATION_STATE_TRANSLATION: dict[str, str] = {
-    "BSH.Common.EnumType.OperationState.Inactive": "inactive",
-    "BSH.Common.EnumType.OperationState.Ready": "ready",
-    "BSH.Common.EnumType.OperationState.DelayedStart": "delayed_start",
-    "BSH.Common.EnumType.OperationState.Run": "run",
-    "BSH.Common.EnumType.OperationState.Pause": "pause",
-    "BSH.Common.EnumType.OperationState.ActionRequired": "action_required",
-    "BSH.Common.EnumType.OperationState.Finished": "finished",
-    "BSH.Common.EnumType.OperationState.Error": "error",
-    "BSH.Common.EnumType.OperationState.Aborting": "aborting",
-}

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -2,8 +2,8 @@
 
 DOMAIN = "home_connect"
 
-OAUTH2_AUTHORIZE = "https://api.home-connect.com/security/oauth/authorize"
-OAUTH2_TOKEN = "https://api.home-connect.com/security/oauth/token"
+OAUTH2_AUTHORIZE = "https://simulator.home-connect.com/security/oauth/authorize"
+OAUTH2_TOKEN = "https://simulator.home-connect.com/security/oauth/token"
 
 BSH_POWER_STATE = "BSH.Common.Setting.PowerState"
 BSH_POWER_ON = "BSH.Common.EnumType.PowerState.On"
@@ -52,3 +52,17 @@ ATTR_SENSOR_TYPE = "sensor_type"
 ATTR_SIGN = "sign"
 ATTR_UNIT = "unit"
 ATTR_VALUE = "value"
+
+OPERATION_STATE_DEVICE_CLASS = "operation__state"
+
+OPERATION_STATE_TRANSLATION: dict[str, str] = {
+    "BSH.Common.EnumType.OperationState.Inactive": "inactive",
+    "BSH.Common.EnumType.OperationState.Ready": "ready",
+    "BSH.Common.EnumType.OperationState.DelayedStart": "delayed_start",
+    "BSH.Common.EnumType.OperationState.Run": "run",
+    "BSH.Common.EnumType.OperationState.Pause": "pause",
+    "BSH.Common.EnumType.OperationState.ActionRequired": "action_required",
+    "BSH.Common.EnumType.OperationState.Finished": "finished",
+    "BSH.Common.EnumType.OperationState.Error": "error",
+    "BSH.Common.EnumType.OperationState.Aborting": "aborting",
+}

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from .const import ATTR_VALUE, BSH_OPERATION_STATE, DOMAIN, OPERATION_STATE_TRANSLATION
+from .const import ATTR_VALUE, BSH_OPERATION_STATE, DOMAIN
 from .entity import HomeConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -80,10 +80,7 @@ class HomeConnectSensor(HomeConnectEntity, SensorEntity):
             else:
                 self._state = status[self._key].get(ATTR_VALUE)
                 if self._key == BSH_OPERATION_STATE:
-                    self._state = (
-                        OPERATION_STATE_TRANSLATION.get(self._state)
-                        or self._state.split(".")[-1]
-                    )
+                    self._state = self._state.split(".")[-1].lower()
         _LOGGER.debug("Updated, new state: %s", self._state)
 
     @property

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from .const import ATTR_VALUE, BSH_OPERATION_STATE, DOMAIN
+from .const import ATTR_VALUE, BSH_OPERATION_STATE, DOMAIN, OPERATION_STATE_TRANSLATION
 from .entity import HomeConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -80,10 +80,7 @@ class HomeConnectSensor(HomeConnectEntity, SensorEntity):
             else:
                 self._state = status[self._key].get(ATTR_VALUE)
                 if self._key == BSH_OPERATION_STATE:
-                    # Value comes back as an enum, we only really care about the
-                    # last part, so split it off
-                    # https://developer.home-connect.com/docs/status/operation_state
-                    self._state = self._state.split(".")[-1]
+                    self._state = OPERATION_STATE_TRANSLATION[self._state]
         _LOGGER.debug("Updated, new state: %s", self._state)
 
     @property

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -80,7 +80,10 @@ class HomeConnectSensor(HomeConnectEntity, SensorEntity):
             else:
                 self._state = status[self._key].get(ATTR_VALUE)
                 if self._key == BSH_OPERATION_STATE:
-                    self._state = OPERATION_STATE_TRANSLATION[self._state]
+                    self._state = (
+                        OPERATION_STATE_TRANSLATION.get(self._state)
+                        or self._state.split(".")[-1]
+                    )
         _LOGGER.debug("Updated, new state: %s", self._state)
 
     @property

--- a/homeassistant/components/home_connect/strings.sensor.json
+++ b/homeassistant/components/home_connect/strings.sensor.json
@@ -1,6 +1,6 @@
 {
   "state": {
-    "operation__state": {
+    "home_connect__operation_state": {
       "inactive": "Inactive",
       "ready": "Ready",
       "delayed_start": "Delayed start",

--- a/homeassistant/components/home_connect/strings.sensor.json
+++ b/homeassistant/components/home_connect/strings.sensor.json
@@ -1,15 +1,15 @@
 {
   "state": {
     "home_connect__operation_state": {
-      "inactive": "Inactive",
-      "ready": "Ready",
-      "delayed_start": "Delayed start",
-      "run": "Run",
-      "pause": "[%key:common::state::paused%]",
-      "action_required": "Action required",
-      "finished": "Finished",
+      "aborting": "Aborting",
+      "actionrequired": "Action required",
+      "delayedstart": "Delayed start",
       "error": "Error",
-      "aborting": "Aborting"
+      "finished": "Finished",
+      "inactive": "Inactive",
+      "pause": "[%key:common::state::paused%]",
+      "ready": "Ready",
+      "run": "Run"
     }
   }
 }

--- a/homeassistant/components/home_connect/strings.sensor.json
+++ b/homeassistant/components/home_connect/strings.sensor.json
@@ -1,0 +1,15 @@
+{
+  "state": {
+    "operation__state": {
+      "inactive": "Inactive",
+      "ready": "Ready",
+      "delayed_start": "Delayed start",
+      "run": "Run",
+      "pause": "[%key:common::state::paused%]",
+      "action_required": "Action required",
+      "finished": "Finished",
+      "error": "Error",
+      "aborting": "Aborting"
+    }
+  }
+}

--- a/homeassistant/components/home_connect/translations/sensor.en.json
+++ b/homeassistant/components/home_connect/translations/sensor.en.json
@@ -1,0 +1,15 @@
+{
+    "state": {
+        "operation__state": {
+            "aborting": "Aborting",
+            "action_required": "Action required",
+            "delayed_start": "Delayed start",
+            "error": "Error",
+            "finished": "Finished",
+            "inactive": "Inactive",
+            "pause": "Paused",
+            "ready": "Ready",
+            "run": "Run"
+        }
+    }
+}

--- a/homeassistant/components/home_connect/translations/sensor.en.json
+++ b/homeassistant/components/home_connect/translations/sensor.en.json
@@ -1,6 +1,6 @@
 {
     "state": {
-        "operation__state": {
+        "home_connect__operation_state": {
             "aborting": "Aborting",
             "action_required": "Action required",
             "delayed_start": "Delayed start",

--- a/homeassistant/components/home_connect/translations/sensor.en.json
+++ b/homeassistant/components/home_connect/translations/sensor.en.json
@@ -2,8 +2,8 @@
     "state": {
         "home_connect__operation_state": {
             "aborting": "Aborting",
-            "action_required": "Action required",
-            "delayed_start": "Delayed start",
+            "actionrequired": "Action required",
+            "delayedstart": "Delayed start",
             "error": "Error",
             "finished": "Finished",
             "inactive": "Inactive",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The operation state sensor now uses lowercase. You need to update automations using this sensor.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds translation support for the operation state sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #78926
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
