### PR TITLE
Add full test coverage to LaMetric

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -660,7 +660,6 @@ omit =
     homeassistant/components/kostal_plenticore/switch.py
     homeassistant/components/kwb/sensor.py
     homeassistant/components/lacrosse/sensor.py
-    homeassistant/components/lametric/notify.py
     homeassistant/components/lannouncer/notify.py
     homeassistant/components/lastfm/sensor.py
     homeassistant/components/launch_library/__init__.py

--- a/tests/components/lametric/test_notify.py
+++ b/tests/components/lametric/test_notify.py
@@ -1,0 +1,124 @@
+"""Tests for the LaMetric notify platform."""
+from unittest.mock import MagicMock
+
+from demetriek import (
+    LaMetricError,
+    Notification,
+    NotificationIconType,
+    NotificationPriority,
+    NotificationSound,
+    NotificationSoundCategory,
+    Simple,
+)
+import pytest
+
+from homeassistant.components.notify import (
+    ATTR_DATA,
+    ATTR_MESSAGE,
+    DOMAIN as NOTIFY_DOMAIN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.common import MockConfigEntry
+
+NOTIFY_SERVICE = "frenck_s_lametric"
+
+
+async def test_notification_defaults(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_lametric: MagicMock,
+) -> None:
+    """Test the LaMetric notification defaults."""
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        NOTIFY_SERVICE,
+        {
+            ATTR_MESSAGE: "Try not to become a man of success. Rather become a man of value",
+        },
+        blocking=True,
+    )
+
+    assert len(mock_lametric.notify.mock_calls) == 1
+
+    notification: Notification = mock_lametric.notify.mock_calls[0][2]["notification"]
+    assert notification.icon_type is NotificationIconType.NONE
+    assert notification.life_time is None
+    assert notification.model.cycles == 1
+    assert notification.model.sound is None
+    assert notification.notification_id is None
+    assert notification.notification_type is None
+    assert notification.priority is NotificationPriority.INFO
+
+    assert len(notification.model.frames) == 1
+    frame = notification.model.frames[0]
+    assert type(frame) is Simple
+    assert frame.icon == "a7956"
+    assert (
+        frame.text == "Try not to become a man of success. Rather become a man of value"
+    )
+
+
+async def test_notification_options(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_lametric: MagicMock,
+) -> None:
+    """Test the LaMetric notification options."""
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        NOTIFY_SERVICE,
+        {
+            ATTR_MESSAGE: "The secret of getting ahead is getting started",
+            ATTR_DATA: {
+                "icon": "1234",
+                "sound": "positive1",
+                "cycles": 3,
+                "icon_type": "alert",
+                "priority": "critical",
+            },
+        },
+        blocking=True,
+    )
+
+    assert len(mock_lametric.notify.mock_calls) == 1
+
+    notification: Notification = mock_lametric.notify.mock_calls[0][2]["notification"]
+    assert notification.icon_type is NotificationIconType.ALERT
+    assert notification.life_time is None
+    assert notification.model.cycles == 3
+    assert notification.model.sound is not None
+    assert notification.model.sound.category is NotificationSoundCategory.NOTIFICATIONS
+    assert notification.model.sound.sound is NotificationSound.POSITIVE1
+    assert notification.model.sound.repeat == 1
+    assert notification.notification_id is None
+    assert notification.notification_type is None
+    assert notification.priority is NotificationPriority.CRITICAL
+
+    assert len(notification.model.frames) == 1
+    frame = notification.model.frames[0]
+    assert type(frame) is Simple
+    assert frame.icon == 1234
+    assert frame.text == "The secret of getting ahead is getting started"
+
+
+async def test_notification_error(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_lametric: MagicMock,
+) -> None:
+    """Test the LaMetric notification error."""
+    mock_lametric.notify.side_effect = LaMetricError
+
+    with pytest.raises(
+        HomeAssistantError, match="Could not send LaMetric notification"
+    ):
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            NOTIFY_SERVICE,
+            {
+                ATTR_MESSAGE: "It's failure that gives you the proper perspective on success",
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Expands the LaMetric coverage to the notify platform, making the test coverage complete.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
