### PR TITLE
Addition of a schedule configure service

### DIFF
--- a/homeassistant/components/schedule/const.py
+++ b/homeassistant/components/schedule/const.py
@@ -35,3 +35,6 @@ WEEKDAY_TO_CONF: Final = {
     5: CONF_SATURDAY,
     6: CONF_SUNDAY,
 }
+
+CONF_WEEKDAYS: Final = "weekdays"
+CONF_CLEAR: Final = "clear"

--- a/homeassistant/components/schedule/services.yaml
+++ b/homeassistant/components/schedule/services.yaml
@@ -1,3 +1,55 @@
+# Describes the format for available schedule services
+
 reload:
   name: Reload
   description: Reload the schedule configuration
+
+configure:
+  name: Configure
+  description: Change schedule parameters
+  target:
+    entity:
+      domain: schedule
+  fields:
+    weekdays:
+      name: Weekdays
+      description: The days to be updated.
+      required: true
+      selector:
+        select:
+          options:
+            - label: "Monday"
+              value: monday
+            - label: "Tuesday"
+              value: tuesday
+            - label: "Wednesday"
+              value: wednesday
+            - label: "Thursday"
+              value: thursday
+            - label: "Friday"
+              value: friday
+            - label: "Saturday"
+              value: saturday
+            - label: "Sunday"
+              value: sunday
+          multiple: true
+    from:
+      name: Time from
+      description: Target start time.
+      required: false
+      example: '"05:00:00"'
+      selector:
+        time:
+    to:
+      name: Time to
+      description: Target finish time.
+      required: false
+      example: '"07:00:00"'
+      selector:
+        time:
+    clear:
+      name: Clear
+      description: Clear selected days before writing new time.
+      default: false
+      selector:
+        boolean:


### PR DESCRIPTION
Adding in the ability to use a service call to be able to add / clear / change a schedule (so it can be done via automations etc).

I have one problem with the current configuration, it seems to work as expected - except it doesn't seem to last after restarts (it goes back to the previous configuration). I have checked the `.storage/schedule` file and it doesn't get updated after a update despite every other service example doing it in the same way that I have used.

When calling the service, it will tell you that you are overlapping previously set times if you press the call service button twice - which is correct. So I know that the Home Assistant state machine is getting it - the states are updated in the user interface too. If a time window is covering the current time it the state of the schedule turns to on as expected. The problem seems to be when I click on the schedule itself to edit it, it does not show the adjusted values - even though the state has changed to match what is happening behind the scenes.

If I could have some help on figuring out the reason for this would be greatly appreciated.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The addition of a schedule service to allow the adapting of a schedule via automations.
I am using it to block out a day within a schedule of mine just by the press of a button (for user friendliness and ease).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
