### PR TITLE
Use `entry.as_dict()` in RainMachine diagnostics

### DIFF
--- a/homeassistant/components/rainmachine/diagnostics.py
+++ b/homeassistant/components/rainmachine/diagnostics.py
@@ -50,16 +50,16 @@ async def async_get_config_entry_diagnostics(
         LOGGER.warning("Unable to download controller-specific diagnostics")
         controller_diagnostics = None
 
-    return {
-        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "data": {
-            "coordinator": async_redact_data(
-                {
+    return async_redact_data(
+        {
+            "entry": entry.as_dict(),
+            "data": {
+                "coordinator": {
                     api_category: controller.data
                     for api_category, controller in data.coordinators.items()
                 },
-                TO_REDACT,
-            ),
-            "controller_diagnostics": controller_diagnostics,
+                "controller_diagnostics": controller_diagnostics,
+            },
         },
-    }
+        TO_REDACT,
+    )

--- a/homeassistant/components/rainmachine/diagnostics.py
+++ b/homeassistant/components/rainmachine/diagnostics.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_PASSWORD,
+    CONF_UNIQUE_ID,
 )
 from homeassistant.core import HomeAssistant
 
@@ -32,6 +33,8 @@ TO_REDACT = {
     CONF_STATION_NAME,
     CONF_STATION_SOURCE,
     CONF_TIMEZONE,
+    # Config entry unique ID may contain sensitive data:
+    CONF_UNIQUE_ID,
 }
 
 
@@ -48,11 +51,7 @@ async def async_get_config_entry_diagnostics(
         controller_diagnostics = None
 
     return {
-        "entry": {
-            "title": entry.title,
-            "data": async_redact_data(entry.data, TO_REDACT),
-            "options": dict(entry.options),
-        },
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
         "data": {
             "coordinator": async_redact_data(
                 {

--- a/tests/components/rainmachine/test_diagnostics.py
+++ b/tests/components/rainmachine/test_diagnostics.py
@@ -10,6 +10,9 @@ async def test_entry_diagnostics(hass, config_entry, hass_client, setup_rainmach
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {
+            "entry_id": config_entry.entry_id,
+            "version": 2,
+            "domain": "rainmachine",
             "title": "Mock Title",
             "data": {
                 "ip_address": "192.168.1.100",
@@ -18,14 +21,15 @@ async def test_entry_diagnostics(hass, config_entry, hass_client, setup_rainmach
                 "ssl": True,
             },
             "options": {},
+            "pref_disable_new_entities": False,
+            "pref_disable_polling": False,
+            "source": "user",
+            "unique_id": REDACTED,
+            "disabled_by": None,
         },
         "data": {
             "coordinator": {
-                "api.versions": {
-                    "apiVer": "4.6.1",
-                    "hwVer": "3",
-                    "swVer": "4.0.1144",
-                },
+                "api.versions": {"apiVer": "4.6.1", "hwVer": "3", "swVer": "4.0.1144"},
                 "machine.firmware_update_status": {
                     "lastUpdateCheckTimestamp": 1657825288,
                     "packageDetails": [],
@@ -628,6 +632,9 @@ async def test_entry_diagnostics_failed_controller_diagnostics(
     controller.diagnostics.current.side_effect = RainMachineError
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {
+            "entry_id": config_entry.entry_id,
+            "version": 2,
+            "domain": "rainmachine",
             "title": "Mock Title",
             "data": {
                 "ip_address": "192.168.1.100",
@@ -636,14 +643,15 @@ async def test_entry_diagnostics_failed_controller_diagnostics(
                 "ssl": True,
             },
             "options": {},
+            "pref_disable_new_entities": False,
+            "pref_disable_polling": False,
+            "source": "user",
+            "unique_id": REDACTED,
+            "disabled_by": None,
         },
         "data": {
             "coordinator": {
-                "api.versions": {
-                    "apiVer": "4.6.1",
-                    "hwVer": "3",
-                    "swVer": "4.0.1144",
-                },
+                "api.versions": {"apiVer": "4.6.1", "hwVer": "3", "swVer": "4.0.1144"},
                 "machine.firmware_update_status": {
                     "lastUpdateCheckTimestamp": 1657825288,
                     "packageDetails": [],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
RainMachine manually included snippets of the config entry in diagnostics; this PR includes the whole thing (properly redacted). In so doing, it also redacts some values that users will likely want to be kept private.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
