### PR TITLE
Join lists when using !include_dir_merge_named in configuration.yaml

### DIFF
--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -291,10 +291,17 @@ def _include_dir_merge_named_yaml(
             continue
         loaded_yaml = load_yaml(fname, loader.secrets)
         if isinstance(loaded_yaml, dict):
+            # If the loaded_yaml contains keys that already have been set
+            # when updating a previous file, we do not want to overwrite the
+            # values of those keys in case they hold a list
             for key, value in loaded_yaml.items():
                 if key not in mapping:
+                    # We can update the key since there is no previous one
                     continue
                 if isinstance(value, list) and isinstance(mapping[key], list):
+                    # If we already have a list instance and the new instance
+                    # is also a list, we merge the list by appending them
+                    # This allows merging keyed entity lists over multiple files
                     loaded_yaml[key] = mapping[key] + loaded_yaml[key]
             mapping.update(loaded_yaml)
     return _add_reference(mapping, loader, node)

--- a/tests/util/yaml/test_init.py
+++ b/tests/util/yaml/test_init.py
@@ -262,6 +262,29 @@ def test_include_dir_merge_named(mock_walk, try_both_loaders):
 
 
 @patch("homeassistant.util.yaml.loader.os.walk")
+def test_join_lists_include_dir_merge_named(mock_walk, try_both_loaders):
+    """Test joining mqtt entity lists with include dir merge named yaml."""
+    mock_walk.return_value = [["/test", [], ["first.yaml", "second.yaml"]]]
+
+    files = {
+        "/test/first.yaml": "sensor:\n  - name: entity_1",
+        "/test/second.yaml": "sensor:\n  - name: entity_2\n  - name: entity_3",
+    }
+
+    with patch_yaml_files(files):
+        conf = "mqtt: !include_dir_merge_named /test"
+        with io.StringIO(conf) as file:
+            doc = yaml_loader.yaml.load(file, Loader=yaml_loader.SafeLineLoader)
+            assert doc["key"] == {
+                "sensor": [
+                    {"name": "entity_1"},
+                    {"name": "entity_2"},
+                    {"name": "entity_3"},
+                ]
+            }
+
+
+@patch("homeassistant.util.yaml.loader.os.walk")
 def test_include_dir_merge_named_recursive(mock_walk, try_both_loaders):
     """Test include dir merge named yaml."""
     mock_walk.return_value = [

--- a/tests/util/yaml/test_init.py
+++ b/tests/util/yaml/test_init.py
@@ -275,7 +275,7 @@ def test_join_lists_include_dir_merge_named(mock_walk, try_both_loaders):
         conf = "mqtt: !include_dir_merge_named /test"
         with io.StringIO(conf) as file:
             doc = yaml_loader.yaml.load(file, Loader=yaml_loader.SafeLineLoader)
-            assert doc["key"] == {
+            assert doc["mqtt"] == {
                 "sensor": [
                     {"name": "entity_1"},
                     {"name": "entity_2"},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
!include_dir_merge_named when used in `configuration.yaml`  does not merging lists since the dictionary is updated with the content of the last file, only the last key update will survive.
To split up manual added MQTT items the entities must be referenced per platform.

E.g. :
```yaml
mqtt:
  sensor: !include_dir_merge_named /test/sensor
```
The files must contain entity lists.

When using:
```yaml
mqtt: !include_dir_merge_named /test/sensor
```
And adding the platform key to the files that are to be merged only the entities of the last loaded file will be loaded.

This PR makes it possible to join entity lists if the root key in file contains a `list`.

Say we have 3 files to me merged:

FIle 1:

```yaml
sensor:
  - name: issue80046_1
    state_topic: test/80046_1/value
```

FIle 2:

```yaml
sensor:
  - name: issue80046_2
    state_topic: test/80046_2/value
```

File 3:

```yaml
sensor:
  - name: issue80046_3a
    state_topic: test/80046_3a/value
  - name: issue80046_3b
    state_topic: test/80046_3b/value
```

This PR will for example join the 3 lists and import all 4 sensors.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80046
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
