### PR TITLE
Add support for Homeowner and Phantom Keypads

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -260,10 +260,7 @@ def _async_register_button_devices(
 
 
 def _handle_none_keypad_serial(keypad_device: dict, bridge_serial: int) -> str:
-    return (
-        keypad_device["serial"]
-        or f"{str(bridge_serial)}_{str(keypad_device['device_id'])}"
-    )
+    return keypad_device["serial"] or f"{bridge_serial}_{keypad_device['device_id']}"
 
 
 def _area_and_name_from_name(device_name: str) -> tuple[str, str]:

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -232,7 +232,9 @@ def _async_register_button_devices(
             # use the parent_device for HA device info
             ha_device = bridge_devices[device["parent_device"]]
 
-        ha_device_serial = _handle_keypad_serial(ha_device, bridge_device["serial"])
+        ha_device_serial = _handle_none_keypad_serial(
+            ha_device, bridge_device["serial"]
+        )
 
         if "serial" not in ha_device or ha_device_serial in seen:
             continue
@@ -257,9 +259,10 @@ def _async_register_button_devices(
     return button_devices_by_dr_id, device_info_by_device_id
 
 
-def _handle_keypad_serial(keypad_device: dict, bridge_serial: int) -> str:
-    return keypad_device["serial"] or "_".join(
-        (str(bridge_serial), str(keypad_device["device_id"]))
+def _handle_none_keypad_serial(keypad_device: dict, bridge_serial: int) -> str:
+    return (
+        keypad_device["serial"]
+        or f"{str(bridge_serial)}_{str(keypad_device['device_id'])}"
     )
 
 
@@ -309,7 +312,7 @@ def _async_subscribe_pico_remote_events(
             # use the parent_device for HA device info
             ha_device = bridge_devices[device["parent_device"]]
 
-        ha_device_serial = _handle_keypad_serial(
+        ha_device_serial = _handle_none_keypad_serial(
             ha_device, bridge_devices[BRIDGE_DEVICE_ID]["serial"]
         )
 

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -232,16 +232,18 @@ def _async_register_button_devices(
             # use the parent_device for HA device info
             ha_device = bridge_devices[device["parent_device"]]
 
-        if "serial" not in ha_device or ha_device["serial"] in seen:
+        ha_device_serial = _handle_keypad_serial(ha_device, bridge_device["serial"])
+
+        if "serial" not in ha_device or ha_device_serial in seen:
             continue
-        seen.add(ha_device["serial"])
+        seen.add(ha_device_serial)
 
         area, name = _area_and_name_from_name(ha_device["name"])
         device_args: dict[str, Any] = {
             "name": f"{area} {name}",
             "manufacturer": MANUFACTURER,
             "config_entry_id": config_entry_id,
-            "identifiers": {(DOMAIN, ha_device["serial"])},
+            "identifiers": {(DOMAIN, ha_device_serial)},
             "model": f"{ha_device['model']} ({ha_device['type']})",
             "via_device": (DOMAIN, bridge_device["serial"]),
         }
@@ -253,6 +255,12 @@ def _async_register_button_devices(
         device_info_by_device_id.setdefault(ha_device["device_id"], device_args)
 
     return button_devices_by_dr_id, device_info_by_device_id
+
+
+def _handle_keypad_serial(keypad_device: dict, bridge_serial: int) -> str:
+    return keypad_device["serial"] or "_".join(
+        (str(bridge_serial), str(keypad_device["device_id"]))
+    )
 
 
 def _area_and_name_from_name(device_name: str) -> tuple[str, str]:
@@ -301,16 +309,20 @@ def _async_subscribe_pico_remote_events(
             # use the parent_device for HA device info
             ha_device = bridge_devices[device["parent_device"]]
 
+        ha_device_serial = _handle_keypad_serial(
+            ha_device, bridge_devices[BRIDGE_DEVICE_ID]["serial"]
+        )
+
         type_ = _lutron_model_to_device_type(ha_device["model"], ha_device["type"])
         area, name = _area_and_name_from_name(ha_device["name"])
         leap_button_number = device["button_number"]
         lip_button_number = async_get_lip_button(type_, leap_button_number)
-        hass_device = dev_reg.async_get_device({(DOMAIN, ha_device["serial"])})
+        hass_device = dev_reg.async_get_device({(DOMAIN, ha_device_serial)})
 
         hass.bus.async_fire(
             LUTRON_CASETA_BUTTON_EVENT,
             {
-                ATTR_SERIAL: ha_device["serial"],
+                ATTR_SERIAL: ha_device_serial,
                 ATTR_TYPE: type_,
                 ATTR_BUTTON_NUMBER: lip_button_number,
                 ATTR_LEAP_BUTTON_NUMBER: leap_button_number,

--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -315,6 +315,27 @@ SUNNATA_KEYPAD_4_BUTTON_TRIGGER_SCHEMA = LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
     }
 )
 
+HOMEOWNER_KEYPAD_BUTTON_TYPES_TO_LEAP = {
+    "button_1": 1,
+    "button_2": 2,
+    "button_3": 3,
+    "button_4": 4,
+    "button_5": 5,
+    "button_6": 6,
+    "button_7": 7,
+}
+HOMEOWNER_KEYPAD_BUTTON_TRIGGER_SCHEMA = LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
+    {
+        vol.Required(CONF_SUBTYPE): vol.In(HOMEOWNER_KEYPAD_BUTTON_TYPES_TO_LEAP),
+    }
+)
+
+PHANTOM_KEYPAD_BUTTON_TYPES_TO_LEAP: dict[str, int] = {}
+PHANTOM_KEYPAD_BUTTON_TRIGGER_SCHEMA = LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
+    {
+        vol.Required(CONF_SUBTYPE): vol.In(PHANTOM_KEYPAD_BUTTON_TYPES_TO_LEAP),
+    }
+)
 
 DEVICE_TYPE_SCHEMA_MAP = {
     "Pico2Button": PICO_2_BUTTON_TRIGGER_SCHEMA,
@@ -329,6 +350,8 @@ DEVICE_TYPE_SCHEMA_MAP = {
     "SunnataKeypad_2Button": SUNNATA_KEYPAD_2_BUTTON_TRIGGER_SCHEMA,
     "SunnataKeypad_3ButtonRaiseLower": SUNNATA_KEYPAD_3_BUTTON_RAISE_LOWER_TRIGGER_SCHEMA,
     "SunnataKeypad_4Button": SUNNATA_KEYPAD_4_BUTTON_TRIGGER_SCHEMA,
+    "HomeownerKeypad": HOMEOWNER_KEYPAD_BUTTON_TRIGGER_SCHEMA,
+    "PhantomKeypad": PHANTOM_KEYPAD_BUTTON_TRIGGER_SCHEMA,
 }
 
 DEVICE_TYPE_SUBTYPE_MAP_TO_LIP = {
@@ -356,6 +379,8 @@ DEVICE_TYPE_SUBTYPE_MAP_TO_LEAP = {
     "SunnataKeypad_2Button": SUNNATA_KEYPAD_2_BUTTON_BUTTON_TYPES_TO_LEAP,
     "SunnataKeypad_3ButtonRaiseLower": SUNNATA_KEYPAD_3_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
     "SunnataKeypad_4Button": SUNNATA_KEYPAD_4_BUTTON_BUTTON_TYPES_TO_LEAP,
+    "HomeownerKeypad": HOMEOWNER_KEYPAD_BUTTON_TYPES_TO_LEAP,
+    "PhantomKeypad": PHANTOM_KEYPAD_BUTTON_TYPES_TO_LEAP,
 }
 
 LEAP_TO_DEVICE_TYPE_SUBTYPE_MAP = {
@@ -373,6 +398,8 @@ TRIGGER_SCHEMA = vol.Any(
     SUNNATA_KEYPAD_2_BUTTON_TRIGGER_SCHEMA,
     SUNNATA_KEYPAD_3_BUTTON_RAISE_LOWER_TRIGGER_SCHEMA,
     SUNNATA_KEYPAD_4_BUTTON_TRIGGER_SCHEMA,
+    HOMEOWNER_KEYPAD_BUTTON_TRIGGER_SCHEMA,
+    PHANTOM_KEYPAD_BUTTON_TRIGGER_SCHEMA,
 )
 
 
@@ -429,9 +456,9 @@ async def async_get_triggers(
 
 def _device_model_to_type(device_registry_model: str) -> str:
     """Convert a lutron_caseta device registry entry model to type."""
-    model, p_device_type = device_registry_model.split(" ")
+    *model_list, p_device_type = device_registry_model.split(" ")
     device_type = p_device_type.replace("(", "").replace(")", "")
-    return _lutron_model_to_device_type(model, device_type)
+    return _lutron_model_to_device_type(" ".join(model_list), device_type)
 
 
 def _lutron_model_to_device_type(model: str, device_type: str) -> str:

--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -456,8 +456,8 @@ async def async_get_triggers(
 
 def _device_model_to_type(device_registry_model: str) -> str:
     """Convert a lutron_caseta device registry entry model to type."""
-    *model_list, p_device_type = device_registry_model.split(" ")
-    device_type = p_device_type.replace("(", "").replace(")", "")
+    model_list = device_registry_model.split(" ")
+    device_type = model_list.pop().replace("(", "").replace(")", "")
     return _lutron_model_to_device_type(" ".join(model_list), device_type)
 
 

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -67,6 +67,25 @@ MOCK_BUTTON_DEVICES = [
         "model": "RRST-W4B-XX",
         "serial": 43845547,
     },
+    {
+        "device_id": "786",
+        "Name": "Example Homeowner Keypad",
+        "ID": 3,
+        "Area": {"Name": "Front Steps"},
+        "Buttons": [
+            {"Number": 12},
+            {"Number": 13},
+            {"Number": 14},
+            {"Number": 15},
+            {"Number": 16},
+            {"Number": 17},
+            {"Number": 18},
+        ],
+        "leap_name": "Front Steps_Example Homeowner Keypad",
+        "type": "HomeownerKeypad",
+        "model": "Homeowner Keypad",
+        "serial": None,
+    },
 ]
 
 
@@ -176,6 +195,18 @@ async def test_get_triggers_for_non_button_device(hass, device_reg):
     )
 
     assert triggers == []
+
+
+async def test_none_serial_keypad(hass, device_reg):
+    """Test serial assignment for keypads without serials."""
+    config_entry_id = await _async_setup_lutron_with_picos(hass, device_reg)
+
+    keypad_device = device_reg.async_get_or_create(
+        config_entry_id=config_entry_id,
+        identifiers={(DOMAIN, "1234_786")},
+    )
+
+    assert keypad_device is not None
 
 
 async def test_if_fires_on_button_event(hass, calls, device_reg):


### PR DESCRIPTION
## Proposed change
Adding support for 2 Keypad Types for RA3/HWQSX
Homeowner Keypad (HomeownerKeypad)
Phantom Keypad (PhantomKeypad)

Homeowner keypad is a 7 button virtual keypad
This keypad shows up in the lutron app, and buttons can be pressed like a real keypad.

Phantom Keypad is a device with a variable amount of buttons, configurable by the user.
These buttons are used to store scenes which can be triggered by integrations.
These keypads do not show up in the lutron app, and cannot have their buttons pressed from within the lutron ecosystem.
A future update will enable HA to "push" these buttons to execute the saved scenes.

Both of these keypads do not present a serial number, and just return None for the serial.
Keypads missing serial numbers will substitute the [bridge_serial]_[keypad device_id] as the serial.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
