### PR TITLE
Deprecate name property of unit system

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -2015,6 +2015,8 @@ class Config:
             "latitude": self.latitude,
             "longitude": self.longitude,
             "elevation": self.elevation,
+            # We don't want any components to use the name of the unit system
+            # so we are using the private attribute here
             "unit_system": self.units._name,  # pylint: disable=protected-access
             "location_name": self.location_name,
             "time_zone": self.time_zone,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -2015,7 +2015,7 @@ class Config:
             "latitude": self.latitude,
             "longitude": self.longitude,
             "elevation": self.elevation,
-            "unit_system": self.units.name,
+            "unit_system": self.units._name,  # pylint: disable=protected-access
             "location_name": self.location_name,
             "time_zone": self.time_zone,
             "external_url": self.external_url,

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     VOLUME_LITERS,
     WIND_SPEED,
 )
+from homeassistant.helpers.frame import report
 
 from .unit_conversion import (
     DistanceConverter,
@@ -107,7 +108,7 @@ class UnitSystem:
         if errors:
             raise ValueError(errors)
 
-        self.name = name
+        self._name = name
         self.accumulated_precipitation_unit = accumulated_precipitation
         self.temperature_unit = temperature
         self.length_unit = length
@@ -117,9 +118,20 @@ class UnitSystem:
         self.wind_speed_unit = wind_speed
 
     @property
+    def name(self) -> str:
+        """Return the name of the unit system."""
+        report(
+            "accesses the name of the unit system. "
+            "This is deprecated and will stop working in Home Assistant 2023.1. "
+            "Please adjust to use instance check instead.",
+            error_if_core=False,
+        )
+        return self._name
+
+    @property
     def is_metric(self) -> bool:
         """Determine if this is the metric unit system."""
-        return self.name == CONF_UNIT_SYSTEM_METRIC
+        return self._name == CONF_UNIT_SYSTEM_METRIC
 
     def temperature(self, temperature: float, from_unit: str) -> float:
         """Convert the given temperature to this unit system."""

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -121,7 +121,7 @@ class UnitSystem:
     def name(self) -> str:
         """Return the name of the unit system."""
         report(
-            "accesses the name of the unit system. "
+            "accesses the `name` property of the unit system. "
             "This is deprecated and will stop working in Home Assistant 2023.1. "
             "Please adjust to use instance check instead.",
             error_if_core=False,

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -3,6 +3,7 @@ import pytest
 
 from homeassistant.const import (
     ACCUMULATED_PRECIPITATION,
+    CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_UNIT_SYSTEM_METRIC,
     LENGTH,
     LENGTH_KILOMETERS,
@@ -301,7 +302,19 @@ def test_is_metric():
     assert not IMPERIAL_SYSTEM.is_metric
 
 
-def test_deprecated_name(caplog: pytest.LogCaptureFixture) -> None:
+@pytest.mark.parametrize(
+    "unit_system, expected_name",
+    [
+        (METRIC_SYSTEM, CONF_UNIT_SYSTEM_METRIC),
+        (IMPERIAL_SYSTEM, CONF_UNIT_SYSTEM_IMPERIAL),
+    ],
+)
+def test_deprecated_name(
+    caplog: pytest.LogCaptureFixture, unit_system: UnitSystem, expected_name: str
+) -> None:
     """Test the name is deprecated."""
-    assert METRIC_SYSTEM.name == CONF_UNIT_SYSTEM_METRIC
-    assert "Detected code that accesses the name of the unit system." in caplog.text
+    assert unit_system.name == expected_name
+    assert (
+        "Detected code that accesses the `name` property of the unit system."
+        in caplog.text
+    )

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -3,6 +3,7 @@ import pytest
 
 from homeassistant.const import (
     ACCUMULATED_PRECIPITATION,
+    CONF_UNIT_SYSTEM_METRIC,
     LENGTH,
     LENGTH_KILOMETERS,
     LENGTH_METERS,
@@ -298,3 +299,9 @@ def test_is_metric():
     """Test the is metric flag."""
     assert METRIC_SYSTEM.is_metric
     assert not IMPERIAL_SYSTEM.is_metric
+
+
+def test_deprecated_name(caplog: pytest.LogCaptureFixture) -> None:
+    """Test the name is deprecated."""
+    assert METRIC_SYSTEM.name == CONF_UNIT_SYSTEM_METRIC
+    assert "Detected code that accesses the name of the unit system." in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The name of a unit system should never be used for checking its type. Instance checks should be used instead:

Correct:
```python
if hass.config.units is IMPERIAL_SYSTEM:
    pass

if hass.config.units is METRIC_SYSTEM:
    pass
```

Incorrect:
```python
if hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL:
    pass

if hass.config.units.name == CONF_UNIT_SYSTEM_METRIC:
    pass
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate the `name` property, and log a warning if it is accessed.

Linked PRs:
- [ ] #80232
- [ ] #80233
- [ ] #80235
- [ ] #80236
- [ ] #80237
- [ ] #80241
- [ ] #80243
- [ ] #80244

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1496

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
