### PR TITLE
Use US_CUSTOMARY_SYSTEM in tests

### DIFF
--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -30,7 +30,7 @@ from homeassistant.const import (
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import init_integration
 
@@ -704,7 +704,7 @@ async def test_manual_update_entity(hass):
 
 async def test_sensor_imperial_units(hass):
     """Test states of the sensor without forecast."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     await init_integration(hass)
 
     state = hass.states.get("sensor.home_cloud_ceiling")

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -30,7 +30,7 @@ from homeassistant.const import STATE_UNKNOWN, TEMP_FAHRENHEIT
 from homeassistant.core import Context
 from homeassistant.helpers import entityfilter
 from homeassistant.setup import async_setup_component
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .test_common import (
     MockConfig,
@@ -2020,7 +2020,7 @@ async def test_unknown_sensor(hass):
 
 async def test_thermostat(hass):
     """Test thermostat discovery."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     device = (
         "climate.test_thermostat",
         "cool",

--- a/tests/components/bmw_connected_drive/test_sensor.py
+++ b/tests/components/bmw_connected_drive/test_sensor.py
@@ -3,8 +3,8 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.util.unit_system import (
-    IMPERIAL_SYSTEM as IMPERIAL,
     METRIC_SYSTEM as METRIC,
+    US_CUSTOMARY_SYSTEM as IMPERIAL,
     UnitSystem,
 )
 

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -17,7 +17,7 @@ from homeassistant.components.repairs import DOMAIN as REPAIRS_DOMAIN
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from tests.components.recorder.common import async_wait_recording_done
 
@@ -84,7 +84,7 @@ async def test_demo_statistics(recorder_mock, mock_history, hass):
 
 async def test_demo_statistics_growth(recorder_mock, mock_history, hass):
     """Test that the demo sum statistics adds to the previous state."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
 
     now = dt_util.now()
     last_week = now - datetime.timedelta(days=7)

--- a/tests/components/demo/test_water_heater.py
+++ b/tests/components/demo/test_water_heater.py
@@ -4,7 +4,7 @@ import voluptuous as vol
 
 from homeassistant.components import water_heater
 from homeassistant.setup import async_setup_component
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from tests.components.water_heater import common
 
@@ -15,7 +15,7 @@ ENTITY_WATER_HEATER_CELSIUS = "water_heater.demo_water_heater_celsius"
 @pytest.fixture(autouse=True)
 async def setup_comp(hass):
     """Set up demo component."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     assert await async_setup_component(
         hass, water_heater.DOMAIN, {"water_heater": {"platform": "demo"}}
     )

--- a/tests/components/gdacs/test_geo_location.py
+++ b/tests/components/gdacs/test_geo_location.py
@@ -34,7 +34,7 @@ from homeassistant.const import (
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import _generate_mock_feed_entry
 
@@ -208,7 +208,7 @@ async def test_setup(hass):
 
 async def test_setup_imperial(hass):
     """Test the setup of the integration using imperial unit system."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(
         "1234",

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -37,7 +37,7 @@ from homeassistant.core import DOMAIN as HASS_DOMAIN, CoreState, State, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from tests.common import (
     assert_setup_component,
@@ -1201,7 +1201,7 @@ async def setup_comp_9(hass):
 
 async def test_precision(hass, setup_comp_9):
     """Test that setting precision to tenths works as intended."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     await common.async_set_temperature(hass, 23.27)
     state = hass.states.get(ENTITY)
     assert state.attributes.get("temperature") == 23.3

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import _generate_mock_feed_entry
 
@@ -171,7 +171,7 @@ async def test_setup(hass):
 
 async def test_setup_imperial(hass):
     """Test the setup of the integration using imperial unit system."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry("1234", "Title 1", 15.5, (38.0, -3.0))
 

--- a/tests/components/geonetnz_volcano/test_sensor.py
+++ b/tests/components/geonetnz_volcano/test_sensor.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 )
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import _generate_mock_feed_entry
 
@@ -150,7 +150,7 @@ async def test_setup(hass):
 
 async def test_setup_imperial(hass):
     """Test the setup of the integration using imperial unit system."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry("1234", "Title 1", 1, 15.5, (38.0, -3.0))
 

--- a/tests/components/google_travel_time/test_sensor.py
+++ b/tests/components/google_travel_time/test_sensor.py
@@ -12,7 +12,11 @@ from homeassistant.components.google_travel_time.const import (
 )
 from homeassistant.const import CONF_UNIT_SYSTEM_IMPERIAL, CONF_UNIT_SYSTEM_METRIC
 from homeassistant.core import HomeAssistant
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
+from homeassistant.util.unit_system import (
+    METRIC_SYSTEM,
+    US_CUSTOMARY_SYSTEM,
+    UnitSystem,
+)
 
 from .const import MOCK_CONFIG
 
@@ -227,7 +231,7 @@ async def test_sensor_deprecation_warning(hass, caplog):
     "unit_system, expected_unit_option",
     [
         (METRIC_SYSTEM, CONF_UNIT_SYSTEM_METRIC),
-        (IMPERIAL_SYSTEM, CONF_UNIT_SYSTEM_IMPERIAL),
+        (US_CUSTOMARY_SYSTEM, CONF_UNIT_SYSTEM_IMPERIAL),
     ],
 )
 async def test_sensor_unit_system(

--- a/tests/components/here_travel_time/test_config_flow.py
+++ b/tests/components/here_travel_time/test_config_flow.py
@@ -31,7 +31,11 @@ from homeassistant.const import (
     CONF_UNIT_SYSTEM_METRIC,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
+from homeassistant.util.unit_system import (
+    METRIC_SYSTEM,
+    US_CUSTOMARY_SYSTEM,
+    UnitSystem,
+)
 
 from .const import (
     API_KEY,
@@ -232,7 +236,7 @@ async def test_step_destination_coordinates(
     "unit_system, expected_unit_option",
     [
         (METRIC_SYSTEM, CONF_UNIT_SYSTEM_METRIC),
-        (IMPERIAL_SYSTEM, CONF_UNIT_SYSTEM_IMPERIAL),
+        (US_CUSTOMARY_SYSTEM, CONF_UNIT_SYSTEM_IMPERIAL),
     ],
 )
 async def test_step_destination_entity(

--- a/tests/components/mazda/test_sensor.py
+++ b/tests/components/mazda/test_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     PRESSURE_PSI,
 )
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import init_integration
 
@@ -132,7 +132,7 @@ async def test_sensors(hass):
 
 async def test_sensors_imperial_units(hass):
     """Test that the sensors work properly with imperial units."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
 
     await init_integration(hass)
 

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -13,14 +13,14 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 
 @pytest.mark.parametrize(
     "unit_system, state_unit, state1, state2",
     (
         (METRIC_SYSTEM, TEMP_CELSIUS, "100", "123"),
-        (IMPERIAL_SYSTEM, TEMP_FAHRENHEIT, "212", "253"),
+        (US_CUSTOMARY_SYSTEM, TEMP_FAHRENHEIT, "212", "253"),
     ),
 )
 async def test_sensor(
@@ -124,9 +124,9 @@ async def test_sensor(
     "unique_id, unit_system, state_unit, state1, state2",
     (
         ("battery_temperature", METRIC_SYSTEM, TEMP_CELSIUS, "100", "123"),
-        ("battery_temperature", IMPERIAL_SYSTEM, TEMP_FAHRENHEIT, "212", "253"),
+        ("battery_temperature", US_CUSTOMARY_SYSTEM, TEMP_FAHRENHEIT, "212", "253"),
         # The unique_id doesn't match that of the mobile app's battery temperature sensor
-        ("battery_temp", IMPERIAL_SYSTEM, TEMP_FAHRENHEIT, "212", "123"),
+        ("battery_temp", US_CUSTOMARY_SYSTEM, TEMP_FAHRENHEIT, "212", "123"),
     ),
 )
 async def test_sensor_migration(

--- a/tests/components/mysensors/test_sensor.py
+++ b/tests/components/mysensors/test_sensor.py
@@ -21,7 +21,11 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
+from homeassistant.util.unit_system import (
+    METRIC_SYSTEM,
+    US_CUSTOMARY_SYSTEM,
+    UnitSystem,
+)
 
 from tests.common import MockConfigEntry
 
@@ -124,7 +128,7 @@ async def test_distance_sensor(
 
 @pytest.mark.parametrize(
     "unit_system, unit",
-    [(METRIC_SYSTEM, TEMP_CELSIUS), (IMPERIAL_SYSTEM, TEMP_FAHRENHEIT)],
+    [(METRIC_SYSTEM, TEMP_CELSIUS), (US_CUSTOMARY_SYSTEM, TEMP_FAHRENHEIT)],
 )
 async def test_temperature_sensor(
     hass: HomeAssistant,

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -25,7 +25,7 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
 from homeassistant.setup import async_setup_component
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from tests.common import mock_restore_cache_with_extra_data
 
@@ -435,7 +435,7 @@ async def test_deprecated_methods(
     "native_min_value, state_min_value, native_step, state_step",
     [
         (
-            IMPERIAL_SYSTEM,
+            US_CUSTOMARY_SYSTEM,
             TEMP_FAHRENHEIT,
             TEMP_FAHRENHEIT,
             100,
@@ -450,7 +450,7 @@ async def test_deprecated_methods(
             3,
         ),
         (
-            IMPERIAL_SYSTEM,
+            US_CUSTOMARY_SYSTEM,
             TEMP_CELSIUS,
             TEMP_FAHRENHEIT,
             38,

--- a/tests/components/nws/test_sensor.py
+++ b/tests/components/nws/test_sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ATTRIBUTION, STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from .const import (
     EXPECTED_FORECAST_IMPERIAL,
@@ -24,7 +24,7 @@ from tests.common import MockConfigEntry
     "units,result_observation,result_forecast",
     [
         (
-            IMPERIAL_SYSTEM,
+            US_CUSTOMARY_SYSTEM,
             SENSOR_EXPECTED_OBSERVATION_IMPERIAL,
             EXPECTED_FORECAST_IMPERIAL,
         ),

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -15,7 +15,7 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from .const import (
     EXPECTED_FORECAST_IMPERIAL,
@@ -34,7 +34,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
     "units,result_observation,result_forecast",
     [
         (
-            IMPERIAL_SYSTEM,
+            US_CUSTOMARY_SYSTEM,
             WEATHER_EXPECTED_OBSERVATION_IMPERIAL,
             EXPECTED_FORECAST_IMPERIAL,
         ),

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -19,7 +19,7 @@ from homeassistant.components.recorder.statistics import (
 from homeassistant.helpers import recorder as recorder_helper
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from .common import (
     async_recorder_block_till_done,
@@ -126,7 +126,7 @@ async def test_statistics_during_period(recorder_mock, hass, hass_ws_client):
     """Test statistics_during_period."""
     now = dt_util.utcnow()
 
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
     hass.states.async_set("sensor.test", 10, attributes=POWER_SENSOR_KW_ATTRIBUTES)
@@ -431,7 +431,7 @@ async def test_statistics_during_period_in_the_past(
     hass.config.set_time_zone("UTC")
     now = dt_util.utcnow().replace()
 
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
 
@@ -589,27 +589,57 @@ async def test_statistics_during_period_bad_end_time(
 @pytest.mark.parametrize(
     "units, attributes, display_unit, statistics_unit, unit_class",
     [
-        (IMPERIAL_SYSTEM, DISTANCE_SENSOR_M_ATTRIBUTES, "m", "m", "distance"),
+        (US_CUSTOMARY_SYSTEM, DISTANCE_SENSOR_M_ATTRIBUTES, "m", "m", "distance"),
         (METRIC_SYSTEM, DISTANCE_SENSOR_M_ATTRIBUTES, "m", "m", "distance"),
-        (IMPERIAL_SYSTEM, DISTANCE_SENSOR_FT_ATTRIBUTES, "ft", "ft", "distance"),
+        (
+            US_CUSTOMARY_SYSTEM,
+            DISTANCE_SENSOR_FT_ATTRIBUTES,
+            "ft",
+            "ft",
+            "distance",
+        ),
         (METRIC_SYSTEM, DISTANCE_SENSOR_FT_ATTRIBUTES, "ft", "ft", "distance"),
-        (IMPERIAL_SYSTEM, ENERGY_SENSOR_WH_ATTRIBUTES, "Wh", "Wh", "energy"),
+        (US_CUSTOMARY_SYSTEM, ENERGY_SENSOR_WH_ATTRIBUTES, "Wh", "Wh", "energy"),
         (METRIC_SYSTEM, ENERGY_SENSOR_WH_ATTRIBUTES, "Wh", "Wh", "energy"),
-        (IMPERIAL_SYSTEM, GAS_SENSOR_FT3_ATTRIBUTES, "ft³", "ft³", "volume"),
+        (US_CUSTOMARY_SYSTEM, GAS_SENSOR_FT3_ATTRIBUTES, "ft³", "ft³", "volume"),
         (METRIC_SYSTEM, GAS_SENSOR_FT3_ATTRIBUTES, "ft³", "ft³", "volume"),
-        (IMPERIAL_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, "kW", "kW", "power"),
+        (US_CUSTOMARY_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, "kW", "kW", "power"),
         (METRIC_SYSTEM, POWER_SENSOR_KW_ATTRIBUTES, "kW", "kW", "power"),
-        (IMPERIAL_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, "hPa", "hPa", "pressure"),
+        (
+            US_CUSTOMARY_SYSTEM,
+            PRESSURE_SENSOR_HPA_ATTRIBUTES,
+            "hPa",
+            "hPa",
+            "pressure",
+        ),
         (METRIC_SYSTEM, PRESSURE_SENSOR_HPA_ATTRIBUTES, "hPa", "hPa", "pressure"),
-        (IMPERIAL_SYSTEM, SPEED_SENSOR_KPH_ATTRIBUTES, "km/h", "km/h", "speed"),
+        (US_CUSTOMARY_SYSTEM, SPEED_SENSOR_KPH_ATTRIBUTES, "km/h", "km/h", "speed"),
         (METRIC_SYSTEM, SPEED_SENSOR_KPH_ATTRIBUTES, "km/h", "km/h", "speed"),
-        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, "°C", "°C", "temperature"),
+        (
+            US_CUSTOMARY_SYSTEM,
+            TEMPERATURE_SENSOR_C_ATTRIBUTES,
+            "°C",
+            "°C",
+            "temperature",
+        ),
         (METRIC_SYSTEM, TEMPERATURE_SENSOR_C_ATTRIBUTES, "°C", "°C", "temperature"),
-        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_F_ATTRIBUTES, "°F", "°F", "temperature"),
+        (
+            US_CUSTOMARY_SYSTEM,
+            TEMPERATURE_SENSOR_F_ATTRIBUTES,
+            "°F",
+            "°F",
+            "temperature",
+        ),
         (METRIC_SYSTEM, TEMPERATURE_SENSOR_F_ATTRIBUTES, "°F", "°F", "temperature"),
-        (IMPERIAL_SYSTEM, VOLUME_SENSOR_FT3_ATTRIBUTES, "ft³", "ft³", "volume"),
+        (US_CUSTOMARY_SYSTEM, VOLUME_SENSOR_FT3_ATTRIBUTES, "ft³", "ft³", "volume"),
         (METRIC_SYSTEM, VOLUME_SENSOR_FT3_ATTRIBUTES, "ft³", "ft³", "volume"),
-        (IMPERIAL_SYSTEM, VOLUME_SENSOR_FT3_ATTRIBUTES_TOTAL, "ft³", "ft³", "volume"),
+        (
+            US_CUSTOMARY_SYSTEM,
+            VOLUME_SENSOR_FT3_ATTRIBUTES_TOTAL,
+            "ft³",
+            "ft³",
+            "volume",
+        ),
         (METRIC_SYSTEM, VOLUME_SENSOR_FT3_ATTRIBUTES_TOTAL, "ft³", "ft³", "volume"),
     ],
 )

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -35,7 +35,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from tests.common import mock_restore_cache_with_extra_data
 
@@ -43,8 +43,8 @@ from tests.common import mock_restore_cache_with_extra_data
 @pytest.mark.parametrize(
     "unit_system,native_unit,state_unit,native_value,state_value",
     [
-        (IMPERIAL_SYSTEM, TEMP_FAHRENHEIT, TEMP_FAHRENHEIT, 100, 100),
-        (IMPERIAL_SYSTEM, TEMP_CELSIUS, TEMP_FAHRENHEIT, 38, 100),
+        (US_CUSTOMARY_SYSTEM, TEMP_FAHRENHEIT, TEMP_FAHRENHEIT, 100, 100),
+        (US_CUSTOMARY_SYSTEM, TEMP_CELSIUS, TEMP_FAHRENHEIT, 38, 100),
         (METRIC_SYSTEM, TEMP_FAHRENHEIT, TEMP_CELSIUS, 100, 38),
         (METRIC_SYSTEM, TEMP_CELSIUS, TEMP_CELSIUS, 38, 38),
     ],

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -26,7 +26,7 @@ from homeassistant.components.recorder.util import get_instance, session_scope
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.setup import async_setup_component, setup_component
 import homeassistant.util.dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from tests.components.recorder.common import (
     async_recorder_block_till_done,
@@ -403,18 +403,18 @@ def test_compile_hourly_statistics_wrong_unit(hass_recorder, caplog, attributes)
 @pytest.mark.parametrize(
     "units, device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
     [
-        (IMPERIAL_SYSTEM, "distance", "m", "m", "m", "distance", 1),
-        (IMPERIAL_SYSTEM, "distance", "mi", "mi", "mi", "distance", 1),
-        (IMPERIAL_SYSTEM, "energy", "kWh", "kWh", "kWh", "energy", 1),
-        (IMPERIAL_SYSTEM, "energy", "Wh", "Wh", "Wh", "energy", 1),
-        (IMPERIAL_SYSTEM, "gas", "m³", "m³", "m³", "volume", 1),
-        (IMPERIAL_SYSTEM, "gas", "ft³", "ft³", "ft³", "volume", 1),
-        (IMPERIAL_SYSTEM, "monetary", "EUR", "EUR", "EUR", None, 1),
-        (IMPERIAL_SYSTEM, "monetary", "SEK", "SEK", "SEK", None, 1),
-        (IMPERIAL_SYSTEM, "volume", "m³", "m³", "m³", "volume", 1),
-        (IMPERIAL_SYSTEM, "volume", "ft³", "ft³", "ft³", "volume", 1),
-        (IMPERIAL_SYSTEM, "weight", "g", "g", "g", "mass", 1),
-        (IMPERIAL_SYSTEM, "weight", "oz", "oz", "oz", "mass", 1),
+        (US_CUSTOMARY_SYSTEM, "distance", "m", "m", "m", "distance", 1),
+        (US_CUSTOMARY_SYSTEM, "distance", "mi", "mi", "mi", "distance", 1),
+        (US_CUSTOMARY_SYSTEM, "energy", "kWh", "kWh", "kWh", "energy", 1),
+        (US_CUSTOMARY_SYSTEM, "energy", "Wh", "Wh", "Wh", "energy", 1),
+        (US_CUSTOMARY_SYSTEM, "gas", "m³", "m³", "m³", "volume", 1),
+        (US_CUSTOMARY_SYSTEM, "gas", "ft³", "ft³", "ft³", "volume", 1),
+        (US_CUSTOMARY_SYSTEM, "monetary", "EUR", "EUR", "EUR", None, 1),
+        (US_CUSTOMARY_SYSTEM, "monetary", "SEK", "SEK", "SEK", None, 1),
+        (US_CUSTOMARY_SYSTEM, "volume", "m³", "m³", "m³", "volume", 1),
+        (US_CUSTOMARY_SYSTEM, "volume", "ft³", "ft³", "ft³", "volume", 1),
+        (US_CUSTOMARY_SYSTEM, "weight", "g", "g", "g", "mass", 1),
+        (US_CUSTOMARY_SYSTEM, "weight", "oz", "oz", "oz", "mass", 1),
         (METRIC_SYSTEM, "distance", "m", "m", "m", "distance", 1),
         (METRIC_SYSTEM, "distance", "mi", "mi", "mi", "distance", 1),
         (METRIC_SYSTEM, "energy", "kWh", "kWh", "kWh", "energy", 1),
@@ -3307,12 +3307,18 @@ def record_states(hass, zero, entity_id, attributes, seq=None):
 @pytest.mark.parametrize(
     "units, attributes, unit, unit2, supported_unit",
     [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
+        (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
         (METRIC_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
-        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_ATTRIBUTES, "°F", "K", "K, °C, °F"),
+        (
+            US_CUSTOMARY_SYSTEM,
+            TEMPERATURE_SENSOR_ATTRIBUTES,
+            "°F",
+            "K",
+            "K, °C, °F",
+        ),
         (METRIC_SYSTEM, TEMPERATURE_SENSOR_ATTRIBUTES, "°C", "K", "K, °C, °F"),
         (
-            IMPERIAL_SYSTEM,
+            US_CUSTOMARY_SYSTEM,
             PRESSURE_SENSOR_ATTRIBUTES,
             "psi",
             "bar",
@@ -3439,7 +3445,7 @@ async def test_validate_unit_change_convertible(
 @pytest.mark.parametrize(
     "units, attributes",
     [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_ATTRIBUTES),
+        (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES),
     ],
 )
 async def test_validate_statistics_unit_ignore_device_class(
@@ -3493,12 +3499,18 @@ async def test_validate_statistics_unit_ignore_device_class(
 @pytest.mark.parametrize(
     "units, attributes, unit, unit2, supported_unit",
     [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
+        (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
         (METRIC_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
-        (IMPERIAL_SYSTEM, TEMPERATURE_SENSOR_ATTRIBUTES, "°F", "K", "K, °C, °F"),
+        (
+            US_CUSTOMARY_SYSTEM,
+            TEMPERATURE_SENSOR_ATTRIBUTES,
+            "°F",
+            "K",
+            "K, °C, °F",
+        ),
         (METRIC_SYSTEM, TEMPERATURE_SENSOR_ATTRIBUTES, "°C", "K", "K, °C, °F"),
         (
-            IMPERIAL_SYSTEM,
+            US_CUSTOMARY_SYSTEM,
             PRESSURE_SENSOR_ATTRIBUTES,
             "psi",
             "bar",
@@ -3625,7 +3637,7 @@ async def test_validate_statistics_unit_change_no_device_class(
 @pytest.mark.parametrize(
     "units, attributes, unit",
     [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
+        (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
     ],
 )
 async def test_validate_statistics_unsupported_state_class(
@@ -3689,7 +3701,7 @@ async def test_validate_statistics_unsupported_state_class(
 @pytest.mark.parametrize(
     "units, attributes, unit",
     [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
+        (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
     ],
 )
 async def test_validate_statistics_sensor_no_longer_recorded(
@@ -3750,7 +3762,7 @@ async def test_validate_statistics_sensor_no_longer_recorded(
 @pytest.mark.parametrize(
     "units, attributes, unit",
     [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
+        (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
     ],
 )
 async def test_validate_statistics_sensor_not_recorded(
@@ -3808,7 +3820,7 @@ async def test_validate_statistics_sensor_not_recorded(
 @pytest.mark.parametrize(
     "units, attributes, unit",
     [
-        (IMPERIAL_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
+        (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
     ],
 )
 async def test_validate_statistics_sensor_removed(

--- a/tests/components/subaru/test_sensor.py
+++ b/tests/components/subaru/test_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.subaru.sensor import (
     SAFETY_SENSORS,
 )
 from homeassistant.util import slugify
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .api_responses import (
     EXPECTED_STATE_EV_IMPERIAL,
@@ -25,7 +25,7 @@ from .conftest import (
 
 async def test_sensors_ev_imperial(hass, ev_entry):
     """Test sensors supporting imperial units."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
 
     with patch(MOCK_API_FETCH), patch(
         MOCK_API_GET_DATA, return_value=VEHICLE_STATUS_EV

--- a/tests/components/tomorrowio/test_sensor.py
+++ b/tests/components/tomorrowio/test_sensor.py
@@ -25,7 +25,7 @@ from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers.entity_registry import async_get
 from homeassistant.util import dt as dt_util
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .const import API_V4_ENTRY_DATA
 
@@ -172,7 +172,7 @@ async def test_v4_sensor(hass: HomeAssistant) -> None:
 
 async def test_v4_sensor_imperial(hass: HomeAssistant) -> None:
     """Test v4 sensor data."""
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
     await _setup(hass, V4_FIELDS, API_V4_ENTRY_DATA)
     check_sensor_state(hass, O3, "91.35")
     check_sensor_state(hass, CO, "0.0")

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -54,7 +54,7 @@ from homeassistant.util.distance import convert as convert_distance
 from homeassistant.util.pressure import convert as convert_pressure
 from homeassistant.util.speed import convert as convert_speed
 from homeassistant.util.temperature import convert as convert_temperature
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from tests.testing_config.custom_components.test import weather as WeatherPlatform
 
@@ -143,7 +143,7 @@ async def create_entity(hass: HomeAssistant, **kwargs):
 @pytest.mark.parametrize("native_unit", (TEMP_FAHRENHEIT, TEMP_CELSIUS))
 @pytest.mark.parametrize(
     "state_unit, unit_system",
-    ((TEMP_CELSIUS, METRIC_SYSTEM), (TEMP_FAHRENHEIT, IMPERIAL_SYSTEM)),
+    ((TEMP_CELSIUS, METRIC_SYSTEM), (TEMP_FAHRENHEIT, US_CUSTOMARY_SYSTEM)),
 )
 async def test_temperature(
     hass: HomeAssistant,
@@ -176,7 +176,7 @@ async def test_temperature(
 @pytest.mark.parametrize("native_unit", (None,))
 @pytest.mark.parametrize(
     "state_unit, unit_system",
-    ((TEMP_CELSIUS, METRIC_SYSTEM), (TEMP_FAHRENHEIT, IMPERIAL_SYSTEM)),
+    ((TEMP_CELSIUS, METRIC_SYSTEM), (TEMP_FAHRENHEIT, US_CUSTOMARY_SYSTEM)),
 )
 async def test_temperature_no_unit(
     hass: HomeAssistant,
@@ -209,7 +209,7 @@ async def test_temperature_no_unit(
 @pytest.mark.parametrize("native_unit", (PRESSURE_INHG, PRESSURE_INHG))
 @pytest.mark.parametrize(
     "state_unit, unit_system",
-    ((PRESSURE_HPA, METRIC_SYSTEM), (PRESSURE_INHG, IMPERIAL_SYSTEM)),
+    ((PRESSURE_HPA, METRIC_SYSTEM), (PRESSURE_INHG, US_CUSTOMARY_SYSTEM)),
 )
 async def test_pressure(
     hass: HomeAssistant,
@@ -237,7 +237,7 @@ async def test_pressure(
 @pytest.mark.parametrize("native_unit", (None,))
 @pytest.mark.parametrize(
     "state_unit, unit_system",
-    ((PRESSURE_HPA, METRIC_SYSTEM), (PRESSURE_INHG, IMPERIAL_SYSTEM)),
+    ((PRESSURE_HPA, METRIC_SYSTEM), (PRESSURE_INHG, US_CUSTOMARY_SYSTEM)),
 )
 async def test_pressure_no_unit(
     hass: HomeAssistant,
@@ -270,7 +270,7 @@ async def test_pressure_no_unit(
     "state_unit, unit_system",
     (
         (SPEED_KILOMETERS_PER_HOUR, METRIC_SYSTEM),
-        (SPEED_MILES_PER_HOUR, IMPERIAL_SYSTEM),
+        (SPEED_MILES_PER_HOUR, US_CUSTOMARY_SYSTEM),
     ),
 )
 async def test_wind_speed(
@@ -304,7 +304,7 @@ async def test_wind_speed(
     "state_unit, unit_system",
     (
         (SPEED_KILOMETERS_PER_HOUR, METRIC_SYSTEM),
-        (SPEED_MILES_PER_HOUR, IMPERIAL_SYSTEM),
+        (SPEED_MILES_PER_HOUR, US_CUSTOMARY_SYSTEM),
     ),
 )
 async def test_wind_speed_no_unit(
@@ -338,7 +338,7 @@ async def test_wind_speed_no_unit(
     "state_unit, unit_system",
     (
         (LENGTH_KILOMETERS, METRIC_SYSTEM),
-        (LENGTH_MILES, IMPERIAL_SYSTEM),
+        (LENGTH_MILES, US_CUSTOMARY_SYSTEM),
     ),
 )
 async def test_visibility(
@@ -369,7 +369,7 @@ async def test_visibility(
     "state_unit, unit_system",
     (
         (LENGTH_KILOMETERS, METRIC_SYSTEM),
-        (LENGTH_MILES, IMPERIAL_SYSTEM),
+        (LENGTH_MILES, US_CUSTOMARY_SYSTEM),
     ),
 )
 async def test_visibility_no_unit(
@@ -400,7 +400,7 @@ async def test_visibility_no_unit(
     "state_unit, unit_system",
     (
         (LENGTH_MILLIMETERS, METRIC_SYSTEM),
-        (LENGTH_INCHES, IMPERIAL_SYSTEM),
+        (LENGTH_INCHES, US_CUSTOMARY_SYSTEM),
     ),
 )
 async def test_precipitation(
@@ -431,7 +431,7 @@ async def test_precipitation(
     "state_unit, unit_system",
     (
         (LENGTH_MILLIMETERS, METRIC_SYSTEM),
-        (LENGTH_INCHES, IMPERIAL_SYSTEM),
+        (LENGTH_INCHES, US_CUSTOMARY_SYSTEM),
     ),
 )
 async def test_precipitation_no_unit(
@@ -719,7 +719,7 @@ async def test_backwards_compatibility_convert_values(
     precipitation_value = 1
     precipitation_unit = LENGTH_MILLIMETERS
 
-    hass.config.units = IMPERIAL_SYSTEM
+    hass.config.units = US_CUSTOMARY_SYSTEM
 
     platform: WeatherPlatform = getattr(hass.components, "test.weather")
     platform.init(empty=True)

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -23,6 +23,7 @@ from homeassistant.util.unit_system import (
     _CONF_UNIT_SYSTEM_IMPERIAL,
     _CONF_UNIT_SYSTEM_METRIC,
     _CONF_UNIT_SYSTEM_US_CUSTOMARY,
+    IMPERIAL_SYSTEM,
     METRIC_SYSTEM,
     US_CUSTOMARY_SYSTEM,
     UnitSystem,
@@ -166,17 +167,15 @@ def test_temperature_to_metric():
     """Test temperature conversion to metric system."""
     assert METRIC_SYSTEM.temperature(25, METRIC_SYSTEM.temperature_unit) == 25
     assert (
-        round(METRIC_SYSTEM.temperature(80, US_CUSTOMARY_SYSTEM.temperature_unit), 1)
+        round(METRIC_SYSTEM.temperature(80, IMPERIAL_SYSTEM.temperature_unit), 1)
         == 26.7
     )
 
 
 def test_temperature_to_imperial():
     """Test temperature conversion to imperial system."""
-    assert (
-        US_CUSTOMARY_SYSTEM.temperature(77, US_CUSTOMARY_SYSTEM.temperature_unit) == 77
-    )
-    assert US_CUSTOMARY_SYSTEM.temperature(25, METRIC_SYSTEM.temperature_unit) == 77
+    assert IMPERIAL_SYSTEM.temperature(77, IMPERIAL_SYSTEM.temperature_unit) == 77
+    assert IMPERIAL_SYSTEM.temperature(25, METRIC_SYSTEM.temperature_unit) == 77
 
 
 def test_length_unknown_unit():
@@ -188,15 +187,15 @@ def test_length_unknown_unit():
 def test_length_to_metric():
     """Test length conversion to metric system."""
     assert METRIC_SYSTEM.length(100, METRIC_SYSTEM.length_unit) == 100
-    assert METRIC_SYSTEM.length(5, US_CUSTOMARY_SYSTEM.length_unit) == pytest.approx(
+    assert METRIC_SYSTEM.length(5, IMPERIAL_SYSTEM.length_unit) == pytest.approx(
         8.04672
     )
 
 
 def test_length_to_imperial():
     """Test length conversion to imperial system."""
-    assert US_CUSTOMARY_SYSTEM.length(100, US_CUSTOMARY_SYSTEM.length_unit) == 100
-    assert US_CUSTOMARY_SYSTEM.length(5, METRIC_SYSTEM.length_unit) == pytest.approx(
+    assert IMPERIAL_SYSTEM.length(100, IMPERIAL_SYSTEM.length_unit) == 100
+    assert IMPERIAL_SYSTEM.length(5, METRIC_SYSTEM.length_unit) == pytest.approx(
         3.106855
     )
 
@@ -212,16 +211,14 @@ def test_wind_speed_to_metric():
     assert METRIC_SYSTEM.wind_speed(100, METRIC_SYSTEM.wind_speed_unit) == 100
     # 1 m/s is about 2.237 mph
     assert METRIC_SYSTEM.wind_speed(
-        2237, US_CUSTOMARY_SYSTEM.wind_speed_unit
+        2237, IMPERIAL_SYSTEM.wind_speed_unit
     ) == pytest.approx(1000, abs=0.1)
 
 
 def test_wind_speed_to_imperial():
     """Test wind_speed conversion to imperial system."""
-    assert (
-        US_CUSTOMARY_SYSTEM.wind_speed(100, US_CUSTOMARY_SYSTEM.wind_speed_unit) == 100
-    )
-    assert US_CUSTOMARY_SYSTEM.wind_speed(
+    assert IMPERIAL_SYSTEM.wind_speed(100, IMPERIAL_SYSTEM.wind_speed_unit) == 100
+    assert IMPERIAL_SYSTEM.wind_speed(
         1000, METRIC_SYSTEM.wind_speed_unit
     ) == pytest.approx(2237, abs=0.1)
 
@@ -240,15 +237,15 @@ def test_pressure_unknown_unit():
 def test_pressure_to_metric():
     """Test pressure conversion to metric system."""
     assert METRIC_SYSTEM.pressure(25, METRIC_SYSTEM.pressure_unit) == 25
-    assert METRIC_SYSTEM.pressure(
-        14.7, US_CUSTOMARY_SYSTEM.pressure_unit
-    ) == pytest.approx(101352.932, abs=1e-1)
+    assert METRIC_SYSTEM.pressure(14.7, IMPERIAL_SYSTEM.pressure_unit) == pytest.approx(
+        101352.932, abs=1e-1
+    )
 
 
 def test_pressure_to_imperial():
     """Test pressure conversion to imperial system."""
-    assert US_CUSTOMARY_SYSTEM.pressure(77, US_CUSTOMARY_SYSTEM.pressure_unit) == 77
-    assert US_CUSTOMARY_SYSTEM.pressure(
+    assert IMPERIAL_SYSTEM.pressure(77, IMPERIAL_SYSTEM.pressure_unit) == 77
+    assert IMPERIAL_SYSTEM.pressure(
         101352.932, METRIC_SYSTEM.pressure_unit
     ) == pytest.approx(14.7, abs=1e-4)
 
@@ -278,19 +275,19 @@ def test_accumulated_precipitation_to_metric():
         == 25
     )
     assert METRIC_SYSTEM.accumulated_precipitation(
-        10, US_CUSTOMARY_SYSTEM.accumulated_precipitation_unit
+        10, IMPERIAL_SYSTEM.accumulated_precipitation_unit
     ) == pytest.approx(254, abs=1e-4)
 
 
 def test_accumulated_precipitation_to_imperial():
     """Test accumulated_precipitation conversion to imperial system."""
     assert (
-        US_CUSTOMARY_SYSTEM.accumulated_precipitation(
-            10, US_CUSTOMARY_SYSTEM.accumulated_precipitation_unit
+        IMPERIAL_SYSTEM.accumulated_precipitation(
+            10, IMPERIAL_SYSTEM.accumulated_precipitation_unit
         )
         == 10
     )
-    assert US_CUSTOMARY_SYSTEM.accumulated_precipitation(
+    assert IMPERIAL_SYSTEM.accumulated_precipitation(
         254, METRIC_SYSTEM.accumulated_precipitation_unit
     ) == pytest.approx(10, abs=1e-4)
 
@@ -310,7 +307,7 @@ def test_properties():
     "unit_system, expected_flag",
     [
         (METRIC_SYSTEM, True),
-        (US_CUSTOMARY_SYSTEM, False),
+        (IMPERIAL_SYSTEM, False),
     ],
 )
 def test_is_metric(
@@ -328,11 +325,7 @@ def test_is_metric(
     "unit_system, expected_name, expected_private_name",
     [
         (METRIC_SYSTEM, _CONF_UNIT_SYSTEM_METRIC, _CONF_UNIT_SYSTEM_METRIC),
-        (
-            US_CUSTOMARY_SYSTEM,
-            _CONF_UNIT_SYSTEM_IMPERIAL,
-            _CONF_UNIT_SYSTEM_US_CUSTOMARY,
-        ),
+        (IMPERIAL_SYSTEM, _CONF_UNIT_SYSTEM_IMPERIAL, _CONF_UNIT_SYSTEM_US_CUSTOMARY),
         (
             US_CUSTOMARY_SYSTEM,
             _CONF_UNIT_SYSTEM_IMPERIAL,

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -23,7 +23,6 @@ from homeassistant.util.unit_system import (
     _CONF_UNIT_SYSTEM_IMPERIAL,
     _CONF_UNIT_SYSTEM_METRIC,
     _CONF_UNIT_SYSTEM_US_CUSTOMARY,
-    IMPERIAL_SYSTEM,
     METRIC_SYSTEM,
     US_CUSTOMARY_SYSTEM,
     UnitSystem,
@@ -167,15 +166,17 @@ def test_temperature_to_metric():
     """Test temperature conversion to metric system."""
     assert METRIC_SYSTEM.temperature(25, METRIC_SYSTEM.temperature_unit) == 25
     assert (
-        round(METRIC_SYSTEM.temperature(80, IMPERIAL_SYSTEM.temperature_unit), 1)
+        round(METRIC_SYSTEM.temperature(80, US_CUSTOMARY_SYSTEM.temperature_unit), 1)
         == 26.7
     )
 
 
 def test_temperature_to_imperial():
     """Test temperature conversion to imperial system."""
-    assert IMPERIAL_SYSTEM.temperature(77, IMPERIAL_SYSTEM.temperature_unit) == 77
-    assert IMPERIAL_SYSTEM.temperature(25, METRIC_SYSTEM.temperature_unit) == 77
+    assert (
+        US_CUSTOMARY_SYSTEM.temperature(77, US_CUSTOMARY_SYSTEM.temperature_unit) == 77
+    )
+    assert US_CUSTOMARY_SYSTEM.temperature(25, METRIC_SYSTEM.temperature_unit) == 77
 
 
 def test_length_unknown_unit():
@@ -187,15 +188,15 @@ def test_length_unknown_unit():
 def test_length_to_metric():
     """Test length conversion to metric system."""
     assert METRIC_SYSTEM.length(100, METRIC_SYSTEM.length_unit) == 100
-    assert METRIC_SYSTEM.length(5, IMPERIAL_SYSTEM.length_unit) == pytest.approx(
+    assert METRIC_SYSTEM.length(5, US_CUSTOMARY_SYSTEM.length_unit) == pytest.approx(
         8.04672
     )
 
 
 def test_length_to_imperial():
     """Test length conversion to imperial system."""
-    assert IMPERIAL_SYSTEM.length(100, IMPERIAL_SYSTEM.length_unit) == 100
-    assert IMPERIAL_SYSTEM.length(5, METRIC_SYSTEM.length_unit) == pytest.approx(
+    assert US_CUSTOMARY_SYSTEM.length(100, US_CUSTOMARY_SYSTEM.length_unit) == 100
+    assert US_CUSTOMARY_SYSTEM.length(5, METRIC_SYSTEM.length_unit) == pytest.approx(
         3.106855
     )
 
@@ -211,14 +212,16 @@ def test_wind_speed_to_metric():
     assert METRIC_SYSTEM.wind_speed(100, METRIC_SYSTEM.wind_speed_unit) == 100
     # 1 m/s is about 2.237 mph
     assert METRIC_SYSTEM.wind_speed(
-        2237, IMPERIAL_SYSTEM.wind_speed_unit
+        2237, US_CUSTOMARY_SYSTEM.wind_speed_unit
     ) == pytest.approx(1000, abs=0.1)
 
 
 def test_wind_speed_to_imperial():
     """Test wind_speed conversion to imperial system."""
-    assert IMPERIAL_SYSTEM.wind_speed(100, IMPERIAL_SYSTEM.wind_speed_unit) == 100
-    assert IMPERIAL_SYSTEM.wind_speed(
+    assert (
+        US_CUSTOMARY_SYSTEM.wind_speed(100, US_CUSTOMARY_SYSTEM.wind_speed_unit) == 100
+    )
+    assert US_CUSTOMARY_SYSTEM.wind_speed(
         1000, METRIC_SYSTEM.wind_speed_unit
     ) == pytest.approx(2237, abs=0.1)
 
@@ -237,15 +240,15 @@ def test_pressure_unknown_unit():
 def test_pressure_to_metric():
     """Test pressure conversion to metric system."""
     assert METRIC_SYSTEM.pressure(25, METRIC_SYSTEM.pressure_unit) == 25
-    assert METRIC_SYSTEM.pressure(14.7, IMPERIAL_SYSTEM.pressure_unit) == pytest.approx(
-        101352.932, abs=1e-1
-    )
+    assert METRIC_SYSTEM.pressure(
+        14.7, US_CUSTOMARY_SYSTEM.pressure_unit
+    ) == pytest.approx(101352.932, abs=1e-1)
 
 
 def test_pressure_to_imperial():
     """Test pressure conversion to imperial system."""
-    assert IMPERIAL_SYSTEM.pressure(77, IMPERIAL_SYSTEM.pressure_unit) == 77
-    assert IMPERIAL_SYSTEM.pressure(
+    assert US_CUSTOMARY_SYSTEM.pressure(77, US_CUSTOMARY_SYSTEM.pressure_unit) == 77
+    assert US_CUSTOMARY_SYSTEM.pressure(
         101352.932, METRIC_SYSTEM.pressure_unit
     ) == pytest.approx(14.7, abs=1e-4)
 
@@ -275,19 +278,19 @@ def test_accumulated_precipitation_to_metric():
         == 25
     )
     assert METRIC_SYSTEM.accumulated_precipitation(
-        10, IMPERIAL_SYSTEM.accumulated_precipitation_unit
+        10, US_CUSTOMARY_SYSTEM.accumulated_precipitation_unit
     ) == pytest.approx(254, abs=1e-4)
 
 
 def test_accumulated_precipitation_to_imperial():
     """Test accumulated_precipitation conversion to imperial system."""
     assert (
-        IMPERIAL_SYSTEM.accumulated_precipitation(
-            10, IMPERIAL_SYSTEM.accumulated_precipitation_unit
+        US_CUSTOMARY_SYSTEM.accumulated_precipitation(
+            10, US_CUSTOMARY_SYSTEM.accumulated_precipitation_unit
         )
         == 10
     )
-    assert IMPERIAL_SYSTEM.accumulated_precipitation(
+    assert US_CUSTOMARY_SYSTEM.accumulated_precipitation(
         254, METRIC_SYSTEM.accumulated_precipitation_unit
     ) == pytest.approx(10, abs=1e-4)
 
@@ -307,7 +310,7 @@ def test_properties():
     "unit_system, expected_flag",
     [
         (METRIC_SYSTEM, True),
-        (IMPERIAL_SYSTEM, False),
+        (US_CUSTOMARY_SYSTEM, False),
     ],
 )
 def test_is_metric(
@@ -325,7 +328,11 @@ def test_is_metric(
     "unit_system, expected_name, expected_private_name",
     [
         (METRIC_SYSTEM, _CONF_UNIT_SYSTEM_METRIC, _CONF_UNIT_SYSTEM_METRIC),
-        (IMPERIAL_SYSTEM, _CONF_UNIT_SYSTEM_IMPERIAL, _CONF_UNIT_SYSTEM_US_CUSTOMARY),
+        (
+            US_CUSTOMARY_SYSTEM,
+            _CONF_UNIT_SYSTEM_IMPERIAL,
+            _CONF_UNIT_SYSTEM_US_CUSTOMARY,
+        ),
         (
             US_CUSTOMARY_SYSTEM,
             _CONF_UNIT_SYSTEM_IMPERIAL,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use US_CUSTOMARY_SYSTEM in tests

As follow-up to #80253 and #80623

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
