### PR TITLE
Move default options to config_flow for waze_travel_time

### DIFF
--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -5,8 +5,10 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME, CONF_REGION
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from .const import (
     CONF_AVOID_FERRIES,
@@ -20,12 +22,22 @@ from .const import (
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
     DEFAULT_NAME,
+    DEFAULT_OPTIONS,
     DOMAIN,
+    IMPERIAL_UNITS,
     REGIONS,
     UNITS,
     VEHICLE_TYPES,
 )
 from .helpers import is_valid_config_entry
+
+
+def default_options(hass: HomeAssistant) -> dict[str, str | bool]:
+    """Get the default options."""
+    defaults = DEFAULT_OPTIONS.copy()
+    if hass.config.units is IMPERIAL_SYSTEM:
+        defaults[CONF_UNITS] = IMPERIAL_UNITS
+    return defaults
 
 
 class WazeOptionsFlow(config_entries.OptionsFlow):
@@ -35,7 +47,7 @@ class WazeOptionsFlow(config_entries.OptionsFlow):
         """Initialize waze options flow."""
         self.config_entry = config_entry
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
         if user_input is not None:
             return self.async_create_entry(
@@ -99,7 +111,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return WazeOptionsFlow(config_entry)
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
         errors = {}
         user_input = user_input or {}
@@ -115,6 +127,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=user_input.get(CONF_NAME, DEFAULT_NAME),
                     data=user_input,
+                    options=default_options(self.hass),
                 )
 
             # If we get here, it's because we couldn't connect

--- a/homeassistant/components/waze_travel_time/const.py
+++ b/homeassistant/components/waze_travel_time/const.py
@@ -1,4 +1,6 @@
 """Constants for waze_travel_time."""
+from __future__ import annotations
+
 DOMAIN = "waze_travel_time"
 
 CONF_DESTINATION = "destination"
@@ -25,3 +27,12 @@ UNITS = [METRIC_UNITS, IMPERIAL_UNITS]
 
 REGIONS = ["US", "NA", "EU", "IL", "AU"]
 VEHICLE_TYPES = ["car", "taxi", "motorcycle"]
+
+DEFAULT_OPTIONS: dict[str, str | bool] = {
+    CONF_REALTIME: DEFAULT_REALTIME,
+    CONF_VEHICLE_TYPE: DEFAULT_VEHICLE_TYPE,
+    CONF_UNITS: METRIC_UNITS,
+    CONF_AVOID_FERRIES: DEFAULT_AVOID_FERRIES,
+    CONF_AVOID_SUBSCRIPTION_ROADS: DEFAULT_AVOID_SUBSCRIPTION_ROADS,
+    CONF_AVOID_TOLL_ROADS: DEFAULT_AVOID_TOLL_ROADS,
+}

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -26,7 +26,6 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.location import find_coordinates
 from homeassistant.util.unit_conversion import DistanceConverter
-from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .const import (
     CONF_AVOID_FERRIES,
@@ -39,15 +38,9 @@ from .const import (
     CONF_REALTIME,
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
-    DEFAULT_AVOID_FERRIES,
-    DEFAULT_AVOID_SUBSCRIPTION_ROADS,
-    DEFAULT_AVOID_TOLL_ROADS,
     DEFAULT_NAME,
-    DEFAULT_REALTIME,
-    DEFAULT_VEHICLE_TYPE,
     DOMAIN,
     IMPERIAL_UNITS,
-    METRIC_UNITS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,39 +54,6 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up a Waze travel time sensor entry."""
-    defaults = {
-        CONF_REALTIME: DEFAULT_REALTIME,
-        CONF_VEHICLE_TYPE: DEFAULT_VEHICLE_TYPE,
-        CONF_UNITS: METRIC_UNITS,
-        CONF_AVOID_FERRIES: DEFAULT_AVOID_FERRIES,
-        CONF_AVOID_SUBSCRIPTION_ROADS: DEFAULT_AVOID_SUBSCRIPTION_ROADS,
-        CONF_AVOID_TOLL_ROADS: DEFAULT_AVOID_TOLL_ROADS,
-    }
-    if hass.config.units is US_CUSTOMARY_SYSTEM:
-        defaults[CONF_UNITS] = IMPERIAL_UNITS
-
-    if not config_entry.options:
-        new_data = config_entry.data.copy()
-        options = {}
-        for key in (
-            CONF_INCL_FILTER,
-            CONF_EXCL_FILTER,
-            CONF_REALTIME,
-            CONF_VEHICLE_TYPE,
-            CONF_AVOID_TOLL_ROADS,
-            CONF_AVOID_SUBSCRIPTION_ROADS,
-            CONF_AVOID_FERRIES,
-            CONF_UNITS,
-        ):
-            if key in new_data:
-                options[key] = new_data.pop(key)
-            elif key in defaults:
-                options[key] = defaults[key]
-
-        hass.config_entries.async_update_entry(
-            config_entry, data=new_data, options=options
-        )
-
     destination = config_entry.data[CONF_DESTINATION]
     origin = config_entry.data[CONF_ORIGIN]
     region = config_entry.data[CONF_REGION]

--- a/tests/components/waze_travel_time/test_config_flow.py
+++ b/tests/components/waze_travel_time/test_config_flow.py
@@ -14,9 +14,11 @@ from homeassistant.components.waze_travel_time.const import (
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
     DEFAULT_NAME,
+    DEFAULT_OPTIONS,
     DOMAIN,
+    IMPERIAL_UNITS,
 )
-from homeassistant.const import CONF_NAME, CONF_REGION, CONF_UNIT_SYSTEM_IMPERIAL
+from homeassistant.const import CONF_NAME, CONF_REGION
 
 from .const import MOCK_CONFIG
 
@@ -53,6 +55,7 @@ async def test_options(hass):
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG,
+        options=DEFAULT_OPTIONS,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -72,7 +75,7 @@ async def test_options(hass):
             CONF_EXCL_FILTER: "exclude",
             CONF_INCL_FILTER: "include",
             CONF_REALTIME: False,
-            CONF_UNITS: CONF_UNIT_SYSTEM_IMPERIAL,
+            CONF_UNITS: IMPERIAL_UNITS,
             CONF_VEHICLE_TYPE: "taxi",
         },
     )
@@ -85,7 +88,7 @@ async def test_options(hass):
         CONF_EXCL_FILTER: "exclude",
         CONF_INCL_FILTER: "include",
         CONF_REALTIME: False,
-        CONF_UNITS: CONF_UNIT_SYSTEM_IMPERIAL,
+        CONF_UNITS: IMPERIAL_UNITS,
         CONF_VEHICLE_TYPE: "taxi",
     }
 
@@ -96,7 +99,7 @@ async def test_options(hass):
         CONF_EXCL_FILTER: "exclude",
         CONF_INCL_FILTER: "include",
         CONF_REALTIME: False,
-        CONF_UNITS: CONF_UNIT_SYSTEM_IMPERIAL,
+        CONF_UNITS: IMPERIAL_UNITS,
         CONF_VEHICLE_TYPE: "taxi",
     }
 

--- a/tests/components/waze_travel_time/test_sensor.py
+++ b/tests/components/waze_travel_time/test_sensor.py
@@ -10,9 +10,10 @@ from homeassistant.components.waze_travel_time.const import (
     CONF_REALTIME,
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
+    DEFAULT_OPTIONS,
     DOMAIN,
+    IMPERIAL_UNITS,
 )
-from homeassistant.const import CONF_UNIT_SYSTEM_IMPERIAL
 
 from .const import MOCK_CONFIG
 
@@ -51,7 +52,7 @@ def mock_update_keyerror_fixture(mock_wrc):
 
 @pytest.mark.parametrize(
     "data,options",
-    [(MOCK_CONFIG, {})],
+    [(MOCK_CONFIG, DEFAULT_OPTIONS)],
 )
 @pytest.mark.usefixtures("mock_update", "mock_config")
 async def test_sensor(hass):
@@ -84,7 +85,7 @@ async def test_sensor(hass):
         (
             MOCK_CONFIG,
             {
-                CONF_UNITS: CONF_UNIT_SYSTEM_IMPERIAL,
+                CONF_UNITS: IMPERIAL_UNITS,
                 CONF_REALTIME: True,
                 CONF_VEHICLE_TYPE: "car",
                 CONF_AVOID_TOLL_ROADS: True,
@@ -105,7 +106,9 @@ async def test_imperial(hass):
 @pytest.mark.usefixtures("mock_update_wrcerror")
 async def test_sensor_failed_wrcerror(hass, caplog):
     """Test that sensor update fails with log message."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, options=DEFAULT_OPTIONS, entry_id="test"
+    )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -117,7 +120,9 @@ async def test_sensor_failed_wrcerror(hass, caplog):
 @pytest.mark.usefixtures("mock_update_keyerror")
 async def test_sensor_failed_keyerror(hass, caplog):
     """Test that sensor update fails with log message."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, options=DEFAULT_OPTIONS, entry_id="test"
+    )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move the default options handling out of the sensor to the config_flow
Equivalent to #80607

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
