### PR TITLE
Allow specifying custom IP "resolver" for Route53.

### DIFF
--- a/tests/components/route53/__init__.py
+++ b/tests/components/route53/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for route53 component."""

--- a/tests/components/route53/test_init.py
+++ b/tests/components/route53/test_init.py
@@ -1,0 +1,107 @@
+"""Test the route53 component."""
+import pytest
+
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.components import route53
+from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
+
+from requests_mock import Mocker
+from tests.common import async_fire_time_changed
+from unittest.mock import patch, MagicMock
+
+IP = "172.13.0.1"
+
+AWS_ACCESS_KEY_ID = "access_key_id"
+AWS_SECRET_ACCESS_KEY = "secret_access_key"
+
+URL = "https://api.ipify.org/"
+TTL = 300
+ZONE = "zone"
+DOMAIN = "domain.example.com"
+RECORDS = ["home"]
+
+
+@pytest.fixture(name="boto3")
+def fixture_boto3() -> None:
+    """Patch boto3 for mocks."""
+    with patch("homeassistant.components.route53.boto3") as boto3_mock:
+        yield boto3_mock
+
+
+async def test_setup(
+    hass: HomeAssistant,
+    requests_mock: Mocker,
+    boto3: MagicMock,
+) -> None:
+    """Test that set-up adds the cron task."""
+    requests_mock.get(URL, text=IP)
+    await _setup_component(hass)
+
+    async_fire_time_changed(
+        hass, utcnow() + timedelta(seconds=route53.INTERVAL.seconds + 1)
+    )
+
+    await hass.async_block_till_done()
+    assert requests_mock.call_count == 1
+
+
+async def test_update(
+    hass: HomeAssistant,
+    requests_mock: Mocker,
+    boto3: MagicMock,
+) -> None:
+    """Test update_records sends the correct values to route53."""
+    requests_mock.get(URL, text=IP)
+    await _setup_component(hass)
+
+    await hass.services.async_call(
+        route53.DOMAIN,
+        "update_records",
+        blocking=True,
+    )
+
+    assert requests_mock.call_count == 1
+
+    boto3.client.assert_called_once_with(
+        "route53",
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+    )
+
+    route53_client = boto3.client.return_value
+    route53_client.change_resource_record_sets.assert_called_once_with(
+        HostedZoneId=ZONE,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "UPSERT",
+                    "ResourceRecordSet": {
+                        "Name": f"{RECORDS[0]}.{DOMAIN}",
+                        "Type": "A",
+                        "TTL": TTL,
+                        "ResourceRecords": [{"Value": IP}],
+                    },
+                },
+            ],
+        },
+    )
+
+
+async def _setup_component(hass: HomeAssistant) -> None:
+    """Sets-up the route53 component for multiple tests."""
+    await async_setup_component(
+        hass,
+        route53.DOMAIN,
+        {
+            route53.DOMAIN: {
+                "aws_access_key_id": AWS_ACCESS_KEY_ID,
+                "aws_secret_access_key": AWS_SECRET_ACCESS_KEY,
+                "zone": ZONE,
+                "domain": DOMAIN,
+                "records": RECORDS,
+            },
+        },
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the Route53 component only resolves/looks-up your IP address
using `api.ipify.org`. This may render the component ineffective when
`api.ipify.org` is inaccessible, possibly due to firewall rules or
ad-blocking software (this domain is blocked by the [Blocklist
Project]). Similarly, a user may just prefer using a different provider.

This commit adds the option, `url`, to specify a custom URL that will be
used to look-up your IP address.  Just like `api.ipify.org`, the URL
specified in the `url` option should return your IP address in
plain-text response with no other content in the response.

This implementation maintains backwards compatibility when `url` is not
specified.

[Blocklist Project]: https://github.com/blocklistproject/Lists


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24462

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io