### PR TITLE
Add error handling to LaMetric button platform

### DIFF
--- a/homeassistant/components/lametric/button.py
+++ b/homeassistant/components/lametric/button.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import LaMetricDataUpdateCoordinator
 from .entity import LaMetricEntity
+from .helpers import lametric_exception_handler
 
 
 @dataclass
@@ -81,6 +82,7 @@ class LaMetricButtonEntity(LaMetricEntity, ButtonEntity):
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.data.serial_number}-{description.key}"
 
+    @lametric_exception_handler
     async def async_press(self) -> None:
         """Send out a command to LaMetric."""
         await self.entity_description.press_fn(self.coordinator.lametric)

--- a/homeassistant/components/lametric/helpers.py
+++ b/homeassistant/components/lametric/helpers.py
@@ -1,0 +1,46 @@
+"""Helpers for LaMetric."""
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import Any, TypeVar
+
+from demetriek import LaMetricConnectionError, LaMetricError
+from typing_extensions import Concatenate, ParamSpec
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .entity import LaMetricEntity
+
+_LaMetricEntityT = TypeVar("_LaMetricEntityT", bound=LaMetricEntity)
+_P = ParamSpec("_P")
+
+
+def lametric_exception_handler(
+    func: Callable[Concatenate[_LaMetricEntityT, _P], Coroutine[Any, Any, Any]]
+) -> Callable[Concatenate[_LaMetricEntityT, _P], Coroutine[Any, Any, None]]:
+    """Decorate LaMetric calls to handle LaMetric exceptions.
+
+    A decorator that wraps the passed in function, catches LaMetric errors,
+    and handles the availability of the device in the data coordinator.
+    """
+
+    async def handler(
+        self: _LaMetricEntityT, *args: _P.args, **kwargs: _P.kwargs
+    ) -> None:
+        try:
+            await func(self, *args, **kwargs)
+            self.coordinator.async_update_listeners()
+
+        except LaMetricConnectionError as error:
+            self.coordinator.last_update_success = False
+            self.coordinator.async_update_listeners()
+            raise HomeAssistantError(
+                "Error communicating with the LaMetric device"
+            ) from error
+
+        except LaMetricError as error:
+            raise HomeAssistantError(
+                "Invalid response from the LaMetric device"
+            ) from error
+
+    return handler

--- a/tests/components/lametric/test_button.py
+++ b/tests/components/lametric/test_button.py
@@ -1,12 +1,19 @@
 """Tests for the LaMetric button platform."""
 from unittest.mock import MagicMock
 
+from demetriek import LaMetricConnectionError, LaMetricError
 import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.lametric.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, STATE_UNKNOWN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_ICON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 
@@ -111,3 +118,52 @@ async def test_button_app_previous(
     state = hass.states.get("button.frenck_s_lametric_previous_app")
     assert state
     assert state.state == "2022-09-19T12:07:30+00:00"
+
+
+@pytest.mark.freeze_time("2022-10-11 22:00:00")
+async def test_button_error(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_lametric: MagicMock,
+) -> None:
+    """Test error handling of the LaMetric buttons."""
+    mock_lametric.app_next.side_effect = LaMetricError
+
+    with pytest.raises(
+        HomeAssistantError, match="Invalid response from the LaMetric device"
+    ):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.frenck_s_lametric_next_app"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("button.frenck_s_lametric_next_app")
+    assert state
+    assert state.state == "2022-10-11T22:00:00+00:00"
+
+
+async def test_button_connection_error(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_lametric: MagicMock,
+) -> None:
+    """Test connection error handling of the LaMetric buttons."""
+    mock_lametric.app_next.side_effect = LaMetricConnectionError
+
+    with pytest.raises(
+        HomeAssistantError, match="Error communicating with the LaMetric device"
+    ):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.frenck_s_lametric_next_app"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("button.frenck_s_lametric_next_app")
+    assert state
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For the LaMetric integration to reach Silver on the integration quality scale, it needs to handle the following:

> Operations like service calls and entity methods (e.g. Set HVAC Mode) have proper exception handling. Raise ValueError on invalid user input and raise HomeAssistantError for other failures such as a problem communicating with a device.

Ref: <https://developers.home-assistant.io/docs/integration_quality_scale_index/#silver->

This PR adds a basic helper for handling this throughout the integration, and applies it to the button platform (including tests).

Other platforms will follow in future PRs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
