### PR TITLE
Add Philips Hue motion sensor config entities to ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -27,6 +27,7 @@ from ..const import (
     SIGNAL_SET_LEVEL,
     SIGNAL_UPDATE_DEVICE,
 )
+from ..helpers import is_hue_motion_sensor
 from .base import AttrReportConfig, ClientChannel, ZigbeeChannel, parse_and_log_command
 
 if TYPE_CHECKING:
@@ -155,15 +156,7 @@ class BasicChannel(ZigbeeChannel):
     def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize Basic channel."""
         super().__init__(cluster, ch_pool)
-        if self.cluster.endpoint.manufacturer in (
-            "Philips",
-            "Signify Netherlands B.V.",
-        ) and self.cluster.endpoint.model in (
-            "SML001",
-            "SML002",
-            "SML003",
-            "SML004",
-        ):
+        if is_hue_motion_sensor(self):
             self.ZCL_INIT_ATTRS = (  # pylint: disable=invalid-name
                 self.ZCL_INIT_ATTRS.copy()
             )

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -152,6 +152,23 @@ class BasicChannel(ZigbeeChannel):
         6: "Emergency mains and transfer switch",
     }
 
+    def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
+        """Initialize Basic channel."""
+        super().__init__(cluster, ch_pool)
+        if self.cluster.endpoint.manufacturer in (
+            "Philips",
+            "Signify Netherlands B.V.",
+        ) and self.cluster.endpoint.model in (
+            "SML001",
+            "SML002",
+            "SML003",
+            "SML004",
+        ):
+            self.ZCL_INIT_ATTRS = (  # pylint: disable=invalid-name
+                self.ZCL_INIT_ATTRS.copy()
+            )
+            self.ZCL_INIT_ATTRS["trigger_indicator"] = True
+
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryInput.cluster_id)
 class BinaryInput(ZigbeeChannel):

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -27,8 +27,8 @@ from ..const import (
     SIGNAL_SET_LEVEL,
     SIGNAL_UPDATE_DEVICE,
 )
-from ..helpers import is_hue_motion_sensor
 from .base import AttrReportConfig, ClientChannel, ZigbeeChannel, parse_and_log_command
+from .helpers import is_hue_motion_sensor
 
 if TYPE_CHECKING:
     from . import ChannelPool

--- a/homeassistant/components/zha/core/channels/helpers.py
+++ b/homeassistant/components/zha/core/channels/helpers.py
@@ -1,0 +1,15 @@
+"""Helpers for use with ZHA Zigbee channels."""
+from .base import ZigbeeChannel
+
+
+def is_hue_motion_sensor(channel: ZigbeeChannel) -> bool:
+    """Return true if the manufacturer and model match known Hue motion sensor models."""
+    return channel.cluster.endpoint.manufacturer in (
+        "Philips",
+        "Signify Netherlands B.V.",
+    ) and channel.cluster.endpoint.model in (
+        "SML001",
+        "SML002",
+        "SML003",
+        "SML004",
+    )

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -13,8 +13,8 @@ from ..const import (
     REPORT_CONFIG_MAX_INT,
     REPORT_CONFIG_MIN_INT,
 )
-from ..helpers import is_hue_motion_sensor
 from .base import AttrReportConfig, ZigbeeChannel
+from .helpers import is_hue_motion_sensor
 
 if TYPE_CHECKING:
     from . import ChannelPool

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -1,4 +1,9 @@
 """Measurement channels module for Zigbee Home Automation."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import zigpy.zcl
 from zigpy.zcl.clusters import measurement
 
 from .. import registries
@@ -9,6 +14,9 @@ from ..const import (
     REPORT_CONFIG_MIN_INT,
 )
 from .base import AttrReportConfig, ZigbeeChannel
+
+if TYPE_CHECKING:
+    from . import ChannelPool
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.FlowMeasurement.cluster_id)
@@ -49,6 +57,23 @@ class OccupancySensing(ZigbeeChannel):
     REPORT_CONFIG = (
         AttrReportConfig(attr="occupancy", config=REPORT_CONFIG_IMMEDIATE),
     )
+
+    def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
+        """Initialize Occupancy channel."""
+        super().__init__(cluster, ch_pool)
+        if self.cluster.endpoint.manufacturer in (
+            "Philips",
+            "Signify Netherlands B.V.",
+        ) and self.cluster.endpoint.model in (
+            "SML001",
+            "SML002",
+            "SML003",
+            "SML004",
+        ):
+            self.ZCL_INIT_ATTRS = (  # pylint: disable=invalid-name
+                self.ZCL_INIT_ATTRS.copy()
+            )
+            self.ZCL_INIT_ATTRS["sensitivity"] = True
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.PressureMeasurement.cluster_id)

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -13,6 +13,7 @@ from ..const import (
     REPORT_CONFIG_MAX_INT,
     REPORT_CONFIG_MIN_INT,
 )
+from ..helpers import is_hue_motion_sensor
 from .base import AttrReportConfig, ZigbeeChannel
 
 if TYPE_CHECKING:
@@ -61,15 +62,7 @@ class OccupancySensing(ZigbeeChannel):
     def __init__(self, cluster: zigpy.zcl.Cluster, ch_pool: ChannelPool) -> None:
         """Initialize Occupancy channel."""
         super().__init__(cluster, ch_pool)
-        if self.cluster.endpoint.manufacturer in (
-            "Philips",
-            "Signify Netherlands B.V.",
-        ) and self.cluster.endpoint.model in (
-            "SML001",
-            "SML002",
-            "SML003",
-            "SML004",
-        ):
+        if is_hue_motion_sensor(self):
             self.ZCL_INIT_ATTRS = (  # pylint: disable=invalid-name
                 self.ZCL_INIT_ATTRS.copy()
             )

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -29,6 +29,7 @@ from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import IntegrationError
 from homeassistant.helpers import device_registry as dr
 
+from .channels.base import ZigbeeChannel
 from .const import (
     CLUSTER_TYPE_IN,
     CLUSTER_TYPE_OUT,
@@ -358,3 +359,16 @@ def qr_to_install_code(qr_code: str) -> tuple[zigpy.types.EUI64, bytes]:
         return ieee, install_code
 
     raise vol.Invalid(f"couldn't convert qr code: {qr_code}")
+
+
+def is_hue_motion_sensor(channel: ZigbeeChannel) -> bool:
+    """Return true if the manufacturer and model match known Hue motion sensor models."""
+    return channel.cluster.endpoint.manufacturer in (
+        "Philips",
+        "Signify Netherlands B.V.",
+    ) and channel.cluster.endpoint.model in (
+        "SML001",
+        "SML002",
+        "SML003",
+        "SML004",
+    )

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -29,7 +29,6 @@ from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import IntegrationError
 from homeassistant.helpers import device_registry as dr
 
-from .channels.base import ZigbeeChannel
 from .const import (
     CLUSTER_TYPE_IN,
     CLUSTER_TYPE_OUT,
@@ -359,16 +358,3 @@ def qr_to_install_code(qr_code: str) -> tuple[zigpy.types.EUI64, bytes]:
         return ieee, install_code
 
     raise vol.Invalid(f"couldn't convert qr code: {qr_code}")
-
-
-def is_hue_motion_sensor(channel: ZigbeeChannel) -> bool:
-    """Return true if the manufacturer and model match known Hue motion sensor models."""
-    return channel.cluster.endpoint.manufacturer in (
-        "Philips",
-        "Signify Netherlands B.V.",
-    ) and channel.cluster.endpoint.model in (
-        "SML001",
-        "SML002",
-        "SML003",
-        "SML004",
-    )

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -22,6 +22,7 @@ from .core import discovery
 from .core.const import (
     CHANNEL_IAS_WD,
     CHANNEL_INOVELLI,
+    CHANNEL_OCCUPANCY,
     CHANNEL_ON_OFF,
     DATA_ZHA,
     SIGNAL_ADD_ENTITIES,
@@ -249,7 +250,7 @@ class HueV1MotionSensitivities(types.enum8):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    channel_names="occupancy",
+    channel_names=CHANNEL_OCCUPANCY,
     manufacturers={"Philips", "Signify Netherlands B.V."},
     models={"SML001"},
 )
@@ -271,7 +272,7 @@ class HueV2MotionSensitivities(types.enum8):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    channel_names="occupancy",
+    channel_names=CHANNEL_OCCUPANCY,
     manufacturers={"Philips", "Signify Netherlands B.V."},
     models={"SML002", "SML003", "SML004"},
 )

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -234,10 +234,52 @@ class AqaraMotionSensitivities(types.enum8):
     channel_names="opple_cluster", models={"lumi.motion.ac01", "lumi.motion.ac02"}
 )
 class AqaraMotionSensitivity(ZCLEnumSelectEntity, id_suffix="motion_sensitivity"):
-    """Representation of a ZHA on off transition time configuration entity."""
+    """Representation of a ZHA motion sensitivity configuration entity."""
 
     _select_attr = "motion_sensitivity"
     _enum = AqaraMotionSensitivities
+
+
+class HueV1MotionSensitivities(types.enum8):
+    """Hue v1 motion sensitivities."""
+
+    Low = 0x00
+    Medium = 0x01
+    High = 0x02
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="occupancy",
+    manufacturers={"Philips", "Signify Netherlands B.V."},
+    models={"SML001"},
+)
+class HueV1MotionSensitivity(ZCLEnumSelectEntity, id_suffix="motion_sensitivity"):
+    """Representation of a ZHA motion sensitivity configuration entity."""
+
+    _select_attr = "sensitivity"
+    _enum = HueV1MotionSensitivities
+
+
+class HueV2MotionSensitivities(types.enum8):
+    """Hue v2 motion sensitivities."""
+
+    Lowest = 0x00
+    Low = 0x01
+    Medium = 0x02
+    High = 0x03
+    Highest = 0x04
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="occupancy",
+    manufacturers={"Philips", "Signify Netherlands B.V."},
+    models={"SML002", "SML003", "SML004"},
+)
+class HueV2MotionSensitivity(ZCLEnumSelectEntity, id_suffix="motion_sensitivity"):
+    """Representation of a ZHA motion sensitivity configuration entity."""
+
+    _select_attr = "sensitivity"
+    _enum = HueV2MotionSensitivities
 
 
 class AqaraMonitoringModess(types.enum8):

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -258,7 +258,7 @@ class HueV1MotionSensitivity(ZCLEnumSelectEntity, id_suffix="motion_sensitivity"
     """Representation of a ZHA motion sensitivity configuration entity."""
 
     _select_attr = "sensitivity"
-    _attr_name = "Hue Motion Sensitivity"
+    _attr_name = "Hue motion sensitivity"
     _enum = HueV1MotionSensitivities
 
 
@@ -281,7 +281,7 @@ class HueV2MotionSensitivity(ZCLEnumSelectEntity, id_suffix="motion_sensitivity"
     """Representation of a ZHA motion sensitivity configuration entity."""
 
     _select_attr = "sensitivity"
-    _attr_name = "Hue Motion Sensitivity"
+    _attr_name = "Hue motion sensitivity"
     _enum = HueV2MotionSensitivities
 
 

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -258,6 +258,7 @@ class HueV1MotionSensitivity(ZCLEnumSelectEntity, id_suffix="motion_sensitivity"
     """Representation of a ZHA motion sensitivity configuration entity."""
 
     _select_attr = "sensitivity"
+    _attr_name = "Hue Motion Sensitivity"
     _enum = HueV1MotionSensitivities
 
 
@@ -280,6 +281,7 @@ class HueV2MotionSensitivity(ZCLEnumSelectEntity, id_suffix="motion_sensitivity"
     """Representation of a ZHA motion sensitivity configuration entity."""
 
     _select_attr = "sensitivity"
+    _attr_name = "Hue Motion Sensitivity"
     _enum = HueV2MotionSensitivities
 
 

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .core import discovery
 from .core.const import (
+    CHANNEL_BASIC,
     CHANNEL_INOVELLI,
     CHANNEL_ON_OFF,
     DATA_ZHA,
@@ -293,7 +294,7 @@ class P1MotionTriggerIndicatorSwitch(
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    channel_names="basic",
+    channel_names=CHANNEL_BASIC,
     manufacturers={"Philips", "Signify Netherlands B.V."},
     models={"SML001", "SML002", "SML003", "SML004"},
 )

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -293,6 +293,19 @@ class P1MotionTriggerIndicatorSwitch(
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="basic",
+    manufacturers={"Philips", "Signify Netherlands B.V."},
+    models={"SML001", "SML002", "SML003", "SML004"},
+)
+class HueMotionTriggerIndicatorSwitch(
+    ZHASwitchConfigurationEntity, id_suffix="trigger_indicator"
+):
+    """Representation of a ZHA motion triggering configuration entity."""
+
+    _zcl_attribute: str = "trigger_indicator"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
     channel_names="ikea_airpurifier",
     models={"STARKVIND Air purifier", "STARKVIND Air purifier table"},
 )

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -304,7 +304,7 @@ class HueMotionTriggerIndicatorSwitch(
     """Representation of a ZHA motion triggering configuration entity."""
 
     _zcl_attribute: str = "trigger_indicator"
-    _attr_name = "LED Trigger Indicator"
+    _attr_name = "LED trigger indicator"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -304,6 +304,7 @@ class HueMotionTriggerIndicatorSwitch(
     """Representation of a ZHA motion triggering configuration entity."""
 
     _zcl_attribute: str = "trigger_indicator"
+    _attr_name = "LED Trigger Indicator"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(


### PR DESCRIPTION
## Proposed change
Entities will only show up after the following PR has been merged:
- https://github.com/home-assistant/core/pull/80489

Adds the config entities for all Philips Hue motion sensors to ZHA:
- Sensitivity Select
- Trigger Indicator LED Switch (this will only show up with an update of ``zhaquirks``):
(shows the following warning **without** a dependency bump:
``WARNING (MainThread) [homeassistant.components.zha.core.channels.base] [0xA5A9:2:0x0000]: 'async_initialize' stage failed: 'trigger_indicator'``)

Since Philips/Signify decided to add all the custom configuration entities to existing clusters, this code isn't as clean as I hoped it would be, but I think it can't be improved much at the moment(?)

I've also copied possible non-empty (?) ``ZCL_INIT_ATTRS``. The existing config entities "override" this (since they're all for manufacturer specific clusters/channels where no other attributes exist).
So I'm not 100% sure if this needs to be done but wanted to be safe for now.

Note: Philips Hue motion sensors also support a custom timeout with the standard ``pir_o_to_u_delay`` (0x10) attribute on the Occupancy cluster. This wasn't added in this PR, as I wanted to keep this specific to Hue's custom attributes for now. A future PR could add a config entity for that attribute for all supported devices (although I'm not sure if any other devices actually use that attribute).

This was tested using a Hue in-door v2 (``SML003``) motion sensor:
![Hue motion sensor config entities](https://user-images.githubusercontent.com/6409465/194734821-71cbd02c-1f95-4edc-b1e0-55aca57ad0e8.png)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
