### PR TITLE
Fix wallbox jwt issue

### DIFF
--- a/homeassistant/components/wallbox/__init__.py
+++ b/homeassistant/components/wallbox/__init__.py
@@ -128,9 +128,9 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 data[CHARGER_STATUS_ID_KEY], ChargerStatus.UNKNOWN
             )
             return data
-        except ConnectionError as wallbox_connection_error:
-            raise UpdateFailed from wallbox_connection_error
-        except requests.exceptions.HTTPError as wallbox_connection_error:
+        except (
+            ConnectionError, requests.exceptions.HTTPError
+        ) as wallbox_connection_error:
             raise UpdateFailed from wallbox_connection_error
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/homeassistant/components/wallbox/__init__.py
+++ b/homeassistant/components/wallbox/__init__.py
@@ -93,8 +93,6 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _authenticate(self) -> None:
         """Authenticate using Wallbox API."""
         try:
-            # Force authentication if the token is about to expire, necessary due to timegap between authenticate and get_data:
-            self._wallbox.jwtToken = ""
             self._wallbox.authenticate()
 
         except requests.exceptions.HTTPError as wallbox_connection_error:

--- a/homeassistant/components/wallbox/__init__.py
+++ b/homeassistant/components/wallbox/__init__.py
@@ -129,7 +129,8 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             return data
         except (
-            ConnectionError, requests.exceptions.HTTPError
+            ConnectionError,
+            requests.exceptions.HTTPError,
         ) as wallbox_connection_error:
             raise UpdateFailed from wallbox_connection_error
 

--- a/homeassistant/components/wallbox/__init__.py
+++ b/homeassistant/components/wallbox/__init__.py
@@ -128,7 +128,8 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 data[CHARGER_STATUS_ID_KEY], ChargerStatus.UNKNOWN
             )
             return data
-
+        except ConnectionError as wallbox_connection_error:
+            raise UpdateFailed from wallbox_connection_error
         except requests.exceptions.HTTPError as wallbox_connection_error:
             raise UpdateFailed from wallbox_connection_error
 

--- a/homeassistant/components/wallbox/__init__.py
+++ b/homeassistant/components/wallbox/__init__.py
@@ -93,7 +93,10 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _authenticate(self) -> None:
         """Authenticate using Wallbox API."""
         try:
+            # Force authentication if the token is about to expire, necessary due to timegap between authenticate and get_data:
+            self._wallbox.jwtToken = ""
             self._wallbox.authenticate()
+
         except requests.exceptions.HTTPError as wallbox_connection_error:
             if wallbox_connection_error.response.status_code == HTTPStatus.FORBIDDEN:
                 raise ConfigEntryAuthFailed from wallbox_connection_error

--- a/homeassistant/components/wallbox/__init__.py
+++ b/homeassistant/components/wallbox/__init__.py
@@ -93,7 +93,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _authenticate(self) -> None:
         """Authenticate using Wallbox API."""
         try:
-            # Force authentication if the token is about to expire, necessary due to timegap between authenticate and get_data:
+            # Force authentication by emptying the token:
             self._wallbox.jwtToken = ""
             self._wallbox.authenticate()
 

--- a/homeassistant/components/wallbox/__init__.py
+++ b/homeassistant/components/wallbox/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
+    UpdateFailed,
 )
 
 from .const import (
@@ -125,11 +126,11 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data[CHARGER_STATUS_DESCRIPTION_KEY] = CHARGER_STATUS.get(
                 data[CHARGER_STATUS_ID_KEY], ChargerStatus.UNKNOWN
             )
-
+            print(self._wallbox.jwtTokenTtl)
             return data
 
         except requests.exceptions.HTTPError as wallbox_connection_error:
-            raise ConnectionError from wallbox_connection_error
+            raise UpdateFailed from wallbox_connection_error
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Get new sensor data for Wallbox component."""

--- a/homeassistant/components/wallbox/__init__.py
+++ b/homeassistant/components/wallbox/__init__.py
@@ -126,7 +126,6 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data[CHARGER_STATUS_DESCRIPTION_KEY] = CHARGER_STATUS.get(
                 data[CHARGER_STATUS_ID_KEY], ChargerStatus.UNKNOWN
             )
-            print(self._wallbox.jwtTokenTtl)
             return data
 
         except requests.exceptions.HTTPError as wallbox_connection_error:

--- a/homeassistant/components/wallbox/lock.py
+++ b/homeassistant/components/wallbox/lock.py
@@ -6,6 +6,7 @@ from typing import Any
 from homeassistant.components.lock import LockEntity, LockEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import InvalidAuth, WallboxCoordinator, WallboxEntity
@@ -36,6 +37,8 @@ async def async_setup_entry(
         )
     except InvalidAuth:
         return
+    except ConnectionError as exc:
+        raise PlatformNotReady from exc
 
     async_add_entities(
         [

--- a/homeassistant/components/wallbox/manifest.json
+++ b/homeassistant/components/wallbox/manifest.json
@@ -3,7 +3,7 @@
   "name": "Wallbox",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wallbox",
-  "requirements": ["wallbox==0.4.9"],
+  "requirements": ["wallbox==0.4.10"],
   "codeowners": ["@hesselonline"],
   "iot_class": "cloud_polling",
   "loggers": ["wallbox"]

--- a/homeassistant/components/wallbox/number.py
+++ b/homeassistant/components/wallbox/number.py
@@ -7,6 +7,7 @@ from typing import Optional, cast
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import InvalidAuth, WallboxCoordinator, WallboxEntity
@@ -46,6 +47,8 @@ async def async_setup_entry(
         )
     except InvalidAuth:
         return
+    except ConnectionError as exc:
+        raise PlatformNotReady from exc
 
     async_add_entities(
         [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2506,7 +2506,7 @@ vultr==0.1.2
 wakeonlan==2.1.0
 
 # homeassistant.components.wallbox
-wallbox==0.4.9
+wallbox==0.4.10
 
 # homeassistant.components.waqi
 waqiasync==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1734,7 +1734,7 @@ vultr==0.1.2
 wakeonlan==2.1.0
 
 # homeassistant.components.wallbox
-wallbox==0.4.9
+wallbox==0.4.10
 
 # homeassistant.components.folder_watcher
 watchdog==2.1.9

--- a/tests/components/wallbox/__init__.py
+++ b/tests/components/wallbox/__init__.py
@@ -173,3 +173,29 @@ async def setup_integration_read_only(hass: HomeAssistant) -> None:
 
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+
+
+async def setup_integration_platform_not_ready(hass: HomeAssistant) -> None:
+    """Test wallbox sensor class setup for read only."""
+
+    with requests_mock.Mocker() as mock_request:
+        mock_request.get(
+            "https://user-api.wall-box.com/users/signin",
+            json=authorisation_response,
+            status_code=HTTPStatus.OK,
+        )
+        mock_request.get(
+            "https://api.wall-box.com/chargers/status/12345",
+            json=test_response,
+            status_code=HTTPStatus.OK,
+        )
+        mock_request.put(
+            "https://api.wall-box.com/v2/charger/12345",
+            json=test_response,
+            status_code=HTTPStatus.NOT_FOUND,
+        )
+
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/components/wallbox/test_lock.py
+++ b/tests/components/wallbox/test_lock.py
@@ -13,6 +13,7 @@ from . import (
     authorisation_response,
     entry,
     setup_integration,
+    setup_integration_platform_not_ready,
     setup_integration_read_only,
 )
 from .const import MOCK_LOCK_ENTITY_ID
@@ -103,6 +104,18 @@ async def test_wallbox_lock_class_authentication_error(hass: HomeAssistant) -> N
     """Test wallbox lock not loaded on authentication error."""
 
     await setup_integration_read_only(hass)
+
+    state = hass.states.get(MOCK_LOCK_ENTITY_ID)
+
+    assert state is None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_wallbox_lock_class_platform_not_ready(hass: HomeAssistant) -> None:
+    """Test wallbox lock not loaded on authentication error."""
+
+    await setup_integration_platform_not_ready(hass)
 
     state = hass.states.get(MOCK_LOCK_ENTITY_ID)
 

--- a/tests/components/wallbox/test_number.py
+++ b/tests/components/wallbox/test_number.py
@@ -9,7 +9,12 @@ from homeassistant.components.wallbox import CHARGER_MAX_CHARGING_CURRENT_KEY
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
-from . import authorisation_response, entry, setup_integration
+from . import (
+    authorisation_response,
+    entry,
+    setup_integration,
+    setup_integration_platform_not_ready,
+)
 from .const import MOCK_NUMBER_ENTITY_ID
 
 
@@ -70,4 +75,16 @@ async def test_wallbox_number_class_connection_error(hass: HomeAssistant) -> Non
                 },
                 blocking=True,
             )
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_wallbox_number_class_platform_not_ready(hass: HomeAssistant) -> None:
+    """Test wallbox lock not loaded on authentication error."""
+
+    await setup_integration_platform_not_ready(hass)
+
+    state = hass.states.get(MOCK_NUMBER_ENTITY_ID)
+
+    assert state is None
+
     await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- I'm fixing an open issue in which the JWT token of the wallbox api expires during refreshing data. The fix is bumping the wallbox package to 4.10, 4.10 includes a fix for the token TTL. (https://github.com/cliviu74/wallbox/pull/19)
I have improved exception handling to prevent spamming the log file when errors occur, something that was also caused by this issue. 
- https://github.com/cliviu74/wallbox/releases/tag/0.4.10


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #79785
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
