### PR TITLE
Add start_application service to fully_kiosk integration

### DIFF
--- a/homeassistant/components/fully_kiosk/const.py
+++ b/homeassistant/components/fully_kiosk/const.py
@@ -24,5 +24,7 @@ MEDIA_SUPPORT_FULLYKIOSK = (
 )
 
 SERVICE_LOAD_URL = "load_url"
+SERVICE_START_APPLICATION = "start_application"
 
 ATTR_URL = "url"
+ATTR_APPLICATION = "application"

--- a/homeassistant/components/fully_kiosk/services.py
+++ b/homeassistant/components/fully_kiosk/services.py
@@ -8,7 +8,13 @@ from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
 
-from .const import ATTR_URL, DOMAIN, SERVICE_LOAD_URL
+from .const import (
+    ATTR_APPLICATION,
+    ATTR_URL,
+    DOMAIN,
+    SERVICE_LOAD_URL,
+    SERVICE_START_APPLICATION,
+)
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
@@ -24,6 +30,16 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 coordinator = hass.data[DOMAIN][list(device.config_entries)[0]]
                 await coordinator.fully.loadUrl(call.data[ATTR_URL])
 
+    async def async_start_app(call: ServiceCall) -> None:
+        """Start an app on the device."""
+        registry = dr.async_get(hass)
+        for target in call.data[ATTR_DEVICE_ID]:
+
+            device = registry.async_get(target)
+            if device:
+                coordinator = hass.data[DOMAIN][list(device.config_entries)[0]]
+                await coordinator.fully.startApplication(call.data[ATTR_APPLICATION])
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_LOAD_URL,
@@ -34,6 +50,22 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     vol.Required(ATTR_DEVICE_ID): cv.ensure_list,
                     vol.Required(
                         ATTR_URL,
+                    ): cv.string,
+                },
+            )
+        ),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_START_APPLICATION,
+        async_start_app,
+        schema=vol.Schema(
+            vol.All(
+                {
+                    vol.Required(ATTR_DEVICE_ID): cv.ensure_list,
+                    vol.Required(
+                        ATTR_APPLICATION,
                     ): cv.string,
                 },
             )

--- a/homeassistant/components/fully_kiosk/services.yaml
+++ b/homeassistant/components/fully_kiosk/services.yaml
@@ -12,3 +12,18 @@ load_url:
       required: true
       selector:
         text:
+
+start_application:
+  name: Start Application
+  description: Start an application on the device running Fully Kiosk Browser.
+  target:
+    device:
+      integration: fully_kiosk
+  fields:
+    url:
+      name: Application
+      description: Package name of the application to start.
+      example: "de.ozerov.fully"
+      required: true
+      selector:
+        text:

--- a/tests/components/fully_kiosk/test_services.py
+++ b/tests/components/fully_kiosk/test_services.py
@@ -2,9 +2,11 @@
 from unittest.mock import MagicMock
 
 from homeassistant.components.fully_kiosk.const import (
+    ATTR_APPLICATION,
     ATTR_URL,
     DOMAIN,
     SERVICE_LOAD_URL,
+    SERVICE_START_APPLICATION,
 )
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant
@@ -34,3 +36,12 @@ async def test_services(
     )
 
     assert len(mock_fully_kiosk.loadUrl.mock_calls) == 1
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_START_APPLICATION,
+        {ATTR_DEVICE_ID: [device_entry.id], ATTR_APPLICATION: "de.ozerov.fully"},
+        blocking=True,
+    )
+
+    assert len(mock_fully_kiosk.startApplication.mock_calls) == 1


### PR DESCRIPTION
## Proposed change
Adds the start_application service to the fully_kiosk integration. This service allows you to launch another app on a device running Fully Kiosk Browser.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24543

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
