### PR TITLE
Improve UniFi PoE unique ID

### DIFF
--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -588,6 +588,7 @@ class UnifiPoePortSwitch(SwitchEntity):
         self._attr_unique_id = f"{self._device_mac}-poe-{index}"
 
         device = self.controller.api.devices[self._device_mac]
+        self._attr_available = controller.available and not device.disabled
         self._attr_device_info = DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, device.mac)},
             manufacturer=ATTR_MANUFACTURER,

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -577,15 +577,15 @@ class UnifiPoePortSwitch(SwitchEntity):
 
     def __init__(self, obj_id: str, controller) -> None:
         """Set up UniFi Network entity base."""
-        self._attr_unique_id = f"{obj_id}-PoE"
-        self._device_mac, port_idx = obj_id.split("_", 1)
-        self._port_idx = int(port_idx)
+        self._device_mac, index = obj_id.split("_", 1)
+        self._index = int(index)
         self._obj_id = obj_id
         self.controller = controller
 
         port = self.controller.api.ports[self._obj_id]
         self._attr_name = f"{port.name} PoE"
         self._attr_is_on = port.poe_mode != "off"
+        self._attr_unique_id = f"{self._device_mac}-poe-{index}"
 
         device = self.controller.api.devices[self._device_mac]
         self._attr_device_info = DeviceInfo(
@@ -594,6 +594,7 @@ class UnifiPoePortSwitch(SwitchEntity):
             model=device.model,
             name=device.name or None,
             sw_version=device.version,
+            hw_version=device.board_revision,
         )
 
     async def async_added_to_hass(self) -> None:
@@ -627,12 +628,12 @@ class UnifiPoePortSwitch(SwitchEntity):
         """Enable POE for client."""
         device = self.controller.api.devices[self._device_mac]
         await self.controller.api.request(
-            DeviceSetPoePortModeRequest.create(device, self._port_idx, "auto")
+            DeviceSetPoePortModeRequest.create(device, self._index, "auto")
         )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable POE for client."""
         device = self.controller.api.devices[self._device_mac]
         await self.controller.api.request(
-            DeviceSetPoePortModeRequest.create(device, self._port_idx, "off")
+            DeviceSetPoePortModeRequest.create(device, self._index, "off")
         )

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -128,6 +128,7 @@ POE_SWITCH_CLIENTS = [
 ]
 
 DEVICE_1 = {
+    "board_rev": 2,
     "device_id": "mock-id",
     "ip": "10.0.1.1",
     "mac": "00:00:00:00:01:01",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Generate PoE entities unique ID in the same way as outlets are defined (noticed the difference when doing #80566)
This is not a breaking change as the PoE implementation was merged a couple of days ago.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
