### PR TITLE
Move AirNow test fixtures to `conftest.py`

### DIFF
--- a/tests/components/airnow/conftest.py
+++ b/tests/components/airnow/conftest.py
@@ -50,8 +50,7 @@ def mock_api_get_fixture(data):
 async def setup_airnow_fixture(hass, config, mock_api_get):
     """Define a fixture to set up AirNow."""
     with patch("pyairnow.WebServiceAPI._get", mock_api_get), patch(
-        "homeassistant.components.airnow.config_flow.WebServiceAPI._get",
-        mock_api_get,
+        "homeassistant.components.airnow.config_flow.WebServiceAPI._get", mock_api_get
     ), patch("homeassistant.components.airnow.PLATFORMS", []):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()

--- a/tests/components/airnow/conftest.py
+++ b/tests/components/airnow/conftest.py
@@ -12,9 +12,13 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture(hass, config, unique_id):
+def config_entry_fixture(hass, config):
     """Define a config entry fixture."""
-    entry = MockConfigEntry(domain=DOMAIN, unique_id=unique_id, data=config)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=f"{config[CONF_LATITUDE]}-{config[CONF_LONGITUDE]}",
+        data=config,
+    )
     entry.add_to_hass(hass)
     return entry
 
@@ -45,9 +49,3 @@ async def setup_airnow_fixture(hass, config):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         yield
-
-
-@pytest.fixture(name="unique_id")
-def unique_id_fixture(hass):
-    """Define a config entry unique ID fixture."""
-    return "34.053718--118.244842"

--- a/tests/components/airnow/conftest.py
+++ b/tests/components/airnow/conftest.py
@@ -1,0 +1,53 @@
+"""Define fixtures for AirNow tests."""
+import json
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.airnow import DOMAIN
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, load_fixture
+
+
+@pytest.fixture(name="config_entry")
+def config_entry_fixture(hass, config, unique_id):
+    """Define a config entry fixture."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=unique_id, data=config)
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture(name="config")
+def config_fixture(hass):
+    """Define a config entry data fixture."""
+    return {
+        CONF_API_KEY: "abc123",
+        CONF_LATITUDE: 34.053718,
+        CONF_LONGITUDE: -118.244842,
+        CONF_RADIUS: 75,
+    }
+
+
+@pytest.fixture(name="response", scope="session")
+def response_fixture():
+    """Define task data."""
+    return json.loads(load_fixture("response.json", "airnow"))
+
+
+@pytest.fixture(name="setup_airnow")
+async def setup_airnow_fixture(hass, config):
+    """Define a fixture to set up AirNow."""
+    with patch("pyairnow.WebServiceAPI._get", return_value=config), patch(
+        "homeassistant.components.airnow.PLATFORMS", []
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+        yield
+
+
+@pytest.fixture(name="unique_id")
+def unique_id_fixture(hass):
+    """Define a config entry unique ID fixture."""
+    return "34.053718--118.244842"

--- a/tests/components/airnow/fixtures/__init__.py
+++ b/tests/components/airnow/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Define AirNow response fixture data."""

--- a/tests/components/airnow/fixtures/response.json
+++ b/tests/components/airnow/fixtures/response.json
@@ -1,0 +1,47 @@
+[
+  {
+    "DateObserved": "2020-12-20",
+    "HourObserved": 15,
+    "LocalTimeZone": "PST",
+    "ReportingArea": "Central LA CO",
+    "StateCode": "CA",
+    "Latitude": 34.0663,
+    "Longitude": -118.2266,
+    "ParameterName": "O3",
+    "AQI": 44,
+    "Category": {
+      "Number": 1,
+      "Name": "Good"
+    }
+  },
+  {
+    "DateObserved": "2020-12-20",
+    "HourObserved": 15,
+    "LocalTimeZone": "PST",
+    "ReportingArea": "Central LA CO",
+    "StateCode": "CA",
+    "Latitude": 34.0663,
+    "Longitude": -118.2266,
+    "ParameterName": "PM2.5",
+    "AQI": 37,
+    "Category": {
+      "Number": 1,
+      "Name": "Good"
+    }
+  },
+  {
+    "DateObserved": "2020-12-20",
+    "HourObserved": 15,
+    "LocalTimeZone": "PST",
+    "ReportingArea": "Central LA CO",
+    "StateCode": "CA",
+    "Latitude": 34.0663,
+    "Longitude": -118.2266,
+    "ParameterName": "PM10",
+    "AQI": 11,
+    "Category": {
+      "Number": 1,
+      "Name": "Good"
+    }
+  }
+]

--- a/tests/components/airnow/test_config_flow.py
+++ b/tests/components/airnow/test_config_flow.py
@@ -5,112 +5,46 @@ from pyairnow.errors import AirNowError, InvalidKeyError
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.airnow.const import DOMAIN
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
-
-from tests.common import MockConfigEntry
-
-CONFIG = {
-    CONF_API_KEY: "abc123",
-    CONF_LATITUDE: 34.053718,
-    CONF_LONGITUDE: -118.244842,
-    CONF_RADIUS: 75,
-}
-
-# Mock AirNow Response
-MOCK_RESPONSE = [
-    {
-        "DateObserved": "2020-12-20",
-        "HourObserved": 15,
-        "LocalTimeZone": "PST",
-        "ReportingArea": "Central LA CO",
-        "StateCode": "CA",
-        "Latitude": 34.0663,
-        "Longitude": -118.2266,
-        "ParameterName": "O3",
-        "AQI": 44,
-        "Category": {
-            "Number": 1,
-            "Name": "Good",
-        },
-    },
-    {
-        "DateObserved": "2020-12-20",
-        "HourObserved": 15,
-        "LocalTimeZone": "PST",
-        "ReportingArea": "Central LA CO",
-        "StateCode": "CA",
-        "Latitude": 34.0663,
-        "Longitude": -118.2266,
-        "ParameterName": "PM2.5",
-        "AQI": 37,
-        "Category": {
-            "Number": 1,
-            "Name": "Good",
-        },
-    },
-    {
-        "DateObserved": "2020-12-20",
-        "HourObserved": 15,
-        "LocalTimeZone": "PST",
-        "ReportingArea": "Central LA CO",
-        "StateCode": "CA",
-        "Latitude": 34.0663,
-        "Longitude": -118.2266,
-        "ParameterName": "PM10",
-        "AQI": 11,
-        "Category": {
-            "Number": 1,
-            "Name": "Good",
-        },
-    },
-]
 
 
-async def test_form(hass):
+async def test_form(hass, config, setup_airnow):
     """Test we get the form."""
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
-    with patch("pyairnow.WebServiceAPI._get", return_value=MOCK_RESPONSE), patch(
-        "homeassistant.components.airnow.async_setup_entry",
-        return_value=True,
+    with patch(
+        "homeassistant.components.airnow.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG,
+            result["flow_id"], config
         )
 
         await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result2["data"] == CONFIG
+    assert result2["data"] == config
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass, config):
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "pyairnow.WebServiceAPI._get",
-        side_effect=InvalidKeyError,
-    ):
+    with patch("pyairnow.WebServiceAPI._get", side_effect=InvalidKeyError):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG,
+            result["flow_id"], config
         )
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_invalid_location(hass):
+async def test_form_invalid_location(hass, config):
     """Test we handle invalid location."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -118,34 +52,29 @@ async def test_form_invalid_location(hass):
 
     with patch("pyairnow.WebServiceAPI._get", return_value={}):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG,
+            result["flow_id"], config
         )
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "invalid_location"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass, config):
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "pyairnow.WebServiceAPI._get",
-        side_effect=AirNowError,
-    ):
+    with patch("pyairnow.WebServiceAPI._get", side_effect=AirNowError):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG,
+            result["flow_id"], config
         )
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unexpected(hass):
+async def test_form_unexpected(hass, config):
     """Test we handle an unexpected error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -156,28 +85,20 @@ async def test_form_unexpected(hass):
         side_effect=RuntimeError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG,
+            result["flow_id"], config
         )
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_entry_already_exists(hass):
+async def test_entry_already_exists(hass, config, config_entry):
     """Test that the form aborts if the Lat/Lng is already configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_id = f"{CONFIG[CONF_LATITUDE]}-{CONFIG[CONF_LONGITUDE]}"
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=mock_id)
-    mock_entry.add_to_hass(hass)
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        CONFIG,
-    )
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], config)
 
     assert result2["type"] == "abort"
     assert result2["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR establishes a `conftest.py` for AirNow and migrates appropriate fixtures there. This is in anticipating of adding diagnostics support, which will make use of many of the same fixtures.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
