### PR TITLE
Move default option handling to config_flow for google_travel_time

### DIFF
--- a/homeassistant/components/google_travel_time/config_flow.py
+++ b/homeassistant/components/google_travel_time/config_flow.py
@@ -5,9 +5,10 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_MODE, CONF_NAME
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from .const import (
     ALL_LANGUAGES,
@@ -34,8 +35,20 @@ from .const import (
     TRAVEL_MODE,
     TRAVEL_MODEL,
     UNITS,
+    UNITS_IMPERIAL,
+    UNITS_METRIC,
 )
 from .helpers import InvalidApiKeyException, UnknownException, validate_config_entry
+
+
+def default_options(hass: HomeAssistant) -> dict[str, str | None]:
+    """Get the default options."""
+    return {
+        CONF_MODE: "driving",
+        CONF_UNITS: (
+            UNITS_IMPERIAL if hass.config.units is IMPERIAL_SYSTEM else UNITS_METRIC
+        ),
+    }
 
 
 class GoogleOptionsFlow(config_entries.OptionsFlow):
@@ -135,6 +148,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=user_input.get(CONF_NAME, DEFAULT_NAME),
                     data=user_input,
+                    options=default_options(self.hass),
                 )
             except InvalidApiKeyException:
                 errors["base"] = "invalid_auth"

--- a/homeassistant/components/google_travel_time/sensor.py
+++ b/homeassistant/components/google_travel_time/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_API_KEY,
-    CONF_MODE,
     CONF_NAME,
     EVENT_HOMEASSISTANT_STARTED,
     TIME_MINUTES,
@@ -22,21 +21,15 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.location import find_coordinates
 import homeassistant.util.dt as dt_util
-from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .const import (
     ATTRIBUTION,
     CONF_ARRIVAL_TIME,
     CONF_DEPARTURE_TIME,
     CONF_DESTINATION,
-    CONF_OPTIONS,
     CONF_ORIGIN,
-    CONF_TRAVEL_MODE,
-    CONF_UNITS,
     DEFAULT_NAME,
     DOMAIN,
-    UNITS_IMPERIAL,
-    UNITS_METRIC,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -60,32 +53,6 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up a Google travel time sensor entry."""
-    if not config_entry.options:
-        new_data = config_entry.data.copy()
-        options = new_data.pop(CONF_OPTIONS, {})
-
-        if CONF_UNITS not in options:
-            options[CONF_UNITS] = UNITS_METRIC
-            if hass.config.units is US_CUSTOMARY_SYSTEM:
-                options[CONF_UNITS] = UNITS_IMPERIAL
-
-        if CONF_TRAVEL_MODE in new_data:
-            wstr = (
-                "Google Travel Time: travel_mode is deprecated, please "
-                "add mode to the options dictionary instead!"
-            )
-            _LOGGER.warning(wstr)
-            travel_mode = new_data.pop(CONF_TRAVEL_MODE)
-            if CONF_MODE not in options:
-                options[CONF_MODE] = travel_mode
-
-        if CONF_MODE not in options:
-            options[CONF_MODE] = "driving"
-
-        hass.config_entries.async_update_entry(
-            config_entry, data=new_data, options=options
-        )
-
     api_key = config_entry.data[CONF_API_KEY]
     origin = config_entry.data[CONF_ORIGIN]
     destination = config_entry.data[CONF_DESTINATION]

--- a/tests/components/google_travel_time/test_config_flow.py
+++ b/tests/components/google_travel_time/test_config_flow.py
@@ -141,7 +141,6 @@ async def test_malformed_api_key(hass):
             MOCK_CONFIG,
             {
                 CONF_MODE: "driving",
-                CONF_ARRIVAL_TIME: "test",
                 CONF_UNITS: UNITS_IMPERIAL,
             },
         )
@@ -198,7 +197,15 @@ async def test_options_flow(hass, mock_config):
 
 @pytest.mark.parametrize(
     "data,options",
-    [(MOCK_CONFIG, {})],
+    [
+        (
+            MOCK_CONFIG,
+            {
+                CONF_MODE: "driving",
+                CONF_UNITS: UNITS_IMPERIAL,
+            },
+        )
+    ],
 )
 @pytest.mark.usefixtures("validate_config_entry")
 async def test_options_flow_departure_time(hass, mock_config):

--- a/tests/components/google_travel_time/test_sensor.py
+++ b/tests/components/google_travel_time/test_sensor.py
@@ -4,10 +4,10 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components.google_travel_time.config_flow import default_options
 from homeassistant.components.google_travel_time.const import (
     CONF_ARRIVAL_TIME,
     CONF_DEPARTURE_TIME,
-    CONF_TRAVEL_MODE,
     DOMAIN,
 )
 from homeassistant.const import CONF_UNIT_SYSTEM_IMPERIAL, CONF_UNIT_SYSTEM_METRIC
@@ -202,31 +202,6 @@ async def test_sensor_arrival_time_custom_timestamp(hass):
     assert hass.states.get("sensor.google_travel_time").state == "27"
 
 
-@pytest.mark.usefixtures("mock_update")
-async def test_sensor_deprecation_warning(hass, caplog):
-    """Test that sensor setup prints a deprecating warning for old configs.
-
-    The mock_config fixture does not work with caplog.
-    """
-    data = MOCK_CONFIG.copy()
-    data[CONF_TRAVEL_MODE] = "driving"
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=data,
-        entry_id="test",
-    )
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("sensor.google_travel_time").state == "27"
-    wstr = (
-        "Google Travel Time: travel_mode is deprecated, please "
-        "add mode to the options dictionary instead!"
-    )
-    assert wstr in caplog.text
-
-
 @pytest.mark.parametrize(
     "unit_system, expected_unit_option",
     [
@@ -245,7 +220,7 @@ async def test_sensor_unit_system(
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG,
-        options={},
+        options=default_options(hass),
         entry_id="test",
     )
     config_entry.add_to_hass(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

1. Remove the warning for deprecated yaml configurations
2. Move the default options handling out of the sensor to the config_flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
