### PR TITLE
Add websocket type hints in blueprint

### DIFF
--- a/homeassistant/components/blueprint/models.py
+++ b/homeassistant/components/blueprint/models.py
@@ -51,7 +51,7 @@ class Blueprint:
 
     def __init__(
         self,
-        data: dict,
+        data: dict[str, Any],
         *,
         path: str | None = None,
         expected_domain: str | None = None,

--- a/homeassistant/components/blueprint/websocket_api.py
+++ b/homeassistant/components/blueprint/websocket_api.py
@@ -1,7 +1,7 @@
 """Websocket API for blueprint."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import async_timeout
 import voluptuous as vol
@@ -122,7 +122,7 @@ async def ws_save_blueprint(
         )
 
     try:
-        yaml_data = yaml.parse_yaml(msg["yaml"])
+        yaml_data = cast(dict[str, Any], yaml.parse_yaml(msg["yaml"]))
         assert isinstance(yaml_data, dict)
         blueprint = models.Blueprint(yaml_data, expected_domain=domain)
         if "source_url" in msg:

--- a/homeassistant/components/blueprint/websocket_api.py
+++ b/homeassistant/components/blueprint/websocket_api.py
@@ -1,6 +1,8 @@
 """Websocket API for blueprint."""
 from __future__ import annotations
 
+from typing import Any
+
 import async_timeout
 import voluptuous as vol
 
@@ -31,12 +33,14 @@ def async_setup(hass: HomeAssistant):
     }
 )
 @websocket_api.async_response
-async def ws_list_blueprints(hass, connection, msg):
+async def ws_list_blueprints(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """List available blueprints."""
-    domain_blueprints: dict[str, models.DomainBlueprints] | None = hass.data.get(
-        DOMAIN, {}
-    )
-    results = {}
+    domain_blueprints: dict[str, models.DomainBlueprints] = hass.data.get(DOMAIN, {})
+    results: dict[str, Any] = {}
 
     if msg["domain"] not in domain_blueprints:
         connection.send_result(msg["id"], results)
@@ -62,7 +66,11 @@ async def ws_list_blueprints(hass, connection, msg):
     }
 )
 @websocket_api.async_response
-async def ws_import_blueprint(hass, connection, msg):
+async def ws_import_blueprint(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Import a blueprint."""
     async with async_timeout.timeout(10):
         imported_blueprint = await importer.fetch_blueprint_from_url(hass, msg["url"])
@@ -96,15 +104,17 @@ async def ws_import_blueprint(hass, connection, msg):
     }
 )
 @websocket_api.async_response
-async def ws_save_blueprint(hass, connection, msg):
+async def ws_save_blueprint(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Save a blueprint."""
 
     path = msg["path"]
     domain = msg["domain"]
 
-    domain_blueprints: dict[str, models.DomainBlueprints] | None = hass.data.get(
-        DOMAIN, {}
-    )
+    domain_blueprints: dict[str, models.DomainBlueprints] = hass.data.get(DOMAIN, {})
 
     if domain not in domain_blueprints:
         connection.send_error(
@@ -112,9 +122,9 @@ async def ws_save_blueprint(hass, connection, msg):
         )
 
     try:
-        blueprint = models.Blueprint(
-            yaml.parse_yaml(msg["yaml"]), expected_domain=domain
-        )
+        yaml_data = yaml.parse_yaml(msg["yaml"])
+        assert isinstance(yaml_data, dict)
+        blueprint = models.Blueprint(yaml_data, expected_domain=domain)
         if "source_url" in msg:
             blueprint.update_metadata(source_url=msg["source_url"])
     except HomeAssistantError as err:
@@ -143,15 +153,17 @@ async def ws_save_blueprint(hass, connection, msg):
     }
 )
 @websocket_api.async_response
-async def ws_delete_blueprint(hass, connection, msg):
+async def ws_delete_blueprint(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Delete a blueprint."""
 
     path = msg["path"]
     domain = msg["domain"]
 
-    domain_blueprints: dict[str, models.DomainBlueprints] | None = hass.data.get(
-        DOMAIN, {}
-    )
+    domain_blueprints: dict[str, models.DomainBlueprints] = hass.data.get(DOMAIN, {})
 
     if domain not in domain_blueprints:
         connection.send_error(

--- a/homeassistant/components/blueprint/websocket_api.py
+++ b/homeassistant/components/blueprint/websocket_api.py
@@ -123,7 +123,6 @@ async def ws_save_blueprint(
 
     try:
         yaml_data = cast(dict[str, Any], yaml.parse_yaml(msg["yaml"]))
-        assert isinstance(yaml_data, dict)
         blueprint = models.Blueprint(yaml_data, expected_domain=domain)
         if "source_url" in msg:
             blueprint.update_metadata(source_url=msg["source_url"])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add websocket type hints in blueprint

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
