### PR TITLE
Improve keypad and device name generation

### DIFF
--- a/tests/components/lutron_caseta/__init__.py
+++ b/tests/components/lutron_caseta/__init__.py
@@ -160,6 +160,7 @@ class MockBridge:
                 "serial": None,
                 "tilt": None,
                 "area": "822",
+                "device_name": "Main Lights",
             },
             "802": {
                 "device_id": "802",
@@ -173,6 +174,7 @@ class MockBridge:
                 "serial": None,
                 "tilt": None,
                 "area": "822",
+                "device_name": "Left Shade",
             },
             "803": {
                 "device_id": "803",
@@ -186,6 +188,7 @@ class MockBridge:
                 "serial": None,
                 "tilt": None,
                 "area": "910",
+                "device_name": "Exhaust Fan",
             },
             "804": {
                 "device_id": "804",
@@ -199,6 +202,7 @@ class MockBridge:
                 "serial": None,
                 "tilt": None,
                 "area": "1024",
+                "device_name": "Ceiling Fan",
             },
             "901": {
                 "device_id": "901",
@@ -212,6 +216,7 @@ class MockBridge:
                 "serial": 5442321,
                 "tilt": None,
                 "area": "1025",
+                "device_name": "Main Lights",
             },
             "9": {
                 "device_id": "9",

--- a/tests/components/lutron_caseta/test_diagnostics.py
+++ b/tests/components/lutron_caseta/test_diagnostics.py
@@ -95,6 +95,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "serial": None,
                     "tilt": None,
                     "area": "822",
+                    "device_name": "Main Lights",
                 },
                 "802": {
                     "device_id": "802",
@@ -108,6 +109,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "serial": None,
                     "tilt": None,
                     "area": "822",
+                    "device_name": "Left Shade",
                 },
                 "803": {
                     "device_id": "803",
@@ -121,6 +123,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "serial": None,
                     "tilt": None,
                     "area": "910",
+                    "device_name": "Exhaust Fan",
                 },
                 "804": {
                     "device_id": "804",
@@ -134,6 +137,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "serial": None,
                     "tilt": None,
                     "area": "1024",
+                    "device_name": "Ceiling Fan",
                 },
                 "901": {
                     "device_id": "901",
@@ -147,6 +151,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "serial": 5442321,
                     "tilt": None,
                     "area": "1025",
+                    "device_name": "Main Lights",
                 },
                 "9": {
                     "device_id": "9",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently device and entity names are generated within the pylutron-caseta library, and used in this integration.

This change moves the device and entity naming logic into the integration, building the names from fundamental fields and parent/child device relationship provided by pylutron-caseta.

The names generated by this change match the current naming so this should be transparent to the users.

This PR will put the integration in a good position to adopt the following naming strategy when ready, and not have to make any changes to the supporting library.
https://developers.home-assistant.io/blog/2022/07/10/entity_naming/


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
