### PR TITLE
Add type hints to aqualogic

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -57,6 +57,7 @@ homeassistant.components.ambient_station.*
 homeassistant.components.amcrest.*
 homeassistant.components.ampio.*
 homeassistant.components.anthemav.*
+homeassistant.components.aqualogic.*
 homeassistant.components.aseko_pool_live.*
 homeassistant.components.asuswrt.*
 homeassistant.components.auth.*

--- a/homeassistant/components/aqualogic/__init__.py
+++ b/homeassistant/components/aqualogic/__init__.py
@@ -1,4 +1,6 @@
 """Support for AquaLogic devices."""
+from __future__ import annotations
+
 from datetime import timedelta
 import logging
 import threading
@@ -13,7 +15,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.typing import ConfigType
@@ -50,7 +52,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 class AquaLogicProcessor(threading.Thread):
     """AquaLogic event processor thread."""
 
-    def __init__(self, hass, host, port):
+    def __init__(self, hass: HomeAssistant, host: str, port: int) -> None:
         """Initialize the data object."""
         super().__init__(daemon=True)
         self._hass = hass
@@ -59,27 +61,28 @@ class AquaLogicProcessor(threading.Thread):
         self._shutdown = False
         self._panel = None
 
-    def start_listen(self, event):
+    def start_listen(self, event: Event) -> None:
         """Start event-processing thread."""
         _LOGGER.debug("Event processing thread started")
         self.start()
 
-    def shutdown(self, event):
+    def shutdown(self, event: Event) -> None:
         """Signal shutdown of processing event."""
         _LOGGER.debug("Event processing signaled exit")
         self._shutdown = True
 
-    def data_changed(self, panel):
+    def data_changed(self, panel: AquaLogic) -> None:
         """Aqualogic data changed callback."""
         dispatcher_send(self._hass, UPDATE_TOPIC)
 
-    def run(self):
+    def run(self) -> None:
         """Event thread."""
 
         while True:
-            self._panel = AquaLogic()
-            self._panel.connect(self._host, self._port)
-            self._panel.process(self.data_changed)
+            panel = AquaLogic()
+            self._panel = panel
+            panel.connect(self._host, self._port)
+            panel.process(self.data_changed)
 
             if self._shutdown:
                 return
@@ -88,6 +91,6 @@ class AquaLogicProcessor(threading.Thread):
             time.sleep(RECONNECT_INTERVAL.total_seconds())
 
     @property
-    def panel(self):
+    def panel(self) -> AquaLogic | None:
         """Retrieve the AquaLogic object."""
         return self._panel

--- a/homeassistant/components/aqualogic/sensor.py
+++ b/homeassistant/components/aqualogic/sensor.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DOMAIN, UPDATE_TOPIC
+from . import DOMAIN, UPDATE_TOPIC, AquaLogicProcessor
 
 
 @dataclass
@@ -120,7 +120,7 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the sensor platform."""
-    processor = hass.data[DOMAIN]
+    processor: AquaLogicProcessor = hass.data[DOMAIN]
     monitored_conditions = config[CONF_MONITORED_CONDITIONS]
 
     entities = [
@@ -138,7 +138,11 @@ class AquaLogicSensor(SensorEntity):
     entity_description: AquaLogicSensorEntityDescription
     _attr_should_poll = False
 
-    def __init__(self, processor, description: AquaLogicSensorEntityDescription):
+    def __init__(
+        self,
+        processor: AquaLogicProcessor,
+        description: AquaLogicSensorEntityDescription,
+    ) -> None:
         """Initialize sensor."""
         self.entity_description = description
         self._processor = processor
@@ -153,7 +157,7 @@ class AquaLogicSensor(SensorEntity):
         )
 
     @callback
-    def async_update_callback(self):
+    def async_update_callback(self) -> None:
         """Update callback."""
         if (panel := self._processor.panel) is not None:
             if panel.is_metric:

--- a/homeassistant/components/aqualogic/switch.py
+++ b/homeassistant/components/aqualogic/switch.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DOMAIN, UPDATE_TOPIC
+from . import DOMAIN, UPDATE_TOPIC, AquaLogicProcessor
 
 SWITCH_TYPES = {
     "lights": "Lights",
@@ -47,7 +47,7 @@ async def async_setup_platform(
     """Set up the switch platform."""
     switches = []
 
-    processor = hass.data[DOMAIN]
+    processor: AquaLogicProcessor = hass.data[DOMAIN]
     for switch_type in config[CONF_MONITORED_CONDITIONS]:
         switches.append(AquaLogicSwitch(processor, switch_type))
 
@@ -59,7 +59,7 @@ class AquaLogicSwitch(SwitchEntity):
 
     _attr_should_poll = False
 
-    def __init__(self, processor, switch_type):
+    def __init__(self, processor: AquaLogicProcessor, switch_type: str) -> None:
         """Initialize switch."""
         self._processor = processor
         self._state_name = {
@@ -77,12 +77,11 @@ class AquaLogicSwitch(SwitchEntity):
         self._attr_name = f"AquaLogic {SWITCH_TYPES[switch_type]}"
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if device is on."""
         if (panel := self._processor.panel) is None:
             return False
-        state = panel.get_state(self._state_name)
-        return state
+        return panel.get_state(self._state_name)  # type: ignore[no-any-return]
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""

--- a/mypy.ini
+++ b/mypy.ini
@@ -322,6 +322,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.aqualogic.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.aseko_pool_live.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to aqualogic

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
