### PR TITLE
Add opt-in/opt-out for temperature conversion

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -397,6 +397,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class SensorEntityDescription(EntityDescription):
     """A class that describes sensor entities."""
 
+    automatic_unit_conversion_enabled: bool | None = None
     device_class: SensorDeviceClass | str | None = None
     last_reset: datetime | None = None
     native_unit_of_measurement: str | None = None
@@ -408,6 +409,7 @@ class SensorEntity(Entity):
     """Base class for sensor entities."""
 
     entity_description: SensorEntityDescription
+    _attr_automatic_unit_conversion_enabled: bool | None
     _attr_device_class: SensorDeviceClass | str | None
     _attr_last_reset: datetime | None
     _attr_native_unit_of_measurement: str | None
@@ -466,6 +468,21 @@ class SensorEntity(Entity):
 
         return None
 
+    @property
+    def automatic_unit_conversion_enabled(self) -> bool | None:
+        """Return True if automatic unit conversion should be enabled.
+
+        Note:
+            SensorDeviceClass.TEMPERATURE is opt-out for °C and °F
+            SensorDeviceClass.TEMPERATURE is opt-in for K
+            Others device classes are opt-in
+        """
+        if hasattr(self, "_automatic_unit_conversion_enabled"):
+            return self._attr_automatic_unit_conversion_enabled
+        if hasattr(self, "entity_description"):
+            return self.entity_description.automatic_unit_conversion_enabled
+        return None
+
     @final
     @property
     def state_attributes(self) -> dict[str, Any] | None:
@@ -518,11 +535,21 @@ class SensorEntity(Entity):
 
         native_unit_of_measurement = self.native_unit_of_measurement
 
+        # SensorDeviceClass.TEMPERATURE is opt-out for °C and °F, opt-in for K
         if (
-            self.device_class == DEVICE_CLASS_TEMPERATURE
-            and native_unit_of_measurement in (TEMP_CELSIUS, TEMP_FAHRENHEIT)
+            self.device_class == SensorDeviceClass.TEMPERATURE
+            and native_unit_of_measurement in {TEMP_CELSIUS, TEMP_FAHRENHEIT}
+            and self.automatic_unit_conversion_enabled is None
         ):
             return self.hass.config.units.temperature_unit
+
+        # Handle opt-in for automatic unit conversion
+        if self.automatic_unit_conversion_enabled:
+            if (
+                self.device_class == SensorDeviceClass.TEMPERATURE
+                and native_unit_of_measurement in TemperatureConverter.VALID_UNITS
+            ):
+                return self.hass.config.units.temperature_unit
 
         return native_unit_of_measurement
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -537,9 +537,9 @@ class SensorEntity(Entity):
 
         # SensorDeviceClass.TEMPERATURE is opt-out for °C and °F, opt-in for K
         if (
-            self.device_class == SensorDeviceClass.TEMPERATURE
+            self.automatic_unit_conversion_enabled is None
+            and self.device_class == SensorDeviceClass.TEMPERATURE
             and native_unit_of_measurement in {TEMP_CELSIUS, TEMP_FAHRENHEIT}
-            and self.automatic_unit_conversion_enabled is None
         ):
             return self.hass.config.units.temperature_unit
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new `automatic_unit_conversion_enabled` to sensor entities.

Currently, `°C` and `°F` temperature sensors are automatically converted.
- With the default `automatic_unit_conversion_enabled = None` this behavior is unchanged
- Opt-out for temperature conversion can be done with `automatic_unit_conversion_enabled = False`
- Opt-in for Kelvin temperature sensors can be done with `automatic_unit_conversion_enabled = True`

After the PR, the unit conversion follows this priority:

1. Convert to display unit according to entity options set by user
2. Convert to display unit according to rules specified by `entity.automatic_unit_conversion_enabled` + `entity.native_unit_of_measurement` + `entity.device_class` + `hass.config.units` configuration
3. No conversion, use `native_unit_of_measurement` 

Note: this is based on a comment on https://github.com/home-assistant/architecture/discussions/809
> Right now, this is already problematic for temperatures with 3D printers, which we now, for example, just convert to F, while even our American friends use C for those.

Needs:
- [ ] tests
- [ ] documentation

Samples:
- If a 3D printer temperature sensor sets `automatic_unit_conversion_enabled` to `False`, that sensor will no longer be converted automatically. The integration would need to mark it as a "breaking change"
- If we in the future add automatic unit conversion for distance sensors, I suggest that it is added as "opt-in", and individual integrations mark it as a breaking change when they set `automatic_unit_conversion_enabled` to `True`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
