### PR TITLE
Bump pysma to 0.7.1

### DIFF
--- a/homeassistant/components/sma/manifest.json
+++ b/homeassistant/components/sma/manifest.json
@@ -3,7 +3,7 @@
   "name": "SMA Solar",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sma",
-  "requirements": ["pysma==0.7.0"],
+  "requirements": ["pysma==0.7.1"],
   "codeowners": ["@kellerza", "@rklomp"],
   "iot_class": "local_polling",
   "loggers": ["pysma"]

--- a/homeassistant/components/sma/manifest.json
+++ b/homeassistant/components/sma/manifest.json
@@ -3,7 +3,7 @@
   "name": "SMA Solar",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sma",
-  "requirements": ["pysma==0.6.12"],
+  "requirements": ["pysma==0.7.0"],
   "codeowners": ["@kellerza", "@rklomp"],
   "iot_class": "local_polling",
   "loggers": ["pysma"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1887,7 +1887,7 @@ pysignalclirestapi==0.3.18
 pyskyqhub==0.1.4
 
 # homeassistant.components.sma
-pysma==0.7.0
+pysma==0.7.1
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1887,7 +1887,7 @@ pysignalclirestapi==0.3.18
 pyskyqhub==0.1.4
 
 # homeassistant.components.sma
-pysma==0.6.12
+pysma==0.7.0
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1328,7 +1328,7 @@ pysiaalarm==3.0.2
 pysignalclirestapi==0.3.18
 
 # homeassistant.components.sma
-pysma==0.6.12
+pysma==0.7.0
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1328,7 +1328,7 @@ pysiaalarm==3.0.2
 pysignalclirestapi==0.3.18
 
 # homeassistant.components.sma
-pysma==0.7.0
+pysma==0.7.1
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/tests/components/sma/conftest.py
+++ b/tests/components/sma/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for sma tests."""
 from unittest.mock import patch
 
-from pysma.const import DEVCLASS_INVERTER
+from pysma.const import GENERIC_SENSORS
 from pysma.definitions import sensor_map
 from pysma.sensor import Sensors
 import pytest
@@ -32,7 +32,7 @@ async def init_integration(hass, mock_config_entry):
     mock_config_entry.add_to_hass(hass)
 
     with patch("pysma.SMA.read"), patch(
-        "pysma.SMA.get_sensors", return_value=Sensors(sensor_map[DEVCLASS_INVERTER])
+        "pysma.SMA.get_sensors", return_value=Sensors(sensor_map[GENERIC_SENSORS])
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This will bump pysma to version 0.7.1. 
Sensors are now dynamically created based on the sensors the device is providing, instead of a more fixed solution in the previous version. This adds support to new new SMA Sunny Tripower Smart Energy devices.
Also adds one new sensor definition.

https://github.com/kellerza/pysma/releases/tag/0.7.0
https://github.com/kellerza/pysma/releases/tag/0.7.1
https://github.com/kellerza/pysma/compare/0.6.12...0.7.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #79546
- This PR is related to issue: https://github.com/kellerza/pysma/issues/105
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24626

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
