### PR TITLE
Reduce unnecessary alarm firing to speed up calendar trigger test

### DIFF
--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -105,6 +105,15 @@ class FakeSchedule:
 
     async def fire_until(self, end: datetime.timedelta) -> None:
         """Simulate the passage of time by firing alarms until the time is reached."""
+
+        current_time = dt_util.as_utc(self.freezer())
+        if (end - current_time) > (TEST_UPDATE_INTERVAL * 2):
+            # Jump ahead to right before the target alarm them to remove
+            # unnecessary waiting, before advancing in smaller increments below.
+            # This leaves time for multiple update intervals to refresh the set
+            # of upcoming events
+            await self.fire_time(end - TEST_UPDATE_INTERVAL * 2)
+
         while dt_util.utcnow() < end:
             self.freezer.tick(TEST_TIME_ADVANCE_INTERVAL)
             await self.fire_time(dt_util.utcnow())


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Speed up the calendar trigger tests by jumping ahead closer to the target trigger time interval rather than looping and advancing in small increments. This is meant to address flake observed:

https://github.com/home-assistant/core/actions/runs/3296288446/jobs/5435889796

Introduced in https://github.com/home-assistant/core/pull/79451

Before fixes, this test is an outlier:
```
$ py.test -vv --durations=10 tests/components/calendar/test_trigger.py
1.58s call     tests/components/calendar/test_trigger.py::test_event_payload[pyloop-all-day]
0.23s call     tests/components/calendar/test_trigger.py::test_event_end_trigger_with_offset[pyloop-+01:00-offset_delta1]
0.21s call     tests/components/calendar/test_trigger.py::test_event_start_trigger_with_offset[pyloop-+01:00-offset_delta1]
0.19s setup    tests/components/calendar/test_trigger.py::test_event_start_trigger[pyloop]
0.14s call     tests/components/calendar/test_trigger.py::test_event_end_trigger[pyloop]
0.10s call     tests/components/calendar/test_trigger.py::test_multiple_end_events[pyloop]
0.09s call     tests/components/calendar/test_trigger.py::test_event_end_trigger_with_offset[pyloop--01:00-offset_delta0]
0.09s call     tests/components/calendar/test_trigger.py::test_multiple_events_sharing_start_time[pyloop]
0.09s call     tests/components/calendar/test_trigger.py::test_multiple_start_events[pyloop]
0.09s call     tests/components/calendar/test_trigger.py::test_update_next_event[pyloop]
```

After fixes, no longer an outlier:
```
$ py.test -vv --durations=10 tests/components/calendar/test_trigger.py
0.25s call     tests/components/calendar/test_trigger.py::test_event_end_trigger_with_offset[pyloop-+01:00-offset_delta1]
0.22s call     tests/components/calendar/test_trigger.py::test_event_start_trigger_with_offset[pyloop-+01:00-offset_delta1]
0.14s call     tests/components/calendar/test_trigger.py::test_event_end_trigger[pyloop]
0.12s setup    tests/components/calendar/test_trigger.py::test_event_start_trigger[pyloop]
0.10s call     tests/components/calendar/test_trigger.py::test_multiple_events_sharing_start_time[pyloop]
0.10s call     tests/components/calendar/test_trigger.py::test_overlap_events[pyloop]
0.10s call     tests/components/calendar/test_trigger.py::test_multiple_end_events[pyloop]
0.09s call     tests/components/calendar/test_trigger.py::test_event_end_trigger_with_offset[pyloop--01:00-offset_delta0]
0.09s call     tests/components/calendar/test_trigger.py::test_multiple_start_events[pyloop]
0.09s call     tests/components/calendar/test_trigger.py::test_update_next_event[pyloop]
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
