### PR TITLE
Use `._attr_*` properties for monoprice integration

### DIFF
--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -5,6 +5,7 @@ from serial import SerialException
 
 from homeassistant import core
 from homeassistant.components.media_player import (
+    MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
@@ -27,6 +28,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+MAX_VOLUME = 38
 PARALLEL_UPDATES = 1
 
 
@@ -114,6 +116,7 @@ async def async_setup_entry(
 class MonopriceZone(MediaPlayerEntity):
     """Representation of a Monoprice amplifier zone."""
 
+    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
     _attr_supported_features = (
         MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.VOLUME_SET
@@ -131,16 +134,18 @@ class MonopriceZone(MediaPlayerEntity):
         # dict source name -> source_id
         self._source_name_id = sources[1]
         # ordered list of all source names
-        self._source_names = sources[2]
+        self._attr_source_list = sources[2]
         self._zone_id = zone_id
-        self._unique_id = f"{namespace}_{self._zone_id}"
-        self._name = f"Zone {self._zone_id}"
+        self._attr_unique_id = f"{namespace}_{self._zone_id}"
+        self._attr_name = f"Zone {self._zone_id}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._attr_unique_id)},
+            manufacturer="Monoprice",
+            model="6-Zone Amplifier",
+            name=self.name,
+        )
 
         self._snapshot = None
-        self._state = None
-        self._volume = None
-        self._source = None
-        self._mute = None
         self._update_success = True
 
     def update(self) -> None:
@@ -156,14 +161,14 @@ class MonopriceZone(MediaPlayerEntity):
             self._update_success = False
             return
 
-        self._state = MediaPlayerState.ON if state.power else MediaPlayerState.OFF
-        self._volume = state.volume
-        self._mute = state.mute
+        self._attr_state = MediaPlayerState.ON if state.power else MediaPlayerState.OFF
+        self._attr_volume_level = state.volume / MAX_VOLUME
+        self._attr_is_volume_muted = state.mute
         idx = state.source
         if idx in self._source_id_name:
-            self._source = self._source_id_name[idx]
+            self._attr_source = self._source_id_name[idx]
         else:
-            self._source = None
+            self._attr_source = None
 
     @property
     def entity_registry_enabled_default(self) -> bool:
@@ -171,56 +176,9 @@ class MonopriceZone(MediaPlayerEntity):
         return self._zone_id < 20 or self._update_success
 
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info for this device."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)},
-            manufacturer="Monoprice",
-            model="6-Zone Amplifier",
-            name=self.name,
-        )
-
-    @property
-    def unique_id(self):
-        """Return unique ID for this device."""
-        return self._unique_id
-
-    @property
-    def name(self):
-        """Return the name of the zone."""
-        return self._name
-
-    @property
-    def state(self):
-        """Return the state of the zone."""
-        return self._state
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1)."""
-        if self._volume is None:
-            return None
-        return self._volume / 38.0
-
-    @property
-    def is_volume_muted(self):
-        """Boolean if volume is currently muted."""
-        return self._mute
-
-    @property
     def media_title(self):
         """Return the current source as medial title."""
-        return self._source
-
-    @property
-    def source(self):
-        """Return the current input source of the device."""
-        return self._source
-
-    @property
-    def source_list(self):
-        """List of available input sources."""
-        return self._source_names
+        return self.source
 
     def snapshot(self):
         """Save zone's current state."""
@@ -253,16 +211,18 @@ class MonopriceZone(MediaPlayerEntity):
 
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
-        self._monoprice.set_volume(self._zone_id, int(volume * 38))
+        self._monoprice.set_volume(self._zone_id, round(volume * MAX_VOLUME))
 
     def volume_up(self) -> None:
         """Volume up the media player."""
-        if self._volume is None:
+        if self.volume_level is None:
             return
-        self._monoprice.set_volume(self._zone_id, min(self._volume + 1, 38))
+        volume = round(self.volume_level * MAX_VOLUME)
+        self._monoprice.set_volume(self._zone_id, min(volume + 1, MAX_VOLUME))
 
     def volume_down(self) -> None:
         """Volume down media player."""
-        if self._volume is None:
+        if self.volume_level is None:
             return
-        self._monoprice.set_volume(self._zone_id, max(self._volume - 1, 0))
+        volume = round(self.volume_level * MAX_VOLUME)
+        self._monoprice.set_volume(self._zone_id, max(volume - 1, 0))


### PR DESCRIPTION
## Proposed change

Setup monoprice media player integration to use `._attr_*` to define the various attributes rather than defining its own set of `@property`'s.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
