### PR TITLE
Redact additional sensitive fields in ReCollect Waste diagnostics

### DIFF
--- a/homeassistant/components/recollect_waste/diagnostics.py
+++ b/homeassistant/components/recollect_waste/diagnostics.py
@@ -30,9 +30,10 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    return {
-        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "data": async_redact_data(
-            [dataclasses.asdict(event) for event in coordinator.data], TO_REDACT
-        ),
-    }
+    return async_redact_data(
+        {
+            "entry": entry.as_dict(),
+            "data": [dataclasses.asdict(event) for event in coordinator.data],
+        },
+        TO_REDACT,
+    )

--- a/homeassistant/components/recollect_waste/diagnostics.py
+++ b/homeassistant/components/recollect_waste/diagnostics.py
@@ -4,11 +4,24 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
+from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
+from .const import CONF_PLACE_ID, DOMAIN
+
+CONF_AREA_NAME = "area_name"
+CONF_TITLE = "title"
+
+TO_REDACT = {
+    CONF_AREA_NAME,
+    CONF_PLACE_ID,
+    # Config entry title and unique ID may contain sensitive data:
+    CONF_TITLE,
+    CONF_UNIQUE_ID,
+}
 
 
 async def async_get_config_entry_diagnostics(
@@ -18,6 +31,8 @@ async def async_get_config_entry_diagnostics(
     coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     return {
-        "entry": entry.as_dict(),
-        "data": [dataclasses.asdict(event) for event in coordinator.data],
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "data": async_redact_data(
+            [dataclasses.asdict(event) for event in coordinator.data], TO_REDACT
+        ),
     }

--- a/tests/components/recollect_waste/test_diagnostics.py
+++ b/tests/components/recollect_waste/test_diagnostics.py
@@ -1,4 +1,6 @@
 """Test ReCollect Waste diagnostics."""
+from homeassistant.components.diagnostics import REDACTED
+
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
@@ -7,7 +9,19 @@ async def test_entry_diagnostics(
 ):
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
-        "entry": config_entry.as_dict(),
+        "entry": {
+            "entry_id": config_entry.entry_id,
+            "version": 2,
+            "domain": "recollect_waste",
+            "title": REDACTED,
+            "data": {"place_id": REDACTED, "service_id": "12345"},
+            "options": {},
+            "pref_disable_new_entities": False,
+            "pref_disable_polling": False,
+            "source": "user",
+            "unique_id": REDACTED,
+            "disabled_by": None,
+        },
         "data": [
             {
                 "date": {
@@ -17,7 +31,7 @@ async def test_entry_diagnostics(
                 "pickup_types": [
                     {"name": "garbage", "friendly_name": "Trash Collection"}
                 ],
-                "area_name": "The Sun",
+                "area_name": REDACTED,
             }
         ],
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR redacts additional ReCollect diagnostics values that users will likely want to be kept private.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
