### PR TITLE
Bump simplepush to 2.1.1

### DIFF
--- a/homeassistant/components/simplepush/config_flow.py
+++ b/homeassistant/components/simplepush/config_flow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from simplepush import UnknownError, send, send_encrypted
+from simplepush import UnknownError, send
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -17,15 +17,19 @@ def validate_input(entry: dict[str, str]) -> dict[str, str] | None:
     """Validate user input."""
     try:
         if CONF_PASSWORD in entry:
-            send_encrypted(
-                entry[CONF_DEVICE_KEY],
-                entry[CONF_PASSWORD],
-                entry[CONF_PASSWORD],
-                "HA test",
-                "Message delivered successfully",
+            send(
+                key=entry[CONF_DEVICE_KEY],
+                password=entry[CONF_PASSWORD],
+                salt=entry[CONF_PASSWORD],
+                title="HA test",
+                message="Message delivered successfully",
             )
         else:
-            send(entry[CONF_DEVICE_KEY], "HA test", "Message delivered successfully")
+            send(
+                key=entry[CONF_DEVICE_KEY],
+                title="HA test",
+                message="Message delivered successfully",
+            )
     except UnknownError:
         return {"base": "cannot_connect"}
 

--- a/homeassistant/components/simplepush/manifest.json
+++ b/homeassistant/components/simplepush/manifest.json
@@ -2,7 +2,7 @@
   "domain": "simplepush",
   "name": "Simplepush",
   "documentation": "https://www.home-assistant.io/integrations/simplepush",
-  "requirements": ["simplepush==2.1.0"],
+  "requirements": ["simplepush==2.1.1"],
   "codeowners": ["@engrbm87"],
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/homeassistant/components/simplepush/manifest.json
+++ b/homeassistant/components/simplepush/manifest.json
@@ -2,7 +2,7 @@
   "domain": "simplepush",
   "name": "Simplepush",
   "documentation": "https://www.home-assistant.io/integrations/simplepush",
-  "requirements": ["simplepush==1.1.4"],
+  "requirements": ["simplepush==2.1.0"],
   "codeowners": ["@engrbm87"],
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/homeassistant/components/simplepush/notify.py
+++ b/homeassistant/components/simplepush/notify.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from simplepush import BadRequest, UnknownError, send, send_encrypted
+from simplepush import BadRequest, UnknownError, send
 
 from homeassistant.components.notify import (
     ATTR_DATA,
@@ -71,16 +71,16 @@ class SimplePushNotificationService(BaseNotificationService):
 
         try:
             if self._password:
-                send_encrypted(
-                    self._device_key,
-                    self._password,
-                    self._salt,
-                    title,
-                    message,
+                send(
+                    key=self._device_key,
+                    password=self._password,
+                    salt=self._salt,
+                    title=title,
+                    message=message,
                     event=event,
                 )
             else:
-                send(self._device_key, title, message, event=event)
+                send(key=self._device_key, title=title, message=message, event=event)
 
         except BadRequest:
             _LOGGER.error("Bad request. Title or message are too long")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2253,7 +2253,7 @@ shodan==1.28.0
 simplehound==0.3
 
 # homeassistant.components.simplepush
-simplepush==2.1.0
+simplepush==2.1.1
 
 # homeassistant.components.simplisafe
 simplisafe-python==2022.07.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2253,7 +2253,7 @@ shodan==1.28.0
 simplehound==0.3
 
 # homeassistant.components.simplepush
-simplepush==1.1.4
+simplepush==2.1.0
 
 # homeassistant.components.simplisafe
 simplisafe-python==2022.07.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1550,7 +1550,7 @@ sharkiq==0.0.1
 simplehound==0.3
 
 # homeassistant.components.simplepush
-simplepush==2.1.0
+simplepush==2.1.1
 
 # homeassistant.components.simplisafe
 simplisafe-python==2022.07.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1550,7 +1550,7 @@ sharkiq==0.0.1
 simplehound==0.3
 
 # homeassistant.components.simplepush
-simplepush==1.1.4
+simplepush==2.1.0
 
 # homeassistant.components.simplisafe
 simplisafe-python==2022.07.1

--- a/tests/components/simplepush/test_config_flow.py
+++ b/tests/components/simplepush/test_config_flow.py
@@ -29,9 +29,7 @@ def simplepush_setup_fixture():
 @pytest.fixture(autouse=True)
 def mock_api_request():
     """Patch simplepush api request."""
-    with patch("homeassistant.components.simplepush.config_flow.send"), patch(
-        "homeassistant.components.simplepush.config_flow.send_encrypted"
-    ):
+    with patch("homeassistant.components.simplepush.config_flow.send"):
         yield
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- This PR updates the Simplepush library from version 1.1.4 to its latest version (2.1.1) and doesn't add or change any functionality.
- Version 1.1.4 was commit [f519815](https://github.com/simplepush/simplepush-python/commit/f519815674133345a3c642203fcb73710f6efdc0).
- https://github.com/simplepush/simplepush-python/compare/v1.1.4...v2.1.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #73471, #80606
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
