### PR TITLE
Change monoprice integration to use data update coordinator

### DIFF
--- a/homeassistant/components/monoprice/const.py
+++ b/homeassistant/components/monoprice/const.py
@@ -16,6 +16,8 @@ CONF_NOT_FIRST_RUN = "not_first_run"
 SERVICE_SNAPSHOT = "snapshot"
 SERVICE_RESTORE = "restore"
 
+COORDINATOR_OBJECT = "coordinator_object"
 FIRST_RUN = "first_run"
 MONOPRICE_OBJECT = "monoprice_object"
 UNDO_UPDATE_LISTENER = "update_update_listener"
+ZONE_IDS = "zone_ids"

--- a/homeassistant/components/monoprice/coordinator.py
+++ b/homeassistant/components/monoprice/coordinator.py
@@ -1,0 +1,51 @@
+"""Coordinator for Monoprice Amplifier."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from pymonoprice import Monoprice, ZoneStatus
+from serial import SerialException
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+_LOGGER = logging.getLogger(__name__)
+
+POLL_INTERVAL = timedelta(seconds=10)
+
+
+class MonopriceDataUpdateCoordinator(DataUpdateCoordinator[dict[int, ZoneStatus]]):
+    """DataUpdateCoordinator to query zone information for Monoprice Amplifier."""
+
+    def __init__(
+        self, hass: HomeAssistant, monoprice: Monoprice, zones: list[int]
+    ) -> None:
+        """Initialize DataUpdateCoordinator to gather data for specific zones."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Monoprice",
+            update_interval=POLL_INTERVAL,
+        )
+        self._monoprice = monoprice
+        self._zones = zones
+
+    async def _async_update_data(self) -> dict[int, ZoneStatus]:
+        """Fetch data for each of the zones."""
+        return await self.hass.async_add_executor_job(self._update_all_zones)
+
+    def _update_all_zones(self) -> dict[int, ZoneStatus]:
+        """Fetch data for each of the zones."""
+        data = {}
+        for zone_id in self._zones:
+            try:
+                zone_status = self._monoprice.zone_status(zone_id)
+            except SerialException as exc:
+                if zone_id < 20:
+                    raise UpdateFailed(f"Failed to update zone {zone_id}") from exc
+            else:
+                if zone_status:
+                    data[zone_id] = zone_status
+
+        return data

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -1,4 +1,6 @@
 """Support for interfacing with Monoprice 6 zone home audio controller."""
+from __future__ import annotations
+
 import logging
 
 from pymonoprice import Monoprice
@@ -154,7 +156,7 @@ class MonopriceZone(
         self._name = f"Zone {self._zone_id}"
 
         self._snapshot = None
-        self._state = None
+        self._state: MediaPlayerState | None = None
         self._volume = None
         self._source = None
         self._mute = None

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -160,7 +160,6 @@ class MonopriceZone(
         self._volume = None
         self._source = None
         self._mute = None
-        self._update_success = True
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
## Proposed change

Setup the Monoprice Amplifier integration to use a data update coordinator to handle polling the device and sending it to all of the associated entities. With this, there is a single coordinator that polls all of the zone status for the device, rather than each of the 18 zones separately polling the device.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
