### PR TITLE
Add support for area field from pylutron_caseta

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -281,14 +281,13 @@ def _area_name_from_id(areas: dict[str, dict], area_id: str) -> str:
     if area_id is None:
         return UNASSIGNED_AREA
 
-    if "parent_id" in areas[area_id]:
-        parent_area = areas[area_id]["parent_id"]
+    area = areas[area_id]
+    if "parent_id" in area:
+        parent_area = area["parent_id"]
         if parent_area is not None:
-            return " ".join(
-                (_area_name_from_id(areas, parent_area), areas[area_id]["name"])
-            )
+            return f"{_area_name_from_id(areas, parent_area)} {area['name']}"
 
-    return areas[area_id]["name"]
+    return area["name"]
 
 
 @callback

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -6,13 +6,14 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_SUGGESTED_AREA
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN as CASETA_DOMAIN, LutronCasetaDevice, _area_and_name_from_name
-from .const import CONFIG_URL, MANUFACTURER
+from . import DOMAIN as CASETA_DOMAIN, LutronCasetaDevice, _area_name_from_id
+from .const import CONFIG_URL, MANUFACTURER, UNASSIGNED_AREA
 from .models import LutronCasetaData
 
 
@@ -43,7 +44,8 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
     def __init__(self, device, data):
         """Init an occupancy sensor."""
         super().__init__(device, data)
-        _, name = _area_and_name_from_name(device["name"])
+        area = _area_name_from_id(self._smartbridge.areas, device["area"])
+        name = f"{area} {device['device_name']}"
         self._attr_name = name
         self._attr_device_info = DeviceInfo(
             identifiers={(CASETA_DOMAIN, self.unique_id)},
@@ -54,6 +56,8 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
             configuration_url=CONFIG_URL,
             entry_type=DeviceEntryType.SERVICE,
         )
+        if area != UNASSIGNED_AREA:
+            self._attr_device_info[ATTR_SUGGESTED_AREA] = area
 
     @property
     def is_on(self):

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -9,7 +9,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import _area_and_name_from_name
 from .const import DOMAIN as CASETA_DOMAIN
 from .models import LutronCasetaData
 from .util import serial_to_unique_id
@@ -42,7 +41,7 @@ class LutronCasetaScene(Scene):
         self._attr_device_info = DeviceInfo(
             identifiers={(CASETA_DOMAIN, data.bridge_device["serial"])},
         )
-        self._attr_name = _area_and_name_from_name(scene["name"])[1]
+        self._attr_name = scene["name"]
         self._attr_unique_id = f"scene_{bridge_unique_id}_{self._scene_id}"
 
     async def async_activate(self, **kwargs: Any) -> None:

--- a/tests/components/lutron_caseta/__init__.py
+++ b/tests/components/lutron_caseta/__init__.py
@@ -105,7 +105,7 @@ class MockBridge:
         """Initialize MockBridge instance with configured mock connectivity."""
         self.can_connect = can_connect
         self.is_currently_connected = False
-        self.areas = {}
+        self.areas = self.load_areas()
         self.occupancy_groups = {}
         self.scenes = self.get_scenes()
         self.devices = self.load_devices()
@@ -126,10 +126,28 @@ class MockBridge:
         """Return whether the mock bridge is connected."""
         return self.is_currently_connected
 
+    def load_areas(self):
+        """Loak mock areas into self.areas."""
+        return {
+            "898": {"id": "898", "name": "Basement", "parent_id": None},
+            "822": {"id": "822", "name": "Bedroom", "parent_id": "898"},
+            "910": {"id": "910", "name": "Bathroom", "parent_id": "898"},
+            "1024": {"id": "1024", "name": "Master Bedroom", "parent_id": None},
+            "1025": {"id": "1025", "name": "Kitchen", "parent_id": None},
+            "1026": {"id": "1026", "name": "Dining Room", "parent_id": None},
+            "1205": {"id": "1205", "name": "Hallway", "parent_id": None},
+        }
+
     def load_devices(self):
         """Load mock devices into self.devices."""
         return {
-            "1": {"serial": 1234, "name": "bridge", "model": "model", "type": "type"},
+            "1": {
+                "serial": 1234,
+                "name": "bridge",
+                "model": "model",
+                "type": "type",
+                "area": "1205",
+            },
             "801": {
                 "device_id": "801",
                 "current_state": 100,
@@ -141,6 +159,7 @@ class MockBridge:
                 "model": None,
                 "serial": None,
                 "tilt": None,
+                "area": "822",
             },
             "802": {
                 "device_id": "802",
@@ -153,6 +172,7 @@ class MockBridge:
                 "model": None,
                 "serial": None,
                 "tilt": None,
+                "area": "822",
             },
             "803": {
                 "device_id": "803",
@@ -165,6 +185,7 @@ class MockBridge:
                 "model": None,
                 "serial": None,
                 "tilt": None,
+                "area": "910",
             },
             "804": {
                 "device_id": "804",
@@ -177,6 +198,7 @@ class MockBridge:
                 "model": None,
                 "serial": None,
                 "tilt": None,
+                "area": "1024",
             },
             "901": {
                 "device_id": "901",
@@ -189,6 +211,7 @@ class MockBridge:
                 "model": None,
                 "serial": 5442321,
                 "tilt": None,
+                "area": "1025",
             },
             "9": {
                 "device_id": "9",
@@ -203,7 +226,7 @@ class MockBridge:
                 "model": "PJ2-3BRL-GXX-X01",
                 "serial": 68551522,
                 "device_name": "Pico",
-                "area": "6",
+                "area": "1026",
             },
             "1355": {
                 "device_id": "1355",

--- a/tests/components/lutron_caseta/test_diagnostics.py
+++ b/tests/components/lutron_caseta/test_diagnostics.py
@@ -40,7 +40,15 @@ async def test_diagnostics(hass, hass_client) -> None:
     diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
     assert diag == {
         "data": {
-            "areas": {},
+            "areas": {
+                "898": {"id": "898", "name": "Basement", "parent_id": None},
+                "822": {"id": "822", "name": "Bedroom", "parent_id": "898"},
+                "910": {"id": "910", "name": "Bathroom", "parent_id": "898"},
+                "1024": {"id": "1024", "name": "Master Bedroom", "parent_id": None},
+                "1025": {"id": "1025", "name": "Kitchen", "parent_id": None},
+                "1026": {"id": "1026", "name": "Dining Room", "parent_id": None},
+                "1205": {"id": "1205", "name": "Hallway", "parent_id": None},
+            },
             "buttons": {
                 "111": {
                     "device_id": "111",
@@ -73,6 +81,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "name": "bridge",
                     "serial": 1234,
                     "type": "type",
+                    "area": "1205",
                 },
                 "801": {
                     "device_id": "801",
@@ -85,6 +94,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "model": None,
                     "serial": None,
                     "tilt": None,
+                    "area": "822",
                 },
                 "802": {
                     "device_id": "802",
@@ -97,6 +107,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "model": None,
                     "serial": None,
                     "tilt": None,
+                    "area": "822",
                 },
                 "803": {
                     "device_id": "803",
@@ -109,6 +120,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "model": None,
                     "serial": None,
                     "tilt": None,
+                    "area": "910",
                 },
                 "804": {
                     "device_id": "804",
@@ -121,6 +133,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "model": None,
                     "serial": None,
                     "tilt": None,
+                    "area": "1024",
                 },
                 "901": {
                     "device_id": "901",
@@ -133,6 +146,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "model": None,
                     "serial": 5442321,
                     "tilt": None,
+                    "area": "1025",
                 },
                 "9": {
                     "device_id": "9",
@@ -147,7 +161,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "model": "PJ2-3BRL-GXX-X01",
                     "serial": 68551522,
                     "device_name": "Pico",
-                    "area": "6",
+                    "area": "1026",
                 },
                 "1355": {
                     "device_id": "1355",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
An area field was introduced in pylutron-caseta 0.16.0

Currently the area is parsed out of the name field provided by the library.
ex. name = "Basement Bedroom_Main Lights"
area is extracted from the text before the underscore, the name after the underscore

This update uses the area field to retrieve the area name from the smartbridge.areas dict.

RA3/HWQSX also supports nested areas.  This update will retrieve the full area name from the area tree.
In the below image, the full area name for the Bedroom will be returned as "Basement Bedroom"
 
![image](https://user-images.githubusercontent.com/24459240/195459803-8882b08d-5e38-441e-bc68-8ccf0f130b0c.png)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
