### PR TITLE
Add ability to convert ZCL schemas to vol schemas to ZHA

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1299,11 +1299,10 @@ def async_load_api(hass: HomeAssistant) -> None:
         args: dict = service.data[ATTR_ARGS]
         manufacturer: int | None = service.data.get(ATTR_MANUFACTURER)
         zha_device = zha_gateway.get_device(ieee)
-        response = None
-        _LOGGER.warning("Service data: %s", service.data)
         if zha_device is not None:
             if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
                 manufacturer = zha_device.manufacturer_code
+
             response = await zha_device.issue_cluster_command(
                 endpoint_id,
                 cluster_id,
@@ -1313,25 +1312,27 @@ def async_load_api(hass: HomeAssistant) -> None:
                 cluster_type=cluster_type,
                 manufacturer=manufacturer,
             )
-        _LOGGER.debug(
-            "Issued command for: %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: %s %s: [%s] %s: %s",
-            ATTR_CLUSTER_ID,
-            cluster_id,
-            ATTR_CLUSTER_TYPE,
-            cluster_type,
-            ATTR_ENDPOINT_ID,
-            endpoint_id,
-            ATTR_COMMAND,
-            command,
-            ATTR_COMMAND_TYPE,
-            command_type,
-            ATTR_ARGS,
-            args,
-            ATTR_MANUFACTURER,
-            manufacturer,
-            RESPONSE,
-            response,
-        )
+            _LOGGER.debug(
+                "Issued command for: %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: %s %s: [%s] %s: %s",
+                ATTR_CLUSTER_ID,
+                cluster_id,
+                ATTR_CLUSTER_TYPE,
+                cluster_type,
+                ATTR_ENDPOINT_ID,
+                endpoint_id,
+                ATTR_COMMAND,
+                command,
+                ATTR_COMMAND_TYPE,
+                command_type,
+                ATTR_ARGS,
+                args,
+                ATTR_MANUFACTURER,
+                manufacturer,
+                RESPONSE,
+                response,
+            )
+        else:
+            raise ValueError(f"Device with IEEE {str(ieee)} not found")
 
     async_register_admin_service(
         hass,

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1303,7 +1303,7 @@ def async_load_api(hass: HomeAssistant) -> None:
             if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
                 manufacturer = zha_device.manufacturer_code
 
-            response = await zha_device.issue_cluster_command(
+            await zha_device.issue_cluster_command(
                 endpoint_id,
                 cluster_id,
                 command,
@@ -1313,7 +1313,7 @@ def async_load_api(hass: HomeAssistant) -> None:
                 manufacturer=manufacturer,
             )
             _LOGGER.debug(
-                "Issued command for: %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: %s %s: [%s] %s: %s",
+                "Issued command for: %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: %s %s: [%s]",
                 ATTR_CLUSTER_ID,
                 cluster_id,
                 ATTR_CLUSTER_TYPE,
@@ -1328,8 +1328,6 @@ def async_load_api(hass: HomeAssistant) -> None:
                 args,
                 ATTR_MANUFACTURER,
                 manufacturer,
-                RESPONSE,
-                response,
             )
         else:
             raise ValueError(f"Device with IEEE {str(ieee)} not found")

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -735,7 +735,8 @@ async def websocket_device_cluster_commands(
                         ID: cmd_id,
                         ATTR_NAME: cmd.name,
                         "schema": voluptuous_serialize.convert(
-                            cluster_command_schema_to_vol_schema(cmd.schema)
+                            cluster_command_schema_to_vol_schema(cmd.schema),
+                            custom_serializer=cv.custom_serializer,
                         ),
                     }
                 )
@@ -746,7 +747,8 @@ async def websocket_device_cluster_commands(
                         ID: cmd_id,
                         ATTR_NAME: cmd.name,
                         "schema": voluptuous_serialize.convert(
-                            cluster_command_schema_to_vol_schema(cmd.schema)
+                            cluster_command_schema_to_vol_schema(cmd.schema),
+                            custom_serializer=cv.custom_serializer,
                         ),
                     }
                 )

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -190,7 +190,7 @@ SERVICE_SCHEMAS = {
             vol.Optional(ATTR_CLUSTER_TYPE, default=CLUSTER_TYPE_IN): cv.string,
             vol.Required(ATTR_COMMAND): cv.positive_int,
             vol.Required(ATTR_COMMAND_TYPE): cv.string,
-            vol.Optional(ATTR_ARGS, default=[]): cv.ensure_list,
+            vol.Optional(ATTR_ARGS): dict,
             vol.Optional(ATTR_MANUFACTURER): cv.positive_int,
         }
     ),
@@ -1296,10 +1296,11 @@ def async_load_api(hass: HomeAssistant) -> None:
         cluster_type: str = service.data[ATTR_CLUSTER_TYPE]
         command: int = service.data[ATTR_COMMAND]
         command_type: str = service.data[ATTR_COMMAND_TYPE]
-        args: list = service.data[ATTR_ARGS]
+        args: dict = service.data[ATTR_ARGS]
         manufacturer: int | None = service.data.get(ATTR_MANUFACTURER)
         zha_device = zha_gateway.get_device(ieee)
         response = None
+        _LOGGER.warning("Service data: %s", service.data)
         if zha_device is not None:
             if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
                 manufacturer = zha_device.manufacturer_code
@@ -1308,7 +1309,7 @@ def async_load_api(hass: HomeAssistant) -> None:
                 cluster_id,
                 command,
                 command_type,
-                *args,
+                args,
                 cluster_type=cluster_type,
                 manufacturer=manufacturer,
             )

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -69,6 +69,7 @@ from .core.group import GroupMember
 from .core.helpers import (
     async_cluster_exists,
     async_is_bindable_target,
+    cluster_command_schema_to_vol_schema,
     convert_install_code,
     get_matched_clusters,
     qr_to_install_code,
@@ -711,6 +712,8 @@ async def websocket_device_cluster_commands(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Return a list of cluster commands."""
+    import voluptuous_serialize  # pylint: disable=import-outside-toplevel
+
     zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     ieee: EUI64 = msg[ATTR_IEEE]
     endpoint_id: int = msg[ATTR_ENDPOINT_ID]
@@ -731,6 +734,9 @@ async def websocket_device_cluster_commands(
                         TYPE: CLIENT,
                         ID: cmd_id,
                         ATTR_NAME: cmd.name,
+                        "schema": voluptuous_serialize.convert(
+                            cluster_command_schema_to_vol_schema(cmd.schema)
+                        ),
                     }
                 )
             for cmd_id, cmd in commands[CLUSTER_COMMANDS_SERVER].items():
@@ -739,6 +745,9 @@ async def websocket_device_cluster_commands(
                         TYPE: CLUSTER_COMMAND_SERVER,
                         ID: cmd_id,
                         ATTR_NAME: cmd.name,
+                        "schema": voluptuous_serialize.convert(
+                            cluster_command_schema_to_vol_schema(cmd.schema)
+                        ),
                     }
                 )
     _LOGGER.debug(

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -702,6 +702,8 @@ class ZHADevice(LogMixin):
             f"{ATTR_MANUFACTURER}: {manufacturer}",
             f"{ATTR_ENDPOINT_ID}: {endpoint_id}",
         )
+        if response is None:
+            return  # client commands don't return a response
         if isinstance(response, Exception):
             raise HomeAssistantError("Failed to issue cluster command") from response
         if response[1] is not ZclStatus.SUCCESS:

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -175,6 +175,8 @@ def convert_to_zcl_values(
                 value = field.type[value.replace(" ", "_")]
         elif issubclass(field.type, enum.Enum):
             value = field.type[value.replace(" ", "_")]
+        else:
+            value = field.type(value)
         _LOGGER.debug(
             "Converted ZCL schema field(%s) value from: %s to: %s",
             field.name,

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -158,7 +158,7 @@ def convert_to_zcl_values(
     fields: dict[str, Any], schema: CommandSchema
 ) -> dict[str, Any]:
     """Convert user input to ZCL values."""
-    converted_fields = {}
+    converted_fields: dict[str, Any] = {}
     for field in schema.fields:
         if field.name not in fields:
             continue

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -168,13 +168,26 @@ def convert_to_zcl_values(
                 value = field.type(
                     functools.reduce(
                         operator.ior,
-                        [field.type[flag.replace(" ", "_")] for flag in value],
+                        [
+                            field.type[flag.replace(" ", "_")]
+                            if isinstance(flag, str)
+                            else field.type(flag)
+                            for flag in value
+                        ],
                     )
                 )
             else:
-                value = field.type[value.replace(" ", "_")]
+                value = (
+                    field.type[value.replace(" ", "_")]
+                    if isinstance(value, str)
+                    else field.type(value)
+                )
         elif issubclass(field.type, enum.Enum):
-            value = field.type[value.replace(" ", "_")]
+            value = (
+                field.type[value.replace(" ", "_")]
+                if isinstance(value, str)
+                else field.type(value)
+            )
         else:
             value = field.type(value)
         _LOGGER.debug(

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -153,6 +153,20 @@ def schema_type_to_vol(field_type):
     return str
 
 
+def process_fields(fields: dict[str, Any], schema: CommandSchema) -> dict[str, Any]:
+    """Process fields."""
+    processed_fields = {}
+    for field in schema.fields:
+        if field.name not in fields:
+            continue
+        value = fields[field.name]
+        if issubclass(field.type, enum.Enum) or issubclass(field.type, enum.Flag):
+            value = field.type[value.replace(" ", "_")]
+            _LOGGER.warning("Converted %s to %s", fields[field.name], value)
+        processed_fields[field.name] = value
+    return processed_fields
+
+
 @callback
 def async_is_bindable_target(source_zha_device, target_zha_device):
     """Determine if target is bindable to source."""

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -137,8 +137,7 @@ def schema_type_to_vol(field_type):
     """Convert a schema type to a voluptuous type."""
     if issubclass(field_type, zigpy.types.FixedIntType):
         return vol.All(
-            vol.Coerce(int),
-            vol.Range(0, field_type._size),  # pylint: disable=protected-access
+            vol.Coerce(int), vol.Range(field_type.min_value, field_type.max_value)
         )
     return str
 

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -135,7 +135,7 @@ def cluster_command_schema_to_vol_schema(schema: CommandSchema) -> vol.Schema:
     )
 
 
-def schema_type_to_vol(field_type):
+def schema_type_to_vol(field_type: Any) -> Any:
     """Convert a schema type to a voluptuous type."""
     if issubclass(field_type, enum.Flag) and len(field_type.__members__.keys()):
         return cv.multi_select(

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -187,6 +187,11 @@ issue_zigbee_cluster_command:
       example: "[arg1, arg2, argN]"
       selector:
         object:
+    params:
+      name: Params
+      description: parameters to pass to the command
+      selector:
+        object:
     manufacturer:
       name: Manufacturer
       description: manufacturer code

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -162,3 +162,36 @@ async def test_zcl_schema_conversions(hass, device_light):
 
     assert isinstance(converted_data["start_hue"], uint16_t)
     assert converted_data["start_hue"] == 196
+
+    raw_data = {
+        "update_flags": [0b0000_0001, 0b0000_1000],
+        "action": 0x02,
+        "direction": 0x01,
+        "time": 20,
+        "start_hue": 196,
+    }
+
+    converted_data = convert_to_zcl_values(raw_data, command_schema)
+
+    assert isinstance(
+        converted_data["update_flags"], lighting.Color.ColorLoopUpdateFlags
+    )
+    assert lighting.Color.ColorLoopUpdateFlags.Action in converted_data["update_flags"]
+    assert (
+        lighting.Color.ColorLoopUpdateFlags.Start_Hue in converted_data["update_flags"]
+    )
+
+    assert isinstance(converted_data["action"], lighting.Color.ColorLoopAction)
+    assert (
+        converted_data["action"]
+        == lighting.Color.ColorLoopAction.Activate_from_current_hue
+    )
+
+    assert isinstance(converted_data["direction"], lighting.Color.ColorLoopDirection)
+    assert converted_data["direction"] == lighting.Color.ColorLoopDirection.Increment
+
+    assert isinstance(converted_data["time"], uint16_t)
+    assert converted_data["time"] == 20
+
+    assert isinstance(converted_data["start_hue"], uint16_t)
+    assert converted_data["start_hue"] == 196

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -1,0 +1,164 @@
+"""Tests for ZHA helpers."""
+import logging
+from unittest.mock import patch
+
+import pytest
+import voluptuous_serialize
+import zigpy.profiles.zha as zha
+from zigpy.types.basic import uint16_t
+import zigpy.zcl.clusters.general as general
+import zigpy.zcl.clusters.lighting as lighting
+
+from homeassistant.components.zha.core.helpers import (
+    cluster_command_schema_to_vol_schema,
+    convert_to_zcl_values,
+)
+from homeassistant.const import Platform
+import homeassistant.helpers.config_validation as cv
+
+from .common import async_enable_traffic
+from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def light_platform_only():
+    """Only setup the light and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.BUTTON,
+            Platform.LIGHT,
+            Platform.NUMBER,
+            Platform.SELECT,
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+async def device_light(hass, zigpy_device_mock, zha_device_joined):
+    """Test light."""
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    general.OnOff.cluster_id,
+                    general.LevelControl.cluster_id,
+                    lighting.Color.cluster_id,
+                    general.Groups.cluster_id,
+                    general.Identify.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
+            }
+        }
+    )
+    color_cluster = zigpy_device.endpoints[1].light_color
+    color_cluster.PLUGGED_ATTR_READS = {
+        "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature
+        | lighting.Color.ColorCapabilities.XY_attributes
+    }
+    zha_device = await zha_device_joined(zigpy_device)
+    zha_device.available = True
+    return color_cluster, zha_device
+
+
+async def test_zcl_schema_conversions(hass, device_light):
+    """Test ZHA ZCL schema conversion helpers."""
+    color_cluster, zha_device = device_light
+    await async_enable_traffic(hass, [zha_device])
+    command_schema = color_cluster.commands_by_name["color_loop_set"].schema
+    expected_schema = [
+        {
+            "type": "multi_select",
+            "options": ["Action", "Direction", "Time", "Start Hue"],
+            "name": "update_flags",
+            "required": True,
+        },
+        {
+            "type": "select",
+            "options": [
+                ("Deactivate", "Deactivate"),
+                ("Activate from color loop hue", "Activate from color loop hue"),
+                ("Activate from current hue", "Activate from current hue"),
+            ],
+            "name": "action",
+            "required": True,
+        },
+        {
+            "type": "select",
+            "options": [("Decrement", "Decrement"), ("Increment", "Increment")],
+            "name": "direction",
+            "required": True,
+        },
+        {
+            "type": "integer",
+            "valueMin": 0,
+            "valueMax": 65535,
+            "name": "time",
+            "required": True,
+        },
+        {
+            "type": "integer",
+            "valueMin": 0,
+            "valueMax": 65535,
+            "name": "start_hue",
+            "required": True,
+        },
+        {
+            "type": "integer",
+            "valueMin": 0,
+            "valueMax": 255,
+            "name": "options_mask",
+            "optional": True,
+        },
+        {
+            "type": "integer",
+            "valueMin": 0,
+            "valueMax": 255,
+            "name": "options_override",
+            "optional": True,
+        },
+    ]
+    vol_schema = voluptuous_serialize.convert(
+        cluster_command_schema_to_vol_schema(command_schema),
+        custom_serializer=cv.custom_serializer,
+    )
+    assert vol_schema == expected_schema
+
+    raw_data = {
+        "update_flags": ["Action", "Start Hue"],
+        "action": "Activate from current hue",
+        "direction": "Increment",
+        "time": 20,
+        "start_hue": 196,
+    }
+
+    converted_data = convert_to_zcl_values(raw_data, command_schema)
+
+    assert isinstance(
+        converted_data["update_flags"], lighting.Color.ColorLoopUpdateFlags
+    )
+    assert lighting.Color.ColorLoopUpdateFlags.Action in converted_data["update_flags"]
+    assert (
+        lighting.Color.ColorLoopUpdateFlags.Start_Hue in converted_data["update_flags"]
+    )
+
+    assert isinstance(converted_data["action"], lighting.Color.ColorLoopAction)
+    assert (
+        converted_data["action"]
+        == lighting.Color.ColorLoopAction.Activate_from_current_hue
+    )
+
+    assert isinstance(converted_data["direction"], lighting.Color.ColorLoopDirection)
+    assert converted_data["direction"] == lighting.Color.ColorLoopDirection.Increment
+
+    assert isinstance(converted_data["time"], uint16_t)
+    assert converted_data["time"] == 20
+
+    assert isinstance(converted_data["start_hue"], uint16_t)
+    assert converted_data["start_hue"] == 196


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability to convert ZCL cluster command schemas into vol schemas. This will be leveraged by the frontend to show forms in the cluster command card in the manage device dialog. It also corrects an argument parsing issue with cluster command schema arguments that was frequently hit in developer tools when attempting to issue cluster commands with complex arguments. Fixes: #79525

arguments can now be passed to cluster commands from developer tools like this: 

![image](https://user-images.githubusercontent.com/1335687/194725912-27fd88dd-35ae-42a4-9866-4277052c4cae.png)

Here is a preview of the cluster command forms in the manage device dialog: 

![image](https://user-images.githubusercontent.com/1335687/194726187-21c92a75-2933-4b94-aad7-cc7eede4568a.png)

and in action:

https://share.icloud.com/photos/085jtifVaz58DQQmMnqQ03hhw


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #79525
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
