### PR TITLE
Bump ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -10,7 +10,7 @@
     "zha-quirks==0.0.82",
     "zigpy-deconz==0.19.0",
     "zigpy==0.51.3",
-    "zigpy-xbee==0.16.1",
+    "zigpy-xbee==0.16.2",
     "zigpy-zigate==0.10.2",
     "zigpy-znp==0.9.1"
   ],

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -11,7 +11,7 @@
     "zigpy-deconz==0.19.0",
     "zigpy==0.51.3",
     "zigpy-xbee==0.16.1",
-    "zigpy-zigate==0.10.1",
+    "zigpy-zigate==0.10.2",
     "zigpy-znp==0.9.1"
   ],
   "usb": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2613,7 +2613,7 @@ zigpy-deconz==0.19.0
 zigpy-xbee==0.16.1
 
 # homeassistant.components.zha
-zigpy-zigate==0.10.1
+zigpy-zigate==0.10.2
 
 # homeassistant.components.zha
 zigpy-znp==0.9.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2610,7 +2610,7 @@ ziggo-mediabox-xl==1.1.0
 zigpy-deconz==0.19.0
 
 # homeassistant.components.zha
-zigpy-xbee==0.16.1
+zigpy-xbee==0.16.2
 
 # homeassistant.components.zha
 zigpy-zigate==0.10.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1805,7 +1805,7 @@ zha-quirks==0.0.82
 zigpy-deconz==0.19.0
 
 # homeassistant.components.zha
-zigpy-xbee==0.16.1
+zigpy-xbee==0.16.2
 
 # homeassistant.components.zha
 zigpy-zigate==0.10.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1808,7 +1808,7 @@ zigpy-deconz==0.19.0
 zigpy-xbee==0.16.1
 
 # homeassistant.components.zha
-zigpy-zigate==0.10.1
+zigpy-zigate==0.10.2
 
 # homeassistant.components.zha
 zigpy-znp==0.9.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA dependencies:
 - zigpy-zigate to [0.10.2](https://github.com/zigpy/zigpy-zigate/releases/tag/v0.10.2)
 - zigpy-xbee to [0.16.2](https://github.com/zigpy/zigpy-xbee/releases/tag/0.16.2)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80023, fixes #79999, fixes #80053
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
