### PR TITLE
Add triggers for SeeTouchHybridKeypad

### DIFF
--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -43,13 +43,13 @@ LUTRON_MODEL_TO_TYPE = {
     "RRST-W2B-XX": "SunnataKeypad_2Button",
     "RRST-W3RL-XX": "SunnataKeypad_3ButtonRaiseLower",
     "RRST-W4B-XX": "SunnataKeypad_4Button",
-    "RRD-HN1RLD-XX": "SeeTouchHybridKeypad_DualGroupRaiseLower",
-    "RRD-HN2RLD-XX": "SeeTouchHybridKeypad_DualGroupDualRaiseLower",
-    "RRD-HN3BSRL-XX": "SeeTouchHybridKeypad_3ButtonRaiseLower",
-    "RRD-HN3S-XX": "SeeTouchHybridKeypad_3SceneRaiseLower",
-    "RRD-HN4S-XX": "SeeTouchHybridKeypad_4SceneRaiseLower",
-    "RRD-HN5BRL-XX": "SeeTouchHybridKeypad_5ButtonRaiseLower",
-    "RRD-HN6BRL-XX": "SeeTouchHybridKeypad_6ButtonRaiseLower",
+    "RRD-HN1RLD": "SeeTouchHybridKeypad_DualGroupRaiseLower",
+    "RRD-HN2RLD": "SeeTouchHybridKeypad_DualGroupDualRaiseLower",
+    "RRD-HN3BSRL": "SeeTouchHybridKeypad_3ButtonRaiseLower",
+    "RRD-HN3S": "SeeTouchHybridKeypad_3SceneRaiseLower",
+    "RRD-HN4S": "SeeTouchHybridKeypad_4SceneRaiseLower",
+    "RRD-HN5BRL": "SeeTouchHybridKeypad_5ButtonRaiseLower",
+    "RRD-HN6BRL": "SeeTouchHybridKeypad_6ButtonRaiseLower",
 }
 
 

--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -45,7 +45,7 @@ LUTRON_MODEL_TO_TYPE = {
     "RRST-W4B-XX": "SunnataKeypad_4Button",
     "RRD-HN1RLD": "SeeTouchHybridKeypad_DualGroupRaiseLower",
     "RRD-HN2RLD": "SeeTouchHybridKeypad_DualGroupDualRaiseLower",
-    "RRD-HN3BSRL": "SeeTouchHybridKeypad_3ButtonRaiseLower",
+    "RRD-HN3BSRL": "SeeTouchHybridKeypad_3ButtonSpaceRaiseLower",
     "RRD-HN3S": "SeeTouchHybridKeypad_3SceneRaiseLower",
     "RRD-HN4S": "SeeTouchHybridKeypad_4SceneRaiseLower",
     "RRD-HN5BRL": "SeeTouchHybridKeypad_5ButtonRaiseLower",
@@ -363,12 +363,87 @@ SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA = (
     )
 )
 
-SEETOUCHHYBRID_KEYPAD_5_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP = {
+SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_DUAL_RAISE_LOWER_BUTTON_TYPES_TO_LEAP = {
+    "group_1_button_1": 1,
+    "group_1_button_2": 2,
+    "lower_1": 16,
+    "raise_1": 17,
+    "group_2_button_1": 5,
+    "group_2_button_2": 6,
+    "lower_2": 18,
+    "raise_2": 19,
+}
+SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_DUAL_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA = (
+    LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
+        {
+            vol.Required(CONF_SUBTYPE): vol.In(
+                SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_DUAL_RAISE_LOWER_BUTTON_TYPES_TO_LEAP
+            ),
+        }
+    )
+)
+
+SEETOUCHHYBRID_KEYPAD_3_BUTTON_SPACE_RAISE_LOWER_BUTTON_TYPES_TO_LEAP = {
+    "group_1_button_1": 1,
+    "group_1_button_2": 2,
+    "lower_1": 16,
+    "raise_1": 17,
+    "group_2_button_1": 5,
+    "group_2_button_2": 6,
+    "lower_2": 18,
+    "raise_2": 19,
+}
+SEETOUCHHYBRID_KEYPAD_3_BUTTON_SPACE_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA = (
+    LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
+        {
+            vol.Required(CONF_SUBTYPE): vol.In(
+                SEETOUCHHYBRID_KEYPAD_3_BUTTON_SPACE_RAISE_LOWER_BUTTON_TYPES_TO_LEAP
+            ),
+        }
+    )
+)
+
+SEETOUCHHYBRID_KEYPAD_3_SCENE_RAISE_LOWER_BUTTON_TYPES_TO_LEAP = {
+    "button_1": 1,
+    "button_2": 2,
+    "button_3": 3,
+    "button_6": 6,
+    "lower": 18,
+    "raise": 19,
+}
+SEETOUCHHYBRID_KEYPAD_3_SCENE_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA = (
+    LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
+        {
+            vol.Required(CONF_SUBTYPE): vol.In(
+                SEETOUCHHYBRID_KEYPAD_3_SCENE_RAISE_LOWER_BUTTON_TYPES_TO_LEAP
+            ),
+        }
+    )
+)
+
+SEETOUCHHYBRID_KEYPAD_4_SCENE_RAISE_LOWER_BUTTON_TYPES_TO_LEAP = {
     "button_1": 1,
     "button_2": 2,
     "button_3": 3,
     "button_4": 4,
-    "button_5": 5,
+    "button_6": 6,
+    "lower": 18,
+    "raise": 19,
+}
+SEETOUCHHYBRID_KEYPAD_4_SCENE_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA = (
+    LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
+        {
+            vol.Required(CONF_SUBTYPE): vol.In(
+                SEETOUCHHYBRID_KEYPAD_4_SCENE_RAISE_LOWER_BUTTON_TYPES_TO_LEAP
+            ),
+        }
+    )
+)
+
+SEETOUCHHYBRID_KEYPAD_5_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP = {
+    "button_1": 1,
+    "button_2": 3,
+    "button_3": 5,
     "lower": 18,
     "raise": 19,
 }
@@ -421,6 +496,10 @@ DEVICE_TYPE_SCHEMA_MAP = {
     "SeeTouchHybridKeypad_6ButtonRaiseLower": SEETOUCHHYBRID_KEYPAD_6_BUTTON_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
     "SeeTouchHybridKeypad_5ButtonRaiseLower": SEETOUCHHYBRID_KEYPAD_5_BUTTON_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
     "SeeTouchHybridKeypad_DualGroupRaiseLower": SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
+    "SeeTouchHybridKeypad_DualGroupDualRaiseLower": SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_DUAL_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
+    "SeeTouchHybridKeypad_3ButtonSpaceRaiseLower": SEETOUCHHYBRID_KEYPAD_3_BUTTON_SPACE_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
+    "SeeTouchHybridKeypad_3SceneRaiseLower": SEETOUCHHYBRID_KEYPAD_3_SCENE_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
+    "SeeTouchHybridKeypad_4SceneRaiseLower": SEETOUCHHYBRID_KEYPAD_4_SCENE_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
 }
 
 DEVICE_TYPE_SUBTYPE_MAP_TO_LIP = {
@@ -453,6 +532,10 @@ DEVICE_TYPE_SUBTYPE_MAP_TO_LEAP = {
     "SeeTouchHybridKeypad_6ButtonRaiseLower": SEETOUCHHYBRID_KEYPAD_6_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
     "SeeTouchHybridKeypad_5ButtonRaiseLower": SEETOUCHHYBRID_KEYPAD_5_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
     "SeeTouchHybridKeypad_DualGroupRaiseLower": SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
+    "SeeTouchHybridKeypad_DualGroupDualRaiseLower": SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_DUAL_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
+    "SeeTouchHybridKeypad_3ButtonSpaceRaiseLower": SEETOUCHHYBRID_KEYPAD_3_BUTTON_SPACE_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
+    "SeeTouchHybridKeypad_3SceneRaiseLower": SEETOUCHHYBRID_KEYPAD_3_SCENE_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
+    "SeeTouchHybridKeypad_4SceneRaiseLower": SEETOUCHHYBRID_KEYPAD_4_SCENE_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
 }
 
 LEAP_TO_DEVICE_TYPE_SUBTYPE_MAP = {

--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -43,6 +43,13 @@ LUTRON_MODEL_TO_TYPE = {
     "RRST-W2B-XX": "SunnataKeypad_2Button",
     "RRST-W3RL-XX": "SunnataKeypad_3ButtonRaiseLower",
     "RRST-W4B-XX": "SunnataKeypad_4Button",
+    "RRD-HN1RLD-XX": "SeeTouchHybridKeypad_DualGroupRaiseLower",
+    "RRD-HN2RLD-XX": "SeeTouchHybridKeypad_DualGroupDualRaiseLower",
+    "RRD-HN3BSRL-XX": "SeeTouchHybridKeypad_3ButtonRaiseLower",
+    "RRD-HN3S-XX": "SeeTouchHybridKeypad_3SceneRaiseLower",
+    "RRD-HN4S-XX": "SeeTouchHybridKeypad_4SceneRaiseLower",
+    "RRD-HN5BRL-XX": "SeeTouchHybridKeypad_5ButtonRaiseLower",
+    "RRD-HN6BRL-XX": "SeeTouchHybridKeypad_6ButtonRaiseLower",
 }
 
 
@@ -337,6 +344,65 @@ PHANTOM_KEYPAD_BUTTON_TRIGGER_SCHEMA = LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
     }
 )
 
+SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_RAISE_LOWER_BUTTON_TYPES_TO_LEAP = {
+    "group_1_button_1": 1,
+    "group_1_button_2": 2,
+    "group_1_button_3": 3,
+    "group_2_button_1": 5,
+    "group_2_button_2": 6,
+    "lower": 18,
+    "raise": 19,
+}
+SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA = (
+    LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
+        {
+            vol.Required(CONF_SUBTYPE): vol.In(
+                SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_RAISE_LOWER_BUTTON_TYPES_TO_LEAP
+            ),
+        }
+    )
+)
+
+SEETOUCHHYBRID_KEYPAD_5_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP = {
+    "button_1": 1,
+    "button_2": 2,
+    "button_3": 3,
+    "button_4": 4,
+    "button_5": 5,
+    "lower": 18,
+    "raise": 19,
+}
+SEETOUCHHYBRID_KEYPAD_5_BUTTON_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA = (
+    LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
+        {
+            vol.Required(CONF_SUBTYPE): vol.In(
+                SEETOUCHHYBRID_KEYPAD_5_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP
+            ),
+        }
+    )
+)
+
+SEETOUCHHYBRID_KEYPAD_6_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP = {
+    "button_1": 1,
+    "button_2": 2,
+    "button_3": 3,
+    "button_4": 4,
+    "button_5": 5,
+    "button_6": 6,
+    "lower": 18,
+    "raise": 19,
+}
+SEETOUCHHYBRID_KEYPAD_6_BUTTON_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA = (
+    LUTRON_BUTTON_TRIGGER_SCHEMA.extend(
+        {
+            vol.Required(CONF_SUBTYPE): vol.In(
+                SEETOUCHHYBRID_KEYPAD_6_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP
+            ),
+        }
+    )
+)
+
+
 DEVICE_TYPE_SCHEMA_MAP = {
     "Pico2Button": PICO_2_BUTTON_TRIGGER_SCHEMA,
     "Pico2ButtonRaiseLower": PICO_2_BUTTON_RAISE_LOWER_TRIGGER_SCHEMA,
@@ -352,6 +418,9 @@ DEVICE_TYPE_SCHEMA_MAP = {
     "SunnataKeypad_4Button": SUNNATA_KEYPAD_4_BUTTON_TRIGGER_SCHEMA,
     "HomeownerKeypad": HOMEOWNER_KEYPAD_BUTTON_TRIGGER_SCHEMA,
     "PhantomKeypad": PHANTOM_KEYPAD_BUTTON_TRIGGER_SCHEMA,
+    "SeeTouchHybridKeypad_6ButtonRaiseLower": SEETOUCHHYBRID_KEYPAD_6_BUTTON_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
+    "SeeTouchHybridKeypad_5ButtonRaiseLower": SEETOUCHHYBRID_KEYPAD_5_BUTTON_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
+    "SeeTouchHybridKeypad_DualGroupRaiseLower": SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_RAISE_LOWER_BUTTON_TRIGGER_SCHEMA,
 }
 
 DEVICE_TYPE_SUBTYPE_MAP_TO_LIP = {
@@ -381,6 +450,9 @@ DEVICE_TYPE_SUBTYPE_MAP_TO_LEAP = {
     "SunnataKeypad_4Button": SUNNATA_KEYPAD_4_BUTTON_BUTTON_TYPES_TO_LEAP,
     "HomeownerKeypad": HOMEOWNER_KEYPAD_BUTTON_TYPES_TO_LEAP,
     "PhantomKeypad": PHANTOM_KEYPAD_BUTTON_TYPES_TO_LEAP,
+    "SeeTouchHybridKeypad_6ButtonRaiseLower": SEETOUCHHYBRID_KEYPAD_6_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
+    "SeeTouchHybridKeypad_5ButtonRaiseLower": SEETOUCHHYBRID_KEYPAD_5_BUTTON_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
+    "SeeTouchHybridKeypad_DualGroupRaiseLower": SEETOUCHHYBRID_KEYPAD_DUAL_GROUP_RAISE_LOWER_BUTTON_TYPES_TO_LEAP,
 }
 
 LEAP_TO_DEVICE_TYPE_SUBTYPE_MAP = {

--- a/homeassistant/components/lutron_caseta/strings.json
+++ b/homeassistant/components/lutron_caseta/strings.json
@@ -38,6 +38,7 @@
       "button_7": "Seventh button",
       "group_1_button_1": "First Group first button",
       "group_1_button_2": "First Group second button",
+      "group_1_button_3": "First Group third button",
       "group_2_button_1": "Second Group first button",
       "group_2_button_2": "Second Group second button",
       "on": "On",


### PR DESCRIPTION
## Proposed change
Adding triggers for the SeeTouchHybridKeypads line of Keypads.
There are 7 models in this line that report their DeviceType as "SeeTouchHybridKeypads"

Models reported in pylutron-caseta:
RRD-HN1RLD - SeeTouchHybridKeypad Dual Group Raise Lower
RRD-HN2RLD - SeeTouchHybridKeypad Dual Group Dual Raise Lower
RRD-HN3BSRL - SeeTouchHybridKeypad 3 Button Space Raise Lower
RRD-HN3S - SeeTouchHybridKeypad 3 Scene Raise Lower
RRD-HN4S - SeeTouchHybridKeypad 4 Scene Raise Lower
RRD-HN5BRL - SeeTouchHybridKeypad 5 Button Raise Lower
RRD-HN6BRL - SeeTouchHybridKeypad 6 Button Raise Lower

Lutron product listing and specifications:
https://www.lutron.com/TechnicalDocumentLibrary/369968_RRD.PDF

I've added an "unassigned" keypad of each type to my system to extract the correct button numbers.

Original discussion here:
https://github.com/danaues/lutron_caseta/issues/3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
