### PR TITLE
Refactor UniFi upgrade entities

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -271,6 +271,7 @@ homeassistant.components.trafikverket_train.*
 homeassistant.components.trafikverket_weatherstation.*
 homeassistant.components.tts.*
 homeassistant.components.twentemilieu.*
+homeassistant.components.unifi.update
 homeassistant.components.unifiprotect.*
 homeassistant.components.upcloud.*
 homeassistant.components.update.*

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from aiounifi.interfaces.api_handlers import ItemEvent
 from aiounifi.models.device import DeviceUpgradeRequest
 
 from homeassistant.components.update import (
@@ -13,7 +14,6 @@ from homeassistant.components.update import (
     UpdateEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -21,7 +21,6 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ATTR_MANUFACTURER, DOMAIN as UNIFI_DOMAIN
-from .unifi_entity_base import UniFiBase
 
 LOGGER = logging.getLogger(__name__)
 
@@ -38,103 +37,84 @@ async def async_setup_entry(
     controller.entities[DOMAIN] = {DEVICE_UPDATE: set()}
 
     @callback
-    def items_added(
-        clients: set = controller.api.clients, devices: set = controller.api.devices
-    ) -> None:
-        """Add device update entities."""
-        add_device_update_entities(controller, async_add_entities, devices)
+    def async_add_update_entity(_: ItemEvent, obj_id: str) -> None:
+        """Add new device update entities from the controller."""
+        async_add_entities([UnifiDeviceUpdateEntity(obj_id, controller)])
 
-    for signal in (controller.signal_update, controller.signal_options_update):
-        config_entry.async_on_unload(
-            async_dispatcher_connect(hass, signal, items_added)
-        )
+    controller.api.devices.subscribe(async_add_update_entity, ItemEvent.ADDED)
 
-    items_added()
+    for device_id in controller.api.devices:
+        async_add_update_entity(ItemEvent.ADDED, device_id)
 
 
-@callback
-def add_device_update_entities(controller, async_add_entities, devices):
-    """Add new device update entities from the controller."""
-    entities = []
-
-    for mac in devices:
-        if mac in controller.entities[DOMAIN][UniFiDeviceUpdateEntity.TYPE]:
-            continue
-
-        device = controller.api.devices[mac]
-        entities.append(UniFiDeviceUpdateEntity(device, controller))
-
-    async_add_entities(entities)
-
-
-class UniFiDeviceUpdateEntity(UniFiBase, UpdateEntity):
+class UnifiDeviceUpdateEntity(UpdateEntity):
     """Update entity for a UniFi network infrastructure device."""
 
     DOMAIN = DOMAIN
     TYPE = DEVICE_UPDATE
     _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_has_entity_name = True
 
-    def __init__(self, device, controller):
+    def __init__(self, obj_id: str, controller) -> None:
         """Set up device update entity."""
-        super().__init__(device, controller)
-
-        self.device = self._item
+        controller.entities[DOMAIN][DEVICE_UPDATE].add(obj_id)
+        self.controller = controller
+        self._obj_id = obj_id
+        self._attr_unique_id = f"{self.TYPE}-{obj_id}"
 
         self._attr_supported_features = UpdateEntityFeature.PROGRESS
-
-        if self.controller.site_role == "admin":
+        if controller.site_role == "admin":
             self._attr_supported_features |= UpdateEntityFeature.INSTALL
 
-    @property
-    def name(self) -> str:
-        """Return the name of the device."""
-        return self.device.name or self.device.model
+        device = controller.api.devices[obj_id]
+        self._attr_available = controller.available and not device.disabled
+        self._attr_in_progress = device.state == 4
+        self._attr_installed_version = device.version
+        self._attr_latest_version = device.upgrade_to_firmware or device.version
 
-    @property
-    def unique_id(self) -> str:
-        """Return a unique identifier for this device."""
-        return f"{self.TYPE}-{self.device.mac}"
-
-    @property
-    def available(self) -> bool:
-        """Return if controller is available."""
-        return not self.device.disabled and self.controller.available
-
-    @property
-    def in_progress(self) -> bool:
-        """Update installation in progress."""
-        return self.device.state == 4
-
-    @property
-    def installed_version(self) -> str | None:
-        """Version currently in use."""
-        return self.device.version
-
-    @property
-    def latest_version(self) -> str | None:
-        """Latest version available for install."""
-        return self.device.upgrade_to_firmware or self.device.version
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return a device description for device registry."""
-        info = DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self.device.mac)},
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, obj_id)},
             manufacturer=ATTR_MANUFACTURER,
-            model=self.device.model,
-            sw_version=self.device.version,
+            model=device.model,
+            name=device.name or None,
+            sw_version=device.version,
+            hw_version=device.board_revision,
         )
 
-        if self.device.name:
-            info[ATTR_NAME] = self.device.name
+    async def async_added_to_hass(self) -> None:
+        """Entity created."""
+        self.async_on_remove(
+            self.controller.api.devices.subscribe(self.async_signalling_callback)
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_reachable,
+                self.async_signal_reachable_callback,
+            )
+        )
 
-        return info
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect object when removed."""
+        self.controller.entities[DOMAIN][DEVICE_UPDATE].remove(self._obj_id)
 
-    async def options_updated(self) -> None:
-        """No action needed."""
+    @callback
+    def async_signalling_callback(self, event: ItemEvent, obj_id: str) -> None:
+        """Object has new event."""
+        device = self.controller.api.devices[self._obj_id]
+        self._attr_available = self.controller.available and not device.disabled
+        self._attr_in_progress = device.state == 4
+        self._attr_installed_version = device.version
+        self._attr_latest_version = device.upgrade_to_firmware or device.version
+        self.async_write_ha_state()
+
+    @callback
+    def async_signal_reachable_callback(self) -> None:
+        """Call when controller connection state change."""
+        self.async_signalling_callback(ItemEvent.ADDED, self._obj_id)
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
-        await self.controller.api.request(DeviceUpgradeRequest.create(self.device.mac))
+        await self.controller.api.request(DeviceUpgradeRequest.create(self._obj_id))

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aiounifi.interfaces.api_handlers import ItemEvent
 from aiounifi.models.device import DeviceUpgradeRequest
@@ -21,6 +21,9 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ATTR_MANUFACTURER, DOMAIN as UNIFI_DOMAIN
+
+if TYPE_CHECKING:
+    from .controller import UniFiController
 
 LOGGER = logging.getLogger(__name__)
 
@@ -55,7 +58,7 @@ class UnifiDeviceUpdateEntity(UpdateEntity):
     _attr_device_class = UpdateDeviceClass.FIRMWARE
     _attr_has_entity_name = True
 
-    def __init__(self, obj_id: str, controller) -> None:
+    def __init__(self, obj_id: str, controller: UniFiController) -> None:
         """Set up device update entity."""
         controller.entities[DOMAIN][DEVICE_UPDATE].add(obj_id)
         self.controller = controller

--- a/mypy.ini
+++ b/mypy.ini
@@ -2463,6 +2463,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.unifi.update]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.unifiprotect.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify the upgrade entity implementation. Shares the same design as #80566 and #80738

The refactoring breaks away from old dependencies as to simplify the overall refactoring compared to the deCONZ one which took way too long by keeping all relations intact.
Once entity refactoring is in place I can start working on consolidating logic once more.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
