### PR TITLE
Enforce kwargs in unit system initialisation

### DIFF
--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -88,13 +88,13 @@ class UnitSystem:
         self,
         name: str,
         *,
-        temperature: str,
+        accumulated_precipitation: str,
         length: str,
-        wind_speed: str,
-        volume: str,
         mass: str,
         pressure: str,
-        accumulated_precipitation: str,
+        temperature: str,
+        volume: str,
+        wind_speed: str,
     ) -> None:
         """Initialize the unit system object."""
         errors: str = ", ".join(
@@ -242,24 +242,24 @@ validate_unit_system = vol.All(
 
 METRIC_SYSTEM = UnitSystem(
     _CONF_UNIT_SYSTEM_METRIC,
-    temperature=TEMP_CELSIUS,
+    accumulated_precipitation=PRECIPITATION_MILLIMETERS,
     length=LENGTH_KILOMETERS,
-    wind_speed=SPEED_METERS_PER_SECOND,
-    volume=VOLUME_LITERS,
     mass=MASS_GRAMS,
     pressure=PRESSURE_PA,
-    accumulated_precipitation=PRECIPITATION_MILLIMETERS,
+    temperature=TEMP_CELSIUS,
+    volume=VOLUME_LITERS,
+    wind_speed=SPEED_METERS_PER_SECOND,
 )
 
 US_CUSTOMARY_SYSTEM = UnitSystem(
     _CONF_UNIT_SYSTEM_US_CUSTOMARY,
-    temperature=TEMP_FAHRENHEIT,
+    accumulated_precipitation=PRECIPITATION_INCHES,
     length=LENGTH_MILES,
-    wind_speed=SPEED_MILES_PER_HOUR,
-    volume=VOLUME_GALLONS,
     mass=MASS_POUNDS,
     pressure=PRESSURE_PSI,
-    accumulated_precipitation=PRECIPITATION_INCHES,
+    temperature=TEMP_FAHRENHEIT,
+    volume=VOLUME_GALLONS,
+    wind_speed=SPEED_MILES_PER_HOUR,
 )
 
 IMPERIAL_SYSTEM = US_CUSTOMARY_SYSTEM

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -9,15 +9,15 @@ import voluptuous as vol
 from homeassistant.const import (
     ACCUMULATED_PRECIPITATION,
     LENGTH,
-    LENGTH_INCHES,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
-    LENGTH_MILLIMETERS,
     MASS,
     MASS_GRAMS,
     MASS_KILOGRAMS,
     MASS_OUNCES,
     MASS_POUNDS,
+    PRECIPITATION_INCHES,
+    PRECIPITATION_MILLIMETERS,
     PRESSURE,
     PRESSURE_PA,
     PRESSURE_PSI,
@@ -87,6 +87,7 @@ class UnitSystem:
     def __init__(
         self,
         name: str,
+        *,
         temperature: str,
         length: str,
         wind_speed: str,
@@ -241,24 +242,24 @@ validate_unit_system = vol.All(
 
 METRIC_SYSTEM = UnitSystem(
     _CONF_UNIT_SYSTEM_METRIC,
-    TEMP_CELSIUS,
-    LENGTH_KILOMETERS,
-    SPEED_METERS_PER_SECOND,
-    VOLUME_LITERS,
-    MASS_GRAMS,
-    PRESSURE_PA,
-    LENGTH_MILLIMETERS,
+    temperature=TEMP_CELSIUS,
+    length=LENGTH_KILOMETERS,
+    wind_speed=SPEED_METERS_PER_SECOND,
+    volume=VOLUME_LITERS,
+    mass=MASS_GRAMS,
+    pressure=PRESSURE_PA,
+    accumulated_precipitation=PRECIPITATION_MILLIMETERS,
 )
 
 US_CUSTOMARY_SYSTEM = UnitSystem(
     _CONF_UNIT_SYSTEM_US_CUSTOMARY,
-    TEMP_FAHRENHEIT,
-    LENGTH_MILES,
-    SPEED_MILES_PER_HOUR,
-    VOLUME_GALLONS,
-    MASS_POUNDS,
-    PRESSURE_PSI,
-    LENGTH_INCHES,
+    temperature=TEMP_FAHRENHEIT,
+    length=LENGTH_MILES,
+    wind_speed=SPEED_MILES_PER_HOUR,
+    volume=VOLUME_GALLONS,
+    mass=MASS_POUNDS,
+    pressure=PRESSURE_PSI,
+    accumulated_precipitation=PRECIPITATION_INCHES,
 )
 
 IMPERIAL_SYSTEM = US_CUSTOMARY_SYSTEM

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -43,13 +43,13 @@ def _set_up_units(hass):
     """Set up the tests."""
     hass.config.units = UnitSystem(
         "custom",
-        TEMP_CELSIUS,
-        LENGTH_METERS,
-        SPEED_KILOMETERS_PER_HOUR,
-        VOLUME_LITERS,
-        MASS_GRAMS,
-        PRESSURE_PA,
-        LENGTH_MILLIMETERS,
+        temperature=TEMP_CELSIUS,
+        length=LENGTH_METERS,
+        wind_speed=SPEED_KILOMETERS_PER_HOUR,
+        volume=VOLUME_LITERS,
+        mass=MASS_GRAMS,
+        pressure=PRESSURE_PA,
+        accumulated_precipitation=LENGTH_MILLIMETERS,
     )
 
 

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -39,85 +39,85 @@ def test_invalid_units():
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            INVALID_UNIT,
-            LENGTH_METERS,
-            SPEED_METERS_PER_SECOND,
-            VOLUME_LITERS,
-            MASS_GRAMS,
-            PRESSURE_PA,
-            LENGTH_MILLIMETERS,
+            temperature=INVALID_UNIT,
+            length=LENGTH_METERS,
+            wind_speed=SPEED_METERS_PER_SECOND,
+            volume=VOLUME_LITERS,
+            mass=MASS_GRAMS,
+            pressure=PRESSURE_PA,
+            accumulated_precipitation=LENGTH_MILLIMETERS,
         )
 
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            TEMP_CELSIUS,
-            INVALID_UNIT,
-            SPEED_METERS_PER_SECOND,
-            VOLUME_LITERS,
-            MASS_GRAMS,
-            PRESSURE_PA,
-            LENGTH_MILLIMETERS,
+            temperature=TEMP_CELSIUS,
+            length=INVALID_UNIT,
+            wind_speed=SPEED_METERS_PER_SECOND,
+            volume=VOLUME_LITERS,
+            mass=MASS_GRAMS,
+            pressure=PRESSURE_PA,
+            accumulated_precipitation=LENGTH_MILLIMETERS,
         )
 
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            TEMP_CELSIUS,
-            LENGTH_METERS,
-            INVALID_UNIT,
-            VOLUME_LITERS,
-            MASS_GRAMS,
-            PRESSURE_PA,
-            LENGTH_MILLIMETERS,
+            temperature=TEMP_CELSIUS,
+            length=LENGTH_METERS,
+            wind_speed=INVALID_UNIT,
+            volume=VOLUME_LITERS,
+            mass=MASS_GRAMS,
+            pressure=PRESSURE_PA,
+            accumulated_precipitation=LENGTH_MILLIMETERS,
         )
 
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            TEMP_CELSIUS,
-            LENGTH_METERS,
-            SPEED_METERS_PER_SECOND,
-            INVALID_UNIT,
-            MASS_GRAMS,
-            PRESSURE_PA,
-            LENGTH_MILLIMETERS,
+            temperature=TEMP_CELSIUS,
+            length=LENGTH_METERS,
+            wind_speed=SPEED_METERS_PER_SECOND,
+            volume=INVALID_UNIT,
+            mass=MASS_GRAMS,
+            pressure=PRESSURE_PA,
+            accumulated_precipitation=LENGTH_MILLIMETERS,
         )
 
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            TEMP_CELSIUS,
-            LENGTH_METERS,
-            SPEED_METERS_PER_SECOND,
-            VOLUME_LITERS,
-            INVALID_UNIT,
-            PRESSURE_PA,
-            LENGTH_MILLIMETERS,
+            temperature=TEMP_CELSIUS,
+            length=LENGTH_METERS,
+            wind_speed=SPEED_METERS_PER_SECOND,
+            volume=VOLUME_LITERS,
+            mass=INVALID_UNIT,
+            pressure=PRESSURE_PA,
+            accumulated_precipitation=LENGTH_MILLIMETERS,
         )
 
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            TEMP_CELSIUS,
-            LENGTH_METERS,
-            SPEED_METERS_PER_SECOND,
-            VOLUME_LITERS,
-            MASS_GRAMS,
-            INVALID_UNIT,
-            LENGTH_MILLIMETERS,
+            temperature=TEMP_CELSIUS,
+            length=LENGTH_METERS,
+            wind_speed=SPEED_METERS_PER_SECOND,
+            volume=VOLUME_LITERS,
+            mass=MASS_GRAMS,
+            pressure=INVALID_UNIT,
+            accumulated_precipitation=LENGTH_MILLIMETERS,
         )
 
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            TEMP_CELSIUS,
-            LENGTH_METERS,
-            SPEED_METERS_PER_SECOND,
-            VOLUME_LITERS,
-            MASS_GRAMS,
-            PRESSURE_PA,
-            INVALID_UNIT,
+            temperature=TEMP_CELSIUS,
+            length=LENGTH_METERS,
+            wind_speed=SPEED_METERS_PER_SECOND,
+            volume=VOLUME_LITERS,
+            mass=MASS_GRAMS,
+            pressure=PRESSURE_PA,
+            accumulated_precipitation=INVALID_UNIT,
         )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enforce kwargs in unit system initialisation
As discussed with @emontnemery in https://github.com/home-assistant/core/pull/80604#discussion_r999522316

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
