### PR TITLE
Remove unnecessary session scoping to several test fixtures

### DIFF
--- a/tests/components/airvisual/conftest.py
+++ b/tests/components/airvisual/conftest.py
@@ -50,7 +50,7 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data")
+@pytest.fixture(name="data", scope="package")
 def data_fixture():
     """Define an update coordinator data example."""
     return json.loads(load_fixture("data.json", "airvisual"))

--- a/tests/components/airvisual/conftest.py
+++ b/tests/components/airvisual/conftest.py
@@ -50,7 +50,7 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data", scope="session")
+@pytest.fixture(name="data")
 def data_fixture():
     """Define an update coordinator data example."""
     return json.loads(load_fixture("data.json", "airvisual"))

--- a/tests/components/ambient_station/conftest.py
+++ b/tests/components/ambient_station/conftest.py
@@ -48,7 +48,7 @@ async def setup_ambient_station_fixture(hass, config, devices):
         yield
 
 
-@pytest.fixture(name="station_data")
+@pytest.fixture(name="station_data", scope="package")
 def station_data_fixture():
     """Define devices data."""
     return json.loads(load_fixture("station_data.json", "ambient_station"))

--- a/tests/components/ambient_station/conftest.py
+++ b/tests/components/ambient_station/conftest.py
@@ -28,7 +28,7 @@ def config_entry_fixture(hass, config):
     return entry
 
 
-@pytest.fixture(name="devices")
+@pytest.fixture(name="devices", scope="package")
 def devices_fixture():
     """Define devices data."""
     return json.loads(load_fixture("devices.json", "ambient_station"))

--- a/tests/components/ambient_station/conftest.py
+++ b/tests/components/ambient_station/conftest.py
@@ -28,7 +28,7 @@ def config_entry_fixture(hass, config):
     return entry
 
 
-@pytest.fixture(name="devices", scope="session")
+@pytest.fixture(name="devices")
 def devices_fixture():
     """Define devices data."""
     return json.loads(load_fixture("devices.json", "ambient_station"))
@@ -48,7 +48,7 @@ async def setup_ambient_station_fixture(hass, config, devices):
         yield
 
 
-@pytest.fixture(name="station_data", scope="session")
+@pytest.fixture(name="station_data")
 def station_data_fixture():
     """Define devices data."""
     return json.loads(load_fixture("station_data.json", "ambient_station"))

--- a/tests/components/guardian/conftest.py
+++ b/tests/components/guardian/conftest.py
@@ -32,31 +32,31 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_sensor_pair_dump")
+@pytest.fixture(name="data_sensor_pair_dump", scope="package")
 def data_sensor_pair_dump_fixture():
     """Define data from a successful sensor_pair_dump response."""
     return json.loads(load_fixture("sensor_pair_dump_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_sensor_pair_sensor")
+@pytest.fixture(name="data_sensor_pair_sensor", scope="package")
 def data_sensor_pair_sensor_fixture():
     """Define data from a successful sensor_pair_sensor response."""
     return json.loads(load_fixture("sensor_pair_sensor_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_sensor_paired_sensor_status")
+@pytest.fixture(name="data_sensor_paired_sensor_status", scope="package")
 def data_sensor_paired_sensor_status_fixture():
     """Define data from a successful sensor_paired_sensor_status response."""
     return json.loads(load_fixture("sensor_paired_sensor_status_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_system_diagnostics")
+@pytest.fixture(name="data_system_diagnostics", scope="package")
 def data_system_diagnostics_fixture():
     """Define data from a successful system_diagnostics response."""
     return json.loads(load_fixture("system_diagnostics_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_system_onboard_sensor_status")
+@pytest.fixture(name="data_system_onboard_sensor_status", scope="package")
 def data_system_onboard_sensor_status_fixture():
     """Define data from a successful system_onboard_sensor_status response."""
     return json.loads(
@@ -64,19 +64,19 @@ def data_system_onboard_sensor_status_fixture():
     )
 
 
-@pytest.fixture(name="data_system_ping")
+@pytest.fixture(name="data_system_ping", scope="package")
 def data_system_ping_fixture():
     """Define data from a successful system_ping response."""
     return json.loads(load_fixture("system_ping_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_valve_status")
+@pytest.fixture(name="data_valve_status", scope="package")
 def data_valve_status_fixture():
     """Define data from a successful valve_status response."""
     return json.loads(load_fixture("valve_status_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_wifi_status")
+@pytest.fixture(name="data_wifi_status", scope="package")
 def data_wifi_status_fixture():
     """Define data from a successful wifi_status response."""
     return json.loads(load_fixture("wifi_status_data.json", "guardian"))

--- a/tests/components/guardian/conftest.py
+++ b/tests/components/guardian/conftest.py
@@ -32,31 +32,31 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_sensor_pair_dump", scope="session")
+@pytest.fixture(name="data_sensor_pair_dump")
 def data_sensor_pair_dump_fixture():
     """Define data from a successful sensor_pair_dump response."""
     return json.loads(load_fixture("sensor_pair_dump_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_sensor_pair_sensor", scope="session")
+@pytest.fixture(name="data_sensor_pair_sensor")
 def data_sensor_pair_sensor_fixture():
     """Define data from a successful sensor_pair_sensor response."""
     return json.loads(load_fixture("sensor_pair_sensor_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_sensor_paired_sensor_status", scope="session")
+@pytest.fixture(name="data_sensor_paired_sensor_status")
 def data_sensor_paired_sensor_status_fixture():
     """Define data from a successful sensor_paired_sensor_status response."""
     return json.loads(load_fixture("sensor_paired_sensor_status_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_system_diagnostics", scope="session")
+@pytest.fixture(name="data_system_diagnostics")
 def data_system_diagnostics_fixture():
     """Define data from a successful system_diagnostics response."""
     return json.loads(load_fixture("system_diagnostics_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_system_onboard_sensor_status", scope="session")
+@pytest.fixture(name="data_system_onboard_sensor_status")
 def data_system_onboard_sensor_status_fixture():
     """Define data from a successful system_onboard_sensor_status response."""
     return json.loads(
@@ -64,19 +64,19 @@ def data_system_onboard_sensor_status_fixture():
     )
 
 
-@pytest.fixture(name="data_system_ping", scope="session")
+@pytest.fixture(name="data_system_ping")
 def data_system_ping_fixture():
     """Define data from a successful system_ping response."""
     return json.loads(load_fixture("system_ping_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_valve_status", scope="session")
+@pytest.fixture(name="data_valve_status")
 def data_valve_status_fixture():
     """Define data from a successful valve_status response."""
     return json.loads(load_fixture("valve_status_data.json", "guardian"))
 
 
-@pytest.fixture(name="data_wifi_status", scope="session")
+@pytest.fixture(name="data_wifi_status")
 def data_wifi_status_fixture():
     """Define data from a successful wifi_status response."""
     return json.loads(load_fixture("wifi_status_data.json", "guardian"))

--- a/tests/components/iqvia/conftest.py
+++ b/tests/components/iqvia/conftest.py
@@ -26,43 +26,43 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_allergy_forecast")
+@pytest.fixture(name="data_allergy_forecast", scope="package")
 def data_allergy_forecast_fixture():
     """Define allergy forecast data."""
     return json.loads(load_fixture("allergy_forecast_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_allergy_index")
+@pytest.fixture(name="data_allergy_index", scope="package")
 def data_allergy_index_fixture():
     """Define allergy index data."""
     return json.loads(load_fixture("allergy_index_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_allergy_outlook")
+@pytest.fixture(name="data_allergy_outlook", scope="package")
 def data_allergy_outlook_fixture():
     """Define allergy outlook data."""
     return json.loads(load_fixture("allergy_outlook_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_asthma_forecast")
+@pytest.fixture(name="data_asthma_forecast", scope="package")
 def data_asthma_forecast_fixture():
     """Define asthma forecast data."""
     return json.loads(load_fixture("asthma_forecast_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_asthma_index")
+@pytest.fixture(name="data_asthma_index", scope="package")
 def data_asthma_index_fixture():
     """Define asthma index data."""
     return json.loads(load_fixture("asthma_index_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_disease_forecast")
+@pytest.fixture(name="data_disease_forecast", scope="package")
 def data_disease_forecast_fixture():
     """Define disease forecast data."""
     return json.loads(load_fixture("disease_forecast_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_disease_index")
+@pytest.fixture(name="data_disease_index", scope="package")
 def data_disease_index_fixture():
     """Define disease index data."""
     return json.loads(load_fixture("disease_index_data.json", "iqvia"))

--- a/tests/components/iqvia/conftest.py
+++ b/tests/components/iqvia/conftest.py
@@ -26,43 +26,43 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_allergy_forecast", scope="session")
+@pytest.fixture(name="data_allergy_forecast")
 def data_allergy_forecast_fixture():
     """Define allergy forecast data."""
     return json.loads(load_fixture("allergy_forecast_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_allergy_index", scope="session")
+@pytest.fixture(name="data_allergy_index")
 def data_allergy_index_fixture():
     """Define allergy index data."""
     return json.loads(load_fixture("allergy_index_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_allergy_outlook", scope="session")
+@pytest.fixture(name="data_allergy_outlook")
 def data_allergy_outlook_fixture():
     """Define allergy outlook data."""
     return json.loads(load_fixture("allergy_outlook_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_asthma_forecast", scope="session")
+@pytest.fixture(name="data_asthma_forecast")
 def data_asthma_forecast_fixture():
     """Define asthma forecast data."""
     return json.loads(load_fixture("asthma_forecast_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_asthma_index", scope="session")
+@pytest.fixture(name="data_asthma_index")
 def data_asthma_index_fixture():
     """Define asthma index data."""
     return json.loads(load_fixture("asthma_index_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_disease_forecast", scope="session")
+@pytest.fixture(name="data_disease_forecast")
 def data_disease_forecast_fixture():
     """Define disease forecast data."""
     return json.loads(load_fixture("disease_forecast_data.json", "iqvia"))
 
 
-@pytest.fixture(name="data_disease_index", scope="session")
+@pytest.fixture(name="data_disease_index")
 def data_disease_index_fixture():
     """Define disease index data."""
     return json.loads(load_fixture("disease_index_data.json", "iqvia"))

--- a/tests/components/notion/conftest.py
+++ b/tests/components/notion/conftest.py
@@ -38,19 +38,19 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_bridge")
+@pytest.fixture(name="data_bridge", scope="package")
 def data_bridge_fixture():
     """Define bridge data."""
     return json.loads(load_fixture("bridge_data.json", "notion"))
 
 
-@pytest.fixture(name="data_sensor")
+@pytest.fixture(name="data_sensor", scope="package")
 def data_sensor_fixture():
     """Define sensor data."""
     return json.loads(load_fixture("sensor_data.json", "notion"))
 
 
-@pytest.fixture(name="data_task")
+@pytest.fixture(name="data_task", scope="package")
 def data_task_fixture():
     """Define task data."""
     return json.loads(load_fixture("task_data.json", "notion"))

--- a/tests/components/notion/conftest.py
+++ b/tests/components/notion/conftest.py
@@ -38,19 +38,19 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_bridge", scope="session")
+@pytest.fixture(name="data_bridge")
 def data_bridge_fixture():
     """Define bridge data."""
     return json.loads(load_fixture("bridge_data.json", "notion"))
 
 
-@pytest.fixture(name="data_sensor", scope="session")
+@pytest.fixture(name="data_sensor")
 def data_sensor_fixture():
     """Define sensor data."""
     return json.loads(load_fixture("sensor_data.json", "notion"))
 
 
-@pytest.fixture(name="data_task", scope="session")
+@pytest.fixture(name="data_task")
 def data_task_fixture():
     """Define task data."""
     return json.loads(load_fixture("task_data.json", "notion"))

--- a/tests/components/openuv/conftest.py
+++ b/tests/components/openuv/conftest.py
@@ -40,13 +40,13 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_protection_window")
+@pytest.fixture(name="data_protection_window", scope="package")
 def data_protection_window_fixture():
     """Define a fixture to return UV protection window data."""
     return json.loads(load_fixture("protection_window_data.json", "openuv"))
 
 
-@pytest.fixture(name="data_uv_index")
+@pytest.fixture(name="data_uv_index", scope="package")
 def data_uv_index_fixture():
     """Define a fixture to return UV index data."""
     return json.loads(load_fixture("uv_index_data.json", "openuv"))

--- a/tests/components/openuv/conftest.py
+++ b/tests/components/openuv/conftest.py
@@ -40,13 +40,13 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_protection_window", scope="session")
+@pytest.fixture(name="data_protection_window")
 def data_protection_window_fixture():
     """Define a fixture to return UV protection window data."""
     return json.loads(load_fixture("protection_window_data.json", "openuv"))
 
 
-@pytest.fixture(name="data_uv_index", scope="session")
+@pytest.fixture(name="data_uv_index")
 def data_uv_index_fixture():
     """Define a fixture to return UV index data."""
     return json.loads(load_fixture("uv_index_data.json", "openuv"))

--- a/tests/components/rainmachine/conftest.py
+++ b/tests/components/rainmachine/conftest.py
@@ -76,19 +76,19 @@ def controller_mac_fixture():
     return "aa:bb:cc:dd:ee:ff"
 
 
-@pytest.fixture(name="data_api_versions")
+@pytest.fixture(name="data_api_versions", scope="package")
 def data_api_versions_fixture():
     """Define API version data."""
     return json.loads(load_fixture("api_versions_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_diagnostics_current")
+@pytest.fixture(name="data_diagnostics_current", scope="package")
 def data_diagnostics_current_fixture():
     """Define current diagnostics data."""
     return json.loads(load_fixture("diagnostics_current_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_machine_firmare_update_status")
+@pytest.fixture(name="data_machine_firmare_update_status", scope="package")
 def data_machine_firmare_update_status_fixture():
     """Define machine firmware update status data."""
     return json.loads(
@@ -96,31 +96,31 @@ def data_machine_firmare_update_status_fixture():
     )
 
 
-@pytest.fixture(name="data_programs")
+@pytest.fixture(name="data_programs", scope="package")
 def data_programs_fixture():
     """Define program data."""
     return json.loads(load_fixture("programs_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_provision_settings")
+@pytest.fixture(name="data_provision_settings", scope="package")
 def data_provision_settings_fixture():
     """Define provisioning settings data."""
     return json.loads(load_fixture("provision_settings_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_restrictions_current")
+@pytest.fixture(name="data_restrictions_current", scope="package")
 def data_restrictions_current_fixture():
     """Define current restrictions settings data."""
     return json.loads(load_fixture("restrictions_current_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_restrictions_universal")
+@pytest.fixture(name="data_restrictions_universal", scope="package")
 def data_restrictions_universal_fixture():
     """Define universal restrictions settings data."""
     return json.loads(load_fixture("restrictions_universal_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_zones")
+@pytest.fixture(name="data_zones", scope="package")
 def data_zones_fixture():
     """Define zone data."""
     return json.loads(load_fixture("zones_data.json", "rainmachine"))

--- a/tests/components/rainmachine/conftest.py
+++ b/tests/components/rainmachine/conftest.py
@@ -76,19 +76,19 @@ def controller_mac_fixture():
     return "aa:bb:cc:dd:ee:ff"
 
 
-@pytest.fixture(name="data_api_versions", scope="session")
+@pytest.fixture(name="data_api_versions")
 def data_api_versions_fixture():
     """Define API version data."""
     return json.loads(load_fixture("api_versions_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_diagnostics_current", scope="session")
+@pytest.fixture(name="data_diagnostics_current")
 def data_diagnostics_current_fixture():
     """Define current diagnostics data."""
     return json.loads(load_fixture("diagnostics_current_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_machine_firmare_update_status", scope="session")
+@pytest.fixture(name="data_machine_firmare_update_status")
 def data_machine_firmare_update_status_fixture():
     """Define machine firmware update status data."""
     return json.loads(
@@ -96,31 +96,31 @@ def data_machine_firmare_update_status_fixture():
     )
 
 
-@pytest.fixture(name="data_programs", scope="session")
+@pytest.fixture(name="data_programs")
 def data_programs_fixture():
     """Define program data."""
     return json.loads(load_fixture("programs_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_provision_settings", scope="session")
+@pytest.fixture(name="data_provision_settings")
 def data_provision_settings_fixture():
     """Define provisioning settings data."""
     return json.loads(load_fixture("provision_settings_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_restrictions_current", scope="session")
+@pytest.fixture(name="data_restrictions_current")
 def data_restrictions_current_fixture():
     """Define current restrictions settings data."""
     return json.loads(load_fixture("restrictions_current_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_restrictions_universal", scope="session")
+@pytest.fixture(name="data_restrictions_universal")
 def data_restrictions_universal_fixture():
     """Define universal restrictions settings data."""
     return json.loads(load_fixture("restrictions_universal_data.json", "rainmachine"))
 
 
-@pytest.fixture(name="data_zones", scope="session")
+@pytest.fixture(name="data_zones")
 def data_zones_fixture():
     """Define zone data."""
     return json.loads(load_fixture("zones_data.json", "rainmachine"))

--- a/tests/components/simplisafe/conftest.py
+++ b/tests/components/simplisafe/conftest.py
@@ -58,25 +58,25 @@ def credentials_config_fixture():
     }
 
 
-@pytest.fixture(name="data_latest_event")
+@pytest.fixture(name="data_latest_event", scope="package")
 def data_latest_event_fixture():
     """Define latest event data."""
     return json.loads(load_fixture("latest_event_data.json", "simplisafe"))
 
 
-@pytest.fixture(name="data_sensor")
+@pytest.fixture(name="data_sensor", scope="package")
 def data_sensor_fixture():
     """Define sensor data."""
     return json.loads(load_fixture("sensor_data.json", "simplisafe"))
 
 
-@pytest.fixture(name="data_settings")
+@pytest.fixture(name="data_settings", scope="package")
 def data_settings_fixture():
     """Define settings data."""
     return json.loads(load_fixture("settings_data.json", "simplisafe"))
 
 
-@pytest.fixture(name="data_subscription")
+@pytest.fixture(name="data_subscription", scope="package")
 def data_subscription_fixture():
     """Define subscription data."""
     return json.loads(load_fixture("subscription_data.json", "simplisafe"))

--- a/tests/components/simplisafe/conftest.py
+++ b/tests/components/simplisafe/conftest.py
@@ -58,25 +58,25 @@ def credentials_config_fixture():
     }
 
 
-@pytest.fixture(name="data_latest_event", scope="session")
+@pytest.fixture(name="data_latest_event")
 def data_latest_event_fixture():
     """Define latest event data."""
     return json.loads(load_fixture("latest_event_data.json", "simplisafe"))
 
 
-@pytest.fixture(name="data_sensor", scope="session")
+@pytest.fixture(name="data_sensor")
 def data_sensor_fixture():
     """Define sensor data."""
     return json.loads(load_fixture("sensor_data.json", "simplisafe"))
 
 
-@pytest.fixture(name="data_settings", scope="session")
+@pytest.fixture(name="data_settings")
 def data_settings_fixture():
     """Define settings data."""
     return json.loads(load_fixture("settings_data.json", "simplisafe"))
 
 
-@pytest.fixture(name="data_subscription", scope="session")
+@pytest.fixture(name="data_subscription")
 def data_subscription_fixture():
     """Define subscription data."""
     return json.loads(load_fixture("subscription_data.json", "simplisafe"))

--- a/tests/components/tile/conftest.py
+++ b/tests/components/tile/conftest.py
@@ -42,7 +42,7 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_tile_details")
+@pytest.fixture(name="data_tile_details", scope="package")
 def data_tile_details_fixture():
     """Define a Tile details data payload."""
     return json.loads(load_fixture("tile_details_data.json", "tile"))

--- a/tests/components/tile/conftest.py
+++ b/tests/components/tile/conftest.py
@@ -42,7 +42,7 @@ def config_fixture(hass):
     }
 
 
-@pytest.fixture(name="data_tile_details", scope="session")
+@pytest.fixture(name="data_tile_details")
 def data_tile_details_fixture():
     """Define a Tile details data payload."""
     return json.loads(load_fixture("tile_details_data.json", "tile"))

--- a/tests/components/watttime/conftest.py
+++ b/tests/components/watttime/conftest.py
@@ -80,13 +80,13 @@ def config_entry_fixture(hass, config_auth, config_coordinates):
     return entry
 
 
-@pytest.fixture(name="data_grid_region")
+@pytest.fixture(name="data_grid_region", scope="package")
 def data_grid_region_fixture():
     """Define grid region data."""
     return json.loads(load_fixture("grid_region_data.json", "watttime"))
 
 
-@pytest.fixture(name="data_realtime_emissions")
+@pytest.fixture(name="data_realtime_emissions", scope="package")
 def data_realtime_emissions_fixture():
     """Define realtime emissions data."""
     return json.loads(load_fixture("realtime_emissions_data.json", "watttime"))

--- a/tests/components/watttime/conftest.py
+++ b/tests/components/watttime/conftest.py
@@ -80,13 +80,13 @@ def config_entry_fixture(hass, config_auth, config_coordinates):
     return entry
 
 
-@pytest.fixture(name="data_grid_region", scope="session")
+@pytest.fixture(name="data_grid_region")
 def data_grid_region_fixture():
     """Define grid region data."""
     return json.loads(load_fixture("grid_region_data.json", "watttime"))
 
 
-@pytest.fixture(name="data_realtime_emissions", scope="session")
+@pytest.fixture(name="data_realtime_emissions")
 def data_realtime_emissions_fixture():
     """Define realtime emissions data."""
     return json.loads(load_fixture("realtime_emissions_data.json", "watttime"))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/pull/79914#discussion_r997386429 made me realize that many of my integrations have one or more session-scoped fixtures, which are kept in memory for other tests (and are thus wasteful of memory). This blanket PR removes that scoping.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
