### PR TITLE
Add websocket type hints in config

### DIFF
--- a/homeassistant/components/config/auth.py
+++ b/homeassistant/components/config/auth.py
@@ -1,7 +1,10 @@
 """Offer API to configure Home Assistant auth."""
+from typing import Any
+
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
 
 WS_TYPE_LIST = "config/auth/list"
 SCHEMA_WS_LIST = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
@@ -29,7 +32,11 @@ async def async_setup(hass):
 
 @websocket_api.require_admin
 @websocket_api.async_response
-async def websocket_list(hass, connection, msg):
+async def websocket_list(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Return a list of users."""
     result = [_user_info(u) for u in await hass.auth.async_get_users()]
 
@@ -38,7 +45,11 @@ async def websocket_list(hass, connection, msg):
 
 @websocket_api.require_admin
 @websocket_api.async_response
-async def websocket_delete(hass, connection, msg):
+async def websocket_delete(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Delete a user."""
     if msg["user_id"] == connection.user.id:
         connection.send_message(
@@ -69,7 +80,11 @@ async def websocket_delete(hass, connection, msg):
     }
 )
 @websocket_api.async_response
-async def websocket_create(hass, connection, msg):
+async def websocket_create(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Create a user."""
     user = await hass.auth.async_create_user(
         msg["name"], group_ids=msg.get("group_ids"), local_only=msg.get("local_only")
@@ -92,7 +107,11 @@ async def websocket_create(hass, connection, msg):
     }
 )
 @websocket_api.async_response
-async def websocket_update(hass, connection, msg):
+async def websocket_update(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Update a user."""
     if not (user := await hass.auth.async_get_user(msg.pop("user_id"))):
         connection.send_message(

--- a/homeassistant/components/config/auth_provider_homeassistant.py
+++ b/homeassistant/components/config/auth_provider_homeassistant.py
@@ -1,9 +1,11 @@
 """Offer API to configure the Home Assistant auth provider."""
+from typing import Any
+
 import voluptuous as vol
 
 from homeassistant.auth.providers import homeassistant as auth_ha
 from homeassistant.components import websocket_api
-from homeassistant.components.websocket_api import decorators
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import Unauthorized
 
 
@@ -16,7 +18,7 @@ async def async_setup(hass):
     return True
 
 
-@decorators.websocket_command(
+@websocket_api.websocket_command(
     {
         vol.Required("type"): "config/auth_provider/homeassistant/create",
         vol.Required("user_id"): str,
@@ -26,7 +28,11 @@ async def async_setup(hass):
 )
 @websocket_api.require_admin
 @websocket_api.async_response
-async def websocket_create(hass, connection, msg):
+async def websocket_create(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Create credentials and attach to a user."""
     provider = auth_ha.async_get_provider(hass)
 
@@ -56,7 +62,7 @@ async def websocket_create(hass, connection, msg):
     connection.send_result(msg["id"])
 
 
-@decorators.websocket_command(
+@websocket_api.websocket_command(
     {
         vol.Required("type"): "config/auth_provider/homeassistant/delete",
         vol.Required("username"): str,
@@ -64,7 +70,11 @@ async def websocket_create(hass, connection, msg):
 )
 @websocket_api.require_admin
 @websocket_api.async_response
-async def websocket_delete(hass, connection, msg):
+async def websocket_delete(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Delete username and related credential."""
     provider = auth_ha.async_get_provider(hass)
     credentials = await provider.async_get_or_create_credentials(
@@ -90,7 +100,7 @@ async def websocket_delete(hass, connection, msg):
     connection.send_result(msg["id"])
 
 
-@decorators.websocket_command(
+@websocket_api.websocket_command(
     {
         vol.Required("type"): "config/auth_provider/homeassistant/change_password",
         vol.Required("current_password"): str,
@@ -98,7 +108,11 @@ async def websocket_delete(hass, connection, msg):
     }
 )
 @websocket_api.async_response
-async def websocket_change_password(hass, connection, msg):
+async def websocket_change_password(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Change current user password."""
     if (user := connection.user) is None:
         connection.send_error(msg["id"], "user_not_found", "User not found")
@@ -130,7 +144,7 @@ async def websocket_change_password(hass, connection, msg):
     connection.send_result(msg["id"])
 
 
-@decorators.websocket_command(
+@websocket_api.websocket_command(
     {
         vol.Required(
             "type"
@@ -139,9 +153,13 @@ async def websocket_change_password(hass, connection, msg):
         vol.Required("password"): str,
     }
 )
-@decorators.require_admin
-@decorators.async_response
-async def websocket_admin_change_password(hass, connection, msg):
+@websocket_api.require_admin
+@websocket_api.async_response
+async def websocket_admin_change_password(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Change password of any user."""
     if not connection.user.is_owner:
         raise Unauthorized(context=connection.context(msg))

--- a/homeassistant/components/config/core.py
+++ b/homeassistant/components/config/core.py
@@ -1,10 +1,13 @@
 """Component to interact with Hassbian tools."""
 
+from typing import Any
+
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.config import async_check_ha_config_file
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import location, unit_system
@@ -49,7 +52,11 @@ class CheckConfigView(HomeAssistantView):
     }
 )
 @websocket_api.async_response
-async def websocket_update_config(hass, connection, msg):
+async def websocket_update_config(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Handle update core config command."""
     data = dict(msg)
     data.pop("id")
@@ -65,12 +72,16 @@ async def websocket_update_config(hass, connection, msg):
 @websocket_api.require_admin
 @websocket_api.websocket_command({"type": "config/core/detect"})
 @websocket_api.async_response
-async def websocket_detect_config(hass, connection, msg):
+async def websocket_detect_config(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Detect core config."""
     session = async_get_clientsession(hass)
     location_info = await location.async_detect_location_info(session)
 
-    info = {}
+    info: dict[str, Any] = {}
 
     if location_info is None:
         connection.send_result(msg["id"], info)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add websocket type hints in config

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
