### PR TITLE
Add diagnostics to Enphase Envoy

### DIFF
--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -24,9 +24,6 @@ async def async_get_config_entry_diagnostics(
     coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
 
     return {
-        "entry": {
-            "title": entry.title,
-            "data": async_redact_data(entry.data, TO_REDACT),
-        },
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
         "data": coordinator.data,
     }

--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -29,7 +29,10 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
 
-    return {
-        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "data": coordinator.data,
-    }
+    return async_redact_data(
+        {
+            "entry": entry.as_dict(),
+            "data": coordinator.data,
+        },
+        TO_REDACT,
+    )

--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -5,14 +5,20 @@ from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_UNIQUE_ID, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import COORDINATOR, DOMAIN
 
+CONF_TITLE = "title"
+
 TO_REDACT = {
+    CONF_NAME,
     CONF_PASSWORD,
+    # Config entry title and unique ID may contain sensitive data:
+    CONF_TITLE,
+    CONF_UNIQUE_ID,
     CONF_USERNAME,
 }
 

--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -1,0 +1,32 @@
+"""Diagnostics support for Enphase Envoy."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import COORDINATOR, DOMAIN
+
+TO_REDACT = {
+    CONF_PASSWORD,
+    CONF_USERNAME,
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+
+    return {
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(entry.data, TO_REDACT),
+        },
+        "data": coordinator.data,
+    }

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -29,10 +29,10 @@ async def test_form(hass: HomeAssistant, config, setup_enphase_envoy) -> None:
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy 1234"
     assert result2["data"] == {
-        "host": "1.1.1.1",
-        "name": "Envoy 1234",
-        "username": "test-username",
-        "password": "test-password",
+        CONF_HOST: "1.1.1.1",
+        CONF_NAME: "Envoy 1234",
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
     }
 
 
@@ -58,10 +58,10 @@ async def test_user_no_serial_number(
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy"
     assert result2["data"] == {
-        "host": "1.1.1.1",
-        "name": "Envoy",
-        "username": "test-username",
-        "password": "test-password",
+        CONF_HOST: "1.1.1.1",
+        CONF_NAME: "Envoy",
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
     }
 
 
@@ -96,10 +96,10 @@ async def test_user_fetching_serial_fails(
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy"
     assert result2["data"] == {
-        "host": "1.1.1.1",
-        "name": "Envoy",
-        "username": "test-username",
-        "password": "test-password",
+        CONF_HOST: "1.1.1.1",
+        CONF_NAME: "Envoy",
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
     }
 
 
@@ -198,10 +198,10 @@ async def test_zeroconf(hass: HomeAssistant, setup_enphase_envoy) -> None:
     assert result2["title"] == "Envoy 1234"
     assert result2["result"].unique_id == "1234"
     assert result2["data"] == {
-        "host": "1.1.1.1",
-        "name": "Envoy 1234",
-        "username": "test-username",
-        "password": "test-password",
+        CONF_HOST: "1.1.1.1",
+        CONF_NAME: "Envoy 1234",
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
     }
 
 

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -29,10 +29,10 @@ async def test_form(hass: HomeAssistant, config, setup_enphase_envoy) -> None:
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy 1234"
     assert result2["data"] == {
-        CONF_HOST: "1.1.1.1",
-        CONF_NAME: "Envoy 1234",
-        CONF_USERNAME: "test-username",
-        CONF_PASSWORD: "test-password",
+        "host": "1.1.1.1",
+        "name": "Envoy 1234",
+        "username": "test-username",
+        "password": "test-password",
     }
 
 
@@ -58,10 +58,10 @@ async def test_user_no_serial_number(
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy"
     assert result2["data"] == {
-        CONF_HOST: "1.1.1.1",
-        CONF_NAME: "Envoy",
-        CONF_USERNAME: "test-username",
-        CONF_PASSWORD: "test-password",
+        "host": "1.1.1.1",
+        "name": "Envoy",
+        "username": "test-username",
+        "password": "test-password",
     }
 
 
@@ -96,10 +96,10 @@ async def test_user_fetching_serial_fails(
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy"
     assert result2["data"] == {
-        CONF_HOST: "1.1.1.1",
-        CONF_NAME: "Envoy",
-        CONF_USERNAME: "test-username",
-        CONF_PASSWORD: "test-password",
+        "host": "1.1.1.1",
+        "name": "Envoy",
+        "username": "test-username",
+        "password": "test-password",
     }
 
 
@@ -198,10 +198,10 @@ async def test_zeroconf(hass: HomeAssistant, setup_enphase_envoy) -> None:
     assert result2["title"] == "Envoy 1234"
     assert result2["result"].unique_id == "1234"
     assert result2["data"] == {
-        CONF_HOST: "1.1.1.1",
-        CONF_NAME: "Envoy 1234",
-        CONF_USERNAME: "test-username",
-        CONF_PASSWORD: "test-password",
+        "host": "1.1.1.1",
+        "name": "Envoy 1234",
+        "username": "test-username",
+        "password": "test-password",
     }
 
 

--- a/tests/components/enphase_envoy/test_diagnostics.py
+++ b/tests/components/enphase_envoy/test_diagnostics.py
@@ -1,0 +1,47 @@
+"""Test Enphase Envoy diagnostics."""
+from homeassistant.components.diagnostics import REDACTED
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_entry_diagnostics(hass, config_entry, hass_client, setup_enphase_envoy):
+    """Test config entry diagnostics."""
+    assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
+        "entry": {
+            "title": "Envoy 1234",
+            "data": {
+                "host": "1.1.1.1",
+                "name": "Envoy 1234",
+                "username": REDACTED,
+                "password": REDACTED,
+            },
+        },
+        "data": {
+            "production": 1840,
+            "daily_production": 28223,
+            "seven_days_production": 174482,
+            "lifetime_production": 5924391,
+            "consumption": 1840,
+            "daily_consumption": 5923857,
+            "seven_days_consumption": 5923857,
+            "lifetime_consumption": 5923857,
+            "inverters_production": {
+                "202140024014": [136, "2022-10-08 16:43:36"],
+                "202140023294": [163, "2022-10-08 16:43:41"],
+                "202140013819": [130, "2022-10-08 16:43:31"],
+                "202140023794": [139, "2022-10-08 16:43:38"],
+                "202140023381": [130, "2022-10-08 16:43:47"],
+                "202140024176": [54, "2022-10-08 16:43:59"],
+                "202140003284": [132, "2022-10-08 16:43:55"],
+                "202140019854": [129, "2022-10-08 16:43:58"],
+                "202140020743": [131, "2022-10-08 16:43:49"],
+                "202140023531": [28, "2022-10-08 16:43:53"],
+                "202140024241": [164, "2022-10-08 16:43:33"],
+                "202140022963": [164, "2022-10-08 16:43:41"],
+                "202140023149": [118, "2022-10-08 16:43:47"],
+                "202140024828": [129, "2022-10-08 16:43:36"],
+                "202140023269": [133, "2022-10-08 16:43:43"],
+                "202140024157": [112, "2022-10-08 16:43:52"],
+            },
+        },
+    }

--- a/tests/components/enphase_envoy/test_diagnostics.py
+++ b/tests/components/enphase_envoy/test_diagnostics.py
@@ -11,10 +11,10 @@ async def test_entry_diagnostics(hass, config_entry, hass_client, setup_enphase_
             "entry_id": config_entry.entry_id,
             "version": 1,
             "domain": "enphase_envoy",
-            "title": "Envoy 1234",
+            "title": REDACTED,
             "data": {
                 "host": "1.1.1.1",
-                "name": "Envoy 1234",
+                "name": REDACTED,
                 "username": REDACTED,
                 "password": REDACTED,
             },
@@ -22,7 +22,7 @@ async def test_entry_diagnostics(hass, config_entry, hass_client, setup_enphase_
             "pref_disable_new_entities": False,
             "pref_disable_polling": False,
             "source": "user",
-            "unique_id": "1234",
+            "unique_id": REDACTED,
             "disabled_by": None,
         },
         "data": {

--- a/tests/components/enphase_envoy/test_diagnostics.py
+++ b/tests/components/enphase_envoy/test_diagnostics.py
@@ -8,6 +8,9 @@ async def test_entry_diagnostics(hass, config_entry, hass_client, setup_enphase_
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {
+            "entry_id": config_entry.entry_id,
+            "version": 1,
+            "domain": "enphase_envoy",
             "title": "Envoy 1234",
             "data": {
                 "host": "1.1.1.1",
@@ -15,6 +18,12 @@ async def test_entry_diagnostics(hass, config_entry, hass_client, setup_enphase_
                 "username": REDACTED,
                 "password": REDACTED,
             },
+            "options": {},
+            "pref_disable_new_entities": False,
+            "pref_disable_polling": False,
+            "source": "user",
+            "unique_id": "1234",
+            "disabled_by": None,
         },
         "data": {
             "production": 1840,


### PR DESCRIPTION
**DO NOT MERGE UNTIL https://github.com/home-assistant/core/pull/79914 IS MERGED.**

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds diagnostics to Enphase Envoy:

```json
{
    "entry": {
        "entry_id": "...",
        "version": 1,
        "domain": "enphase_envoy",
        "title": "**REDACTED**",
        "data": {
            "host": "1.1.1.1",
            "name": "**REDACTED**",
            "username": "**REDACTED**",
            "password": "**REDACTED**"
        },
        "options": {},
        "pref_disable_new_entities": false,
        "pref_disable_polling": false,
        "source": "user",
        "unique_id": "**REDACTED**",
        "disabled_by": null
    },
    "data": {
        "production": 1840,
        "daily_production": 28223,
        "seven_days_production": 174482,
        "lifetime_production": 5924391,
        "consumption": 1840,
        "daily_consumption": 5923857,
        "seven_days_consumption": 5923857,
        "lifetime_consumption": 5923857,
        "inverters_production": {
            "202140024014": [136, "2022-10-08 16:43:36"],
            "202140023294": [163, "2022-10-08 16:43:41"],
            "202140013819": [130, "2022-10-08 16:43:31"],
            "202140023794": [139, "2022-10-08 16:43:38"],
            "202140023381": [130, "2022-10-08 16:43:47"],
            "202140024176": [54, "2022-10-08 16:43:59"],
            "202140003284": [132, "2022-10-08 16:43:55"],
            "202140019854": [129, "2022-10-08 16:43:58"],
            "202140020743": [131, "2022-10-08 16:43:49"],
            "202140023531": [28, "2022-10-08 16:43:53"],
            "202140024241": [164, "2022-10-08 16:43:33"],
            "202140022963": [164, "2022-10-08 16:43:41"],
            "202140023149": [118, "2022-10-08 16:43:47"],
            "202140024828": [129, "2022-10-08 16:43:36"],
            "202140023269": [133, "2022-10-08 16:43:43"],
            "202140024157": [112, "2022-10-08 16:43:52"]
      }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/core/pull/79914

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
