### PR TITLE
Revert "Add Mazda brand"

### DIFF
--- a/homeassistant/brands/mazda.json
+++ b/homeassistant/brands/mazda.json
@@ -1,5 +1,0 @@
-{
-  "domain": "mazda",
-  "name": "Mazda",
-  "integrations": ["mazda"]
-}

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2433,14 +2433,9 @@
       "name": "Matrix"
     },
     "mazda": {
-      "name": "Mazda",
-      "integrations": {
-        "mazda": {
-          "config_flow": true,
-          "iot_class": "cloud_polling",
-          "name": "Mazda Connected Services"
-        }
-      }
+      "config_flow": true,
+      "iot_class": "cloud_polling",
+      "name": "Mazda Connected Services"
     },
     "meater": {
       "config_flow": true,


### PR DESCRIPTION
This PR reverts home-assistant/core#79683

It is a brand with a single integration that has been merged. We currently don't do that yet and want to prevent unchaining lots of PRs doing the same.

There is some more work and challenges to be solved around "brands" that need to be done first.

I placed a comment on the reverting PR 5 days ago but didn't get a response from the author or reviewer. Hence now, a revert.

../Frenck