### PR TITLE
Add camera last image endpoint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,11 @@
   "postStartCommand": "script/bootstrap",
   "containerEnv": { "DEVCONTAINER": "1" },
   "appPort": 8123,
+  "portsAttributes": {
+    "8123": {
+      "label": "Home Assistant"
+    }
+  },
   "runArgs": ["-e", "GIT_EDITOR=code --wait"],
   "extensions": [
     "ms-python.vscode-pylance",
@@ -16,6 +21,7 @@
   ],
   // Please keep this file in sync with settings in home-assistant/.vscode/settings.default.json
   "settings": {
+    "remote.autoForwardPorts": false,
     "python.pythonPath": "/usr/local/bin/python",
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": true,

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9
+FROM mcr.microsoft.com/devcontainers/python:0-3.10
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -29,6 +29,7 @@ RUN \
         libturbojpeg0 \
         libyaml-dev \
         libxml2 \
+        ffmpeg \
         git \
         cmake \
     && apt-get clean \

--- a/homeassistant/components/prusalink/camera.py
+++ b/homeassistant/components/prusalink/camera.py
@@ -23,7 +23,7 @@ class PrusaLinkJobPreviewEntity(PrusaLinkEntity, Camera):
     """Defines a PrusaLink camera."""
 
     last_path = ""
-    last_image: bytes
+    prusa_last_image: bytes
     _attr_name = "Job Preview"
 
     def __init__(self, coordinator: JobUpdateCoordinator) -> None:
@@ -47,8 +47,8 @@ class PrusaLinkJobPreviewEntity(PrusaLinkEntity, Camera):
         path = self.coordinator.data["job"]["file"]["path"]
 
         if self.last_path == path:
-            return self.last_image
+            return self.prusa_last_image
 
-        self.last_image = await self.coordinator.api.get_large_thumbnail(path)
+        self.prusa_last_image = await self.coordinator.api.get_large_thumbnail(path)
         self.last_path = path
-        return self.last_image
+        return self.prusa_last_image


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a new endpoint `/api/camera_last_image/<entity-id>` similar to  `/api/camera_proxy/<entity-id>` to serve the last known image.

Under the hoods, HA will save the last image fetched by Home Assistant into memory so that calls to the new endpoint will return an image extremely fast, as opposed to the existing endpoint which triggers different actions for fetching the current image, and depending on the implementation it can take several seconds to return (like my battery-powered Tuya doorbell which takes 10 seconds to wake up).

When this new endpoint gets merged, I plan to send a PR for the frontend to make the Picture Glance card leverage it.

My end goal is to make frontends be able to show something (which may or may not be current) very quickly during the initialization.

Ultimately I want the Frigate Hass Card to leverage this feature (cc @dermotduffy -- your feedback is more than welcome!).

Demo:


https://user-images.githubusercontent.com/29582865/196784868-1bf1ac58-6efb-4aaa-bff0-8b0d71ff0e3b.mp4



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: TODO

I updated some devcontainer related configurations as well, and while I think they are self-explanatory, I would be happy to clarify each if needed.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
