### PR TITLE
Only reload modified automations

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -1,7 +1,9 @@
 """Allow to set up simple automation rules via the config file."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 import logging
 from typing import Any, Protocol, cast
 
@@ -274,7 +276,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def reload_service_handler(service_call: ServiceCall) -> None:
         """Remove all automations and load new ones from config."""
-        if (conf := await component.async_prepare_reload()) is None:
+        if (conf := await component.async_prepare_reload(skip_reset=True)) is None:
             return
         async_get_blueprints(hass).async_reset_cache()
         await _async_process_config(hass, conf, component)
@@ -660,20 +662,27 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         )
 
 
-async def _async_process_config(
-    hass: HomeAssistant,
-    config: dict[str, Any],
-    component: EntityComponent[AutomationEntity],
-) -> bool:
-    """Process config and add automations.
+@dataclass
+class AutomationEntityConfig:
+    """Container for prepared automation entity configuration."""
 
-    Returns if blueprints were used.
-    """
-    entities: list[AutomationEntity] = []
+    config_block: ConfigType
+    config_key: str
+    list_no: int
+    raw_blueprint_inputs: ConfigType | None
+    raw_config: ConfigType | None
+
+
+async def _prepare_automation_config(
+    hass: HomeAssistant,
+    config: ConfigType,
+) -> tuple[bool, list[AutomationEntityConfig]]:
+    """Parse configuration and prepare automation entity configuration."""
+    automation_configs: list[AutomationEntityConfig] = []
     blueprints_used = False
 
     for config_key in extract_domain_configs(config, DOMAIN):
-        conf: list[dict[str, Any] | blueprint.BlueprintInputs] = config[config_key]
+        conf: list[ConfigType | blueprint.BlueprintInputs] = config[config_key]
 
         for list_no, config_block in enumerate(conf):
             raw_blueprint_inputs = None
@@ -700,62 +709,121 @@ async def _async_process_config(
             else:
                 raw_config = cast(AutomationConfig, config_block).raw_config
 
-            automation_id: str | None = config_block.get(CONF_ID)
-            name: str = config_block.get(CONF_ALIAS) or f"{config_key} {list_no}"
-
-            initial_state: bool | None = config_block.get(CONF_INITIAL_STATE)
-
-            action_script = Script(
-                hass,
-                config_block[CONF_ACTION],
-                name,
-                DOMAIN,
-                running_description="automation actions",
-                script_mode=config_block[CONF_MODE],
-                max_runs=config_block[CONF_MAX],
-                max_exceeded=config_block[CONF_MAX_EXCEEDED],
-                logger=LOGGER,
-                # We don't pass variables here
-                # Automation will already render them to use them in the condition
-                # and so will pass them on to the script.
-            )
-
-            if CONF_CONDITION in config_block:
-                cond_func = await _async_process_if(hass, name, config, config_block)
-
-                if cond_func is None:
-                    continue
-            else:
-                cond_func = None
-
-            # Add trigger variables to variables
-            variables = None
-            if CONF_TRIGGER_VARIABLES in config_block:
-                variables = ScriptVariables(
-                    dict(config_block[CONF_TRIGGER_VARIABLES].as_dict())
+            automation_configs.append(
+                AutomationEntityConfig(
+                    config_block, config_key, list_no, raw_blueprint_inputs, raw_config
                 )
-            if CONF_VARIABLES in config_block:
-                if variables:
-                    variables.variables.update(config_block[CONF_VARIABLES].as_dict())
-                else:
-                    variables = config_block[CONF_VARIABLES]
-
-            entity = AutomationEntity(
-                automation_id,
-                name,
-                config_block[CONF_TRIGGER],
-                cond_func,
-                action_script,
-                initial_state,
-                variables,
-                config_block.get(CONF_TRIGGER_VARIABLES),
-                raw_config,
-                raw_blueprint_inputs,
-                config_block[CONF_TRACE],
             )
 
-            entities.append(entity)
+    return (blueprints_used, automation_configs)
 
+
+async def _create_automation_entities(
+    hass: HomeAssistant, automation_configs: list[AutomationEntityConfig]
+) -> list[AutomationEntity]:
+    """Create automation entities from prepared configuration."""
+    entities: list[AutomationEntity] = []
+
+    for automation_config in automation_configs:
+        config_block = automation_config.config_block
+        config_key = automation_config.config_key
+        list_no = automation_config.list_no
+
+        automation_id: str | None = config_block.get(CONF_ID)
+        name: str = config_block.get(CONF_ALIAS) or f"{config_key} {list_no}"
+
+        initial_state: bool | None = config_block.get(CONF_INITIAL_STATE)
+
+        action_script = Script(
+            hass,
+            config_block[CONF_ACTION],
+            name,
+            DOMAIN,
+            running_description="automation actions",
+            script_mode=config_block[CONF_MODE],
+            max_runs=config_block[CONF_MAX],
+            max_exceeded=config_block[CONF_MAX_EXCEEDED],
+            logger=LOGGER,
+            # We don't pass variables here
+            # Automation will already render them to use them in the condition
+            # and so will pass them on to the script.
+        )
+
+        if CONF_CONDITION in config_block:
+            cond_func = await _async_process_if(hass, name, config_block)
+
+            if cond_func is None:
+                continue
+        else:
+            cond_func = None
+
+        # Add trigger variables to variables
+        variables = None
+        if CONF_TRIGGER_VARIABLES in config_block:
+            variables = ScriptVariables(
+                dict(config_block[CONF_TRIGGER_VARIABLES].as_dict())
+            )
+        if CONF_VARIABLES in config_block:
+            if variables:
+                variables.variables.update(config_block[CONF_VARIABLES].as_dict())
+            else:
+                variables = config_block[CONF_VARIABLES]
+
+        entity = AutomationEntity(
+            automation_id,
+            name,
+            config_block[CONF_TRIGGER],
+            cond_func,
+            action_script,
+            initial_state,
+            variables,
+            config_block.get(CONF_TRIGGER_VARIABLES),
+            automation_config.raw_config,
+            automation_config.raw_blueprint_inputs,
+            config_block[CONF_TRACE],
+        )
+        entities.append(entity)
+
+    return entities
+
+
+async def _async_process_config(
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    component: EntityComponent[AutomationEntity],
+) -> bool:
+    """Process config and add automations.
+
+    Returns if blueprints were used.
+    """
+
+    def find_match(
+        automations: list[AutomationEntity],
+        automation_configs: list[AutomationEntityConfig],
+    ) -> tuple[int, int] | None:
+        """Return indices of first automation and matching configuration."""
+        for automation_idx, automation in enumerate(automations):
+            for config_idx, config in enumerate(automation_configs):
+                if automation.raw_config == config.raw_config:
+                    return (automation_idx, config_idx)
+        return None
+
+    blueprints_used, updated_automation_configs = await _prepare_automation_config(
+        hass, config
+    )
+    automations_to_remove: list[AutomationEntity] = list(component.entities)
+
+    # Drop unchanged automations
+    while idx := find_match(automations_to_remove, updated_automation_configs):
+        del automations_to_remove[idx[0]]
+        del updated_automation_configs[idx[1]]
+
+    # Remove automations which have changed config or no longer exist
+    tasks = [automation.async_remove() for automation in automations_to_remove]
+    await asyncio.gather(*tasks)
+
+    # Crete automations which have new config or have been added
+    entities = await _create_automation_entities(hass, updated_automation_configs)
     if entities:
         await component.async_add_entities(entities)
 
@@ -763,10 +831,10 @@ async def _async_process_config(
 
 
 async def _async_process_if(
-    hass: HomeAssistant, name: str, config: dict[str, Any], p_config: dict[str, Any]
+    hass: HomeAssistant, name: str, config: dict[str, Any]
 ) -> IfAction | None:
     """Process if checks."""
-    if_configs = p_config[CONF_CONDITION]
+    if_configs = config[CONF_CONDITION]
 
     checks: list[condition.ConditionCheckerType] = []
     for if_config in if_configs:

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -822,7 +822,7 @@ async def _async_process_config(
     tasks = [automation.async_remove() for automation in automations_to_remove]
     await asyncio.gather(*tasks)
 
-    # Crete automations which have new config or have been added
+    # Create automations which have new config or have been added
     entities = await _create_automation_entities(hass, updated_automation_configs)
     if entities:
         await component.async_add_entities(entities)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -832,6 +832,108 @@ async def test_reload_moved_automation_without_alias(hass, calls):
         assert len(calls) == 2
 
 
+async def test_reload_identical_automations_without_id(hass, calls):
+    """Test reloading of identical automations without id."""
+    with patch(
+        "homeassistant.components.automation.AutomationEntity", wraps=AutomationEntity
+    ) as automation_entity_init:
+        config = {
+            automation.DOMAIN: [
+                {
+                    "alias": "dolly",
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "action": [{"service": "test.automation"}],
+                },
+                {
+                    "alias": "dolly",
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "action": [{"service": "test.automation"}],
+                },
+                {
+                    "alias": "dolly",
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "action": [{"service": "test.automation"}],
+                },
+            ]
+        }
+        assert await async_setup_component(hass, automation.DOMAIN, config)
+        assert automation_entity_init.call_count == 3
+        automation_entity_init.reset_mock()
+
+        assert hass.states.get("automation.dolly")
+        assert hass.states.get("automation.dolly_2")
+        assert hass.states.get("automation.dolly_3")
+
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+        assert len(calls) == 3
+
+        # Reload the automations without any change
+        with patch(
+            "homeassistant.config.load_yaml_config_file",
+            autospec=True,
+            return_value=config,
+        ):
+            await hass.services.async_call(
+                automation.DOMAIN, SERVICE_RELOAD, blocking=True
+            )
+
+        assert automation_entity_init.call_count == 0
+        automation_entity_init.reset_mock()
+
+        assert hass.states.get("automation.dolly")
+        assert hass.states.get("automation.dolly_2")
+        assert hass.states.get("automation.dolly_3")
+
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+        assert len(calls) == 6
+
+        # Remove two clones
+        del config[automation.DOMAIN][-1]
+        del config[automation.DOMAIN][-1]
+        with patch(
+            "homeassistant.config.load_yaml_config_file",
+            autospec=True,
+            return_value=config,
+        ):
+            await hass.services.async_call(
+                automation.DOMAIN, SERVICE_RELOAD, blocking=True
+            )
+
+        assert automation_entity_init.call_count == 0
+        automation_entity_init.reset_mock()
+
+        assert hass.states.get("automation.dolly")
+
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+        assert len(calls) == 7
+
+        # Add two clones
+        config[automation.DOMAIN].append(config[automation.DOMAIN][-1])
+        config[automation.DOMAIN].append(config[automation.DOMAIN][-1])
+        with patch(
+            "homeassistant.config.load_yaml_config_file",
+            autospec=True,
+            return_value=config,
+        ):
+            await hass.services.async_call(
+                automation.DOMAIN, SERVICE_RELOAD, blocking=True
+            )
+
+        assert automation_entity_init.call_count == 2
+        automation_entity_init.reset_mock()
+
+        assert hass.states.get("automation.dolly")
+        assert hass.states.get("automation.dolly_2")
+        assert hass.states.get("automation.dolly_3")
+
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+        assert len(calls) == 10
+
+
 async def test_automation_restore_state(hass):
     """Ensure states are restored on startup."""
     time = dt_util.utcnow()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only reload modified automation when automation configuration is reloaded

Similar to https://github.com/home-assistant/core/pull/80254, but works also when manually editing the YAML configuration

WTH: https://community.home-assistant.io/t/wth-do-all-automatons-get-reloaded-when-you-change-any-of-them/467270

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
