### PR TITLE
Add Vicare switch to allow disabling the onetimecharge

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -33,6 +33,12 @@ class ViCareRequiredKeysMixin:
 
     value_getter: Callable[[Device], bool]
 
+@dataclass()
+class ViCareToggleKeysMixin:
+    """Mixin for enable/disable callables for toggle."""
+    enabler: Callable[[Device], bool]
+    disabler: Callable[[Device], bool]
+
 
 @dataclass()
 class ViCareRequiredKeysMixinWithSet:

--- a/homeassistant/components/vicare/const.py
+++ b/homeassistant/components/vicare/const.py
@@ -12,6 +12,7 @@ PLATFORMS = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.WATER_HEATER,
+    Platform.SWITCH,
 ]
 
 VICARE_DEVICE_CONFIG = "device_conf"

--- a/homeassistant/components/vicare/switch.py
+++ b/homeassistant/components/vicare/switch.py
@@ -1,0 +1,211 @@
+"""Viessmann ViCare sensor device."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import suppress
+from dataclasses import dataclass
+import datetime
+from datetime import timedelta
+import logging
+
+from PyViCare.PyViCareUtils import (
+    PyViCareInvalidDataError,
+    PyViCareNotSupportedFeatureError,
+    PyViCareRateLimitError,
+)
+import requests
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+
+from . import ViCareRequiredKeysMixin, ViCareToggleKeysMixin
+from .const import DOMAIN, VICARE_API, VICARE_DEVICE_CONFIG, VICARE_NAME
+
+_LOGGER = logging.getLogger(__name__)
+
+SWITCH_DHW_ONETIME_CHARGE = "dhw_onetimecharge"
+TIMEDELTA_UPDATE = timedelta(seconds=5)
+
+
+@dataclass
+class ViCareSwitchEntityDescription(
+    SwitchEntityDescription, ViCareRequiredKeysMixin, ViCareToggleKeysMixin
+):
+    """Describes ViCare switch entity."""
+
+
+SWITCH_DESCRIPTIONS: tuple[ViCareSwitchEntityDescription, ...] = (
+    ViCareSwitchEntityDescription(
+        key=SWITCH_DHW_ONETIME_CHARGE,
+        name="Activate one-time charge",
+        icon="mdi:shower-head",
+        entity_category=EntityCategory.CONFIG,
+        value_getter=lambda api: api.getOneTimeCharge(),
+        enabler=lambda api: api.activateOneTimeCharge(),
+        disabler=lambda api: api.deactivateOneTimeCharge(),
+    ),
+)
+
+
+def _build_entity(name, vicare_api, device_config, description):
+    """Create a ViCare button entity."""
+    _LOGGER.debug("Found device %s", name)
+    try:
+        description.value_getter(vicare_api)
+        _LOGGER.debug("Found entity %s", name)
+    except PyViCareNotSupportedFeatureError:
+        _LOGGER.info("Feature not supported %s", name)
+        return None
+    except AttributeError:
+        _LOGGER.debug("Attribute Error %s", name)
+        return None
+
+    return ViCareSwitch(
+        name,
+        vicare_api,
+        device_config,
+        description,
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create the ViCare switch devices."""
+    name = VICARE_NAME
+    api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
+
+    entities = []
+
+    for description in SWITCH_DESCRIPTIONS:
+        entity = await hass.async_add_executor_job(
+            _build_entity,
+            f"{name} {description.name}",
+            api,
+            hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG],
+            description,
+        )
+        if entity is not None:
+            entities.append(entity)
+
+    async_add_entities(entities)
+
+
+class ViCareSwitch(SwitchEntity):
+    """Representation of a ViCare switch."""
+
+    entity_description: ViCareSwitchEntityDescription
+
+    def __init__(
+        self, name, api, device_config, description: ViCareSwitchEntityDescription
+    ):
+        """Initialize the switch."""
+        self.entity_description = description
+        self._device_config = device_config
+        self._api = api
+        self._ignore_update_until = datetime.datetime.utcnow()
+        self._state = None
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return self._state
+
+    async def async_update(self):
+        """update internal state"""
+        now = datetime.datetime.utcnow()
+        """we have identified that the API does not directly sync the represented state, therefore we want to keep
+        an assumed state for a couple of seconds - so lets ignore an update
+        """
+        if now < self._ignore_update_until:
+            _LOGGER.debug(
+                "Ignoring Update Request for OneTime Charging for some seconds"
+            )
+            return
+
+        try:
+            with suppress(PyViCareNotSupportedFeatureError):
+                _LOGGER.debug("Fetching DHW One Time Charging Status")
+                self._state = await self.hass.async_add_executor_job(
+                    self.entity_description.value_getter, self._api
+                )
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("Unable to retrieve data from ViCare server")
+        except ValueError:
+            _LOGGER.error("Unable to decode data from ViCare server")
+        except PyViCareRateLimitError as limit_exception:
+            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
+        except PyViCareInvalidDataError as invalid_data_exception:
+            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Handle the button press."""
+        try:
+            with suppress(PyViCareNotSupportedFeatureError):
+                """Turn the switch on."""
+                _LOGGER.debug("Enabling DHW One-Time-Charging")
+                await self.hass.async_add_executor_job(
+                    self.entity_description.enabler, self._api
+                )
+                self._ignore_update_until = (
+                    datetime.datetime.utcnow() + TIMEDELTA_UPDATE
+                )
+                self._state = True
+
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("Unable to retrieve data from ViCare server")
+        except ValueError:
+            _LOGGER.error("Unable to decode data from ViCare server")
+        except PyViCareRateLimitError as limit_exception:
+            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
+        except PyViCareInvalidDataError as invalid_data_exception:
+            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Handle the button press."""
+        try:
+            with suppress(PyViCareNotSupportedFeatureError):
+                _LOGGER.debug("Disabling DHW One-Time-Charging")
+                await self.hass.async_add_executor_job(
+                    self.entity_description.disabler, self._api
+                )
+                self._ignore_update_until = (
+                    datetime.datetime.utcnow() + TIMEDELTA_UPDATE
+                )
+                self._state = False
+
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("Unable to retrieve data from ViCare server")
+        except ValueError:
+            _LOGGER.error("Unable to decode data from ViCare server")
+        except PyViCareRateLimitError as limit_exception:
+            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
+        except PyViCareInvalidDataError as invalid_data_exception:
+            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for this device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_config.getConfig().serial)},
+            name=self._device_config.getModel(),
+            manufacturer="Viessmann",
+            model=self._device_config.getModel(),
+            configuration_url="https://developer.viessmann.com/",
+        )
+
+    @property
+    def unique_id(self) -> str:
+        """Return unique ID for this device."""
+        tmp_id = (
+            f"{self._device_config.getConfig().serial}-{self.entity_description.key}"
+        )
+        if hasattr(self._api, "id"):
+            return f"{tmp_id}-{self._api.id}"
+        return tmp_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The vicare integration currently exposes a fire-and-forget style button to heat the Domestic Hot Water (DHW) once to a certain level. Since the API offers to deactivate the one-time-charge, and to read its status, I have now enhanced this to offering a switch entity. This will make the status of DHW heating more transparent to vicare users, and allows further use cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/oischinger/ha_vicare/issues/96
- This PR is related to issue: https://github.com/oischinger/ha_vicare/issues/96
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24501

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
