### PR TITLE
Fix broken wheel for iaqualink

### DIFF
--- a/homeassistant/components/iaqualink/manifest.json
+++ b/homeassistant/components/iaqualink/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/iaqualink/",
   "codeowners": ["@flz"],
-  "requirements": ["iaqualink==0.4.1"],
+  "requirements": ["iaqualink==0.4.1 --no-binary=iaqualink"],
   "iot_class": "cloud_polling",
   "loggers": ["iaqualink"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -901,7 +901,7 @@ hyperion-py==0.7.5
 iammeter==0.1.7
 
 # homeassistant.components.iaqualink
-iaqualink==0.4.1
+iaqualink==0.4.1 --no-binary=iaqualink
 
 # homeassistant.components.ibeacon
 ibeacon_ble==0.7.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -672,7 +672,7 @@ huawei-lte-api==1.6.3
 hyperion-py==0.7.5
 
 # homeassistant.components.iaqualink
-iaqualink==0.4.1
+iaqualink==0.4.1 --no-binary=iaqualink
 
 # homeassistant.components.ibeacon
 ibeacon_ble==0.7.4

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -44,7 +44,7 @@ IGNORE_VIOLATIONS = {
     "blink",
     "ezviz",
     "hdmi_cec",
-    "Jandy iAqualink",
+    "iaqualink",
     "juicenet",
     "lupusec",
     "rainbird",
@@ -53,7 +53,7 @@ IGNORE_VIOLATIONS = {
 }
 
 IGNORE_FORMAT_VIOLATIONS = {
-    "Jandy iAqualink",
+    "iaqualink",
 }
 
 
@@ -62,7 +62,7 @@ def validate(integrations: dict[str, Integration], config: Config):
     # Check if we are doing format-only validation.
     if not config.requirements:
         for integration in integrations.values():
-            if integration.name in IGNORE_FORMAT_VIOLATIONS:
+            if integration.domain in IGNORE_FORMAT_VIOLATIONS:
                 continue
             validate_requirements_format(integration)
         return
@@ -125,11 +125,11 @@ def validate_requirements_format(integration: Integration) -> bool:
 
 def validate_requirements(integration: Integration):
     """Validate requirements."""
-    if not validate_requirements_format(integration):
-        return
-
     # Some integrations have not been fixed yet so are allowed to have violations.
     if integration.domain in IGNORE_VIOLATIONS:
+        return
+
+    if not validate_requirements_format(integration):
         return
 
     integration_requirements = set()

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -51,12 +51,18 @@ IGNORE_VIOLATIONS = {
     "suez_water",
 }
 
+IGNORE_FORMAT_VIOLATIONS = {
+    "Jandy iAqualink",
+}
+
 
 def validate(integrations: dict[str, Integration], config: Config):
     """Handle requirements for integrations."""
     # Check if we are doing format-only validation.
     if not config.requirements:
         for integration in integrations.values():
+            if integration.name in IGNORE_FORMAT_VIOLATIONS:
+                continue
             validate_requirements_format(integration)
         return
 

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -44,6 +44,7 @@ IGNORE_VIOLATIONS = {
     "blink",
     "ezviz",
     "hdmi_cec",
+    "Jandy iAqualink",
     "juicenet",
     "lupusec",
     "rainbird",


### PR DESCRIPTION
## Proposed change
A new version for `iaqualink` was released yesterday. It seems that during the release the wheel for `v0.4.1` were  overwritten accidentally. See issue: https://github.com/flz/iaqualink-py/issues/26

Until either the wheel on PyPI is fixed or we can update to `v0.5.0` CI jobs for pylint and pytest are broken. Luckily the source distribution is still available to fall back to. The `v0.5.0` update seems to require a bit more work, the changes are quite extensive, which is why I didn't choose to do that. https://github.com/flz/iaqualink-py/compare/v0.4.1...v0.5.0

The change isn't pretty, but it works and can be reverted once it's fixed.

**Broken CI run**
pylint: https://github.com/cdce8p/ha-core/actions/runs/3242632837/jobs/5316195811
pytest: https://github.com/home-assistant/core/actions/runs/3242542140/jobs/5316055187


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
