### PR TITLE
Fix Goodwe spinlock

### DIFF
--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -209,7 +209,7 @@ class InverterSensor(CoordinatorEntity, SensorEntity):
             self._previous_value = 0
             self.coordinator.data[self._sensor.id_] = 0
             self.async_write_ha_state()
-        next_midnight = dt_util.start_of_local_day(dt_util.utcnow() + timedelta(days=1))
+        next_midnight = dt_util.start_of_local_day(dt_util.now() + timedelta(days=1, minutes=1))
         self._stop_reset = async_track_point_in_time(
             self.hass, self.async_reset, next_midnight
         )
@@ -218,7 +218,7 @@ class InverterSensor(CoordinatorEntity, SensorEntity):
         """Schedule reset task at midnight."""
         if self._sensor.id_ in DAILY_RESET:
             next_midnight = dt_util.start_of_local_day(
-                dt_util.utcnow() + timedelta(days=1)
+                dt_util.now() + timedelta(days=1)
             )
             self._stop_reset = async_track_point_in_time(
                 self.hass, self.async_reset, next_midnight

--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -1,11 +1,10 @@
 """Support for GoodWe inverter via UDP."""
-import logging
-
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
+import logging
 from typing import Any, cast
 
 from goodwe import Inverter, Sensor, SensorKind
@@ -213,8 +212,10 @@ class InverterSensor(CoordinatorEntity, SensorEntity):
             self._previous_value = 0
             self.coordinator.data[self._sensor.id_] = 0
             self.async_write_ha_state()
-            _LOGGER.debug(f"Goodwe reset {self.name} to 0")
-        next_midnight = dt_util.start_of_local_day(dt_util.now() + timedelta(days=1, minutes=1))
+            _LOGGER.debug("Goodwe reset %s to 0", self.name)
+        next_midnight = dt_util.start_of_local_day(
+            dt_util.now() + timedelta(days=1, minutes=1)
+        )
         self._stop_reset = async_track_point_in_time(
             self.hass, self.async_reset, next_midnight
         )

--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -1,4 +1,6 @@
 """Support for GoodWe inverter via UDP."""
+import logging
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -35,6 +37,8 @@ from homeassistant.helpers.update_coordinator import (
 import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN, KEY_COORDINATOR, KEY_DEVICE_INFO, KEY_INVERTER
+
+_LOGGER = logging.getLogger(__name__)
 
 # Sensor name of battery SoC
 BATTERY_SOC = "battery_soc"
@@ -209,6 +213,7 @@ class InverterSensor(CoordinatorEntity, SensorEntity):
             self._previous_value = 0
             self.coordinator.data[self._sensor.id_] = 0
             self.async_write_ha_state()
+            _LOGGER.debug(f"Goodwe reset {self.name} to 0")
         next_midnight = dt_util.start_of_local_day(dt_util.now() + timedelta(days=1, minutes=1))
         self._stop_reset = async_track_point_in_time(
             self.hass, self.async_reset, next_midnight


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As explained in this issue: https://github.com/home-assistant/core/issues/80145 the Goodwe integration is causing high CPU load between midnight and midnight + the UTC offset of the timezone.
I myself also see high CPU between midnight (00:00) and 2AM (02:00), I am in timezone UTC+2.

The next_midnight is not calculated correclty and gives the already pasted midnight (between midnigth and the UTC offset), this causes the callback to fire imediatly and this causes a spin of the callback which locks up the CPU.
~At least I highly suspect that is what is going on.~

I think the problem is utcnow is used instead of now, (utc vs local time).

~Still needs testing to make sure it is now fixed.~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/80145 https://github.com/home-assistant/core/issues/80588
- This PR is related to issue: https://github.com/home-assistant/core/issues/80216 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
