### PR TITLE
Add Freebox button to mark calls as read

### DIFF
--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -36,6 +36,7 @@ BUTTON_DESCRIPTIONS: tuple[FreeboxButtonEntityDescription, ...] = (
     FreeboxButtonEntityDescription(
         key="reboot",
         name="Reboot",
+        has_entity_name=True,
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
         async_press=lambda router: router.reboot(),

--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -39,6 +39,11 @@ BUTTON_DESCRIPTIONS: tuple[FreeboxButtonEntityDescription, ...] = (
         device_class=ButtonDeviceClass.RESTART,
         async_press=lambda router: router.reboot(),
     ),
+    FreeboxButtonEntityDescription(
+        key="mark_calls_as_read",
+        name="Mark missed calls as read",
+        async_press=lambda router: router.call.mark_calls_log_as_read(),
+    ),
 )
 
 

--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -35,8 +35,7 @@ class FreeboxButtonEntityDescription(
 BUTTON_DESCRIPTIONS: tuple[FreeboxButtonEntityDescription, ...] = (
     FreeboxButtonEntityDescription(
         key="reboot",
-        name="Reboot",
-        has_entity_name=True,
+        name="Reboot Freebox",
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
         async_press=lambda router: router.reboot(),

--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -72,7 +72,7 @@ class FreeboxButton(ButtonEntity):
         """Initialize a Freebox button."""
         self.entity_description = description
         self._router = router
-        self._attr_unique_id = f"{router.mac} {description.key}"
+        self._attr_unique_id = f"{router.mac} {description.name}"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -11,7 +11,7 @@ from homeassistant.components.button import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -35,13 +35,15 @@ class FreeboxButtonEntityDescription(
 BUTTON_DESCRIPTIONS: tuple[FreeboxButtonEntityDescription, ...] = (
     FreeboxButtonEntityDescription(
         key="reboot",
-        name="Reboot Freebox",
+        name="Reboot",
         device_class=ButtonDeviceClass.RESTART,
+        entity_category=EntityCategory.CONFIG,
         async_press=lambda router: router.reboot(),
     ),
     FreeboxButtonEntityDescription(
         key="mark_calls_as_read",
         name="Mark missed calls as read",
+        entity_category=EntityCategory.DIAGNOSTIC,
         async_press=lambda router: router.call.mark_calls_log_as_read(),
     ),
 )

--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -43,7 +43,7 @@ BUTTON_DESCRIPTIONS: tuple[FreeboxButtonEntityDescription, ...] = (
     ),
     FreeboxButtonEntityDescription(
         key="mark_calls_as_read",
-        name="Mark missed calls as read",
+        name="Mark calls as read",
         entity_category=EntityCategory.DIAGNOSTIC,
         async_press=lambda router: router.call.mark_calls_log_as_read(),
     ),

--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -72,7 +72,7 @@ class FreeboxButton(ButtonEntity):
         """Initialize a Freebox button."""
         self.entity_description = description
         self._router = router
-        self._attr_unique_id = f"{router.mac} {description.name}"
+        self._attr_unique_id = f"{router.mac} {description.key}"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/freebox/manifest.json
+++ b/homeassistant/components/freebox/manifest.json
@@ -3,7 +3,7 @@
   "name": "Freebox",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/freebox",
-  "requirements": ["freebox-api==1.0.0"],
+  "requirements": ["freebox-api==1.0.1"],
   "zeroconf": ["_fbx-api._tcp.local."],
   "codeowners": ["@hacf-fr", "@Quentame"],
   "iot_class": "local_polling",

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -192,7 +192,6 @@ class FreeboxRouter:
         """Return the call."""
         return self._api.call
 
-
     @property
     def wifi(self) -> Wifi:
         """Return the wifi."""

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from freebox_api import Freepybox
+from freebox_api.api.call import Call
 from freebox_api.api.wifi import Wifi
 from freebox_api.exceptions import NotOpenError
 
@@ -185,6 +186,12 @@ class FreeboxRouter:
     def sensors(self) -> dict[str, Any]:
         """Return sensors."""
         return {**self.sensors_temperature, **self.sensors_connection}
+
+    @property
+    def call(self) -> Call:
+        """Return the call."""
+        return self._api.call
+
 
     @property
     def wifi(self) -> Wifi:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -709,7 +709,7 @@ forecast_solar==2.2.0
 fortiosapi==1.0.5
 
 # homeassistant.components.freebox
-freebox-api==1.0.0
+freebox-api==1.0.1
 
 # homeassistant.components.free_mobile
 freesms==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -528,7 +528,7 @@ foobot_async==1.0.0
 forecast_solar==2.2.0
 
 # homeassistant.components.freebox
-freebox-api==1.0.0
+freebox-api==1.0.1
 
 # homeassistant.components.fritz
 # homeassistant.components.fritzbox_callmonitor


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a button to mark missed calls as read.
A dependency bump is required because it ships with a needed fix.

Lib bump release : https://github.com/hacf-fr/freebox-api/releases/tag/v1.0.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
