### PR TITLE
Add WS API recorder/statistic_during_period

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1369,7 +1369,7 @@ def statistic_during_period(
     metadata = None
 
     if not types:
-        types = {"max", "mean", "min", "sum"}
+        types = {"max", "mean", "min", "change"}
 
     result: dict[str, Any] = {}
 
@@ -1439,7 +1439,7 @@ def statistic_during_period(
                 types,
             )
 
-        if "sum" in types:
+        if "change" in types:
             oldest_sum: float | None
             if start_time is None:
                 oldest_sum = 0.0
@@ -1465,9 +1465,9 @@ def statistic_during_period(
             )
             # Calculate the difference between the oldest and newest sum
             if oldest_sum is not None and newest_sum is not None:
-                result["sum"] = newest_sum - oldest_sum
+                result["change"] = newest_sum - oldest_sum
             else:
-                result["sum"] = None
+                result["change"] = None
 
     def no_conversion(val: float | None) -> float | None:
         """Return val."""

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1469,7 +1469,19 @@ def statistic_during_period(
             else:
                 result["sum"] = None
 
-    return result
+    def no_conversion(val: float | None) -> float | None:
+        """Return val."""
+        return val
+
+    state_unit = unit = metadata[statistic_id][1]["unit_of_measurement"]
+    if state := hass.states.get(statistic_id):
+        state_unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+    if unit is not None:
+        convert = _get_statistic_to_display_unit_converter(unit, state_unit, units)
+    else:
+        convert = no_conversion
+
+    return {key: convert(value) for key, value in result.items()}
 
 
 def statistics_during_period(

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -79,15 +79,12 @@ def _ws_get_statistic_during_period(
     )
 
 
-_LOGGER = logging.getLogger(__name__)
-
-
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "recorder/statistic_during_period",
         vol.Exclusive("calendar", "period"): vol.Schema(
             {
-                vol.Required("period"): str,
+                vol.Required("period"): vol.Any("hour", "day", "week", "month", "year"),
                 vol.Optional("offset"): int,
             }
         ),
@@ -140,7 +137,7 @@ async def ws_get_statistic_during_period(
             start_time = dt_util.now().replace(minute=0, second=0, microsecond=0)
             start_time += timedelta(hours=offset)
             end_time = start_time + timedelta(hours=1)
-        if calendar_period == "day":
+        elif calendar_period == "day":
             start_time = start_of_day
             start_time += timedelta(days=offset)
             end_time = start_time + timedelta(days=1)

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -31,6 +31,7 @@ from .statistics import (
     async_change_statistics_unit,
     async_import_statistics,
     list_statistic_ids,
+    statistic_during_period,
     statistics_during_period,
     validate_statistics,
 )
@@ -47,6 +48,7 @@ def async_setup(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_backup_start)
     websocket_api.async_register_command(hass, ws_change_statistics_unit)
     websocket_api.async_register_command(hass, ws_clear_statistics)
+    websocket_api.async_register_command(hass, ws_get_statistic_during_period)
     websocket_api.async_register_command(hass, ws_get_statistics_during_period)
     websocket_api.async_register_command(hass, ws_get_statistics_metadata)
     websocket_api.async_register_command(hass, ws_list_statistic_ids)
@@ -54,6 +56,87 @@ def async_setup(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_info)
     websocket_api.async_register_command(hass, ws_update_statistics_metadata)
     websocket_api.async_register_command(hass, ws_validate_statistics)
+
+
+def _ws_get_statistic_during_period(
+    hass: HomeAssistant,
+    msg_id: int,
+    start_time: dt | None,
+    end_time: dt | None,
+    statistic_id: str,
+    types: list[str] | None,
+    units: dict[str, str],
+) -> str:
+    """Fetch statistics and convert them to json in the executor."""
+    return JSON_DUMP(
+        messages.result_message(
+            msg_id,
+            statistic_during_period(
+                hass, start_time, end_time, statistic_id, types, units=units
+            ),
+        )
+    )
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "recorder/statistic_during_period",
+        vol.Optional("start_time"): str,
+        vol.Optional("end_time"): str,
+        vol.Optional("statistic_id"): str,
+        vol.Optional("types"): list[str],
+        vol.Optional("units"): vol.Schema(
+            {
+                vol.Optional("distance"): vol.In(DistanceConverter.VALID_UNITS),
+                vol.Optional("energy"): vol.In(EnergyConverter.VALID_UNITS),
+                vol.Optional("mass"): vol.In(MassConverter.VALID_UNITS),
+                vol.Optional("power"): vol.In(PowerConverter.VALID_UNITS),
+                vol.Optional("pressure"): vol.In(PressureConverter.VALID_UNITS),
+                vol.Optional("speed"): vol.In(SpeedConverter.VALID_UNITS),
+                vol.Optional("temperature"): vol.In(TemperatureConverter.VALID_UNITS),
+                vol.Optional("volume"): vol.In(VolumeConverter.VALID_UNITS),
+            }
+        ),
+    }
+)
+@websocket_api.async_response
+async def ws_get_statistic_during_period(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Handle statistics websocket command."""
+    start_time_str = msg["start_time"]
+    end_time_str = msg.get("end_time")
+
+    if start_time_str:
+        if start_time := dt_util.parse_datetime(start_time_str):
+            start_time = dt_util.as_utc(start_time)
+        else:
+            connection.send_error(msg["id"], "invalid_start_time", "Invalid start_time")
+            return
+    else:
+        start_time = None
+
+    if end_time_str:
+        if end_time := dt_util.parse_datetime(end_time_str):
+            end_time = dt_util.as_utc(end_time)
+        else:
+            connection.send_error(msg["id"], "invalid_end_time", "Invalid end_time")
+            return
+    else:
+        end_time = None
+
+    connection.send_message(
+        await get_instance(hass).async_add_executor_job(
+            _ws_get_statistic_during_period,
+            hass,
+            msg["id"],
+            start_time,
+            end_time,
+            msg.get("statistic_id"),
+            msg.get("types"),
+            msg.get("units"),
+        )
+    )
 
 
 def _ws_get_statistics_during_period(

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -260,7 +260,12 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
     )
     response = await client.receive_json()
     assert response["success"]
-    assert response["result"] == {"max": None, "mean": None, "min": None, "sum": None}
+    assert response["result"] == {
+        "max": None,
+        "mean": None,
+        "min": None,
+        "change": None,
+    }
 
     # This should include imported_statistics_5min[:]
     await client.send_json(
@@ -276,7 +281,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[:]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[:]),
         "min": min(stat["min"] for stat in imported_stats_5min[:]),
-        "sum": imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"],
+        "change": imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"],
     }
 
     # This should also include imported_statistics_5min[:]
@@ -299,7 +304,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[:]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[:]),
         "min": min(stat["min"] for stat in imported_stats_5min[:]),
-        "sum": imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"],
+        "change": imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"],
     }
 
     # This should also include imported_statistics_5min[:]
@@ -322,7 +327,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[:]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[:]),
         "min": min(stat["min"] for stat in imported_stats_5min[:]),
-        "sum": imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"],
+        "change": imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"],
     }
 
     # This should include imported_statistics_5min[26:]
@@ -344,7 +349,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[26:]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[26:]),
         "min": min(stat["min"] for stat in imported_stats_5min[26:]),
-        "sum": imported_stats_5min[-1]["sum"] - imported_stats_5min[25]["sum"],
+        "change": imported_stats_5min[-1]["sum"] - imported_stats_5min[25]["sum"],
     }
 
     # This should also include imported_statistics_5min[26:]
@@ -365,7 +370,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[26:]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[26:]),
         "min": min(stat["min"] for stat in imported_stats_5min[26:]),
-        "sum": imported_stats_5min[-1]["sum"] - imported_stats_5min[25]["sum"],
+        "change": imported_stats_5min[-1]["sum"] - imported_stats_5min[25]["sum"],
     }
 
     # This should include imported_statistics_5min[:26]
@@ -387,7 +392,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[:26]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[:26]),
         "min": min(stat["min"] for stat in imported_stats_5min[:26]),
-        "sum": imported_stats_5min[25]["sum"] - 0,
+        "change": imported_stats_5min[25]["sum"] - 0,
     }
 
     # This should include imported_statistics_5min[26:32] (less than a full hour)
@@ -412,7 +417,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[26:32]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[26:32]),
         "min": min(stat["min"] for stat in imported_stats_5min[26:32]),
-        "sum": imported_stats_5min[31]["sum"] - imported_stats_5min[25]["sum"],
+        "change": imported_stats_5min[31]["sum"] - imported_stats_5min[25]["sum"],
     }
 
     # This should include imported_statistics[2:] + imported_statistics_5min[36:]
@@ -435,7 +440,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[24:]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[24:]),
         "min": min(stat["min"] for stat in imported_stats_5min[24:]),
-        "sum": imported_stats_5min[-1]["sum"] - imported_stats_5min[23]["sum"],
+        "change": imported_stats_5min[-1]["sum"] - imported_stats_5min[23]["sum"],
     }
 
     # This should also include imported_statistics[2:] + imported_statistics_5min[36:]
@@ -455,7 +460,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[24:]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[24:]),
         "min": min(stat["min"] for stat in imported_stats_5min[24:]),
-        "sum": imported_stats_5min[-1]["sum"] - imported_stats_5min[23]["sum"],
+        "change": imported_stats_5min[-1]["sum"] - imported_stats_5min[23]["sum"],
     }
 
     # This should include imported_statistics[2:3]
@@ -476,7 +481,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[24:36]),
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[24:36]),
         "min": min(stat["min"] for stat in imported_stats_5min[24:36]),
-        "sum": imported_stats_5min[35]["sum"] - imported_stats_5min[23]["sum"],
+        "change": imported_stats_5min[35]["sum"] - imported_stats_5min[23]["sum"],
     }
 
     # Test we can get only selected types
@@ -485,14 +490,14 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
             "id": next_id(),
             "type": "recorder/statistic_during_period",
             "statistic_id": "sensor.test",
-            "types": ["max", "sum"],
+            "types": ["max", "change"],
         }
     )
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {
         "max": max(stat["max"] for stat in imported_stats_5min[:]),
-        "sum": imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"],
+        "change": imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"],
     }
 
     # Test we can convert units
@@ -510,7 +515,8 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[:]) / 1000,
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[:]) / 1000,
         "min": min(stat["min"] for stat in imported_stats_5min[:]) / 1000,
-        "sum": (imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"]) / 1000,
+        "change": (imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"])
+        / 1000,
     }
 
     # Test we can automatically convert units
@@ -528,7 +534,8 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": max(stat["max"] for stat in imported_stats_5min[:]) * 1000,
         "mean": fmean(stat["mean"] for stat in imported_stats_5min[:]) * 1000,
         "min": min(stat["min"] for stat in imported_stats_5min[:]) * 1000,
-        "sum": (imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"]) * 1000,
+        "change": (imported_stats_5min[-1]["sum"] - imported_stats_5min[0]["sum"])
+        * 1000,
     }
 
 

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -202,12 +202,14 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
         "max": 20,
         "mean": 0,
         "min": -10,
+        "sum": 0,
     }
     imported_statistics2 = {
         "start": period2.isoformat(),
         "max": 10,
         "mean": 20,
         "min": -20,
+        "sum": 1,
     }
 
     imported_metadata = {
@@ -254,7 +256,7 @@ async def test_statistic_during_period(recorder_mock, hass, hass_ws_client):
     )
     response = await client.receive_json()
     assert response["success"]
-    assert response["result"] == {"max": 20, "mean": 10, "min": -20}
+    assert response["result"] == {"max": 20, "mean": 10, "min": -20, "sum": -1}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add WS API `recorder/statistic_during_period`:
```py
@websocket_api.websocket_command(
    {
        vol.Required("type"): "recorder/statistic_during_period",
        vol.Exclusive("calendar", "period"): vol.Schema(
            {
                vol.Required("period"): str,
                vol.Optional("offset"): int,
            }
        ),
        vol.Exclusive("fixed_period", "period"): vol.Schema(
            {
                vol.Optional("start_time"): str,
                vol.Optional("end_time"): str,
            }
        ),
        vol.Exclusive("rolling_window", "period"): vol.Schema(
            {
                vol.Required("duration"): cv.time_period_dict,
                vol.Optional("offset"): cv.time_period_dict,
            }
        ),
        vol.Optional("statistic_id"): str,
        vol.Optional("types"): vol.All([str], vol.Coerce(set)),
        vol.Optional("units"): vol.Schema(
            {
                vol.Optional("distance"): vol.In(DistanceConverter.VALID_UNITS),
                vol.Optional("energy"): vol.In(EnergyConverter.VALID_UNITS),
                vol.Optional("mass"): vol.In(MassConverter.VALID_UNITS),
                vol.Optional("power"): vol.In(PowerConverter.VALID_UNITS),
                vol.Optional("pressure"): vol.In(PressureConverter.VALID_UNITS),
                vol.Optional("speed"): vol.In(SpeedConverter.VALID_UNITS),
                vol.Optional("temperature"): vol.In(TemperatureConverter.VALID_UNITS),
                vol.Optional("volume"): vol.In(VolumeConverter.VALID_UNITS),
            }
        ),
    }
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
