### PR TITLE
Fix connectable Bluetooth devices not being seen if the nearest scanner is non-connectable

### DIFF
--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -123,7 +123,6 @@ class BluetoothManager:
             tuple[AdvertisementDataCallback, dict[str, set[str]]]
         ] = []
         self._all_history: dict[str, BluetoothServiceInfoBleak] = {}
-        self._non_connectable_history: dict[str, BluetoothServiceInfoBleak] = {}
         self._connectable_history: dict[str, BluetoothServiceInfoBleak] = {}
         self._non_connectable_scanners: list[BaseHaScanner] = []
         self._connectable_scanners: list[BaseHaScanner] = []
@@ -157,9 +156,8 @@ class BluetoothManager:
                 service_info.as_dict()
                 for service_info in self._connectable_history.values()
             ],
-            "non_connectable_history": [
-                service_info.as_dict()
-                for service_info in self._non_connectable_history.values()
+            "all_history": [
+                service_info.as_dict() for service_info in self._all_history.values()
             ],
             "advertisement_tracker": self._advertisement_tracker.async_diagnostics(),
         }
@@ -256,7 +254,6 @@ class BluetoothManager:
         """Watch for unavailable devices and cleanup state history."""
         monotonic_now = MONOTONIC_TIME()
         connectable_history = self._connectable_history
-        non_connectable_history = self._non_connectable_history
         all_history = self._all_history
         tracker = self._advertisement_tracker
         intervals = tracker.intervals
@@ -279,8 +276,6 @@ class BluetoothManager:
                         time_since_seen = monotonic_now - all_history[address].time
                         if time_since_seen <= advertising_interval:
                             continue
-
-                    non_connectable_history.pop(address, None)
 
                     # The second loop (connectable=False) is responsible for removing
                     # the device from all the interval tracking since it is no longer
@@ -363,8 +358,24 @@ class BluetoothManager:
         device = service_info.device
         address = device.address
         all_history = self._all_history
+        connectable = service_info.connectable
+        connectable_history = self._connectable_history
 
         source = service_info.source
+        # This logic is complex due to the many combinations of scanners that are supported.
+        #
+        # We need to handle multiple connectable and non-connectable scanners
+        # and we need to handle the case where a device is connectable on one scanner
+        # but not on another.
+        #
+        # The device may also be connectable only by a scanner that has worse signal strength
+        # than a non-connectable scanner.
+        #
+        # all_history - the history of all advertisements from all scanners with the best
+        #               advertisement from each scanner
+        # connectable_history - the history of all connectable advertisements from all scanners
+        #                       with the best advertisement from each connectable scanner
+        #
         if (
             (old_service_info := all_history.get(address))
             and source != old_service_info.source
@@ -372,12 +383,35 @@ class BluetoothManager:
                 old_service_info, service_info
             )
         ):
+            # If we are rejecting the new advertisement and the device is connectable
+            # but not in the connectable history or the connectable source is the same
+            # as the new source, we need to add it to the connectable history
+            if connectable:
+                old_connectable_service_info = connectable_history.get(address)
+                if old_connectable_service_info and (
+                    # If its the same as the preferred source, we are done
+                    # as we know we prefer the old advertisement
+                    # from the check above
+                    (old_connectable_service_info is old_service_info)
+                    # If the old connectable source is different from the preferred
+                    # source, we need to check it as well to see if we prefer
+                    # the old connectable advertisement
+                    or (
+                        source != old_connectable_service_info.source
+                        and self._prefer_previous_adv_from_different_source(
+                            old_connectable_service_info, service_info
+                        )
+                    )
+                ):
+                    return
+
+                connectable_history[address] = service_info
+
             return
 
-        if connectable := service_info.connectable:
-            self._connectable_history[address] = service_info
-        else:
-            self._non_connectable_history[address] = service_info
+        if connectable:
+            connectable_history[address] = service_info
+
         all_history[address] = service_info
 
         # Track advertisement intervals to determine when we need to

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -116,7 +116,7 @@ async def test_diagnostics(
                     "timings": {},
                 },
                 "connectable_history": [],
-                "non_connectable_history": [],
+                "all_history": [],
                 "scanners": [
                     {
                         "adapter": "hci0",
@@ -239,7 +239,30 @@ async def test_diagnostics_macos(
                         "time": ANY,
                     }
                 ],
-                "non_connectable_history": [],
+                "all_history": [
+                    {
+                        "address": "44:44:33:11:23:45",
+                        "advertisement": [
+                            "wohand",
+                            {"1": {"__type": "<class " "'bytes'>", "repr": "b'\\x01'"}},
+                            {},
+                            [],
+                            -127,
+                            -127,
+                            [[]],
+                        ],
+                        "connectable": True,
+                        "manufacturer_data": {
+                            "1": {"__type": "<class " "'bytes'>", "repr": "b'\\x01'"}
+                        },
+                        "name": "wohand",
+                        "rssi": -127,
+                        "service_data": {},
+                        "service_uuids": [],
+                        "source": "local",
+                        "time": ANY,
+                    }
+                ],
                 "scanners": [
                     {
                         "adapter": "Core Bluetooth",


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If we saw the non-connectable scanner advertisement first we would reject the connectable scanner advertisement because it had worse signal strength.

In this case we need to check both

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
