### PR TITLE
Support for bytearray transfer on tcp sensor

### DIFF
--- a/homeassistant/components/tcp/const.py
+++ b/homeassistant/components/tcp/const.py
@@ -11,3 +11,5 @@ DEFAULT_NAME: Final = "TCP Sensor"
 DEFAULT_TIMEOUT: Final = 10
 DEFAULT_SSL: Final = False
 DEFAULT_VERIFY_SSL: Final = True
+CONF_PAYLOAD_IS_HEX: Final = "payload_is_hex"
+DEFAULT_PAYLOAD_HEX: Final = False

--- a/homeassistant/components/tcp/model.py
+++ b/homeassistant/components/tcp/model.py
@@ -14,6 +14,7 @@ class TcpSensorConfig(TypedDict):
     port: str
     timeout: int
     payload: str
+    payload_is_hex: bool
     unit_of_measurement: str | None
     value_template: Template | None
     value_on: str | None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added support for [HEX values in payload](https://community.home-assistant.io/t/tcp-sensor-hex-value-in-payload/351229)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

Aded **payload_is_hex** boolean (default: false) flag to handle bytearray data on sender and receiver socket.
**payload_is_hex** flasg is optional, so all existing configurations are compatible and handled same way.

### Payload and value format if payload_is_hex set to true
**payload** and value format is a HEX string with space separator for better readability. see [byteaaray.fromhex](https://docs.python.org/dev/library/stdtypes.html#bytearray.fromhex) for more information.
Example:
`payload: "10 00 FF FF B6 00 00 00 C4"`

### Payload handling on socket
If **payload_is_hex** is set to **true** the socket sends and receive string data in **payload** as following:
Send:
```
sock.send(bytearray.fromhex(payload))
```
Receive:
```
value = " ".join("%02x" % b for b in sock.recv())
```

If **payload_is_hex** is set to **false** (default) the socket sends and receive string data in **payload** as following:
Send:
```
sock.send(payload.encode())
```
Receive:
```
value = sock.recv().decode()
```
### Configuration Example
Example for RS485 Wifi device [EW11](http://www.hi-flying.com/elfin-ew10-elfin-ew11):
```
sensor:
  - platform: tcp
    name: TESTING_TCP
    host: 192.168.178.111
    port: 8899
    timeout: 10
    payload: "10 00 FF FF B6 00 00 00 C4"
    payload_is_hex: true
    value_template: "{{ value }}"
```

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:  no issues created 
- This PR is related to issue: no issues created
- Link to documentation pull request: TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
TODO: add description for "payload_is_hex" optional configuration of tcp sensor.
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
