### PR TITLE
Refactor KNX Config and Options flows

### DIFF
--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -561,6 +561,6 @@ async def scan_for_gateways(stop_on_found: int = 0) -> list[GatewayDescriptor]:
     """Scan for gateways within the network."""
     xknx = XKNX()
     gatewayscanner = GatewayScanner(
-        xknx, stop_on_found=stop_on_found, timeout_in_seconds=3
+        xknx, stop_on_found=stop_on_found, timeout_in_seconds=2
     )
     return await gatewayscanner.scan()

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -432,7 +432,7 @@ class KNXCommonFlow(ABC, FlowHandler):
                 )
                 return self.finish_flow(
                     new_entry_data=entry_data,
-                    title=CONF_KNX_ROUTING.capitalize(),
+                    title=f"Routing as {_individual_address}",
                 )
 
         fields = {

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -47,7 +47,6 @@ from .schema import ia_validator, ip_v4_validator
 
 CONF_KNX_GATEWAY: Final = "gateway"
 CONF_MAX_RATE_LIMIT: Final = 60
-CONF_DEFAULT_LOCAL_IP: Final = "0.0.0.0"
 
 DEFAULT_ENTRY_DATA = KNXConfigEntryData(
     individual_address=XKNX.DEFAULT_ADDRESS,

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -268,6 +268,8 @@ class KNXCommonFlow(ABC, FlowHandler):
         if self.show_advanced_options:
             fields[vol.Optional(CONF_KNX_LOCAL_IP)] = _IP_SELECTOR
 
+        if not self._found_tunnels:
+            errors["base"] = "no_tunnel_discovered"
         return self.async_show_form(
             step_id="manual_tunnel", data_schema=vol.Schema(fields), errors=errors
         )
@@ -407,6 +409,10 @@ class KNXCommonFlow(ABC, FlowHandler):
             # Optional with default doesn't work properly in flow UI
             fields[vol.Optional(CONF_KNX_LOCAL_IP)] = _IP_SELECTOR
 
+        if not any(
+            router for router in self._found_gateways if router.supports_routing
+        ):
+            errors["base"] = "no_router_discovered"
         return self.async_show_form(
             step_id="routing", data_schema=vol.Schema(fields), errors=errors
         )

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -608,6 +608,6 @@ async def scan_for_gateways(stop_on_found: int = 0) -> list[GatewayDescriptor]:
     """Scan for gateways within the network."""
     xknx = XKNX()
     gatewayscanner = GatewayScanner(
-        xknx, stop_on_found=stop_on_found, timeout_in_seconds=2
+        xknx, stop_on_found=stop_on_found, timeout_in_seconds=3
     )
     return await gatewayscanner.scan()

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -31,7 +31,7 @@
         "description": "Select how you want to configure KNX/IP Secure.",
         "menu_options": {
           "secure_knxkeys": "Use a `.knxkeys` file containing IP secure keys",
-          "secure_manual": "Configure IP secure keys manually"
+          "secure_tunnel_manual": "Configure IP secure keys manually"
         }
       },
       "secure_knxkeys": {
@@ -45,7 +45,7 @@
           "knxkeys_password": "This was set when exporting the file from ETS."
         }
       },
-      "secure_manual": {
+      "secure_tunnel_manual": {
         "description": "Please enter your IP secure information.",
         "data": {
           "user_id": "User ID",

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -19,11 +19,13 @@
           "tunneling_type": "KNX Tunneling Type",
           "port": "[%key:common::config_flow::data::port%]",
           "host": "[%key:common::config_flow::data::host%]",
+          "route_back": "Route back / NAT mode",
           "local_ip": "Local IP of Home Assistant"
         },
         "data_description": {
           "port": "Port of the KNX/IP tunneling device.",
           "host": "IP address of the KNX/IP tunneling device.",
+          "route_back": "Enable if your KNXnet/IP tunneling server is behind NAT. Only applies for UDP connections.",
           "local_ip": "Leave blank to use auto-discovery."
         }
       },
@@ -122,11 +124,13 @@
           "tunneling_type": "[%key:component::knx::config::step::manual_tunnel::data::tunneling_type%]",
           "port": "[%key:common::config_flow::data::port%]",
           "host": "[%key:common::config_flow::data::host%]",
+          "route_back": "[%key:component::knx::config::step::manual_tunnel::data::route_back%]",
           "local_ip": "[%key:component::knx::config::step::manual_tunnel::data::local_ip%]"
         },
         "data_description": {
           "port": "[%key:component::knx::config::step::manual_tunnel::data_description::port%]",
           "host": "[%key:component::knx::config::step::manual_tunnel::data_description::host%]",
+          "route_back": "[%key:component::knx::config::step::manual_tunnel::data_description::route_back%]",
           "local_ip": "[%key:component::knx::config::step::manual_tunnel::data_description::local_ip%]"
         }
       },

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -172,6 +172,13 @@
           "local_ip": "[%key:component::knx::config::step::routing::data_description::local_ip%]"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_individual_address": "[%key:component::knx::config::error::invalid_individual_address%]",
+      "invalid_ip_address": "[%key:component::knx::config::error::invalid_ip_address%]",
+      "invalid_signature": "[%key:component::knx::config::error::invalid_signature%]",
+      "file_not_found": "[%key:component::knx::config::error::file_not_found%]"
     }
   }
 }

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "type": {
+      "connection_type": {
         "description": "Please enter the connection type we should use for your KNX connection. \n AUTOMATIC - The integration takes care of the connectivity to your KNX Bus by performing a gateway scan. \n TUNNELING - The integration will connect to your KNX bus via tunneling. \n ROUTING - The integration will connect to your KNX bus via routing.",
         "data": {
           "connection_type": "KNX Connection Type"
@@ -86,34 +86,90 @@
   },
   "options": {
     "step": {
-      "init": {
+      "options_init": {
+        "menu_options": {
+          "connection_type": "Configure KNX interface",
+          "communication_settings": "Communication settings"
+        }
+      },
+      "communication_settings": {
         "data": {
-          "connection_type": "KNX Connection Type",
-          "individual_address": "Default individual address",
-          "multicast_group": "[%key:component::knx::config::step::routing::data::multicast_group%]",
-          "multicast_port": "[%key:component::knx::config::step::routing::data::multicast_port%]",
-          "local_ip": "Local IP of Home Assistant",
           "state_updater": "State updater",
           "rate_limit": "Rate limit"
         },
         "data_description": {
-          "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`",
-          "multicast_group": "Used for routing and discovery. Default: `224.0.23.12`",
-          "multicast_port": "Used for routing and discovery. Default: `3671`",
-          "local_ip": "Use `0.0.0.0` for auto-discovery.",
           "state_updater": "Set default for reading states from the KNX Bus. When disabled, Home Assistant will not actively retrieve entity states from the KNX Bus. Can be overridden by `sync_state` entity options.",
-          "rate_limit": "Maximum outgoing telegrams per second.\nRecommended: 20 to 40"
+          "rate_limit": "Maximum outgoing telegrams per second.\n`0` to disable limit. Recommended: 0 or 20 to 40"
+        }
+      },
+      "connection_type": {
+        "description": "Please enter the connection type we should use for your KNX connection. \n AUTOMATIC - The integration takes care of the connectivity to your KNX Bus by performing a gateway scan. \n TUNNELING - The integration will connect to your KNX bus via tunneling. \n ROUTING - The integration will connect to your KNX bus via routing.",
+        "data": {
+          "connection_type": "KNX Connection Type"
         }
       },
       "tunnel": {
+        "description": "[%key:component::knx::config::step::tunnel::description%]",
         "data": {
-          "tunneling_type": "KNX Tunneling Type",
+          "gateway": "[%key:component::knx::config::step::tunnel::data::gateway%]"
+        }
+      },
+      "manual_tunnel": {
+        "description": "[%key:component::knx::config::step::manual_tunnel::description%]",
+        "data": {
+          "tunneling_type": "[%key:component::knx::config::step::manual_tunnel::data::tunneling_type%]",
           "port": "[%key:common::config_flow::data::port%]",
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "local_ip": "[%key:component::knx::config::step::manual_tunnel::data::local_ip%]"
         },
         "data_description": {
           "port": "[%key:component::knx::config::step::manual_tunnel::data_description::port%]",
-          "host": "[%key:component::knx::config::step::manual_tunnel::data_description::host%]"
+          "host": "[%key:component::knx::config::step::manual_tunnel::data_description::host%]",
+          "local_ip": "[%key:component::knx::config::step::manual_tunnel::data_description::local_ip%]"
+        }
+      },
+      "secure_tunneling": {
+        "description": "[%key:component::knx::config::step::secure_tunneling::description%]",
+        "menu_options": {
+          "secure_knxkeys": "[%key:component::knx::config::step::secure_tunneling::menu_options::secure_knxkeys%]",
+          "secure_tunnel_manual": "[%key:component::knx::config::step::secure_tunneling::menu_options::secure_tunnel_manual%]"
+        }
+      },
+      "secure_knxkeys": {
+        "description": "[%key:component::knx::config::step::secure_knxkeys::description%]",
+        "data": {
+          "knxkeys_filename": "[%key:component::knx::config::step::secure_knxkeys::data::knxkeys_filename%]",
+          "knxkeys_password": "[%key:component::knx::config::step::secure_knxkeys::data::knxkeys_password%]"
+        },
+        "data_description": {
+          "knxkeys_filename": "[%key:component::knx::config::step::secure_knxkeys::data_description::knxkeys_filename%]",
+          "knxkeys_password": "[%key:component::knx::config::step::secure_knxkeys::data_description::knxkeys_password%]"
+        }
+      },
+      "secure_tunnel_manual": {
+        "description": "[%key:component::knx::config::step::secure_tunnel_manual::description%]",
+        "data": {
+          "user_id": "[%key:component::knx::config::step::secure_tunnel_manual::data::user_id%]",
+          "user_password": "[%key:component::knx::config::step::secure_tunnel_manual::data::user_password%]",
+          "device_authentication": "[%key:component::knx::config::step::secure_tunnel_manual::data::device_authentication%]"
+        },
+        "data_description": {
+          "user_id": "[%key:component::knx::config::step::secure_tunnel_manual::data_description::user_id%]",
+          "user_password": "[%key:component::knx::config::step::secure_tunnel_manual::data_description::user_password%]",
+          "device_authentication": "[%key:component::knx::config::step::secure_tunnel_manual::data_description::device_authentication%]"
+        }
+      },
+      "routing": {
+        "description": "[%key:component::knx::config::step::routing::description%]",
+        "data": {
+          "individual_address": "[%key:component::knx::config::step::routing::data::individual_address%]",
+          "multicast_group": "[%key:component::knx::config::step::routing::data::multicast_group%]",
+          "multicast_port": "[%key:component::knx::config::step::routing::data::multicast_port%]",
+          "local_ip": "[%key:component::knx::config::step::routing::data::local_ip%]"
+        },
+        "data_description": {
+          "individual_address": "[%key:component::knx::config::step::routing::data_description::individual_address%]",
+          "local_ip": "[%key:component::knx::config::step::routing::data_description::local_ip%]"
         }
       }
     }

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -81,7 +81,9 @@
       "invalid_individual_address": "Value does not match pattern for KNX individual address.\n'area.line.device'",
       "invalid_ip_address": "Invalid IPv4 address.",
       "invalid_signature": "The password to decrypt the `.knxkeys` file is wrong.",
-      "file_not_found": "The specified `.knxkeys` file was not found in the path config/.storage/knx/"
+      "file_not_found": "The specified `.knxkeys` file was not found in the path config/.storage/knx/",
+      "no_router_discovered": "No KNXnet/IP router was discovered on the network.",
+      "no_tunnel_discovered": "Could not find a KNX tunneling server on your network."
     }
   },
   "options": {
@@ -178,7 +180,9 @@
       "invalid_individual_address": "[%key:component::knx::config::error::invalid_individual_address%]",
       "invalid_ip_address": "[%key:component::knx::config::error::invalid_ip_address%]",
       "invalid_signature": "[%key:component::knx::config::error::invalid_signature%]",
-      "file_not_found": "[%key:component::knx::config::error::file_not_found%]"
+      "file_not_found": "[%key:component::knx::config::error::file_not_found%]",
+      "no_router_discovered": "[%key:component::knx::config::error::no_router_discovered%]",
+      "no_tunnel_discovered": "[%key:component::knx::config::error::no_tunnel_discovered%]"
     }
   }
 }

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -9,7 +9,9 @@
             "file_not_found": "The specified `.knxkeys` file was not found in the path config/.storage/knx/",
             "invalid_individual_address": "Value does not match pattern for KNX individual address.\n'area.line.device'",
             "invalid_ip_address": "Invalid IPv4 address.",
-            "invalid_signature": "The password to decrypt the `.knxkeys` file is wrong."
+            "invalid_signature": "The password to decrypt the `.knxkeys` file is wrong.",
+            "no_router_discovered": "No KNXnet/IP router was discovered on the network.",
+            "no_tunnel_discovered": "Could not find a KNX tunneling server on your network."
         },
         "step": {
             "connection_type": {
@@ -90,7 +92,9 @@
             "file_not_found": "The specified `.knxkeys` file was not found in the path config/.storage/knx/",
             "invalid_individual_address": "Value does not match pattern for KNX individual address.\n'area.line.device'",
             "invalid_ip_address": "Invalid IPv4 address.",
-            "invalid_signature": "The password to decrypt the `.knxkeys` file is wrong."
+            "invalid_signature": "The password to decrypt the `.knxkeys` file is wrong.",
+            "no_router_discovered": "No KNXnet/IP router was discovered on the network.",
+            "no_tunnel_discovered": "Could not find a KNX tunneling server on your network."
         },
         "step": {
             "communication_settings": {

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -85,6 +85,13 @@
         }
     },
     "options": {
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "file_not_found": "The specified `.knxkeys` file was not found in the path config/.storage/knx/",
+            "invalid_individual_address": "Value does not match pattern for KNX individual address.\n'area.line.device'",
+            "invalid_ip_address": "Invalid IPv4 address.",
+            "invalid_signature": "The password to decrypt the `.knxkeys` file is wrong."
+        },
         "step": {
             "communication_settings": {
                 "data": {

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -12,6 +12,12 @@
             "invalid_signature": "The password to decrypt the `.knxkeys` file is wrong."
         },
         "step": {
+            "connection_type": {
+                "data": {
+                    "connection_type": "KNX Connection Type"
+                },
+                "description": "Please enter the connection type we should use for your KNX connection. \n AUTOMATIC - The integration takes care of the connectivity to your KNX Bus by performing a gateway scan. \n TUNNELING - The integration will connect to your KNX bus via tunneling. \n ROUTING - The integration will connect to your KNX bus via routing."
+            },
             "manual_tunnel": {
                 "data": {
                     "host": "Host",
@@ -50,7 +56,7 @@
                 },
                 "description": "Please enter the information for your `.knxkeys` file."
             },
-            "secure_manual": {
+            "secure_tunnel_manual": {
                 "data": {
                     "device_authentication": "Device authentication password",
                     "user_id": "User ID",
@@ -67,7 +73,7 @@
                 "description": "Select how you want to configure KNX/IP Secure.",
                 "menu_options": {
                     "secure_knxkeys": "Use a `.knxkeys` file containing IP secure keys",
-                    "secure_manual": "Configure IP secure keys manually"
+                    "secure_tunnel_manual": "Configure IP secure keys manually"
                 }
             },
             "tunnel": {
@@ -75,46 +81,96 @@
                     "gateway": "KNX Tunnel Connection"
                 },
                 "description": "Please select a gateway from the list."
-            },
-            "type": {
-                "data": {
-                    "connection_type": "KNX Connection Type"
-                },
-                "description": "Please enter the connection type we should use for your KNX connection. \n AUTOMATIC - The integration takes care of the connectivity to your KNX Bus by performing a gateway scan. \n TUNNELING - The integration will connect to your KNX bus via tunneling. \n ROUTING - The integration will connect to your KNX bus via routing."
             }
         }
     },
     "options": {
         "step": {
-            "init": {
+            "communication_settings": {
                 "data": {
-                    "connection_type": "KNX Connection Type",
-                    "individual_address": "Default individual address",
-                    "local_ip": "Local IP of Home Assistant",
-                    "multicast_group": "Multicast group",
-                    "multicast_port": "Multicast port",
                     "rate_limit": "Rate limit",
                     "state_updater": "State updater"
                 },
                 "data_description": {
-                    "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`",
-                    "local_ip": "Use `0.0.0.0` for auto-discovery.",
-                    "multicast_group": "Used for routing and discovery. Default: `224.0.23.12`",
-                    "multicast_port": "Used for routing and discovery. Default: `3671`",
-                    "rate_limit": "Maximum outgoing telegrams per second.\nRecommended: 20 to 40",
+                    "rate_limit": "Maximum outgoing telegrams per second.\n`0` to disable limit. Recommended: 0 or 20 to 40",
                     "state_updater": "Set default for reading states from the KNX Bus. When disabled, Home Assistant will not actively retrieve entity states from the KNX Bus. Can be overridden by `sync_state` entity options."
                 }
             },
-            "tunnel": {
+            "connection_type": {
+                "data": {
+                    "connection_type": "KNX Connection Type"
+                },
+                "description": "Please enter the connection type we should use for your KNX connection. \n AUTOMATIC - The integration takes care of the connectivity to your KNX Bus by performing a gateway scan. \n TUNNELING - The integration will connect to your KNX bus via tunneling. \n ROUTING - The integration will connect to your KNX bus via routing."
+            },
+            "manual_tunnel": {
                 "data": {
                     "host": "Host",
+                    "local_ip": "Local IP of Home Assistant",
                     "port": "Port",
                     "tunneling_type": "KNX Tunneling Type"
                 },
                 "data_description": {
                     "host": "IP address of the KNX/IP tunneling device.",
+                    "local_ip": "Leave blank to use auto-discovery.",
                     "port": "Port of the KNX/IP tunneling device."
+                },
+                "description": "Please enter the connection information of your tunneling device."
+            },
+            "options_init": {
+                "menu_options": {
+                    "communication_settings": "Communication settings",
+                    "connection_type": "Configure KNX interface"
                 }
+            },
+            "routing": {
+                "data": {
+                    "individual_address": "Individual address",
+                    "local_ip": "Local IP of Home Assistant",
+                    "multicast_group": "Multicast group",
+                    "multicast_port": "Multicast port"
+                },
+                "data_description": {
+                    "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`",
+                    "local_ip": "Leave blank to use auto-discovery."
+                },
+                "description": "Please configure the routing options."
+            },
+            "secure_knxkeys": {
+                "data": {
+                    "knxkeys_filename": "The filename of your `.knxkeys` file (including extension)",
+                    "knxkeys_password": "The password to decrypt the `.knxkeys` file"
+                },
+                "data_description": {
+                    "knxkeys_filename": "The file is expected to be found in your config directory in `.storage/knx/`.\nIn Home Assistant OS this would be `/config/.storage/knx/`\nExample: `my_project.knxkeys`",
+                    "knxkeys_password": "This was set when exporting the file from ETS."
+                },
+                "description": "Please enter the information for your `.knxkeys` file."
+            },
+            "secure_tunnel_manual": {
+                "data": {
+                    "device_authentication": "Device authentication password",
+                    "user_id": "User ID",
+                    "user_password": "User password"
+                },
+                "data_description": {
+                    "device_authentication": "This is set in the 'IP' panel of the interface in ETS.",
+                    "user_id": "This is often tunnel number +1. So 'Tunnel 2' would have User-ID '3'.",
+                    "user_password": "Password for the specific tunnel connection set in the 'Properties' panel of the tunnel in ETS."
+                },
+                "description": "Please enter your IP secure information."
+            },
+            "secure_tunneling": {
+                "description": "Select how you want to configure KNX/IP Secure.",
+                "menu_options": {
+                    "secure_knxkeys": "Use a `.knxkeys` file containing IP secure keys",
+                    "secure_tunnel_manual": "Configure IP secure keys manually"
+                }
+            },
+            "tunnel": {
+                "data": {
+                    "gateway": "KNX Tunnel Connection"
+                },
+                "description": "Please select a gateway from the list."
             }
         }
     }

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -25,12 +25,14 @@
                     "host": "Host",
                     "local_ip": "Local IP of Home Assistant",
                     "port": "Port",
+                    "route_back": "Route back / NAT mode",
                     "tunneling_type": "KNX Tunneling Type"
                 },
                 "data_description": {
                     "host": "IP address of the KNX/IP tunneling device.",
                     "local_ip": "Leave blank to use auto-discovery.",
-                    "port": "Port of the KNX/IP tunneling device."
+                    "port": "Port of the KNX/IP tunneling device.",
+                    "route_back": "Enable if your KNXnet/IP tunneling server is behind NAT. Only applies for UDP connections."
                 },
                 "description": "Please enter the connection information of your tunneling device."
             },
@@ -118,12 +120,14 @@
                     "host": "Host",
                     "local_ip": "Local IP of Home Assistant",
                     "port": "Port",
+                    "route_back": "Route back / NAT mode",
                     "tunneling_type": "KNX Tunneling Type"
                 },
                 "data_description": {
                     "host": "IP address of the KNX/IP tunneling device.",
                     "local_ip": "Leave blank to use auto-discovery.",
-                    "port": "Port of the KNX/IP tunneling device."
+                    "port": "Port of the KNX/IP tunneling device.",
+                    "route_back": "Enable if your KNXnet/IP tunneling server is behind NAT. Only applies for UDP connections."
                 },
                 "description": "Please enter the connection information of your tunneling device."
             },

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -9,10 +9,6 @@ from xknx.io.gateway_scanner import GatewayDescriptor
 from homeassistant import config_entries
 from homeassistant.components.knx.config_flow import (
     CONF_KNX_GATEWAY,
-    CONF_KNX_LABEL_TUNNELING_TCP,
-    CONF_KNX_LABEL_TUNNELING_TCP_SECURE,
-    CONF_KNX_LABEL_TUNNELING_UDP,
-    CONF_KNX_LABEL_TUNNELING_UDP_ROUTE_BACK,
     CONF_KNX_TUNNELING_TYPE,
     DEFAULT_ENTRY_DATA,
     OPTION_MANUAL_TUNNEL,
@@ -206,9 +202,10 @@ async def test_routing_setup_advanced(hass: HomeAssistant) -> None:
     [
         (
             {
-                CONF_KNX_TUNNELING_TYPE: CONF_KNX_LABEL_TUNNELING_UDP,
+                CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING,
                 CONF_HOST: "192.168.0.1",
                 CONF_PORT: 3675,
+                CONF_KNX_ROUTE_BACK: False,
             },
             {
                 **DEFAULT_ENTRY_DATA,
@@ -222,9 +219,10 @@ async def test_routing_setup_advanced(hass: HomeAssistant) -> None:
         ),
         (
             {
-                CONF_KNX_TUNNELING_TYPE: CONF_KNX_LABEL_TUNNELING_TCP,
+                CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING_TCP,
                 CONF_HOST: "192.168.0.1",
                 CONF_PORT: 3675,
+                CONF_KNX_ROUTE_BACK: False,
             },
             {
                 **DEFAULT_ENTRY_DATA,
@@ -238,9 +236,10 @@ async def test_routing_setup_advanced(hass: HomeAssistant) -> None:
         ),
         (
             {
-                CONF_KNX_TUNNELING_TYPE: CONF_KNX_LABEL_TUNNELING_UDP_ROUTE_BACK,
+                CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING,
                 CONF_HOST: "192.168.0.1",
                 CONF_PORT: 3675,
+                CONF_KNX_ROUTE_BACK: True,
             },
             {
                 **DEFAULT_ENTRY_DATA,
@@ -322,7 +321,7 @@ async def test_tunneling_setup_for_local_ip(hass: HomeAssistant) -> None:
     result_invalid_host = await hass.config_entries.flow.async_configure(
         result2["flow_id"],
         {
-            CONF_KNX_TUNNELING_TYPE: CONF_KNX_LABEL_TUNNELING_UDP,
+            CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING,
             CONF_HOST: DEFAULT_MCAST_GRP,  # multicast addresses are invalid
             CONF_PORT: 3675,
             CONF_KNX_LOCAL_IP: "192.168.1.112",
@@ -339,7 +338,7 @@ async def test_tunneling_setup_for_local_ip(hass: HomeAssistant) -> None:
     result_invalid_local = await hass.config_entries.flow.async_configure(
         result2["flow_id"],
         {
-            CONF_KNX_TUNNELING_TYPE: CONF_KNX_LABEL_TUNNELING_UDP,
+            CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING,
             CONF_HOST: "192.168.0.2",
             CONF_PORT: 3675,
             CONF_KNX_LOCAL_IP: "asdf",
@@ -361,7 +360,7 @@ async def test_tunneling_setup_for_local_ip(hass: HomeAssistant) -> None:
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
             {
-                CONF_KNX_TUNNELING_TYPE: CONF_KNX_LABEL_TUNNELING_UDP,
+                CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING,
                 CONF_HOST: "192.168.0.2",
                 CONF_PORT: 3675,
                 CONF_KNX_LOCAL_IP: "192.168.1.112",
@@ -582,7 +581,7 @@ async def test_get_secure_menu_step_manual_tunnelling(
     result3 = await hass.config_entries.flow.async_configure(
         manual_tunnel_flow["flow_id"],
         {
-            CONF_KNX_TUNNELING_TYPE: CONF_KNX_LABEL_TUNNELING_TCP_SECURE,
+            CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
             CONF_HOST: "192.168.0.1",
             CONF_PORT: 3675,
         },

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -586,23 +586,23 @@ async def test_get_secure_menu_step_manual_tunnelling(
     assert result3["step_id"] == "secure_tunneling"
 
 
-async def test_configure_secure_manual(hass: HomeAssistant):
-    """Test configure secure manual."""
+async def test_configure_secure_tunnel_manual(hass: HomeAssistant):
+    """Test configure tunnelling secure keys manually."""
     menu_step = await _get_menu_step(hass)
 
     result = await hass.config_entries.flow.async_configure(
         menu_step["flow_id"],
-        {"next_step_id": "secure_manual"},
+        {"next_step_id": "secure_tunnel_manual"},
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "secure_manual"
+    assert result["step_id"] == "secure_tunnel_manual"
     assert not result["errors"]
 
     with patch(
         "homeassistant.components.knx.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        secure_manual = await hass.config_entries.flow.async_configure(
+        secure_tunnel_manual = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_KNX_SECURE_USER_ID: 2,
@@ -611,8 +611,8 @@ async def test_configure_secure_manual(hass: HomeAssistant):
             },
         )
         await hass.async_block_till_done()
-        assert secure_manual["type"] == FlowResultType.CREATE_ENTRY
-        assert secure_manual["data"] == {
+        assert secure_tunnel_manual["type"] == FlowResultType.CREATE_ENTRY
+        assert secure_tunnel_manual["data"] == {
             **DEFAULT_ENTRY_DATA,
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
             CONF_KNX_SECURE_USER_ID: 2,

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components.knx.config_flow import (
     CONF_KNX_LABEL_TUNNELING_UDP_ROUTE_BACK,
     CONF_KNX_TUNNELING_TYPE,
     DEFAULT_ENTRY_DATA,
+    OPTION_MANUAL_TUNNEL,
     get_knx_tunneling_type,
 )
 from homeassistant.components.knx.const import (
@@ -41,16 +42,19 @@ from homeassistant.components.knx.const import (
 )
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.data_entry_flow import FlowResult, FlowResultType
 
 from tests.common import MockConfigEntry
 
 
 def _gateway_descriptor(
-    ip: str, port: int, supports_tunnelling_tcp: bool = False
+    ip: str,
+    port: int,
+    supports_tunnelling_tcp: bool = False,
+    requires_secure: bool = False,
 ) -> GatewayDescriptor:
     """Get mock gw descriptor."""
-    return GatewayDescriptor(
+    descriptor = GatewayDescriptor(
         name="Test",
         ip_addr=ip,
         port=port,
@@ -60,6 +64,9 @@ def _gateway_descriptor(
         supports_tunnelling=True,
         supports_tunnelling_tcp=supports_tunnelling_tcp,
     )
+    descriptor.tunnelling_requires_secure = requires_secure
+    descriptor.routing_requires_secure = requires_secure
+    return descriptor
 
 
 async def test_user_single_instance(hass):
@@ -247,13 +254,12 @@ async def test_routing_setup_advanced(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_tunneling_setup(
+async def test_tunneling_setup_manual(
     hass: HomeAssistant, user_input, config_entry_data
 ) -> None:
-    """Test tunneling if only one gateway is found."""
-    gateway = _gateway_descriptor("192.168.0.1", 3675, True)
+    """Test tunneling if no gateway was found found (or `manual` option was chosen)."""
     with patch("xknx.io.gateway_scanner.GatewayScanner.scan") as gateways:
-        gateways.return_value = [gateway]
+        gateways.return_value = []
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -289,9 +295,8 @@ async def test_tunneling_setup(
 
 async def test_tunneling_setup_for_local_ip(hass: HomeAssistant) -> None:
     """Test tunneling if only one gateway is found."""
-    gateway = _gateway_descriptor("192.168.0.2", 3675)
     with patch("xknx.io.gateway_scanner.GatewayScanner.scan") as gateways:
-        gateways.return_value = [gateway]
+        gateways.return_value = []
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={
@@ -395,29 +400,17 @@ async def test_tunneling_setup_for_multiple_found_gateways(hass: HomeAssistant) 
     assert tunnel_flow["step_id"] == "tunnel"
     assert not tunnel_flow["errors"]
 
-    manual_tunnel = await hass.config_entries.flow.async_configure(
-        tunnel_flow["flow_id"],
-        {CONF_KNX_GATEWAY: str(gateway)},
-    )
-    await hass.async_block_till_done()
-    assert manual_tunnel["type"] == FlowResultType.FORM
-    assert manual_tunnel["step_id"] == "manual_tunnel"
-
     with patch(
         "homeassistant.components.knx.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        manual_tunnel_flow = await hass.config_entries.flow.async_configure(
-            manual_tunnel["flow_id"],
-            {
-                CONF_KNX_TUNNELING_TYPE: CONF_KNX_LABEL_TUNNELING_UDP,
-                CONF_HOST: "192.168.0.1",
-                CONF_PORT: 3675,
-            },
+        result = await hass.config_entries.flow.async_configure(
+            tunnel_flow["flow_id"],
+            {CONF_KNX_GATEWAY: str(gateway)},
         )
         await hass.async_block_till_done()
-        assert manual_tunnel_flow["type"] == FlowResultType.CREATE_ENTRY
-        assert manual_tunnel_flow["data"] == {
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"] == {
             **DEFAULT_ENTRY_DATA,
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
             CONF_HOST: "192.168.0.1",
@@ -430,10 +423,22 @@ async def test_tunneling_setup_for_multiple_found_gateways(hass: HomeAssistant) 
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_manual_tunnel_step_when_no_gateway(hass: HomeAssistant) -> None:
-    """Test manual tunnel if no gateway is found and tunneling is selected."""
+@pytest.mark.parametrize(
+    "gateway",
+    [
+        _gateway_descriptor("192.168.0.1", 3675),
+        _gateway_descriptor("192.168.0.1", 3675, supports_tunnelling_tcp=True),
+        _gateway_descriptor(
+            "192.168.0.1", 3675, supports_tunnelling_tcp=True, requires_secure=True
+        ),
+    ],
+)
+async def test_manual_tunnel_step_with_found_gateway(
+    hass: HomeAssistant, gateway
+) -> None:
+    """Test manual tunnel if gateway was found and tunneling is selected."""
     with patch("xknx.io.gateway_scanner.GatewayScanner.scan") as gateways:
-        gateways.return_value = []
+        gateways.return_value = [gateway]
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -448,8 +453,19 @@ async def test_manual_tunnel_step_when_no_gateway(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     assert tunnel_flow["type"] == FlowResultType.FORM
-    assert tunnel_flow["step_id"] == "manual_tunnel"
+    assert tunnel_flow["step_id"] == "tunnel"
     assert not tunnel_flow["errors"]
+
+    manual_tunnel_flow = await hass.config_entries.flow.async_configure(
+        tunnel_flow["flow_id"],
+        {
+            CONF_KNX_GATEWAY: OPTION_MANUAL_TUNNEL,
+        },
+    )
+    await hass.async_block_till_done()
+    assert manual_tunnel_flow["type"] == FlowResultType.FORM
+    assert manual_tunnel_flow["step_id"] == "manual_tunnel"
+    assert not manual_tunnel_flow["errors"]
 
 
 async def test_form_with_automatic_connection_handling(hass: HomeAssistant) -> None:
@@ -484,9 +500,14 @@ async def test_form_with_automatic_connection_handling(hass: HomeAssistant) -> N
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def _get_menu_step(hass: HomeAssistant) -> None:
-    """Test ip secure manuel."""
-    gateway = _gateway_descriptor("192.168.0.1", 3675, True)
+async def _get_menu_step(hass: HomeAssistant) -> FlowResult:
+    """Return flow in secure_tunnellinn menu step."""
+    gateway = _gateway_descriptor(
+        "192.168.0.1",
+        3675,
+        supports_tunnelling_tcp=True,
+        requires_secure=True,
+    )
     with patch("xknx.io.gateway_scanner.GatewayScanner.scan") as gateways:
         gateways.return_value = [gateway]
         result = await hass.config_entries.flow.async_init(
@@ -503,11 +524,57 @@ async def _get_menu_step(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
-    assert result2["step_id"] == "manual_tunnel"
+    assert result2["step_id"] == "tunnel"
     assert not result2["errors"]
 
     result3 = await hass.config_entries.flow.async_configure(
         result2["flow_id"],
+        {CONF_KNX_GATEWAY: str(gateway)},
+    )
+    await hass.async_block_till_done()
+    assert result3["type"] == FlowResultType.MENU
+    assert result3["step_id"] == "secure_tunneling"
+    return result3
+
+
+async def test_get_secure_menu_step_manual_tunnelling(
+    hass: HomeAssistant,
+):
+    """Test flow reaches secure_tunnellinn menu step from manual tunnelling configuration."""
+    gateway = _gateway_descriptor(
+        "192.168.0.1",
+        3675,
+        supports_tunnelling_tcp=True,
+        requires_secure=True,
+    )
+    with patch("xknx.io.gateway_scanner.GatewayScanner.scan") as gateways:
+        gateways.return_value = [gateway]
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert not result["errors"]
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
+        },
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "tunnel"
+    assert not result2["errors"]
+
+    manual_tunnel_flow = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {
+            CONF_KNX_GATEWAY: OPTION_MANUAL_TUNNEL,
+        },
+    )
+
+    result3 = await hass.config_entries.flow.async_configure(
+        manual_tunnel_flow["flow_id"],
         {
             CONF_KNX_TUNNELING_TYPE: CONF_KNX_LABEL_TUNNELING_TCP_SECURE,
             CONF_HOST: "192.168.0.1",
@@ -517,7 +584,6 @@ async def _get_menu_step(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert result3["type"] == FlowResultType.MENU
     assert result3["step_id"] == "secure_tunneling"
-    return result3
 
 
 async def test_configure_secure_manual(hass: HomeAssistant):
@@ -702,6 +768,7 @@ async def test_options_flow(
             CONF_KNX_MCAST_GRP: DEFAULT_MCAST_GRP,
             CONF_KNX_RATE_LIMIT: 20,
             CONF_KNX_STATE_UPDATER: True,
+            CONF_KNX_ROUTE_BACK: False,
         }
 
 
@@ -835,6 +902,7 @@ async def test_tunneling_options_flow(
                 CONF_KNX_RATE_LIMIT: 25,
                 CONF_KNX_STATE_UPDATER: False,
                 CONF_KNX_LOCAL_IP: "192.168.1.112",
+                CONF_KNX_ROUTE_BACK: False,
             },
         ),
         (
@@ -856,6 +924,7 @@ async def test_tunneling_options_flow(
                 CONF_KNX_RATE_LIMIT: 25,
                 CONF_KNX_STATE_UPDATER: False,
                 CONF_KNX_LOCAL_IP: None,
+                CONF_KNX_ROUTE_BACK: False,
             },
         ),
     ],

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -98,7 +98,7 @@ async def test_routing_setup(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "routing"
-    assert not result2["errors"]
+    assert result2["errors"] == {"base": "no_router_discovered"}
 
     with patch(
         "homeassistant.components.knx.async_setup_entry",
@@ -150,7 +150,7 @@ async def test_routing_setup_advanced(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "routing"
-    assert not result2["errors"]
+    assert result2["errors"] == {"base": "no_router_discovered"}
 
     # invalid user input
     result_invalid_input = await hass.config_entries.flow.async_configure(
@@ -169,6 +169,7 @@ async def test_routing_setup_advanced(hass: HomeAssistant) -> None:
         CONF_KNX_MCAST_GRP: "invalid_ip_address",
         CONF_KNX_INDIVIDUAL_ADDRESS: "invalid_individual_address",
         CONF_KNX_LOCAL_IP: "invalid_ip_address",
+        "base": "no_router_discovered",
     }
 
     # valid user input
@@ -274,7 +275,7 @@ async def test_tunneling_setup_manual(
     await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "manual_tunnel"
-    assert not result2["errors"]
+    assert result2["errors"] == {"base": "no_tunnel_discovered"}
 
     with patch(
         "homeassistant.components.knx.async_setup_entry",
@@ -315,7 +316,7 @@ async def test_tunneling_setup_for_local_ip(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "manual_tunnel"
-    assert not result2["errors"]
+    assert result2["errors"] == {"base": "no_tunnel_discovered"}
 
     # invalid host ip address
     result_invalid_host = await hass.config_entries.flow.async_configure(
@@ -330,7 +331,10 @@ async def test_tunneling_setup_for_local_ip(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert result_invalid_host["type"] == FlowResultType.FORM
     assert result_invalid_host["step_id"] == "manual_tunnel"
-    assert result_invalid_host["errors"] == {CONF_HOST: "invalid_ip_address"}
+    assert result_invalid_host["errors"] == {
+        CONF_HOST: "invalid_ip_address",
+        "base": "no_tunnel_discovered",
+    }
     # invalid local ip address
     result_invalid_local = await hass.config_entries.flow.async_configure(
         result2["flow_id"],
@@ -344,7 +348,10 @@ async def test_tunneling_setup_for_local_ip(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert result_invalid_local["type"] == FlowResultType.FORM
     assert result_invalid_local["step_id"] == "manual_tunnel"
-    assert result_invalid_local["errors"] == {CONF_KNX_LOCAL_IP: "invalid_ip_address"}
+    assert result_invalid_local["errors"] == {
+        CONF_KNX_LOCAL_IP: "invalid_ip_address",
+        "base": "no_tunnel_discovered",
+    }
 
     # valid user input
     with patch(

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -114,7 +114,7 @@ async def test_routing_setup(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         assert result3["type"] == FlowResultType.CREATE_ENTRY
-        assert result3["title"] == CONF_KNX_ROUTING.capitalize()
+        assert result3["title"] == "Routing as 1.1.110"
         assert result3["data"] == {
             **DEFAULT_ENTRY_DATA,
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING,
@@ -188,7 +188,7 @@ async def test_routing_setup_advanced(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         assert result3["type"] == FlowResultType.CREATE_ENTRY
-        assert result3["title"] == CONF_KNX_ROUTING.capitalize()
+        assert result3["title"] == "Routing as 1.1.110"
         assert result3["data"] == {
             **DEFAULT_ENTRY_DATA,
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prepare for adding Secure Routing configuration support

- Directly [create entry when tunnel gateway is selected](https://github.com/home-assistant/core/commit/428c39a74af1ef780fe86dbe3690b9201b0690ec)
  - skip manual step when a specific interface is selected
  - add option to manually configure tunnel interface to list of found interfaces
- [show error when no gateway was found](https://github.com/home-assistant/core/pull/80641/commits/01210d29115f176930c565ba95042872cc541107) to inform users they may check their network configuration (which we can't really know as there are interfaces that allow disabling discovery)
- [refactor OptionsFlow](https://github.com/home-assistant/core/pull/80641/commits/423906c851c6aa9718c9a574b2db1a764557c8f5) to have all connection options as ConfigFlow. This allows to switch to eg. Secure Tunnelling from non-secure Tunnelling without deleting the integration (and thus deleting area assignments of entities)
- [route_back as BooleanSelector](https://github.com/home-assistant/core/pull/80641/commits/5e7451af5f24ae00d7704a273361ce4f206946cb) and new labels for manual tunnelling types. `data_description` is used to inform the user that route_back is only used for UDP connections.

~[increase gateway search time to 3 seconds](https://github.com/home-assistant/core/commit/bbe78d5185fe3221bacae76a0040efb1a8429985) as I found some interfaces were not listed on my test system sometimes~ this was caused by a bug in xknx that's fixed in the coming release
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
