### PR TITLE
Add websocket type hints in lovelace

### DIFF
--- a/homeassistant/components/lovelace/websocket.py
+++ b/homeassistant/components/lovelace/websocket.py
@@ -1,23 +1,31 @@
 """Websocket API for Lovelace."""
+from __future__ import annotations
+
 from functools import wraps
+from typing import Any
 
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 
 from .const import CONF_URL_PATH, DOMAIN, ConfigNotFound
+from .dashboard import LovelaceStorage
 
 
 def _handle_errors(func):
     """Handle error with WebSocket calls."""
 
     @wraps(func)
-    async def send_with_error_handling(hass, connection, msg):
+    async def send_with_error_handling(
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
+    ) -> None:
         url_path = msg.get(CONF_URL_PATH)
-        config = hass.data[DOMAIN]["dashboards"].get(url_path)
+        config: LovelaceStorage | None = hass.data[DOMAIN]["dashboards"].get(url_path)
 
         if config is None:
             connection.send_error(
@@ -44,7 +52,11 @@ def _handle_errors(func):
 
 @websocket_api.websocket_command({"type": "lovelace/resources"})
 @websocket_api.async_response
-async def websocket_lovelace_resources(hass, connection, msg):
+async def websocket_lovelace_resources(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Send Lovelace UI resources over WebSocket configuration."""
     resources = hass.data[DOMAIN]["resources"]
 
@@ -64,7 +76,12 @@ async def websocket_lovelace_resources(hass, connection, msg):
 )
 @websocket_api.async_response
 @_handle_errors
-async def websocket_lovelace_config(hass, connection, msg, config):
+async def websocket_lovelace_config(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+    config: LovelaceStorage,
+) -> None:
     """Send Lovelace UI config over WebSocket configuration."""
     return await config.async_load(msg["force"])
 
@@ -79,7 +96,12 @@ async def websocket_lovelace_config(hass, connection, msg, config):
 )
 @websocket_api.async_response
 @_handle_errors
-async def websocket_lovelace_save_config(hass, connection, msg, config):
+async def websocket_lovelace_save_config(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+    config: LovelaceStorage,
+) -> None:
     """Save Lovelace UI configuration."""
     await config.async_save(msg["config"])
 
@@ -93,14 +115,23 @@ async def websocket_lovelace_save_config(hass, connection, msg, config):
 )
 @websocket_api.async_response
 @_handle_errors
-async def websocket_lovelace_delete_config(hass, connection, msg, config):
+async def websocket_lovelace_delete_config(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+    config: LovelaceStorage,
+) -> None:
     """Delete Lovelace UI configuration."""
     await config.async_delete()
 
 
 @websocket_api.websocket_command({"type": "lovelace/dashboards/list"})
 @callback
-def websocket_lovelace_dashboards(hass, connection, msg):
+def websocket_lovelace_dashboards(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
     """Delete Lovelace UI configuration."""
     connection.send_result(
         msg["id"],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add websocket type hints in lovelace

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
