### PR TITLE
Add themes for LIFX multi-zone devices via a new select entity

### DIFF
--- a/homeassistant/components/lifx/const.py
+++ b/homeassistant/components/lifx/const.py
@@ -36,6 +36,8 @@ ATTR_POWER = "power"
 ATTR_REMAINING = "remaining"
 ATTR_ZONES = "zones"
 
+ATTR_THEME = "theme"
+
 HEV_CYCLE_STATE = "hev_cycle_state"
 INFRARED_BRIGHTNESS = "infrared_brightness"
 INFRARED_BRIGHTNESS_VALUES_MAP = {

--- a/homeassistant/components/lifx/coordinator.py
+++ b/homeassistant/components/lifx/coordinator.py
@@ -14,6 +14,7 @@ from aiolifx.aiolifx import (
     TileEffectType,
 )
 from aiolifx.connection import LIFXConnection
+from aiolifx_themes.themes import ThemeLibrary, ThemePainter
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
@@ -69,6 +70,7 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator):
         self.lock = asyncio.Lock()
         self.active_effect = FirmwareEffect.OFF
         update_interval = timedelta(seconds=10)
+        self.last_used_theme: str = ""
 
         super().__init__(
             hass,
@@ -288,12 +290,17 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator):
         effect: str,
         speed: float = 3,
         direction: str = "RIGHT",
+        theme_name: str | None = None,
         power_on: bool = True,
     ) -> None:
         """Control the firmware-based Move effect on a multizone device."""
         if lifx_features(self.device)["multizone"] is True:
             if power_on and self.device.power_level == 0:
                 await self.async_set_power(True, 0)
+
+            if theme_name is not None:
+                theme = ThemeLibrary().get_theme(theme_name)
+                await ThemePainter(self.hass.loop).paint(theme, [self.device], speed)
 
             await async_execute_lifx(
                 partial(
@@ -345,3 +352,13 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator):
         """Set infrared brightness."""
         infrared_brightness = infrared_brightness_option_to_value(option)
         await async_execute_lifx(partial(self.device.set_infrared, infrared_brightness))
+
+    def async_get_available_themes(self) -> list[str]:
+        """Return a list of available themes."""
+        return [theme.title() for theme in ThemeLibrary().themes]
+
+    async def async_apply_theme(self, theme_name: str) -> None:
+        """Apply the selected theme to the device."""
+        self.last_used_theme = theme_name
+        theme = ThemeLibrary().get_theme(theme_name)
+        await ThemePainter(self.hass.loop).paint(theme, [self.device])

--- a/homeassistant/components/lifx/coordinator.py
+++ b/homeassistant/components/lifx/coordinator.py
@@ -288,7 +288,7 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator):
     async def async_set_multizone_effect(
         self,
         effect: str,
-        speed: float = 3,
+        speed: float = 3.0,
         direction: str = "RIGHT",
         theme_name: str | None = None,
         power_on: bool = True,
@@ -300,7 +300,9 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator):
 
             if theme_name is not None:
                 theme = ThemeLibrary().get_theme(theme_name)
-                await ThemePainter(self.hass.loop).paint(theme, [self.device], speed)
+                await ThemePainter(self.hass.loop).paint(
+                    theme, [self.device], round(speed)
+                )
 
             await async_execute_lifx(
                 partial(
@@ -352,10 +354,6 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator):
         """Set infrared brightness."""
         infrared_brightness = infrared_brightness_option_to_value(option)
         await async_execute_lifx(partial(self.device.set_infrared, infrared_brightness))
-
-    def async_get_available_themes(self) -> list[str]:
-        """Return a list of available themes."""
-        return [theme.title() for theme in ThemeLibrary().themes]
 
     async def async_apply_theme(self, theme_name: str) -> None:
         """Apply the selected theme to the device."""

--- a/homeassistant/components/lifx/manager.py
+++ b/homeassistant/components/lifx/manager.py
@@ -29,7 +29,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import async_extract_referenced_entity_ids
 
-from .const import DATA_LIFX_MANAGER, DOMAIN
+from .const import ATTR_THEME, DATA_LIFX_MANAGER, DOMAIN
 from .coordinator import LIFXUpdateCoordinator, Light
 from .util import convert_8_to_16, find_hsbk
 
@@ -51,7 +51,6 @@ ATTR_CHANGE = "change"
 ATTR_DIRECTION = "direction"
 ATTR_SPEED = "speed"
 ATTR_PALETTE = "palette"
-ATTR_THEME = "theme"
 
 EFFECT_FLAME = "FLAME"
 EFFECT_MORPH = "MORPH"
@@ -177,6 +176,7 @@ LIFX_EFFECT_MOVE_SCHEMA = cv.make_entity_service_schema(
         **LIFX_EFFECT_SCHEMA,
         ATTR_SPEED: vol.All(vol.Coerce(float), vol.Clamp(min=0.1, max=60)),
         ATTR_DIRECTION: vol.In(EFFECT_MOVE_DIRECTIONS),
+        ATTR_THEME: vol.Optional(vol.In(ThemeLibrary().themes)),
     }
 )
 
@@ -324,6 +324,7 @@ class LIFXManager:
                         direction=kwargs.get(
                             ATTR_DIRECTION, EFFECT_MOVE_DEFAULT_DIRECTION
                         ),
+                        theme_name=kwargs.get(ATTR_THEME, None),
                         power_on=kwargs.get(ATTR_POWER_ON, False),
                     )
                     for coordinator in coordinators

--- a/homeassistant/components/lifx/select.py
+++ b/homeassistant/components/lifx/select.py
@@ -1,13 +1,20 @@
 """Select sensor entities for LIFX integration."""
 from __future__ import annotations
 
+from aiolifx_themes.themes import ThemeLibrary
+
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, INFRARED_BRIGHTNESS, INFRARED_BRIGHTNESS_VALUES_MAP
+from .const import (
+    ATTR_THEME,
+    DOMAIN,
+    INFRARED_BRIGHTNESS,
+    INFRARED_BRIGHTNESS_VALUES_MAP,
+)
 from .coordinator import LIFXUpdateCoordinator
 from .entity import LIFXEntity
 from .util import lifx_features
@@ -17,6 +24,13 @@ INFRARED_BRIGHTNESS_ENTITY = SelectEntityDescription(
     name="Infrared brightness",
     entity_category=EntityCategory.CONFIG,
     options=list(INFRARED_BRIGHTNESS_VALUES_MAP.values()),
+)
+
+THEME_ENTITY = SelectEntityDescription(
+    key=ATTR_THEME,
+    name="Theme",
+    entity_category=EntityCategory.CONFIG,
+    options=[theme.title() for theme in ThemeLibrary().themes],
 )
 
 
@@ -30,9 +44,14 @@ async def async_setup_entry(
         async_add_entities(
             [
                 LIFXInfraredBrightnessSelectEntity(
-                    coordinator, description=INFRARED_BRIGHTNESS_ENTITY
+                    coordinator=coordinator, description=INFRARED_BRIGHTNESS_ENTITY
                 )
             ]
+        )
+
+    if lifx_features(coordinator.device)["multizone"] is True:
+        async_add_entities(
+            [LIFXThemeSelectEntity(coordinator=coordinator, description=THEME_ENTITY)]
         )
 
 
@@ -65,3 +84,37 @@ class LIFXInfraredBrightnessSelectEntity(LIFXEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the infrared brightness value."""
         await self.coordinator.async_set_infrared_brightness(option)
+
+
+class LIFXThemeSelectEntity(LIFXEntity, SelectEntity):
+    """Theme entity for LIFX multizone devices."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self, coordinator: LIFXUpdateCoordinator, description: SelectEntityDescription
+    ) -> None:
+        """Initialise the theme selection entity."""
+
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_name = description.name
+        self._attr_unique_id = f"{coordinator.serial_number}_{description.key}"
+        self._attr_options = coordinator.async_get_available_themes()
+        self._attr_current_option = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update attrs from coordinator data."""
+        self._attr_current_option = self.coordinator.last_used_theme
+
+    async def async_select_option(self, option: str) -> None:
+        """Paint the selected theme onto the device."""
+        await self.coordinator.async_apply_theme(option.lower())

--- a/homeassistant/components/lifx/select.py
+++ b/homeassistant/components/lifx/select.py
@@ -19,6 +19,8 @@ from .coordinator import LIFXUpdateCoordinator
 from .entity import LIFXEntity
 from .util import lifx_features
 
+THEME_NAMES = [theme_name.lower() for theme_name in ThemeLibrary().themes]
+
 INFRARED_BRIGHTNESS_ENTITY = SelectEntityDescription(
     key=INFRARED_BRIGHTNESS,
     name="Infrared brightness",
@@ -30,7 +32,7 @@ THEME_ENTITY = SelectEntityDescription(
     key=ATTR_THEME,
     name="Theme",
     entity_category=EntityCategory.CONFIG,
-    options=[theme.title() for theme in ThemeLibrary().themes],
+    options=THEME_NAMES,
 )
 
 
@@ -101,7 +103,6 @@ class LIFXThemeSelectEntity(LIFXEntity, SelectEntity):
         self.entity_description = description
         self._attr_name = description.name
         self._attr_unique_id = f"{coordinator.serial_number}_{description.key}"
-        self._attr_options = coordinator.async_get_available_themes()
         self._attr_current_option = None
 
     @callback

--- a/homeassistant/components/lifx/services.yaml
+++ b/homeassistant/components/lifx/services.yaml
@@ -183,6 +183,7 @@ effect_move:
       name: Speed
       description: How long in seconds for the effect to move across the length of the light.
       default: 3.0
+      example: 3.0
       selector:
         number:
           min: 0.1
@@ -193,6 +194,7 @@ effect_move:
       name: Direction
       description: Direction the effect will move across the device.
       default: right
+      example: right
       selector:
         select:
           mode: dropdown
@@ -202,60 +204,36 @@ effect_move:
     theme:
       name: Theme
       description: (Optional) set one of the predefined themes onto the device before starting the effect.
-      example: Exciting
+      example: exciting
       default: exciting
       selector:
         select:
           mode: dropdown
           options:
-            - label: Autumn
-              value: autumn
-            - label: Blissful
-              value: blissful
-            - label: Cheerful
-              value: cheerful
-            - label: Dream
-              value: dream
-            - label: Energizing
-              value: energizing
-            - label: Epic
-              value: epic
-            - label: Exciting
-              value: exciting
-            - label: Focusing
-              value: focusing
-            - label: Halloween
-              value: halloween
-            - label: Hanukkah
-              value: hanukkah
-            - label: Holly
-              value: holly
-            - label: Independence Day
-              value: independence_day
-            - label: Intense
-              value: intense
-            - label: Mellow
-              value: mellow
-            - label: Peaceful
-              value: peaceful
-            - label: Powerful
-              value: powerful
-            - label: Relaxing
-              value: relaxing
-            - label: Santa
-              value: santa
-            - label: Serene
-              value: serene
-            - label: Soothing
-              value: soothing
-            - label: Sports
-              value: sports
-            - label: Spring
-              value: spring
-            - label: Tranquil
-              value: tranquil
-            - label: Warming
-              value: warming
+            - "autumn"
+            - "blissful"
+            - "cheerful"
+            - "dream"
+            - "energizing"
+            - "epic"
+            - "exciting"
+            - "focusing"
+            - "halloween"
+            - "hanukkah"
+            - "holly"
+            - "independence_day"
+            - "intense"
+            - "mellow"
+            - "peaceful"
+            - "powerful"
+            - "relaxing"
+            - "santa"
+            - "serene"
+            - "soothing"
+            - "sports"
+            - "spring"
+            - "tranquil"
+            - "warming"
     power_on:
       name: Power on
       description: Powered off lights will be turned on before starting the effect.
@@ -317,54 +295,30 @@ effect_morph:
       selector:
         select:
           options:
-            - label: Autumn
-              value: autumn
-            - label: Blissful
-              value: blissful
-            - label: Cheerful
-              value: cheerful
-            - label: Dream
-              value: dream
-            - label: Energizing
-              value: energizing
-            - label: Epic
-              value: epic
-            - label: Exciting
-              value: exciting
-            - label: Focusing
-              value: focusing
-            - label: Halloween
-              value: halloween
-            - label: Hanukkah
-              value: hanukkah
-            - label: Holly
-              value: holly
-            - label: Independence Day
-              value: independence_day
-            - label: Intense
-              value: intense
-            - label: Mellow
-              value: mellow
-            - label: Peaceful
-              value: peaceful
-            - label: Powerful
-              value: powerful
-            - label: Relaxing
-              value: relaxing
-            - label: Santa
-              value: santa
-            - label: Serene
-              value: serene
-            - label: Soothing
-              value: soothing
-            - label: Sports
-              value: sports
-            - label: Spring
-              value: spring
-            - label: Tranquil
-              value: tranquil
-            - label: Warming
-              value: warming
+            - "autumn"
+            - "blissful"
+            - "cheerful"
+            - "dream"
+            - "energizing"
+            - "epic"
+            - "exciting"
+            - "focusing"
+            - "halloween"
+            - "hanukkah"
+            - "holly"
+            - "independence_day"
+            - "intense"
+            - "mellow"
+            - "peaceful"
+            - "powerful"
+            - "relaxing"
+            - "santa"
+            - "serene"
+            - "soothing"
+            - "sports"
+            - "spring"
+            - "tranquil"
+            - "warming"
     power_on:
       name: Power on
       description: Powered off lights will be turned on before starting the effect.

--- a/homeassistant/components/lifx/services.yaml
+++ b/homeassistant/components/lifx/services.yaml
@@ -199,6 +199,63 @@ effect_move:
           options:
             - right
             - left
+    theme:
+      name: Theme
+      description: (Optional) set one of the predefined themes onto the device before starting the effect.
+      example: Exciting
+      default: exciting
+      selector:
+        select:
+          mode: dropdown
+          options:
+            - label: Autumn
+              value: autumn
+            - label: Blissful
+              value: blissful
+            - label: Cheerful
+              value: cheerful
+            - label: Dream
+              value: dream
+            - label: Energizing
+              value: energizing
+            - label: Epic
+              value: epic
+            - label: Exciting
+              value: exciting
+            - label: Focusing
+              value: focusing
+            - label: Halloween
+              value: halloween
+            - label: Hanukkah
+              value: hanukkah
+            - label: Holly
+              value: holly
+            - label: Independence Day
+              value: independence_day
+            - label: Intense
+              value: intense
+            - label: Mellow
+              value: mellow
+            - label: Peaceful
+              value: peaceful
+            - label: Powerful
+              value: powerful
+            - label: Relaxing
+              value: relaxing
+            - label: Santa
+              value: santa
+            - label: Serene
+              value: serene
+            - label: Soothing
+              value: soothing
+            - label: Sports
+              value: sports
+            - label: Spring
+              value: spring
+            - label: Tranquil
+              value: tranquil
+            - label: Warming
+              value: warming
     power_on:
       name: Power on
       description: Powered off lights will be turned on before starting the effect.
@@ -260,30 +317,54 @@ effect_morph:
       selector:
         select:
           options:
-            - "autumn"
-            - "blissful"
-            - "cheerful"
-            - "dream"
-            - "energizing"
-            - "epic"
-            - "exciting"
-            - "focusing"
-            - "halloween"
-            - "hanukkah"
-            - "holly"
-            - "independence day"
-            - "intense"
-            - "mellow"
-            - "peaceful"
-            - "powerful"
-            - "relaxing"
-            - "santa"
-            - "serene"
-            - "soothing"
-            - "sports"
-            - "spring"
-            - "tranquil"
-            - "warming"
+            - label: Autumn
+              value: autumn
+            - label: Blissful
+              value: blissful
+            - label: Cheerful
+              value: cheerful
+            - label: Dream
+              value: dream
+            - label: Energizing
+              value: energizing
+            - label: Epic
+              value: epic
+            - label: Exciting
+              value: exciting
+            - label: Focusing
+              value: focusing
+            - label: Halloween
+              value: halloween
+            - label: Hanukkah
+              value: hanukkah
+            - label: Holly
+              value: holly
+            - label: Independence Day
+              value: independence_day
+            - label: Intense
+              value: intense
+            - label: Mellow
+              value: mellow
+            - label: Peaceful
+              value: peaceful
+            - label: Powerful
+              value: powerful
+            - label: Relaxing
+              value: relaxing
+            - label: Santa
+              value: santa
+            - label: Serene
+              value: serene
+            - label: Soothing
+              value: soothing
+            - label: Sports
+              value: sports
+            - label: Spring
+              value: spring
+            - label: Tranquil
+              value: tranquil
+            - label: Warming
+              value: warming
     power_on:
       name: Power on
       description: Powered off lights will be turned on before starting the effect.

--- a/homeassistant/components/lifx/util.py
+++ b/homeassistant/components/lifx/util.py
@@ -24,7 +24,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 import homeassistant.util.color as color_util
 
-from .const import _LOGGER, DOMAIN, INFRARED_BRIGHTNESS_VALUES_MAP, OVERALL_TIMEOUT
+from .const import DOMAIN, INFRARED_BRIGHTNESS_VALUES_MAP, OVERALL_TIMEOUT
 
 FIX_MAC_FW = AwesomeVersion("3.70")
 
@@ -154,7 +154,7 @@ async def async_execute_lifx(method: Callable) -> Message:
             # us by async_timeout when we hit the OVERALL_TIMEOUT
             future.set_result(message)
 
-    _LOGGER.debug("Sending LIFX command: %s", method)
+    # _LOGGER.debug("Sending LIFX command: %s", method)
 
     method(callb=_callback)
     result = None

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -801,6 +801,7 @@ async def test_lightstrip_move_effect(hass: HomeAssistant) -> None:
     )
     config_entry.add_to_hass(hass)
     bulb = _mocked_light_strip()
+    bulb.product = 38
     bulb.power_level = 0
     bulb.color = [65535, 65535, 65535, 65535]
     with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
@@ -828,6 +829,7 @@ async def test_lightstrip_move_effect(hass: HomeAssistant) -> None:
         "speed": 3.0,
         "direction": 0,
     }
+
     bulb.get_multizone_effect.reset_mock()
     bulb.set_multizone_effect.reset_mock()
     bulb.set_power.reset_mock()
@@ -836,7 +838,12 @@ async def test_lightstrip_move_effect(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         DOMAIN,
         SERVICE_EFFECT_MOVE,
-        {ATTR_ENTITY_ID: entity_id, ATTR_SPEED: 4.5, ATTR_DIRECTION: "left"},
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_SPEED: 4.5,
+            ATTR_DIRECTION: "left",
+            ATTR_THEME: "sports",
+        },
         blocking=True,
     )
 
@@ -849,6 +856,7 @@ async def test_lightstrip_move_effect(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
 
     assert len(bulb.set_power.calls) == 1
+    assert len(bulb.set_extended_color_zones.calls) == 1
     assert len(bulb.set_multizone_effect.calls) == 1
     call_dict = bulb.set_multizone_effect.calls[0][1]
     call_dict.pop("callb")

--- a/tests/components/lifx/test_select.py
+++ b/tests/components/lifx/test_select.py
@@ -55,7 +55,7 @@ async def test_theme_select(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         SELECT_DOMAIN,
         "select_option",
-        {ATTR_ENTITY_ID: entity_id, "option": "Intense"},
+        {ATTR_ENTITY_ID: entity_id, "option": "intense"},
         blocking=True,
     )
 

--- a/tests/components/lifx/test_select.py
+++ b/tests/components/lifx/test_select.py
@@ -17,12 +17,50 @@ from . import (
     SERIAL,
     MockLifxCommand,
     _mocked_infrared_bulb,
+    _mocked_light_strip,
     _patch_config_flow_try_connect,
     _patch_device,
     _patch_discovery,
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_theme_select(hass: HomeAssistant) -> None:
+    """Test selecting a theme."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_ENTRY_TITLE,
+        data={CONF_HOST: IP_ADDRESS},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_light_strip()
+    bulb.product = 38
+    bulb.power_level = 0
+    bulb.color = [0, 0, 65535, 3500]
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "select.my_bulb_theme"
+
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    assert not entity.disabled
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        "select_option",
+        {ATTR_ENTITY_ID: entity_id, "option": "Intense"},
+        blocking=True,
+    )
+
+    assert len(bulb.set_extended_color_zones.calls) == 1
+    bulb.set_extended_color_zones.reset_mock()
 
 
 async def test_infrared_brightness(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

Add the ability to apply a predefined theme to a LIFX multizone device via a new select entity which is automatically populated with a list of available themes provided by the `aiolifx_themes` library. The `lifx.effect_move` service has also been updated to accept the name of a theme to apply before starting the effect.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24509

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
