### PR TITLE
Defer bluetooth scanner watchdog restart if one is already in progress

### DIFF
--- a/homeassistant/components/bluetooth/scanner.py
+++ b/homeassistant/components/bluetooth/scanner.py
@@ -347,6 +347,12 @@ class HaScanner(BaseHaScanner):
         )
         if time_since_last_detection < SCANNER_WATCHDOG_TIMEOUT:
             return
+        if self._start_stop_lock.locked():
+            _LOGGER.debug(
+                "%s: Scanner is already restarting, deferring restart",
+                self.name,
+            )
+            return
         _LOGGER.info(
             "%s: Bluetooth scanner has gone quiet for %ss, restarting",
             self.name,

--- a/tests/components/bluetooth/test_scanner.py
+++ b/tests/components/bluetooth/test_scanner.py
@@ -1,4 +1,5 @@
 """Tests for the Bluetooth integration scanners."""
+import asyncio
 from datetime import timedelta
 import time
 from unittest.mock import MagicMock, patch
@@ -487,3 +488,68 @@ async def test_adapter_fails_to_start_and_takes_a_bit_to_init(
 
     assert len(mock_recover_adapter.mock_calls) == 1
     assert "Waiting for adapter to initialize" in caplog.text
+
+
+async def test_restart_takes_longer_than_watchdog_time(hass, one_adapter, caplog):
+    """Test we do not try to recover the adapter again if the restart is still in progress."""
+
+    release_start_event = asyncio.Event()
+    called_start = 0
+
+    class MockBleakScanner:
+        async def start(self, *args, **kwargs):
+            """Mock Start."""
+            nonlocal called_start
+            called_start += 1
+            if called_start == 1:
+                return
+            await release_start_event.wait()
+
+        async def stop(self, *args, **kwargs):
+            """Mock Start."""
+
+        @property
+        def discovered_devices(self):
+            """Mock discovered_devices."""
+            return []
+
+        def register_detection_callback(self, callback: AdvertisementDataCallback):
+            """Mock Register Detection Callback."""
+
+    scanner = MockBleakScanner()
+    start_time_monotonic = time.monotonic()
+
+    with patch(
+        "homeassistant.components.bluetooth.scanner.ADAPTER_INIT_TIME",
+        0,
+    ), patch(
+        "homeassistant.components.bluetooth.scanner.MONOTONIC_TIME",
+        return_value=start_time_monotonic,
+    ), patch(
+        "homeassistant.components.bluetooth.scanner.OriginalBleakScanner",
+        return_value=scanner,
+    ), patch(
+        "homeassistant.components.bluetooth.util.recover_adapter", return_value=True
+    ):
+        await async_setup_with_one_adapter(hass)
+
+        assert called_start == 1
+
+        # Now force a recover adapter 2x
+        for _ in range(2):
+            with patch(
+                "homeassistant.components.bluetooth.scanner.MONOTONIC_TIME",
+                return_value=start_time_monotonic
+                + SCANNER_WATCHDOG_TIMEOUT
+                + SCANNER_WATCHDOG_INTERVAL.total_seconds(),
+            ):
+                async_fire_time_changed(
+                    hass, dt_util.utcnow() + SCANNER_WATCHDOG_INTERVAL
+                )
+                await asyncio.sleep(0)
+
+        # Now release the start event
+        release_start_event.set()
+        await hass.async_block_till_done()
+
+    assert "already restarting" in caplog.text


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid trying to restart again if a previous restart is still in progress

This prevents restarts from building up if the system is in a bad state
https://github.com/home-assistant/core/pull/80640#discussion_r1000682506

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
