### PR TITLE
Fix oncue data unavailable when genset disconnected

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -796,8 +796,8 @@ build.json @home-assistant/supervisor
 /tests/components/omnilogic/ @oliver84 @djtimca @gentoosu
 /homeassistant/components/onboarding/ @home-assistant/core
 /tests/components/onboarding/ @home-assistant/core
-/homeassistant/components/oncue/ @bdraco
-/tests/components/oncue/ @bdraco
+/homeassistant/components/oncue/ @bdraco @peterager
+/tests/components/oncue/ @bdraco @peterager
 /homeassistant/components/ondilo_ico/ @JeromeHXP
 /tests/components/ondilo_ico/ @JeromeHXP
 /homeassistant/components/onewire/ @garbled1 @epenet

--- a/homeassistant/components/oncue/const.py
+++ b/homeassistant/components/oncue/const.py
@@ -8,4 +8,6 @@ DOMAIN = "oncue"
 
 CONNECTION_EXCEPTIONS = (asyncio.TimeoutError, aiohttp.ClientError)
 
+CONNECTION_ESTABLISHED_KEY: str = "NetworkConnectionEstablished"
+
 VALUE_UNAVAILABLE: str = "--"

--- a/homeassistant/components/oncue/const.py
+++ b/homeassistant/components/oncue/const.py
@@ -7,3 +7,5 @@ import aiohttp
 DOMAIN = "oncue"
 
 CONNECTION_EXCEPTIONS = (asyncio.TimeoutError, aiohttp.ClientError)
+
+VALUE_UNAVAILABLE: str = "--"

--- a/homeassistant/components/oncue/entity.py
+++ b/homeassistant/components/oncue/entity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from aiooncue import OncueDevice, OncueSensor
 
-from homeassistant.const import ATTR_CONNECTIONS
+from homeassistant.const import ATTR_CONNECTIONS, STATE_UNAVAILABLE
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 from homeassistant.helpers.update_coordinator import (
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, VALUE_UNAVAILABLE
 
 
 class OncueEntity(CoordinatorEntity, Entity):
@@ -52,4 +52,6 @@ class OncueEntity(CoordinatorEntity, Entity):
         """Return the sensor value."""
         device: OncueDevice = self.coordinator.data[self._device_id]
         sensor: OncueSensor = device.sensors[self.entity_description.key]
+        if sensor.value == VALUE_UNAVAILABLE:
+            return STATE_UNAVAILABLE
         return sensor.value

--- a/homeassistant/components/oncue/entity.py
+++ b/homeassistant/components/oncue/entity.py
@@ -57,15 +57,19 @@ class OncueEntity(CoordinatorEntity, Entity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if self._oncue_value == VALUE_UNAVAILABLE:
-            return False
-        # If the cloud is reporting that the generator is not connected
-        # this also indicates the data is not available.
-        # The battery voltage sensor reports 0.0 rather than -- hence the purpose of this check.
-        # However, the binary sensor that tracks the connection should not go unavailable.
+        # The binary sensor that tracks the connection should not go unavailable.
         if self.entity_description.key != CONNECTION_ESTABLISHED_KEY:
+            # If Kohler returns -- the entity is unavailable.
+            if self._oncue_value == VALUE_UNAVAILABLE:
+                return False
+            # If the cloud is reporting that the generator is not connected
+            # this also indicates the data is not available.
+            # The battery voltage sensor reports 0.0 rather than -- hence the purpose of this check.
             device: OncueDevice = self.coordinator.data[self._device_id]
             conn_established: OncueSensor = device.sensors[CONNECTION_ESTABLISHED_KEY]
-            if conn_established is not None and conn_established.value == "false":
+            if (
+                conn_established is not None
+                and conn_established.value == VALUE_UNAVAILABLE
+            ):
                 return False
         return super().available

--- a/homeassistant/components/oncue/manifest.json
+++ b/homeassistant/components/oncue/manifest.json
@@ -10,7 +10,7 @@
   ],
   "documentation": "https://www.home-assistant.io/integrations/oncue",
   "requirements": ["aiooncue==0.3.4"],
-  "codeowners": ["@bdraco"],
+  "codeowners": ["@bdraco","@peterager"],
   "iot_class": "cloud_polling",
   "loggers": ["aiooncue"]
 }

--- a/tests/components/oncue/__init__.py
+++ b/tests/components/oncue/__init__.py
@@ -825,7 +825,7 @@ def _patch_login_and_data_offline_device():
 def _patch_login_and_data_unavailable():
     @contextmanager
     def _patcher():
-        with patch("homeassistant.components.oncue.Oncue.async_login",), patch(
+        with patch("homeassistant.components.oncue.Oncue.async_login"), patch(
             "homeassistant.components.oncue.Oncue.async_fetch_all",
             return_value=MOCK_ASYNC_FETCH_ALL_UNAVAILABLE_DEVICE,
         ):

--- a/tests/components/oncue/__init__.py
+++ b/tests/components/oncue/__init__.py
@@ -593,7 +593,7 @@ MOCK_ASYNC_FETCH_ALL_UNAVAILABLE_DEVICE = {
             "BatteryVoltage": OncueSensor(
                 name="BatteryVoltage",
                 display_name="Battery Voltage",
-                value="--",
+                value="0.0",
                 display_value="13.4 V",
                 unit="V",
             ),
@@ -782,7 +782,7 @@ MOCK_ASYNC_FETCH_ALL_UNAVAILABLE_DEVICE = {
             "NetworkConnectionEstablished": OncueSensor(
                 name="NetworkConnectionEstablished",
                 display_name="Network Connection Established",
-                value="false",
+                value="--",
                 display_value="True",
                 unit=None,
             ),

--- a/tests/components/oncue/__init__.py
+++ b/tests/components/oncue/__init__.py
@@ -533,6 +533,270 @@ MOCK_ASYNC_FETCH_ALL_OFFLINE_DEVICE = {
     )
 }
 
+MOCK_ASYNC_FETCH_ALL_UNAVAILABLE_DEVICE = {
+    "456789": OncueDevice(
+        name="My Generator",
+        state="Off",
+        product_name="RDC 2.4",
+        hardware_version="319",
+        serial_number="SERIAL",
+        sensors={
+            "Product": OncueSensor(
+                name="Product",
+                display_name="Controller Type",
+                value="--",
+                display_value="RDC 2.4",
+                unit=None,
+            ),
+            "FirmwareVersion": OncueSensor(
+                name="FirmwareVersion",
+                display_name="Current Firmware",
+                value="--",
+                display_value="2.0.6",
+                unit=None,
+            ),
+            "LatestFirmware": OncueSensor(
+                name="LatestFirmware",
+                display_name="Latest Firmware",
+                value="--",
+                display_value="2.0.6",
+                unit=None,
+            ),
+            "EngineSpeed": OncueSensor(
+                name="EngineSpeed",
+                display_name="Engine Speed",
+                value="--",
+                display_value="0 R/min",
+                unit="R/min",
+            ),
+            "EngineTargetSpeed": OncueSensor(
+                name="EngineTargetSpeed",
+                display_name="Engine Target Speed",
+                value="--",
+                display_value="0 R/min",
+                unit="R/min",
+            ),
+            "EngineOilPressure": OncueSensor(
+                name="EngineOilPressure",
+                display_name="Engine Oil Pressure",
+                value="--",
+                display_value="0 Psi",
+                unit="Psi",
+            ),
+            "EngineCoolantTemperature": OncueSensor(
+                name="EngineCoolantTemperature",
+                display_name="Engine Coolant Temperature",
+                value="--",
+                display_value="32 F",
+                unit="F",
+            ),
+            "BatteryVoltage": OncueSensor(
+                name="BatteryVoltage",
+                display_name="Battery Voltage",
+                value="--",
+                display_value="13.4 V",
+                unit="V",
+            ),
+            "LubeOilTemperature": OncueSensor(
+                name="LubeOilTemperature",
+                display_name="Lube Oil Temperature",
+                value="--",
+                display_value="32 F",
+                unit="F",
+            ),
+            "GensetControllerTemperature": OncueSensor(
+                name="GensetControllerTemperature",
+                display_name="Generator Controller Temperature",
+                value="--",
+                display_value="84.2 F",
+                unit="F",
+            ),
+            "EngineCompartmentTemperature": OncueSensor(
+                name="EngineCompartmentTemperature",
+                display_name="Engine Compartment Temperature",
+                value="--",
+                display_value="62.6 F",
+                unit="F",
+            ),
+            "GeneratorTrueTotalPower": OncueSensor(
+                name="GeneratorTrueTotalPower",
+                display_name="Generator True Total Power",
+                value="--",
+                display_value="0.0 W",
+                unit="W",
+            ),
+            "GeneratorTruePercentOfRatedPower": OncueSensor(
+                name="GeneratorTruePercentOfRatedPower",
+                display_name="Generator True Percent Of Rated Power",
+                value="--",
+                display_value="0 %",
+                unit="%",
+            ),
+            "GeneratorVoltageAB": OncueSensor(
+                name="GeneratorVoltageAB",
+                display_name="Generator Voltage AB",
+                value="--",
+                display_value="0.0 V",
+                unit="V",
+            ),
+            "GeneratorVoltageAverageLineToLine": OncueSensor(
+                name="GeneratorVoltageAverageLineToLine",
+                display_name="Generator Voltage Average Line To Line",
+                value="--",
+                display_value="0.0 V",
+                unit="V",
+            ),
+            "GeneratorCurrentAverage": OncueSensor(
+                name="GeneratorCurrentAverage",
+                display_name="Generator Current Average",
+                value="--",
+                display_value="0.0 A",
+                unit="A",
+            ),
+            "GeneratorFrequency": OncueSensor(
+                name="GeneratorFrequency",
+                display_name="Generator Frequency",
+                value="--",
+                display_value="0.0 Hz",
+                unit="Hz",
+            ),
+            "GensetSerialNumber": OncueSensor(
+                name="GensetSerialNumber",
+                display_name="Generator Serial Number",
+                value="--",
+                display_value="33FDGMFR0026",
+                unit=None,
+            ),
+            "GensetState": OncueSensor(
+                name="GensetState",
+                display_name="Generator State",
+                value="--",
+                display_value="Off",
+                unit=None,
+            ),
+            "GensetControllerSerialNumber": OncueSensor(
+                name="GensetControllerSerialNumber",
+                display_name="Generator Controller Serial Number",
+                value="--",
+                display_value="-1",
+                unit=None,
+            ),
+            "GensetModelNumberSelect": OncueSensor(
+                name="GensetModelNumberSelect",
+                display_name="Genset Model Number Select",
+                value="--",
+                display_value="38 RCLB",
+                unit=None,
+            ),
+            "GensetControllerClockTime": OncueSensor(
+                name="GensetControllerClockTime",
+                display_name="Generator Controller Clock Time",
+                value="--",
+                display_value="2022-01-13 18:08:13",
+                unit=None,
+            ),
+            "GensetControllerTotalOperationTime": OncueSensor(
+                name="GensetControllerTotalOperationTime",
+                display_name="Generator Controller Total Operation Time",
+                value="--",
+                display_value="16770.8 h",
+                unit="h",
+            ),
+            "EngineTotalRunTime": OncueSensor(
+                name="EngineTotalRunTime",
+                display_name="Engine Total Run Time",
+                value="--",
+                display_value="28.1 h",
+                unit="h",
+            ),
+            "EngineTotalRunTimeLoaded": OncueSensor(
+                name="EngineTotalRunTimeLoaded",
+                display_name="Engine Total Run Time Loaded",
+                value="--",
+                display_value="5.5 h",
+                unit="h",
+            ),
+            "EngineTotalNumberOfStarts": OncueSensor(
+                name="EngineTotalNumberOfStarts",
+                display_name="Engine Total Number Of Starts",
+                value="--",
+                display_value="101",
+                unit=None,
+            ),
+            "GensetTotalEnergy": OncueSensor(
+                name="GensetTotalEnergy",
+                display_name="Genset Total Energy",
+                value="--",
+                display_value="1.2022309E7 kWh",
+                unit="kWh",
+            ),
+            "AtsContactorPosition": OncueSensor(
+                name="AtsContactorPosition",
+                display_name="Ats Contactor Position",
+                value="--",
+                display_value="Source1",
+                unit=None,
+            ),
+            "AtsSourcesAvailable": OncueSensor(
+                name="AtsSourcesAvailable",
+                display_name="Ats Sources Available",
+                value="--",
+                display_value="Source1",
+                unit=None,
+            ),
+            "Source1VoltageAverageLineToLine": OncueSensor(
+                name="Source1VoltageAverageLineToLine",
+                display_name="Source1 Voltage Average Line To Line",
+                value="--",
+                display_value="253.5 V",
+                unit="V",
+            ),
+            "Source2VoltageAverageLineToLine": OncueSensor(
+                name="Source2VoltageAverageLineToLine",
+                display_name="Source2 Voltage Average Line To Line",
+                value="--",
+                display_value="0.0 V",
+                unit="V",
+            ),
+            "IPAddress": OncueSensor(
+                name="IPAddress",
+                display_name="IP Address",
+                value="--",
+                display_value="1.2.3.4:1026",
+                unit=None,
+            ),
+            "MacAddress": OncueSensor(
+                name="MacAddress",
+                display_name="Mac Address",
+                value="--",
+                display_value="--",
+                unit=None,
+            ),
+            "ConnectedServerIPAddress": OncueSensor(
+                name="ConnectedServerIPAddress",
+                display_name="Connected Server IP Address",
+                value="--",
+                display_value="40.117.195.28",
+                unit=None,
+            ),
+            "NetworkConnectionEstablished": OncueSensor(
+                name="NetworkConnectionEstablished",
+                display_name="Network Connection Established",
+                value="false",
+                display_value="True",
+                unit=None,
+            ),
+            "SerialNumber": OncueSensor(
+                name="SerialNumber",
+                display_name="Serial Number",
+                value="--",
+                display_value="1073879692",
+                unit=None,
+            ),
+        },
+    )
+}
+
 
 def _patch_login_and_data():
     @contextmanager
@@ -552,6 +816,31 @@ def _patch_login_and_data_offline_device():
         with patch("homeassistant.components.oncue.Oncue.async_login",), patch(
             "homeassistant.components.oncue.Oncue.async_fetch_all",
             return_value=MOCK_ASYNC_FETCH_ALL_OFFLINE_DEVICE,
+        ):
+            yield
+
+    return _patcher()
+
+
+def _patch_login_and_data_unavailable():
+    @contextmanager
+    def _patcher():
+        with patch("homeassistant.components.oncue.Oncue.async_login",), patch(
+            "homeassistant.components.oncue.Oncue.async_fetch_all",
+            return_value=MOCK_ASYNC_FETCH_ALL_UNAVAILABLE_DEVICE,
+        ):
+            yield
+
+    return _patcher()
+
+
+def _patch_login_and_data_unavailable_device():
+    @contextmanager
+    def _patcher():
+
+        with patch("homeassistant.components.oncue.Oncue.async_login",), patch(
+            "homeassistant.components.oncue.Oncue.async_fetch_all",
+            return_value=MOCK_ASYNC_FETCH_ALL_UNAVAILABLE_DEVICE,
         ):
             yield
 

--- a/tests/components/oncue/__init__.py
+++ b/tests/components/oncue/__init__.py
@@ -838,7 +838,7 @@ def _patch_login_and_data_unavailable_device():
     @contextmanager
     def _patcher():
 
-        with patch("homeassistant.components.oncue.Oncue.async_login",), patch(
+        with patch("homeassistant.components.oncue.Oncue.async_login"), patch(
             "homeassistant.components.oncue.Oncue.async_fetch_all",
             return_value=MOCK_ASYNC_FETCH_ALL_UNAVAILABLE_DEVICE,
         ):

--- a/tests/components/oncue/test_sensor.py
+++ b/tests/components/oncue/test_sensor.py
@@ -297,3 +297,8 @@ async def test_sensors_unavailable(hass: HomeAssistant, patcher, connections) ->
         hass.states.get("sensor.my_generator_generator_current_average").state
         == STATE_UNAVAILABLE
     )
+
+    assert (
+        hass.states.get("sensor.my_generator_battery_voltage").state
+        == STATE_UNAVAILABLE
+    )

--- a/tests/components/oncue/test_sensor.py
+++ b/tests/components/oncue/test_sensor.py
@@ -6,12 +6,17 @@ import pytest
 from homeassistant.components import oncue
 from homeassistant.components.oncue.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from . import _patch_login_and_data, _patch_login_and_data_offline_device
+from . import (
+    _patch_login_and_data,
+    _patch_login_and_data_offline_device,
+    _patch_login_and_data_unavailable,
+    _patch_login_and_data_unavailable_device,
+)
 
 from tests.common import MockConfigEntry
 
@@ -140,4 +145,155 @@ async def test_sensors(hass: HomeAssistant, patcher, connections) -> None:
     )
     assert (
         hass.states.get("sensor.my_generator_generator_current_average").state == "0.0"
+    )
+
+
+@pytest.mark.parametrize(
+    "patcher, connections",
+    [
+        [_patch_login_and_data_unavailable_device, set()],
+        [_patch_login_and_data_unavailable, {("mac", "c9:24:22:6f:14:00")}],
+    ],
+)
+async def test_sensors_unavailable(hass: HomeAssistant, patcher, connections) -> None:
+    """Test that the sensors are unavailable."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "any", CONF_PASSWORD: "any"},
+        unique_id="any",
+    )
+    config_entry.add_to_hass(hass)
+    with patcher():
+        await async_setup_component(hass, oncue.DOMAIN, {oncue.DOMAIN: {}})
+        await hass.async_block_till_done()
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    assert len(hass.states.async_all("sensor")) == 25
+    assert (
+        hass.states.get("sensor.my_generator_latest_firmware").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_engine_speed").state == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_engine_oil_pressure").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_engine_coolant_temperature").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_battery_voltage").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_lube_oil_temperature").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_generator_controller_temperature").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_engine_compartment_temperature").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_generator_true_total_power").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get(
+            "sensor.my_generator_generator_true_percent_of_rated_power"
+        ).state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get(
+            "sensor.my_generator_generator_voltage_average_line_to_line"
+        ).state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_generator_frequency").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_generator_state").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get(
+            "sensor.my_generator_generator_controller_total_operation_time"
+        ).state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_engine_total_run_time").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_ats_contactor_position").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert hass.states.get("sensor.my_generator_ip_address").state == STATE_UNAVAILABLE
+
+    assert (
+        hass.states.get("sensor.my_generator_connected_server_ip_address").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_engine_target_speed").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_engine_total_run_time_loaded").state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get(
+            "sensor.my_generator_source1_voltage_average_line_to_line"
+        ).state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get(
+            "sensor.my_generator_source2_voltage_average_line_to_line"
+        ).state
+        == STATE_UNAVAILABLE
+    )
+
+    assert (
+        hass.states.get("sensor.my_generator_genset_total_energy").state
+        == STATE_UNAVAILABLE
+    )
+    assert (
+        hass.states.get("sensor.my_generator_engine_total_number_of_starts").state
+        == STATE_UNAVAILABLE
+    )
+    assert (
+        hass.states.get("sensor.my_generator_generator_current_average").state
+        == STATE_UNAVAILABLE
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
When the generator became disconnected from Oncue; entities would be reported in HASS as "--", now the entities will report as unavailable


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make the entities return unavailable; when the genset is disconnected and the oncue cloud is reporting "--" back as the data values.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes ##80666
- This PR is related to issue: #80666
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
