### PR TITLE
Automatically convert distances between km and mi

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -473,8 +473,8 @@ class SensorEntity(Entity):
         native_unit_of_measurement = self.native_unit_of_measurement
 
         if self.device_class == SensorDeviceClass.DISTANCE:
-            initial_unit_of_measurement = self.hass.config.units.length_conversions.get(
-                native_unit_of_measurement
+            initial_unit_of_measurement = self.hass.config.units.get_converted_unit(
+                self.device_class, native_unit_of_measurement
             )
 
         if initial_unit_of_measurement is None:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -341,6 +341,17 @@ class Entity(ABC):
         return self._attr_capability_attributes
 
     @property
+    def initial_entity_options(self) -> Mapping[str, Mapping[str, Any]] | None:
+        """Return initial entity options.
+
+        These will be stored in the entity registry the first time the  entity is seen,
+        and then never updated.
+
+        Implemented by component base class, should not be extended by integrations.
+        """
+        return None
+
+    @property
     def state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes.
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -610,6 +610,7 @@ class EntityPlatform:
                 hidden_by=hidden_by,
                 known_object_ids=self.entities.keys(),
                 has_entity_name=entity.has_entity_name,
+                initial_options=entity.initial_entity_options,
                 original_device_class=entity.device_class,
                 original_icon=entity.icon,
                 original_name=entity.name,

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -397,6 +397,8 @@ class EntityRegistry:
         # To disable or hide an entity if it gets created
         disabled_by: RegistryEntryDisabler | None = None,
         hidden_by: RegistryEntryHider | None = None,
+        # Initial entity options if it gets created
+        initial_options: Mapping[str, Mapping[str, Any]] | None = None,
         # Data that we want entry to have
         capabilities: Mapping[str, Any] | None | UndefinedType = UNDEFINED,
         config_entry: ConfigEntry | None | UndefinedType = UNDEFINED,
@@ -474,6 +476,7 @@ class EntityRegistry:
             entity_id=entity_id,
             hidden_by=hidden_by,
             has_entity_name=none_if_undefined(has_entity_name) or False,
+            options=initial_options,
             original_device_class=none_if_undefined(original_device_class),
             original_icon=none_if_undefined(original_icon),
             original_name=none_if_undefined(original_name),

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -93,6 +93,7 @@ class UnitSystem:
         mass: str,
         pressure: str,
         accumulated_precipitation: str,
+        length_conversions: dict[str | None, str],
     ) -> None:
         """Initialize the unit system object."""
         errors: str = ", ".join(
@@ -120,6 +121,7 @@ class UnitSystem:
         self.pressure_unit = pressure
         self.volume_unit = volume
         self.wind_speed_unit = wind_speed
+        self.length_conversions = length_conversions
 
     @property
     def name(self) -> str:
@@ -233,6 +235,7 @@ METRIC_SYSTEM = UnitSystem(
     MASS_GRAMS,
     PRESSURE_PA,
     LENGTH_MILLIMETERS,
+    {LENGTH_MILES: LENGTH_KILOMETERS},
 )
 
 IMPERIAL_SYSTEM = UnitSystem(
@@ -244,4 +247,5 @@ IMPERIAL_SYSTEM = UnitSystem(
     MASS_POUNDS,
     PRESSURE_PSI,
     LENGTH_INCHES,
+    {LENGTH_KILOMETERS: LENGTH_MILES},
 )

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from numbers import Number
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import voluptuous as vol
 
@@ -41,6 +41,9 @@ from .unit_conversion import (
     TemperatureConverter,
     VolumeConverter,
 )
+
+if TYPE_CHECKING:
+    from homeassistant.components.sensor import SensorDeviceClass
 
 _CONF_UNIT_SYSTEM_IMPERIAL: Final = "imperial"
 _CONF_UNIT_SYSTEM_METRIC: Final = "metric"
@@ -121,7 +124,7 @@ class UnitSystem:
         self.pressure_unit = pressure
         self.volume_unit = volume
         self.wind_speed_unit = wind_speed
-        self.length_conversions = length_conversions
+        self._length_conversions = length_conversions
 
     @property
     def name(self) -> str:
@@ -211,6 +214,17 @@ class UnitSystem:
             VOLUME: self.volume_unit,
             WIND_SPEED: self.wind_speed_unit,
         }
+
+    def get_converted_unit(
+        self,
+        device_class: SensorDeviceClass | str | None,
+        original_unit: str | None,
+    ) -> str | None:
+        """Return converted unit given a device class or an original unit."""
+        if device_class == "distance":
+            return self._length_conversions.get(original_unit)
+
+        return None
 
 
 def get_unit_system(key: str) -> UnitSystem:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -50,6 +50,7 @@ def _set_up_units(hass):
         MASS_GRAMS,
         PRESSURE_PA,
         LENGTH_MILLIMETERS,
+        {},
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow-up to https://github.com/home-assistant/core/pull/80600, and adds rules:
 - Distances in `mi` are converted to `km` if the unit system is `metric`
 - Temperatures in `km` are converted to `mi` if the unit system is `imperial` (US customary units)

The new rules will only apply to new entities with a `unique_id` to ensure:
  - Existing entities will not have units changed
  - Users can always override the unit if the automatic unit conversion is not to their liking

TODO: Add tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
