### PR TITLE
Bayesian - More informative repairs link

### DIFF
--- a/homeassistant/components/bayesian/repairs.py
+++ b/homeassistant/components/bayesian/repairs.py
@@ -24,7 +24,7 @@ def raise_mirrored_entries(
             severity=issue_registry.IssueSeverity.WARNING,
             translation_key="manual_migration",
             translation_placeholders={"entity": text},
-            learn_more_url="https://github.com/home-assistant/core/pull/67631",
+            learn_more_url="https://www.home-assistant.io/blog/2022/10/05/release-202210/#breaking-changes",
         )
 
 
@@ -40,5 +40,5 @@ def raise_no_prob_given_false(hass: HomeAssistant, text: str) -> None:
         severity=issue_registry.IssueSeverity.ERROR,
         translation_key="no_prob_given_false",
         translation_placeholders={"entity": text},
-        learn_more_url="https://github.com/home-assistant/core/pull/67631",
+        learn_more_url="https://www.home-assistant.io/blog/2022/10/05/release-202210/#breaking-changes",
     )

--- a/homeassistant/components/bayesian/repairs.py
+++ b/homeassistant/components/bayesian/repairs.py
@@ -11,7 +11,12 @@ from .helpers import Observation
 def raise_mirrored_entries(
     hass: HomeAssistant, observations: list[Observation], text: str = ""
 ) -> None:
-    """If there are mirrored entries, the user is probably using a workaround for a patched bug."""
+    """If there are mirrored entries, the user is probably using a workaround for a patched bug.
+    
+    In rare cases the user may have happened to configure 2 entries for a non binary sensor and 
+    is ignoring the other possible states - this will still technically be an incorrect (but
+    working) config as prob_given_true should not sum to 1 if more than the 2 states are possible.
+    """
     if len(observations) != 2:
         return
     if observations[0].is_mirror(observations[1]):

--- a/homeassistant/components/bayesian/repairs.py
+++ b/homeassistant/components/bayesian/repairs.py
@@ -12,8 +12,8 @@ def raise_mirrored_entries(
     hass: HomeAssistant, observations: list[Observation], text: str = ""
 ) -> None:
     """If there are mirrored entries, the user is probably using a workaround for a patched bug.
-    
-    In rare cases the user may have happened to configure 2 entries for a non binary sensor and 
+
+    In rare cases the user may have happened to configure 2 entries for a non binary sensor and
     is ignoring the other possible states - this will still technically be an incorrect (but
     working) config as prob_given_true should not sum to 1 if more than the 2 states are possible.
     """

--- a/homeassistant/components/bayesian/strings.json
+++ b/homeassistant/components/bayesian/strings.json
@@ -1,7 +1,7 @@
 {
   "issues": {
     "manual_migration": {
-      "description": "The Bayesian integration now also updates the probability if the observed `to_state`, `above`, `below`, or `value_template` evaluates to `False` rather than only `True`. So it is no longer required to have duplicate, complementary entries for each binary state. Please remove the mirrored entry for `{entity}`.",
+      "description": "The Bayesian integration now also updates the probability if the observed `to_state`, `above`, `below`, or `value_template` evaluates to `False` rather than only `True`. So it is no longer required to have duplicate, complementary entries for each binary state. Please remove the mirrored entry for `{entity}` or else the probability updates may be duplicated. If these probabilities are deliberately configured for 2 states of a sensor that can hold more than 2 states then your `prob_given_true`s and `prob_given_false`s should not sum to 1 as other states are possible (but will be ignored).",
       "title": "Manual YAML fix required for Bayesian"
     },
     "no_prob_given_false": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since https://github.com/home-assistant/home-assistant.io/pull/24470 the breaking text is a better repository of information.
Would be good to get this into a minor release

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  https://github.com/home-assistant/core/issues/79694
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24470

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
