### PR TITLE
Migrate attributes to separate sensors in Brother integration

### DIFF
--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 import logging
-from typing import Any
 
 from brother import BrotherSensors
 
@@ -41,7 +40,6 @@ class BrotherSensorRequiredKeysMixin:
     """Class for Brother entity required keys."""
 
     value: Callable[[BrotherSensors], StateType | datetime]
-    extra_state_attrs: Callable[[BrotherSensors], dict[str, Any]]
 
 
 @dataclass
@@ -58,7 +56,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         name="Status",
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.status,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="page_counter",
@@ -68,7 +65,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.page_counter,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="bw_counter",
@@ -78,7 +74,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.bw_counter,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="color_counter",
@@ -88,7 +83,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.color_counter,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="duplex_unit_pages_counter",
@@ -98,7 +92,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.duplex_unit_pages_counter,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="drum_remaining_life",
@@ -108,10 +101,24 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.drum_remaining_life,
-        extra_state_attrs=lambda data: {
-            ATTR_REMAINING_PAGES: data.drum_remaining_pages,
-            ATTR_COUNTER: data.drum_counter,
-        },
+    ),
+    BrotherSensorEntityDescription(
+        key="drum_remaining_pages",
+        icon="mdi:chart-donut",
+        name="Drum remaining pages",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.drum_remaining_pages,
+    ),
+    BrotherSensorEntityDescription(
+        key="drum_counter",
+        icon="mdi:chart-donut",
+        name="Drum counter",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.drum_counter,
     ),
     BrotherSensorEntityDescription(
         key="black_drum_remaining_life",
@@ -121,10 +128,24 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.black_drum_remaining_life,
-        extra_state_attrs=lambda data: {
-            ATTR_REMAINING_PAGES: data.black_drum_remaining_pages,
-            ATTR_COUNTER: data.black_drum_counter,
-        },
+    ),
+    BrotherSensorEntityDescription(
+        key="black_drum_remaining_pages",
+        icon="mdi:chart-donut",
+        name="Black drum remaining pages",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.black_drum_remaining_pages,
+    ),
+    BrotherSensorEntityDescription(
+        key="black_drum_counter",
+        icon="mdi:chart-donut",
+        name="Black drum counter",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.black_drum_counter,
     ),
     BrotherSensorEntityDescription(
         key="cyan_drum_remaining_life",
@@ -134,10 +155,24 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.cyan_drum_remaining_life,
-        extra_state_attrs=lambda data: {
-            ATTR_REMAINING_PAGES: data.cyan_drum_remaining_pages,
-            ATTR_COUNTER: data.cyan_drum_counter,
-        },
+    ),
+    BrotherSensorEntityDescription(
+        key="cyan_drum_remaining_pages",
+        icon="mdi:chart-donut",
+        name="Cyan drum remaining pages",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.cyan_drum_remaining_pages,
+    ),
+    BrotherSensorEntityDescription(
+        key="cyan_drum_counter",
+        icon="mdi:chart-donut",
+        name="Cyan drum counter",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.cyan_drum_counter,
     ),
     BrotherSensorEntityDescription(
         key="magenta_drum_remaining_life",
@@ -147,10 +182,24 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.magenta_drum_remaining_life,
-        extra_state_attrs=lambda data: {
-            ATTR_REMAINING_PAGES: data.magenta_drum_remaining_pages,
-            ATTR_COUNTER: data.magenta_drum_counter,
-        },
+    ),
+    BrotherSensorEntityDescription(
+        key="magenta_drum_remaining_pages",
+        icon="mdi:chart-donut",
+        name="Magenta drum remaining pages",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.magenta_drum_remaining_pages,
+    ),
+    BrotherSensorEntityDescription(
+        key="magenta_drum_counter",
+        icon="mdi:chart-donut",
+        name="Magenta drum counter",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.magenta_drum_counter,
     ),
     BrotherSensorEntityDescription(
         key="yellow_drum_remaining_life",
@@ -160,10 +209,24 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.yellow_drum_remaining_life,
-        extra_state_attrs=lambda data: {
-            ATTR_REMAINING_PAGES: data.yellow_drum_remaining_pages,
-            ATTR_COUNTER: data.yellow_drum_counter,
-        },
+    ),
+    BrotherSensorEntityDescription(
+        key="yellow_drum_remaining_pages",
+        icon="mdi:chart-donut",
+        name="Yellow drum remaining pages",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.yellow_drum_remaining_pages,
+    ),
+    BrotherSensorEntityDescription(
+        key="yellow_drum_counter",
+        icon="mdi:chart-donut",
+        name="Yellow drum counter",
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda data: data.yellow_drum_counter,
     ),
     BrotherSensorEntityDescription(
         key="belt_unit_remaining_life",
@@ -173,7 +236,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.belt_unit_remaining_life,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="fuser_remaining_life",
@@ -183,7 +245,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.fuser_remaining_life,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="laser_remaining_life",
@@ -193,7 +254,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.laser_remaining_life,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="pf_kit_1_remaining_life",
@@ -203,7 +263,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.pf_kit_1_remaining_life,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="pf_kit_mp_remaining_life",
@@ -213,7 +272,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.pf_kit_mp_remaining_life,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="black_toner_remaining",
@@ -223,7 +281,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.black_toner_remaining,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="cyan_toner_remaining",
@@ -233,7 +290,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.cyan_toner_remaining,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="magenta_toner_remaining",
@@ -243,7 +299,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.magenta_toner_remaining,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="yellow_toner_remaining",
@@ -253,7 +308,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.yellow_toner_remaining,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="black_ink_remaining",
@@ -263,7 +317,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.black_ink_remaining,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="cyan_ink_remaining",
@@ -273,7 +326,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.cyan_ink_remaining,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="magenta_ink_remaining",
@@ -283,7 +335,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.magenta_ink_remaining,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="yellow_ink_remaining",
@@ -293,7 +344,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.yellow_ink_remaining,
-        extra_state_attrs=lambda _: {},
     ),
     BrotherSensorEntityDescription(
         key="uptime",
@@ -302,7 +352,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.uptime,
-        extra_state_attrs=lambda _: {},
     ),
 )
 
@@ -361,9 +410,6 @@ class BrotherPrinterSensor(CoordinatorEntity, SensorEntity):
         """Initialize."""
         super().__init__(coordinator)
         self._attr_device_info = device_info
-        self._attr_extra_state_attributes = description.extra_state_attrs(
-            coordinator.data
-        )
         self._attr_native_value = description.value(coordinator.data)
         self._attr_unique_id = f"{coordinator.data.serial.lower()}_{description.key}"
         self.entity_description = description
@@ -372,7 +418,4 @@ class BrotherPrinterSensor(CoordinatorEntity, SensorEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_native_value = self.entity_description.value(self.coordinator.data)
-        self._attr_extra_state_attributes = self.entity_description.extra_state_attrs(
-            self.coordinator.data
-        )
         self.async_write_ha_state()

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -113,8 +113,6 @@ async def test_sensors(hass: HomeAssistant) -> None:
     state = hass.states.get("sensor.hl_l2340dw_drum_remaining_life")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
-    assert state.attributes.get(ATTR_REMAINING_PAGES) == 11014
-    assert state.attributes.get(ATTR_COUNTER) == 986
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -123,11 +121,31 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_drum_remaining_life"
 
+    state = hass.states.get("sensor.hl_l2340dw_drum_remaining_pages")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "11014"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_drum_remaining_pages")
+    assert entry
+    assert entry.unique_id == "0123456789_drum_remaining_pages"
+
+    state = hass.states.get("sensor.hl_l2340dw_drum_counter")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "986"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_drum_counter")
+    assert entry
+    assert entry.unique_id == "0123456789_drum_counter"
+
     state = hass.states.get("sensor.hl_l2340dw_black_drum_remaining_life")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
-    assert state.attributes.get(ATTR_REMAINING_PAGES) == 16389
-    assert state.attributes.get(ATTR_COUNTER) == 1611
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -136,11 +154,31 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_black_drum_remaining_life"
 
+    state = hass.states.get("sensor.hl_l2340dw_black_drum_remaining_pages")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "16389"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_black_drum_remaining_pages")
+    assert entry
+    assert entry.unique_id == "0123456789_black_drum_remaining_pages"
+
+    state = hass.states.get("sensor.hl_l2340dw_black_drum_counter")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "1611"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_black_drum_counter")
+    assert entry
+    assert entry.unique_id == "0123456789_black_drum_counter"
+
     state = hass.states.get("sensor.hl_l2340dw_cyan_drum_remaining_life")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
-    assert state.attributes.get(ATTR_REMAINING_PAGES) == 16389
-    assert state.attributes.get(ATTR_COUNTER) == 1611
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -149,11 +187,31 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_cyan_drum_remaining_life"
 
+    state = hass.states.get("sensor.hl_l2340dw_cyan_drum_remaining_pages")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "16389"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_cyan_drum_remaining_pages")
+    assert entry
+    assert entry.unique_id == "0123456789_cyan_drum_remaining_pages"
+
+    state = hass.states.get("sensor.hl_l2340dw_cyan_drum_counter")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "1611"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_cyan_drum_counter")
+    assert entry
+    assert entry.unique_id == "0123456789_cyan_drum_counter"
+
     state = hass.states.get("sensor.hl_l2340dw_magenta_drum_remaining_life")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
-    assert state.attributes.get(ATTR_REMAINING_PAGES) == 16389
-    assert state.attributes.get(ATTR_COUNTER) == 1611
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -162,11 +220,31 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_magenta_drum_remaining_life"
 
+    state = hass.states.get("sensor.hl_l2340dw_magenta_drum_remaining_pages")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "16389"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_magenta_drum_remaining_pages")
+    assert entry
+    assert entry.unique_id == "0123456789_magenta_drum_remaining_pages"
+
+    state = hass.states.get("sensor.hl_l2340dw_magenta_drum_counter")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "1611"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_magenta_drum_counter")
+    assert entry
+    assert entry.unique_id == "0123456789_magenta_drum_counter"
+
     state = hass.states.get("sensor.hl_l2340dw_yellow_drum_remaining_life")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
-    assert state.attributes.get(ATTR_REMAINING_PAGES) == 16389
-    assert state.attributes.get(ATTR_COUNTER) == 1611
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -174,6 +252,28 @@ async def test_sensors(hass: HomeAssistant) -> None:
     entry = registry.async_get("sensor.hl_l2340dw_yellow_drum_remaining_life")
     assert entry
     assert entry.unique_id == "0123456789_yellow_drum_remaining_life"
+
+    state = hass.states.get("sensor.hl_l2340dw_yellow_drum_remaining_pages")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "16389"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_yellow_drum_remaining_pages")
+    assert entry
+    assert entry.unique_id == "0123456789_yellow_drum_remaining_pages"
+
+    state = hass.states.get("sensor.hl_l2340dw_yellow_drum_counter")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PAGES
+    assert state.state == "1611"
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    entry = registry.async_get("sensor.hl_l2340dw_yellow_drum_counter")
+    assert entry
+    assert entry.unique_id == "0123456789_yellow_drum_counter"
 
     state = hass.states.get("sensor.hl_l2340dw_fuser_remaining_life")
     assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
`counter` and `remaining pages` attributes of the sensors `drum remaining life`, `black drum remaining life`, `cyan drum remaining life`, `magenta drum remaining life` and `yellow drum remaining life` will be migrated to the sensor entities. Users need to update their automations.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR addresses late review https://github.com/home-assistant/core/pull/79864#discussion_r990740093

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
