### PR TITLE
Update simplepush integration

### DIFF
--- a/homeassistant/components/simplepush/config_flow.py
+++ b/homeassistant/components/simplepush/config_flow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from simplepush import UnknownError, send, send_encrypted
+from simplepush import UnknownError, send
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -17,15 +17,19 @@ def validate_input(entry: dict[str, str]) -> dict[str, str] | None:
     """Validate user input."""
     try:
         if CONF_PASSWORD in entry:
-            send_encrypted(
-                entry[CONF_DEVICE_KEY],
-                entry[CONF_PASSWORD],
-                entry[CONF_PASSWORD],
-                "HA test",
-                "Message delivered successfully",
+            send(
+                key=entry[CONF_DEVICE_KEY],
+                password=entry[CONF_PASSWORD],
+                salt=entry[CONF_PASSWORD],
+                title="HA test",
+                message="Message delivered successfully",
             )
         else:
-            send(entry[CONF_DEVICE_KEY], "HA test", "Message delivered successfully")
+            send(
+                key=entry[CONF_DEVICE_KEY],
+                title="HA test",
+                message="Message delivered successfully",
+            )
     except UnknownError:
         return {"base": "cannot_connect"}
 

--- a/homeassistant/components/simplepush/const.py
+++ b/homeassistant/components/simplepush/const.py
@@ -6,6 +6,7 @@ DOMAIN: Final = "simplepush"
 DEFAULT_NAME: Final = "simplepush"
 DATA_HASS_CONFIG: Final = "simplepush_hass_config"
 
+ATTR_ATTACHMENTS: Final = "attachments"
 ATTR_ENCRYPTED: Final = "encrypted"
 ATTR_EVENT: Final = "event"
 

--- a/homeassistant/components/simplepush/const.py
+++ b/homeassistant/components/simplepush/const.py
@@ -6,9 +6,13 @@ DOMAIN: Final = "simplepush"
 DEFAULT_NAME: Final = "simplepush"
 DATA_HASS_CONFIG: Final = "simplepush_hass_config"
 
+ATTR_ACTIONS: Final = "actions"
 ATTR_ATTACHMENTS: Final = "attachments"
 ATTR_ENCRYPTED: Final = "encrypted"
 ATTR_EVENT: Final = "event"
+ATTR_FEEDBACK_ACTION_TIMEOUT: Final = "feedback_action_timeout"
+
+EVENT_ACTION_TRIGGERED: Final = "simplepush_action_triggered_event"
 
 CONF_DEVICE_KEY: Final = "device_key"
 CONF_SALT: Final = "salt"

--- a/homeassistant/components/simplepush/manifest.json
+++ b/homeassistant/components/simplepush/manifest.json
@@ -2,7 +2,7 @@
   "domain": "simplepush",
   "name": "Simplepush",
   "documentation": "https://www.home-assistant.io/integrations/simplepush",
-  "requirements": ["simplepush==1.1.4"],
+  "requirements": ["simplepush==2.1.0"],
   "codeowners": ["@engrbm87"],
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/homeassistant/components/simplepush/notify.py
+++ b/homeassistant/components/simplepush/notify.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from simplepush import BadRequest, UnknownError, send, send_encrypted
+from simplepush import BadRequest, UnknownError, send
 
 from homeassistant.components.notify import (
     ATTR_DATA,
@@ -71,16 +71,16 @@ class SimplePushNotificationService(BaseNotificationService):
 
         try:
             if self._password:
-                send_encrypted(
-                    self._device_key,
-                    self._password,
-                    self._salt,
-                    title,
-                    message,
+                send(
+                    key=self._device_key,
+                    password=self._password,
+                    salt=self._salt,
+                    title=title,
+                    message=message,
                     event=event,
                 )
             else:
-                send(self._device_key, title, message, event=event)
+                send(key=self._device_key, title=title, message=message, event=event)
 
         except BadRequest:
             _LOGGER.error("Bad request. Title or message are too long")

--- a/homeassistant/components/simplepush/notify.py
+++ b/homeassistant/components/simplepush/notify.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from simplepush import BadRequest, UnknownError, send
+from simplepush import BadRequest, FeedbackActionTimeout, UnknownError, async_send
 
 from homeassistant.components.notify import (
     ATTR_DATA,
@@ -15,10 +15,20 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import CONF_EVENT, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import ATTR_ATTACHMENTS, ATTR_EVENT, CONF_DEVICE_KEY, CONF_SALT, DOMAIN
+from .const import (
+    ATTR_ACTIONS,
+    ATTR_ATTACHMENTS,
+    ATTR_EVENT,
+    ATTR_FEEDBACK_ACTION_TIMEOUT,
+    CONF_DEVICE_KEY,
+    CONF_SALT,
+    DOMAIN,
+    EVENT_ACTION_TRIGGERED,
+)
 
 # Configuring Simplepush under the notify has been removed in 2022.9.0
 PLATFORM_SCHEMA = BASE_PLATFORM_SCHEMA
@@ -44,28 +54,52 @@ async def async_get_service(
         )
         return None
 
-    return SimplePushNotificationService(discovery_info)
+    return SimplePushNotificationService(hass, discovery_info)
 
 
 class SimplePushNotificationService(BaseNotificationService):
     """Implementation of the notification service for Simplepush."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, hass: HomeAssistant, config: dict[str, Any]) -> None:
         """Initialize the Simplepush notification service."""
+        self.hass = hass
+        self.session = async_get_clientsession(hass)
         self._device_key: str = config[CONF_DEVICE_KEY]
         self._event: str | None = config.get(CONF_EVENT)
         self._password: str | None = config.get(CONF_PASSWORD)
         self._salt: str | None = config.get(CONF_SALT)
 
-    def send_message(self, message: str, **kwargs: Any) -> None:
+    async def async_send_message(self, message: str, **kwargs: Any) -> None:
         """Send a message to a Simplepush user."""
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
 
+        actions = None
+        action_ids = {}
         attachments = None
         # event can now be passed in the service data
         event = None
+        feedback_action_timeout = None
+
         if data := kwargs.get(ATTR_DATA):
             event = data.get(ATTR_EVENT)
+
+            actions_data = data.get(ATTR_ACTIONS)
+            if isinstance(actions_data, list) and actions_data:
+                actions = []
+                for action in actions_data:
+                    if "action" in action and "url" in action:
+                        actions.append({"name": action["action"], "url": action["url"]})
+                    elif "action" in action:
+                        actions.append(action["action"])
+                        if "id" in action:
+                            action_ids.update({action["action"]: action["id"]})
+
+                try:
+                    feedback_action_timeout = int(
+                        data.get(ATTR_FEEDBACK_ACTION_TIMEOUT)
+                    )
+                except (ValueError, TypeError):
+                    feedback_action_timeout = 60
 
             attachments_data = data.get(ATTR_ATTACHMENTS)
             if isinstance(attachments_data, list) and attachments_data:
@@ -84,27 +118,56 @@ class SimplePushNotificationService(BaseNotificationService):
         # use event from config until YAML config is removed
         event = event or self._event
 
+        def feedback_action_callback(
+            action_selected, action_selected_at, action_delivered_at, feedback_id
+        ):
+            payload = {
+                "action_selected": action_selected,
+                "action_selected_at": action_selected_at,
+                "action_delivered_at": action_delivered_at,
+                "feedback_id": feedback_id,
+            }
+
+            if action_selected in action_ids:
+                payload.update({"id": action_ids[action_selected]})
+
+            self.hass.bus.async_fire(EVENT_ACTION_TRIGGERED, payload)
+
         try:
             if self._password:
-                send(
-                    key=self._device_key,
-                    password=self._password,
-                    salt=self._salt,
-                    title=title,
-                    message=message,
-                    attachments=attachments,
-                    event=event,
+                self.hass.async_create_task(
+                    async_send(
+                        key=self._device_key,
+                        password=self._password,
+                        salt=self._salt,
+                        title=title,
+                        message=message,
+                        actions=actions,
+                        attachments=attachments,
+                        event=event,
+                        feedback_callback=feedback_action_callback,
+                        feedback_callback_timeout=feedback_action_timeout,
+                        aiohttp_session=self.session,
+                    )
                 )
             else:
-                send(
-                    key=self._device_key,
-                    title=title,
-                    message=message,
-                    attachments=attachments,
-                    event=event,
+                self.hass.async_create_task(
+                    async_send(
+                        key=self._device_key,
+                        title=title,
+                        message=message,
+                        actions=actions,
+                        attachments=attachments,
+                        event=event,
+                        feedback_callback=feedback_action_callback,
+                        feedback_callback_timeout=feedback_action_timeout,
+                        aiohttp_session=self.session,
+                    )
                 )
 
         except BadRequest:
             _LOGGER.error("Bad request. Title or message are too long")
         except UnknownError:
             _LOGGER.error("Failed to send the notification")
+        except FeedbackActionTimeout:
+            _LOGGER.error("Feedback action timed out")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2253,7 +2253,7 @@ shodan==1.28.0
 simplehound==0.3
 
 # homeassistant.components.simplepush
-simplepush==1.1.4
+simplepush==2.1.0
 
 # homeassistant.components.simplisafe
 simplisafe-python==2022.07.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1550,7 +1550,7 @@ sharkiq==0.0.1
 simplehound==0.3
 
 # homeassistant.components.simplepush
-simplepush==1.1.4
+simplepush==2.1.0
 
 # homeassistant.components.simplisafe
 simplisafe-python==2022.07.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the Simplepush library to include newly added functionality (actions and attachments).
It also aims to use the Home Assistant's shared aiohttp client session in order to improve performance.

As per this discussion (https://github.com/home-assistant/core/pull/73471#discussion_r902393867), the Simplepush library previously had to stay at version 1.1.4. This PR wants to update it to its latest release (2.1.0).

I will update the documentation (https://www.home-assistant.io/integrations/simplepush/), after this PR gets merged.

The new functionality can be tested with the following automations.

Sending an action that can trigger a logbook entry:
```
alias: Test
description: >-
  Send an action and if triggered within 10 seconds, log success message to the
  logbook
trigger: []
condition: []
action:
  - service: notify.simplepush
    data:
      message: test
      data:
        feedback_action_timeout: 10
        actions:
          - action: "yes"
            id: 123
  - wait_for_trigger:
      - platform: event
        event_type: simplepush_action_triggered_event
        event_data:
          id: 123
  - service: logbook.log
    data:
      name: Test
      message: Success
mode: restart
```

Sending a notification with two attachments:
```
alias: Test
description: >-
  Send a notification with two attachments
trigger: []
condition: []
action:
  - service: notify.simplepush
    data:
      message: test
      data:
        attachments:
          - attachment: https://upload.wikimedia.org/wikipedia/commons/e/ee/Sample_abc.jpg
          - attachment: http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4
            thumbnail: http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerEscapes.jpg
mode: restart
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #73471
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
