### PR TITLE
Expose UniFi PoE ports as individual switches

### DIFF
--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -3,7 +3,7 @@
   "name": "UniFi Network",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
-  "requirements": ["aiounifi==39"],
+  "requirements": ["aiounifi==40"],
   "codeowners": ["@Kane610"],
   "quality_scale": "platinum",
   "ssdp": [

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -611,20 +611,18 @@ class UnifiPoePortSwitch(SwitchEntity):
     @callback
     def async_signalling_callback(self, event: ItemEvent, obj_id: str) -> None:
         """Object has new event."""
-        port = self.controller.api.ports[self._obj_id]
-        if event == ItemEvent.CHANGED:
-            self._attr_is_on = port.poe_mode != "off"
-        self.async_write_ha_state()
-
-    @callback
-    def async_signal_reachable_callback(self) -> None:
-        """Call when controller connection state change."""
         device = self.controller.api.devices[self._device_mac]
         port = self.controller.api.ports[self._obj_id]
         self._attr_available = (
             self.controller.available and not device.disabled and port.up
         )
+        self._attr_is_on = port.poe_mode != "off"
         self.async_write_ha_state()
+
+    @callback
+    def async_signal_reachable_callback(self) -> None:
+        """Call when controller connection state change."""
+        self.async_signalling_callback(ItemEvent.ADDED, self._obj_id)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable POE for client."""

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -8,7 +8,7 @@ Support for controlling deep packet inspection (DPI) restriction groups.
 import asyncio
 from typing import Any
 
-from aiounifi.interfaces.api_handlers import SOURCE_EVENT
+from aiounifi.interfaces.api_handlers import SOURCE_EVENT, ItemEvent
 from aiounifi.models.client import ClientBlockRequest
 from aiounifi.models.device import (
     DeviceSetOutletRelayRequest,
@@ -34,6 +34,9 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from .const import ATTR_MANUFACTURER, DOMAIN as UNIFI_DOMAIN
 from .unifi_client import UniFiClient
 from .unifi_entity_base import UniFiBase
+
+# if TYPE_CHECKING:
+#     from .controller import UniFiController
 
 BLOCK_SWITCH = "block"
 DPI_SWITCH = "dpi"
@@ -110,6 +113,18 @@ async def async_setup_entry(
 
     items_added()
     known_poe_clients.clear()
+
+    @callback
+    def async_add_poe_switch(_: ItemEvent, obj_id: str) -> None:
+        """Add port PoE switch from UniFi controller."""
+        if not controller.api.ports[obj_id].port_poe:
+            return
+        async_add_entities([UnifiPoePortSwitch(obj_id, controller)])
+
+    controller.api.ports.subscribe(async_add_poe_switch, ItemEvent.ADDED)
+
+    for port_idx in controller.api.ports:
+        async_add_poe_switch(ItemEvent.ADDED, port_idx)
 
 
 @callback
@@ -550,3 +565,72 @@ class UniFiOutletSwitch(UniFiBase, SwitchEntity):
 
     async def options_updated(self) -> None:
         """Config entry options are updated, no options to act on."""
+
+
+class UnifiPoePortSwitch(SwitchEntity):
+    """UniFi PoE port switch entity."""
+
+    _attr_should_poll = False
+    _attr_entity_registry_enabled_default = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_device_class = SwitchDeviceClass.OUTLET
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:ethernet"
+
+    # def __init__(self, obj_id: str, controller: UniFiController) -> None:
+    def __init__(self, obj_id: str, controller) -> None:
+        """Set up UniFi Network entity base."""
+        self._attr_unique_id = f"{obj_id}-PoE"
+        self._device_id, port_idx = obj_id.split("_", 1)
+        self._port_idx = int(port_idx)
+        self._device = controller.api.devices[self._device_id]
+        self._attr_name = f"PoE port {self._port_idx}"
+        self._obj_id = obj_id
+        self.controller = controller
+
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, self._device_id)}
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Entity created."""
+        self.async_on_remove(
+            self.controller.api.ports.subscribe(self.async_signalling_callback)
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_reachable,
+                self.async_signal_reachable_callback,
+            )
+        )
+
+    @callback
+    def async_signalling_callback(self, event: ItemEvent, obj_id: str) -> None:
+        """Object has new event."""
+        port = self.controller.api.ports[obj_id]
+        if event == ItemEvent.CHANGED:
+            self._attr_is_on = port.poe_mode != "off"
+        self.async_write_ha_state()
+
+    @callback
+    def async_signal_reachable_callback(self) -> None:
+        """Call when controller connection state change."""
+        port = self.controller.api.ports[self._obj_id]
+        self._attr_available = (
+            self.controller.available and not self._device.disabled and port.up
+        )
+        # self.async_update_callback()
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable POE for client."""
+        await self.controller.api.request(
+            DeviceSetPoePortModeRequest.create(self._device, self._port_idx, "auto")
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable POE for client."""
+        await self.controller.api.request(
+            DeviceSetPoePortModeRequest.create(self._device, self._port_idx, "off")
+        )

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -613,9 +613,7 @@ class UnifiPoePortSwitch(SwitchEntity):
         """Object has new event."""
         device = self.controller.api.devices[self._device_mac]
         port = self.controller.api.ports[self._obj_id]
-        self._attr_available = (
-            self.controller.available and not device.disabled and port.up
-        )
+        self._attr_available = self.controller.available and not device.disabled
         self._attr_is_on = port.poe_mode != "off"
         self.async_write_ha_state()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -276,7 +276,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.4
 
 # homeassistant.components.unifi
-aiounifi==39
+aiounifi==40
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -251,7 +251,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.4
 
 # homeassistant.components.unifi
-aiounifi==39
+aiounifi==40
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1495,25 +1495,3 @@ async def test_poe_port_switches(hass, aioclient_mock, mock_unifi_websocket):
     )
     await hass.async_block_till_done()
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_OFF
-
-    # Port gets disabled
-    device_1["port_table"][0]["up"] = False
-    mock_unifi_websocket(
-        data={
-            "meta": {"message": MessageKey.DEVICE.value},
-            "data": [device_1],
-        }
-    )
-    await hass.async_block_till_done()
-    assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_UNAVAILABLE
-
-    # Port gets re-enabled
-    device_1["port_table"][0]["up"] = True
-    mock_unifi_websocket(
-        data={
-            "meta": {"message": MessageKey.DEVICE.value},
-            "data": [device_1],
-        }
-    )
-    await hass.async_block_till_done()
-    assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_OFF

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1,5 +1,7 @@
 """UniFi Network switch platform tests."""
+
 from copy import deepcopy
+from datetime import timedelta
 
 from aiounifi.controller import MESSAGE_CLIENT_REMOVED, MESSAGE_DEVICE, MESSAGE_EVENT
 
@@ -8,6 +10,7 @@ from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    SwitchDeviceClass,
 )
 from homeassistant.components.unifi.const import (
     CONF_BLOCK_CLIENT,
@@ -18,10 +21,19 @@ from homeassistant.components.unifi.const import (
     DOMAIN as UNIFI_DOMAIN,
 )
 from homeassistant.components.unifi.switch import POE_SWITCH
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_registry import RegistryEntryDisabler
+from homeassistant.util import dt
 
 from .test_controller import (
     CONTROLLER_HOST,
@@ -31,7 +43,7 @@ from .test_controller import (
     setup_unifi_integration,
 )
 
-from tests.common import mock_restore_cache
+from tests.common import async_fire_time_changed, mock_restore_cache
 
 CLIENT_1 = {
     "hostname": "client_1",
@@ -1373,3 +1385,68 @@ async def test_restore_client_no_old_state(hass, aioclient_mock):
 
     poe_client = hass.states.get("switch.poe_client")
     assert poe_client.state == "unavailable"  # self.poe_mode is None
+
+
+async def test_poe_port_switches(hass, aioclient_mock):
+    """Test the update_items function with some clients."""
+    config_entry = await setup_unifi_integration(
+        hass, aioclient_mock, devices_response=[DEVICE_1]
+    )
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
+
+    ent_reg = er.async_get(hass)
+    ent_reg_entry = ent_reg.async_get("switch.mock_name_port_1_poe")
+    assert ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert ent_reg_entry.entity_category is EntityCategory.CONFIG
+
+    # Enable entity
+
+    ent_reg.async_update_entity(
+        entity_id="switch.mock_name_port_1_poe", disabled_by=None
+    )
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(
+        hass,
+        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    # Validate state object
+    switch_1 = hass.states.get("switch.mock_name_port_1_poe")
+    assert switch_1 is not None
+    assert switch_1.state == "on"
+    assert switch_1.attributes.get(ATTR_DEVICE_CLASS) == SwitchDeviceClass.OUTLET
+
+    # Turn off PoE
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.put(
+        f"https://{controller.host}:1234/api/s/{controller.site}/rest/device/mock-id",
+    )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_off",
+        {"entity_id": "switch.mock_name_port_1_poe"},
+        blocking=True,
+    )
+    assert aioclient_mock.call_count == 1
+    assert aioclient_mock.mock_calls[0][2] == {
+        "port_overrides": [{"poe_mode": "off", "port_idx": 1, "portconf_id": "1a1"}]
+    }
+
+    # Turn on PoE
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_on",
+        {"entity_id": "switch.mock_name_port_1_poe"},
+        blocking=True,
+    )
+    assert aioclient_mock.call_count == 2
+    assert aioclient_mock.mock_calls[1][2] == {
+        "port_overrides": [{"poe_mode": "auto", "port_idx": 1, "portconf_id": "1a1"}]
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Inspiration taken from https://github.com/home-assistant/core/pull/59194 thanks @Flameeyes 

https://github.com/Kane610/aiounifi/compare/v39...v40
Adds new entities (disabled by default) to control the PoE. The Entity will just represent the port thus allowing users to control PoE for UniFi devices or other infrastructure not identified as a client. The Previous implementation tried to figure out and map the control to the underlying client but has shown to be a bit complex and error prone.

The New UnifiPoePortSwitch class is completely stand alone and I plan to build a simpler structure than what is the current implementation in the UniFi integration.

This will not resolve the issue of trying to turn off PoE on multiple ports too quickly, but will be its own PR down the line.

I plan to remove the old PoE implementation in the 2023.1 release.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59194, fixes #78574, fixes #79636
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
