### PR TITLE
Add AirQuality SensorState support for Google Assistant

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -170,6 +170,7 @@ DEVICE_CLASS_TO_GOOGLE_TYPES = {
     (media_player.DOMAIN, media_player.MediaPlayerDeviceClass.RECEIVER): TYPE_RECEIVER,
     (media_player.DOMAIN, media_player.MediaPlayerDeviceClass.SPEAKER): TYPE_SPEAKER,
     (media_player.DOMAIN, media_player.MediaPlayerDeviceClass.TV): TYPE_TV,
+    (sensor.DOMAIN, sensor.SensorDeviceClass.AQI): TYPE_SENSOR,
     (sensor.DOMAIN, sensor.SensorDeviceClass.HUMIDITY): TYPE_SENSOR,
     (sensor.DOMAIN, sensor.SensorDeviceClass.TEMPERATURE): TYPE_SENSOR,
     (switch.DOMAIN, switch.SwitchDeviceClass.OUTLET): TYPE_OUTLET,

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2414,20 +2414,20 @@ class SensorStateTrait(_Trait):
     commands: list[str] = []
 
     def _air_quality_description_for_aqi(self, aqi):
-        if (aqi is None or aqi.isnumeric() == False):
+        if aqi is None or aqi.isnumeric() is False:
             return "unknown"
-        elif (int(aqi) <= 50):
+        if int(aqi) <= 50:
             return "healthy"
-        elif (int(aqi) <= 100):
+        if int(aqi) <= 100:
             return "moderate"
-        elif (int(aqi) <= 150):
+        if int(aqi) <= 150:
             return "unhealthy for sensitive groups"
-        elif (int(aqi) <= 200):
+        if int(aqi) <= 200:
             return "unhealthy"
-        elif (int(aqi) <= 300):
+        if int(aqi) <= 300:
             return "very unhealthy"
-        else:
-            return "hazardous"
+
+        return "hazardous"
 
     @classmethod
     def supported(cls, domain, features, device_class, _):
@@ -2438,46 +2438,55 @@ class SensorStateTrait(_Trait):
         """Return attributes for a sync request."""
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)
         data = self.sensor_types.get(device_class)
-        
-        if (data[0] == self.sensor_types.get(sensor.SensorDeviceClass.AQI)[0]):
+
+        if data[0] == self.sensor_types.get(sensor.SensorDeviceClass.AQI)[0]:
             return {
-                "sensorStatesSupported": [{
-                    "name": data[0],
-                    "numericCapabilities": {"rawValueUnit": data[1]},
-                    "descriptiveCapabilities": {
-                        "availableStates": [
-                            "healthy",
-                            "moderate",
-                            "unhealthy for sensitive groups",
-                            "unhealthy",
-                            "very unhealthy",
-                            "hazardous",
-                            "unknown"
-                        ],
-                    },
-                }]
+                "sensorStatesSupported": [
+                    {
+                        "name": data[0],
+                        "numericCapabilities": {"rawValueUnit": data[1]},
+                        "descriptiveCapabilities": {
+                            "availableStates": [
+                                "healthy",
+                                "moderate",
+                                "unhealthy for sensitive groups",
+                                "unhealthy",
+                                "very unhealthy",
+                                "hazardous",
+                                "unknown",
+                            ],
+                        },
+                    }
+                ]
             }
-        elif data is not None:
+        if data is not None:
             return {
-                "sensorStatesSupported": [{
-                    "name": data[0],
-                    "numericCapabilities": {"rawValueUnit": data[1]},
-                }]
+                "sensorStatesSupported": [
+                    {
+                        "name": data[0],
+                        "numericCapabilities": {"rawValueUnit": data[1]},
+                    }
+                ]
             }
 
     def query_attributes(self):
         """Return the attributes of this trait for this entity."""
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)
         data = self.sensor_types.get(device_class)
-        
+
         if data[0] == self.sensor_types.get(sensor.SensorDeviceClass.AQI)[0]:
             return {
                 "currentSensorStateData": [
-                    {"name": data[0], "currentSensorState": self._air_quality_description_for_aqi(self.state.state)},
-                    {"name": data[1], "rawValue": self.state.state}
+                    {
+                        "name": data[0],
+                        "currentSensorState": self._air_quality_description_for_aqi(
+                            self.state.state
+                        ),
+                    },
+                    {"name": data[1], "rawValue": self.state.state},
                 ]
             }
-        elif data is not None:
+        if data is not None:
             return {
                 "currentSensorStateData": [
                     {"name": data[0], "rawValue": self.state.state}

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2414,7 +2414,7 @@ class SensorStateTrait(_Trait):
     commands: list[str] = []
 
     def _air_quality_description_for_aqi(self, aqi):
-        if aqi is None or aqi.isnumeric() is False:
+        if aqi is None or str(aqi).isnumeric() is False:
             return "unknown"
         if int(aqi) <= 50:
             return "healthy"

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2439,6 +2439,9 @@ class SensorStateTrait(_Trait):
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)
         data = self.sensor_types.get(device_class)
 
+        if device_class is None:
+            return {}
+        
         if device_class == sensor.SensorDeviceClass.AQI:
             return {
                 "sensorStatesSupported": [
@@ -2474,6 +2477,9 @@ class SensorStateTrait(_Trait):
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)
         data = self.sensor_types.get(device_class)
 
+        if device_class is None:
+            return {}
+        
         if device_class == sensor.SensorDeviceClass.AQI:
             return {
                 "currentSensorStateData": [

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2414,7 +2414,7 @@ class SensorStateTrait(_Trait):
     commands: list[str] = []
 
     def _air_quality_description_for_aqi(self, aqi):
-        if aqi is None or str(aqi).isnumeric() is False:
+        if aqi is None or aqi.isnumeric() is False:
             return "unknown"
         if int(aqi) <= 50:
             return "healthy"

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2441,36 +2441,26 @@ class SensorStateTrait(_Trait):
 
         if device_class is None or data is None:
             return {}
-        
+
+        sensor_state = {
+            "name": data[0],
+            "numericCapabilities": {"rawValueUnit": data[1]},
+        }
+
         if device_class == sensor.SensorDeviceClass.AQI:
-            return {
-                "sensorStatesSupported": [
-                    {
-                        "name": data[0],
-                        "numericCapabilities": {"rawValueUnit": data[1]},
-                        "descriptiveCapabilities": {
-                            "availableStates": [
-                                "healthy",
-                                "moderate",
-                                "unhealthy for sensitive groups",
-                                "unhealthy",
-                                "very unhealthy",
-                                "hazardous",
-                                "unknown",
-                            ],
-                        },
-                    }
-                ]
+            sensor_state["descriptiveCapabilities"] = {
+                "availableStates": [
+                    "healthy",
+                    "moderate",
+                    "unhealthy for sensitive groups",
+                    "unhealthy",
+                    "very unhealthy",
+                    "hazardous",
+                    "unknown",
+                ],
             }
-        else:
-            return {
-                "sensorStatesSupported": [
-                    {
-                        "name": data[0],
-                        "numericCapabilities": {"rawValueUnit": data[1]},
-                    }
-                ]
-            }
+
+        return {"sensorStatesSupported": [sensor_state]}
 
     def query_attributes(self):
         """Return the attributes of this trait for this entity."""
@@ -2479,22 +2469,12 @@ class SensorStateTrait(_Trait):
 
         if device_class is None or data is None:
             return {}
-        
+
+        sensor_data = {"name": data[0], "rawValue": self.state.state}
+
         if device_class == sensor.SensorDeviceClass.AQI:
-            return {
-                "currentSensorStateData": [
-                    {
-                        "name": data[0],
-                        "currentSensorState": self._air_quality_description_for_aqi(
-                            self.state.state
-                        ),
-                    },
-                    {"name": data[1], "rawValue": self.state.state},
-                ]
-            }
-        else:
-            return {
-                "currentSensorStateData": [
-                    {"name": data[0], "rawValue": self.state.state}
-                ]
-            }
+            sensor_data["currentSensorState"] = self._air_quality_description_for_aqi(
+                self.state.state
+            )
+
+        return {"currentSensorStateData": [sensor_data]}

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2439,7 +2439,7 @@ class SensorStateTrait(_Trait):
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)
         data = self.sensor_types.get(device_class)
 
-        if data[0] == self.sensor_types.get(sensor.SensorDeviceClass.AQI)[0]:
+        if device_class == sensor.SensorDeviceClass.AQI:
             return {
                 "sensorStatesSupported": [
                     {
@@ -2474,7 +2474,7 @@ class SensorStateTrait(_Trait):
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)
         data = self.sensor_types.get(device_class)
 
-        if data[0] == self.sensor_types.get(sensor.SensorDeviceClass.AQI)[0]:
+        if device_class == sensor.SensorDeviceClass.AQI:
             return {
                 "currentSensorStateData": [
                     {

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2439,7 +2439,7 @@ class SensorStateTrait(_Trait):
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)
         data = self.sensor_types.get(device_class)
 
-        if device_class is None:
+        if device_class is None or data is None:
             return {}
         
         if device_class == sensor.SensorDeviceClass.AQI:
@@ -2477,7 +2477,7 @@ class SensorStateTrait(_Trait):
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)
         data = self.sensor_types.get(device_class)
 
-        if device_class is None:
+        if device_class is None or data is None:
             return {}
         
         if device_class == sensor.SensorDeviceClass.AQI:

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2462,7 +2462,7 @@ class SensorStateTrait(_Trait):
                     }
                 ]
             }
-        if data is not None:
+        else:
             return {
                 "sensorStatesSupported": [
                     {
@@ -2492,7 +2492,7 @@ class SensorStateTrait(_Trait):
                     {"name": data[1], "rawValue": self.state.state},
                 ]
             }
-        if data is not None:
+        else:
             return {
                 "currentSensorStateData": [
                     {"name": data[0], "rawValue": self.state.state}

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2416,15 +2416,16 @@ class SensorStateTrait(_Trait):
     def _air_quality_description_for_aqi(self, aqi):
         if aqi is None or aqi.isnumeric() is False:
             return "unknown"
-        if int(aqi) <= 50:
+        aqi = int(aqi)
+        if aqi <= 50:
             return "healthy"
-        if int(aqi) <= 100:
+        if aqi <= 100:
             return "moderate"
-        if int(aqi) <= 150:
+        if aqi <= 150:
             return "unhealthy for sensitive groups"
-        if int(aqi) <= 200:
+        if aqi <= 200:
             return "unhealthy"
-        if int(aqi) <= 300:
+        if aqi <= 300:
             return "very unhealthy"
 
         return "hazardous"

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -3291,6 +3291,48 @@ async def test_channel(hass: HomeAssistant) -> None:
     assert len(media_player_calls) == 1
 
 
+async def test_air_quality_description_for_aqi(hass: HomeAssistant) -> None:
+    """Test air quality description for a given AQI value."""
+    trt = trait.SensorStateTrait(
+        hass,
+        State(
+            "sensor.test",
+            100.0,
+            {
+                "device_class": sensor.SensorDeviceClass.AQI,
+            },
+        ),
+        BASIC_CONFIG,
+    )
+
+    assert trt._air_quality_description_for_aqi(0) == "healthy"
+    assert trt._air_quality_description_for_aqi(75) == "moderate"
+    assert trt._air_quality_description_for_aqi(125) == "unhealthy for sensitive groups"
+    assert trt._air_quality_description_for_aqi(175) == "unhealthy"
+    assert trt._air_quality_description_for_aqi(250) == "very unhealthy"
+    assert trt._air_quality_description_for_aqi(350) == "hazardous"
+    assert trt._air_quality_description_for_aqi(-1) == "unknown"
+    assert trt._air_quality_description_for_aqi("string") == "unknown"
+
+
+async def test_null_device_class(hass: HomeAssistant) -> None:
+    """Test handling a null device_class in sync_attributes and query_attributes."""
+    trt = trait.SensorStateTrait(
+        hass,
+        State(
+            "sensor.test",
+            100.0,
+            {
+                "device_class": None,
+            },
+        ),
+        BASIC_CONFIG,
+    )
+
+    assert trt.sync_attributes() == {}
+    assert trt.query_attributes() == {}
+
+
 async def test_sensorstate(hass: HomeAssistant) -> None:
     """Test SensorState trait support for sensor domain."""
     sensor_types = {

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -3362,8 +3362,8 @@ async def test_sensorstate(hass: HomeAssistant) -> None:
                         "currentSensorState": trt._air_quality_description_for_aqi(
                             trt.state.state
                         ),
+                        "rawValue": trt.state.state,
                     },
-                    {"name": unit, "rawValue": trt.state.state},
                 ]
             }
         else:

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -3305,14 +3305,16 @@ async def test_air_quality_description_for_aqi(hass: HomeAssistant) -> None:
         BASIC_CONFIG,
     )
 
-    assert trt._air_quality_description_for_aqi(0) == "healthy"
-    assert trt._air_quality_description_for_aqi(75) == "moderate"
-    assert trt._air_quality_description_for_aqi(125) == "unhealthy for sensitive groups"
-    assert trt._air_quality_description_for_aqi(175) == "unhealthy"
-    assert trt._air_quality_description_for_aqi(250) == "very unhealthy"
-    assert trt._air_quality_description_for_aqi(350) == "hazardous"
-    assert trt._air_quality_description_for_aqi(-1) == "unknown"
-    assert trt._air_quality_description_for_aqi("string") == "unknown"
+    assert trt._air_quality_description_for_aqi("0") == "healthy"
+    assert trt._air_quality_description_for_aqi("75") == "moderate"
+    assert (
+        trt._air_quality_description_for_aqi("125") == "unhealthy for sensitive groups"
+    )
+    assert trt._air_quality_description_for_aqi("175") == "unhealthy"
+    assert trt._air_quality_description_for_aqi("250") == "very unhealthy"
+    assert trt._air_quality_description_for_aqi("350") == "hazardous"
+    assert trt._air_quality_description_for_aqi("-1") == "unknown"
+    assert trt._air_quality_description_for_aqi("non-numeric") == "unknown"
 
 
 async def test_null_device_class(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

No breaking changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds support for `AirQuality` `SensorState` to `google_assistant` component.

Docs here: https://developers.google.com/assistant/smarthome/traits/sensorstate#air-quality

This allows for AQI sensors (such as PurpleAir) to be exposed to Google Assistant / Home. This allows you to say "Hey Google, what's the air quality at home?" and have it reply with a realtime value of what your sensor reads.

This also fixes the response format of `currentSensorStateData` for other Sensor types. The response expects an `array` to be returned, but the current implementation returns an `object`. 

Docs here: https://developers.google.com/assistant/smarthome/traits/sensorstate#device-states

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
