### PR TITLE
Verisure

### DIFF
--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
 
@@ -32,7 +33,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = VerisureDataUpdateCoordinator(hass, entry=entry)
 
-    await coordinator.async_login()
+    if not await coordinator.async_login():
+        raise ConfigEntryNotReady
 
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, coordinator.async_logout)

--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
 
@@ -33,8 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = VerisureDataUpdateCoordinator(hass, entry=entry)
 
-    if not await coordinator.async_login():
-        raise ConfigEntryAuthFailed
+    await coordinator.async_login()
 
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, coordinator.async_logout)

--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -55,33 +55,47 @@ class VerisureAlarm(
         """Return the unique ID for this entity."""
         return self.coordinator.entry.data[CONF_GIID]
 
-    async def _async_set_arm_state(self, state: str, code: str | None = None) -> None:
+    async def _async_set_arm_state(self, state: str, command_data: dict) -> None:
         """Send set arm state command."""
         arm_state = await self.hass.async_add_executor_job(
-            self.coordinator.verisure.set_arm_state, code, state
+            self.coordinator.verisure.request, command_data
         )
         LOGGER.debug("Verisure set arm state %s", state)
-        transaction = {}
-        while "result" not in transaction:
+        result = None
+        while result is None:
             await asyncio.sleep(0.5)
             transaction = await self.hass.async_add_executor_job(
-                self.coordinator.verisure.get_arm_state_transaction,
-                arm_state["armStateChangeTransactionId"],
+                self.coordinator.verisure.request,
+                self.coordinator.verisure.poll_arm_state(
+                    list(arm_state["data"].values())[0], state
+                ),
+            )
+            result = (
+                transaction.get("data", {})
+                .get("installation", {})
+                .get("armStateChangePollResult", {})
+                .get("result", None)
             )
 
         await self.coordinator.async_refresh()
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
-        await self._async_set_arm_state("DISARMED", code)
+        await self._async_set_arm_state(
+            "DISARMED", self.coordinator.verisure.disarm(code)
+        )
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
-        await self._async_set_arm_state("ARMED_HOME", code)
+        await self._async_set_arm_state(
+            "ARMED_HOME", self.coordinator.verisure.arm_home(code)
+        )
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-        await self._async_set_arm_state("ARMED_AWAY", code)
+        await self._async_set_arm_state(
+            "ARMED_AWAY", self.coordinator.verisure.arm_away(code)
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -108,9 +108,9 @@ class VerisureEthernetStatus(
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return self.coordinator.data["ethernet"]
+        return self.coordinator.data["broadband"]["isBroadbandConnected"]
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return super().available and self.coordinator.data["ethernet"] is not None
+        return super().available and self.coordinator.data["broadband"] is not None

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -63,12 +63,12 @@ class VerisureSmartcam(CoordinatorEntity[VerisureDataUpdateCoordinator], Camera)
         self.serial_number = serial_number
         self._directory_path = directory_path
         self._image: str | None = None
-        self._image_id = None
+        self._image_id: str | None = None
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this entity."""
-        area = self.coordinator.data["cameras"][self.serial_number]["area"]
+        area = self.coordinator.data["cameras"][self.serial_number]["device"]["area"]
         return DeviceInfo(
             name=area,
             suggested_area=area,
@@ -95,16 +95,16 @@ class VerisureSmartcam(CoordinatorEntity[VerisureDataUpdateCoordinator], Camera)
         """Check the contents of the image list."""
         self.coordinator.update_smartcam_imageseries()
 
-        images = self.coordinator.imageseries.get("imageSeries", [])
-        new_image_id = None
-        for image in images:
+        new_image = None
+        for image in self.coordinator.imageseries:
             if image["deviceLabel"] == self.serial_number:
-                new_image_id = image["image"][0]["imageId"]
+                new_image = image
                 break
 
-        if not new_image_id:
+        if not new_image:
             return
 
+        new_image_id = new_image["mediaId"]
         if new_image_id in ("-1", self._image_id):
             LOGGER.debug("The image is the same, or loading image_id")
             return
@@ -113,9 +113,8 @@ class VerisureSmartcam(CoordinatorEntity[VerisureDataUpdateCoordinator], Camera)
         new_image_path = os.path.join(
             self._directory_path, "{}{}".format(new_image_id, ".jpg")
         )
-        self.coordinator.verisure.download_image(
-            self.serial_number, new_image_id, new_image_path
-        )
+        new_image_url = new_image["contentUrl"]
+        self.coordinator.verisure.download_image(new_image_url, new_image_path)
         LOGGER.debug("Old image_id=%s", self._image_id)
         self.delete_image()
 

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -193,7 +193,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 username=self.email,
                 password=self.password,
                 cookie_file_name=self.hass.config.path(
-                    STORAGE_DIR, f"verisure-{user_input[CONF_EMAIL]}"
+                    STORAGE_DIR, f"verisure_{user_input[CONF_EMAIL]}"
                 ),
             )
 

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -56,7 +56,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             self.verisure = Verisure(
                 username=self.email,
                 password=self.password,
-                cookieFileName=self.hass.config.path(
+                cookie_file_name=self.hass.config.path(
                     STORAGE_DIR, f"verisure_{user_input[CONF_EMAIL]}"
                 ),
             )
@@ -66,7 +66,9 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             except VerisureLoginError as ex:
                 if "Multifactor authentication enabled" in str(ex):
                     try:
-                        await self.hass.async_add_executor_job(self.verisure.login_mfa)
+                        await self.hass.async_add_executor_job(
+                            self.verisure.request_mfa
+                        )
                     except (
                         VerisureLoginError,
                         VerisureError,
@@ -108,9 +110,8 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await self.hass.async_add_executor_job(
-                    self.verisure.mfa_validate, user_input[CONF_CODE], True
+                    self.verisure.validate_mfa, user_input[CONF_CODE]
                 )
-                await self.hass.async_add_executor_job(self.verisure.login)
             except VerisureLoginError as ex:
                 LOGGER.debug("Could not log in to Verisure, %s", ex)
                 errors["base"] = "invalid_auth"
@@ -136,9 +137,16 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Select Verisure installation to add."""
+        installations_data = await self.hass.async_add_executor_job(
+            self.verisure.get_installations
+        )
         installations = {
-            inst["giid"]: f"{inst['alias']} ({inst['street']})"
-            for inst in self.verisure.installations or []
+            inst["giid"]: f"{inst['alias']}"
+            for inst in (
+                installations_data.get("data", {})
+                .get("account", {})
+                .get("installations", [])
+            )
         }
 
         if user_input is None:
@@ -184,7 +192,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             self.verisure = Verisure(
                 username=self.email,
                 password=self.password,
-                cookieFileName=self.hass.config.path(
+                cookie_file_name=self.hass.config.path(
                     STORAGE_DIR, f"verisure-{user_input[CONF_EMAIL]}"
                 ),
             )
@@ -194,7 +202,9 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             except VerisureLoginError as ex:
                 if "Multifactor authentication enabled" in str(ex):
                     try:
-                        await self.hass.async_add_executor_job(self.verisure.login_mfa)
+                        await self.hass.async_add_executor_job(
+                            self.verisure.request_mfa
+                        )
                     except (
                         VerisureLoginError,
                         VerisureError,
@@ -248,7 +258,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await self.hass.async_add_executor_job(
-                    self.verisure.mfa_validate, user_input[CONF_CODE], True
+                    self.verisure.validate_mfa, user_input[CONF_CODE]
                 )
                 await self.hass.async_add_executor_job(self.verisure.login)
             except VerisureLoginError as ex:

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -141,7 +141,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             self.verisure.get_installations
         )
         installations = {
-            inst["giid"]: f"{inst['alias'] ({inst['address']['street']})}"
+            inst["giid"]: f"{inst['alias']} ({inst['address']['street']})"
             for inst in (
                 installations_data.get("data", {})
                 .get("account", {})

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -141,7 +141,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             self.verisure.get_installations
         )
         installations = {
-            inst["giid"]: f"{inst['alias']}"
+            inst["giid"]: f"{inst['alias'] ({inst['address']['street']})}"
             for inst in (
                 installations_data.get("data", {})
                 .get("account", {})

--- a/homeassistant/components/verisure/const.py
+++ b/homeassistant/components/verisure/const.py
@@ -36,6 +36,9 @@ DEVICE_TYPE_NAME = {
     "SMOKE3": "Smoke detector",
     "VOICEBOX1": "VoiceBox",
     "WATER1": "Water detector",
+    "SMOKE": "Smoke detector",
+    "SIREN": "Siren",
+    "VOICEBOX": "VoiceBox",
 }
 
 ALARM_STATE_TO_HA = {

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -52,7 +52,6 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_logout(self, _event: Event) -> None:
         """Logout from Verisure."""
-        await self.hass.async_add_executor_job(self.verisure.logout)
 
     async def _async_update_data(self) -> dict:
         """Fetch data from Verisure."""

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 from datetime import timedelta
 from time import sleep
 
-from verisure import LoginError as VerisureLoginError, Session as Verisure
+from verisure import (
+    LoginError as VerisureLoginError,
+    ResponseError as VerisureResponseError,
+    Session as Verisure,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -41,7 +45,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         """Login to Verisure."""
         try:
             await self.hass.async_add_executor_job(self.verisure.login_cookie)
-        except VerisureLoginError as ex:
+        except (VerisureLoginError, VerisureResponseError) as ex:
             LOGGER.error("Could not log in to verisure, %s", ex)
             raise ConfigEntryAuthFailed("Credentials expired for Verisure") from ex
 
@@ -58,7 +62,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from Verisure."""
         try:
             await self.hass.async_add_executor_job(self.verisure.login_cookie)
-        except VerisureLoginError as ex:
+        except (VerisureLoginError, VerisureResponseError) as ex:
             LOGGER.error("Could not log in to Verisure, %s", ex)
             raise ConfigEntryAuthFailed("Credentials expired for Verisure") from ex
         try:

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -56,6 +56,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict:
         """Fetch data from Verisure."""
+        await self.hass.async_add_executor_job(self.verisure.login_cookie)
         try:
             overview = await self.hass.async_add_executor_job(
                 self.verisure.request,

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -45,9 +45,11 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         """Login to Verisure."""
         try:
             await self.hass.async_add_executor_job(self.verisure.login_cookie)
-        except (VerisureLoginError, VerisureResponseError) as ex:
+        except VerisureLoginError as ex:
             LOGGER.error("Could not log in to verisure, %s", ex)
             raise ConfigEntryAuthFailed("Credentials expired for Verisure") from ex
+        except VerisureResponseError as ex:
+            LOGGER.error("Could not log in to verisure, %s", ex)
 
         await self.hass.async_add_executor_job(
             self.verisure.set_giid, self.entry.data[CONF_GIID]

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -50,6 +50,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
             raise ConfigEntryAuthFailed("Credentials expired for Verisure") from ex
         except VerisureResponseError as ex:
             LOGGER.error("Could not log in to verisure, %s", ex)
+            return False
 
         await self.hass.async_add_executor_job(
             self.verisure.set_giid, self.entry.data[CONF_GIID]

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -82,7 +82,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
             try:
                 await self.hass.async_add_executor_job(self.verisure.update_cookie)
             except VerisureResponseError as ex:
-                LOGGER.error("Credentials for Verisure expired, %s", ex)
+                LOGGER.info("Credentials for Verisure expired, %s", ex)
                 raise ConfigEntryAuthFailed("Credentials for Verisure expired.") from ex
             except Exception as ex:
                 LOGGER.error("Could not read overview, %s", ex)

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -43,7 +43,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
             await self.hass.async_add_executor_job(self.verisure.login_cookie)
         except VerisureLoginError as ex:
             LOGGER.error("Could not log in to verisure, %s", ex)
-            return False
+            raise ConfigEntryAuthFailed("Credentials expired for Verisure") from ex
 
         await self.hass.async_add_executor_job(
             self.verisure.set_giid, self.entry.data[CONF_GIID]

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -82,7 +82,6 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
             try:
                 await self.hass.async_add_executor_job(self.verisure.update_cookie)
             except VerisureResponseError as ex:
-                LOGGER.info("Credentials for Verisure expired, %s", ex)
                 raise ConfigEntryAuthFailed("Credentials for Verisure expired.") from ex
             except Exception as ex:
                 LOGGER.error("Could not read overview, %s", ex)

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -61,9 +61,9 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict:
         """Fetch data from Verisure."""
         try:
-            await self.hass.async_add_executor_job(self.verisure.login_cookie)
+            await self.hass.async_add_executor_job(self.verisure.update_cookie)
         except (VerisureLoginError, VerisureResponseError) as ex:
-            LOGGER.error("Could not log in to Verisure, %s", ex)
+            LOGGER.error("Credentials expired for Verisure, %s", ex)
             raise ConfigEntryAuthFailed("Credentials expired for Verisure") from ex
         try:
             overview = await self.hass.async_add_executor_job(

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -82,7 +82,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.error("Could not read overview, %s", ex)
             raise
 
-        def unpack(overview: list, value: str) -> dict:
+        def unpack(overview: list, value: str) -> dict[str, str] | list[dict[str, str]]:
             unpacked = [
                 item["data"]["installation"][value]
                 for item in overview

--- a/homeassistant/components/verisure/diagnostics.py
+++ b/homeassistant/components/verisure/diagnostics.py
@@ -16,6 +16,7 @@ TO_REDACT = {
     "deviceArea",
     "name",
     "time",
+    "reportTime",
     "userString",
 }
 

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -77,7 +77,7 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this entity."""
-        area = self.coordinator.data["locks"][self.serial_number]["area"]
+        area = self.coordinator.data["locks"][self.serial_number]["device"]["area"]
         return DeviceInfo(
             name=area,
             suggested_area=area,
@@ -98,12 +98,16 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
     @property
     def changed_by(self) -> str | None:
         """Last change triggered by."""
-        return self.coordinator.data["locks"][self.serial_number].get("userString")
+        return (
+            self.coordinator.data["locks"][self.serial_number]
+            .get("user", {})
+            .get("name")
+        )
 
     @property
     def changed_method(self) -> str:
         """Last change method."""
-        return self.coordinator.data["locks"][self.serial_number]["method"]
+        return self.coordinator.data["locks"][self.serial_number]["lockMethod"]
 
     @property
     def code_format(self) -> str:
@@ -114,8 +118,7 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
     def is_locked(self) -> bool:
         """Return true if lock is locked."""
         return (
-            self.coordinator.data["locks"][self.serial_number]["lockedState"]
-            == "LOCKED"
+            self.coordinator.data["locks"][self.serial_number]["lockStatus"] == "LOCKED"
         )
 
     @property
@@ -147,28 +150,39 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
 
     async def async_set_lock_state(self, code: str, state: str) -> None:
         """Send set lock state command."""
-        target_state = "lock" if state == STATE_LOCKED else "unlock"
-        lock_state = await self.hass.async_add_executor_job(
-            self.coordinator.verisure.set_lock_state,
-            code,
-            self.serial_number,
-            target_state,
+        command = (
+            self.coordinator.verisure.door_lock(self.serial_number, code)
+            if state == STATE_LOCKED
+            else self.coordinator.verisure.door_unlock(self.serial_number, code)
         )
-
+        lock_request = await self.hass.async_add_executor_job(
+            self.coordinator.verisure.request,
+            command,
+        )
         LOGGER.debug("Verisure doorlock %s", state)
-        transaction = {}
+        transaction_id = lock_request.get("data", {}).get(command["operationName"])
+        target_state = "LOCKED" if state == STATE_LOCKED else "UNLOCKED"
+        lock_status = None
         attempts = 0
-        while "result" not in transaction:
-            transaction = await self.hass.async_add_executor_job(
-                self.coordinator.verisure.get_lock_state_transaction,
-                lock_state["doorLockStateChangeTransactionId"],
-            )
-            attempts += 1
+        while lock_status != "OK":
             if attempts == 30:
                 break
             if attempts > 1:
                 await asyncio.sleep(0.5)
-        if transaction["result"] == "OK":
+            attempts += 1
+            poll_data = await self.hass.async_add_executor_job(
+                self.coordinator.verisure.request,
+                self.coordinator.verisure.poll_lock_state(
+                    transaction_id, self.serial_number, target_state
+                ),
+            )
+            lock_status = (
+                poll_data.get("data", {})
+                .get("installation", {})
+                .get("doorLockStateChangePollResult", {})
+                .get("result")
+            )
+        if lock_status == "OK":
             self._state = state
 
     def disable_autolock(self) -> None:

--- a/homeassistant/components/verisure/manifest.json
+++ b/homeassistant/components/verisure/manifest.json
@@ -2,7 +2,7 @@
   "domain": "verisure",
   "name": "Verisure",
   "documentation": "https://www.home-assistant.io/integrations/verisure",
-  "requirements": ["vsure==1.8.1"],
+  "requirements": ["vsure==2.5.4"],
   "codeowners": ["@frenck"],
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
     sensors.extend(
         VerisureHygrometer(coordinator, serial_number)
         for serial_number, values in coordinator.data["climate"].items()
-        if "humidityValue" in values
+        if values.get("humidityEnabled")
     )
 
     async_add_entities(sensors)

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -28,18 +28,13 @@ async def async_setup_entry(
     sensors: list[Entity] = [
         VerisureThermometer(coordinator, serial_number)
         for serial_number, values in coordinator.data["climate"].items()
-        if "temperature" in values
+        if "temperatureValue" in values
     ]
 
     sensors.extend(
         VerisureHygrometer(coordinator, serial_number)
         for serial_number, values in coordinator.data["climate"].items()
-        if "humidity" in values
-    )
-
-    sensors.extend(
-        VerisureMouseDetection(coordinator, serial_number)
-        for serial_number in coordinator.data["mice"]
+        if "humidityValue" in values
     )
 
     async_add_entities(sensors)
@@ -67,10 +62,10 @@ class VerisureThermometer(
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this entity."""
-        device_type = self.coordinator.data["climate"][self.serial_number].get(
-            "deviceType"
-        )
-        area = self.coordinator.data["climate"][self.serial_number]["deviceArea"]
+        device_type = self.coordinator.data["climate"][self.serial_number]["device"][
+            "gui"
+        ]["label"]
+        area = self.coordinator.data["climate"][self.serial_number]["device"]["area"]
         return DeviceInfo(
             name=area,
             suggested_area=area,
@@ -84,7 +79,7 @@ class VerisureThermometer(
     @property
     def native_value(self) -> str | None:
         """Return the state of the entity."""
-        return self.coordinator.data["climate"][self.serial_number]["temperature"]
+        return self.coordinator.data["climate"][self.serial_number]["temperatureValue"]
 
     @property
     def available(self) -> bool:
@@ -92,7 +87,8 @@ class VerisureThermometer(
         return (
             super().available
             and self.serial_number in self.coordinator.data["climate"]
-            and "temperature" in self.coordinator.data["climate"][self.serial_number]
+            and "temperatureValue"
+            in self.coordinator.data["climate"][self.serial_number]
         )
 
 
@@ -118,10 +114,10 @@ class VerisureHygrometer(
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this entity."""
-        device_type = self.coordinator.data["climate"][self.serial_number].get(
-            "deviceType"
-        )
-        area = self.coordinator.data["climate"][self.serial_number]["deviceArea"]
+        device_type = self.coordinator.data["climate"][self.serial_number]["device"][
+            "gui"
+        ]["label"]
+        area = self.coordinator.data["climate"][self.serial_number]["device"]["area"]
         return DeviceInfo(
             name=area,
             suggested_area=area,
@@ -135,7 +131,7 @@ class VerisureHygrometer(
     @property
     def native_value(self) -> str | None:
         """Return the state of the entity."""
-        return self.coordinator.data["climate"][self.serial_number]["humidity"]
+        return self.coordinator.data["climate"][self.serial_number]["humidityValue"]
 
     @property
     def available(self) -> bool:
@@ -143,51 +139,5 @@ class VerisureHygrometer(
         return (
             super().available
             and self.serial_number in self.coordinator.data["climate"]
-            and "humidity" in self.coordinator.data["climate"][self.serial_number]
-        )
-
-
-class VerisureMouseDetection(
-    CoordinatorEntity[VerisureDataUpdateCoordinator], SensorEntity
-):
-    """Representation of a Verisure mouse detector."""
-
-    _attr_name = "Mouse"
-    _attr_has_entity_name = True
-    _attr_native_unit_of_measurement = "Mice"
-
-    def __init__(
-        self, coordinator: VerisureDataUpdateCoordinator, serial_number: str
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{serial_number}_mice"
-        self.serial_number = serial_number
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this entity."""
-        area = self.coordinator.data["mice"][self.serial_number]["area"]
-        return DeviceInfo(
-            name=area,
-            suggested_area=area,
-            manufacturer="Verisure",
-            model="Mouse detector",
-            identifiers={(DOMAIN, self.serial_number)},
-            via_device=(DOMAIN, self.coordinator.entry.data[CONF_GIID]),
-            configuration_url="https://mypages.verisure.com",
-        )
-
-    @property
-    def native_value(self) -> str | None:
-        """Return the state of the entity."""
-        return self.coordinator.data["mice"][self.serial_number]["detections"]
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return (
-            super().available
-            and self.serial_number in self.coordinator.data["mice"]
-            and "detections" in self.coordinator.data["mice"][self.serial_number]
+            and "humidityValue" in self.coordinator.data["climate"][self.serial_number]
         )

--- a/homeassistant/components/verisure/switch.py
+++ b/homeassistant/components/verisure/switch.py
@@ -47,7 +47,9 @@ class VerisureSmartplug(CoordinatorEntity[VerisureDataUpdateCoordinator], Switch
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this entity."""
-        area = self.coordinator.data["smart_plugs"][self.serial_number]["area"]
+        area = self.coordinator.data["smart_plugs"][self.serial_number]["device"][
+            "area"
+        ]
         return DeviceInfo(
             name=area,
             suggested_area=area,
@@ -79,14 +81,14 @@ class VerisureSmartplug(CoordinatorEntity[VerisureDataUpdateCoordinator], Switch
 
     def turn_on(self, **kwargs: Any) -> None:
         """Set smartplug status on."""
-        self.coordinator.verisure.set_smartplug_state(self.serial_number, True)
+        self.coordinator.verisure.set_smartplug(self.serial_number, True)
         self._state = True
         self._change_timestamp = monotonic()
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs: Any) -> None:
         """Set smartplug status off."""
-        self.coordinator.verisure.set_smartplug_state(self.serial_number, False)
+        self.coordinator.verisure.set_smartplug(self.serial_number, False)
         self._state = False
         self._change_timestamp = monotonic()
         self.schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2536,7 +2536,7 @@ volkszaehler==0.3.2
 volvooncall==0.10.1
 
 # homeassistant.components.verisure
-vsure==1.8.1
+vsure==2.5.4
 
 # homeassistant.components.vasttrafik
 vtjp==0.1.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1773,7 +1773,7 @@ vilfo-api-client==0.3.2
 volvooncall==0.10.1
 
 # homeassistant.components.verisure
-vsure==1.8.1
+vsure==2.5.4
 
 # homeassistant.components.vulcan
 vulcan-api==2.1.1

--- a/tests/components/verisure/conftest.py
+++ b/tests/components/verisure/conftest.py
@@ -43,18 +43,22 @@ def mock_verisure_config_flow() -> Generator[None, MagicMock, None]:
     ) as verisure_mock:
         verisure = verisure_mock.return_value
         verisure.login.return_value = True
-
-        def func():
-            return {
-                "data": {
-                    "account": {
-                        "installations": [
-                            {"giid": "12345", "alias": "ascending"},
-                            {"giid": "54321", "alias": "descending"},
-                        ]
-                    }
+        verisure.get_installations.return_value = {
+            "data": {
+                "account": {
+                    "installations": [
+                        {
+                            "giid": "12345",
+                            "alias": "ascending",
+                            "address": {"street": "12345th street"},
+                        },
+                        {
+                            "giid": "54321",
+                            "alias": "descending",
+                            "address": {"street": "54321th street"},
+                        },
+                    ]
                 }
             }
-
-        verisure.get_installations = func
+        }
         yield verisure

--- a/tests/components/verisure/conftest.py
+++ b/tests/components/verisure/conftest.py
@@ -43,8 +43,18 @@ def mock_verisure_config_flow() -> Generator[None, MagicMock, None]:
     ) as verisure_mock:
         verisure = verisure_mock.return_value
         verisure.login.return_value = True
-        verisure.installations = [
-            {"giid": "12345", "alias": "ascending", "street": "12345th street"},
-            {"giid": "54321", "alias": "descending", "street": "54321th street"},
-        ]
+
+        def func():
+            return {
+                "data": {
+                    "account": {
+                        "installations": [
+                            {"giid": "12345", "alias": "ascending"},
+                            {"giid": "54321", "alias": "descending"},
+                        ]
+                    }
+                }
+            }
+
+        verisure.get_installations = func
         yield verisure

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -35,18 +35,10 @@ async def test_full_user_flow_single_installation(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
 
-    def func():
-        return {
-            "data": {
-                "account": {
-                    "installations": [
-                        {"giid": "12345", "alias": "ascending"},
-                    ]
-                }
-            }
-        }
-
-    mock_verisure_config_flow.get_installations = func
+    mock_verisure_config_flow.get_installations.return_value = {
+        k1: {k2: {k3: [v3[0]] for k3, v3 in v2.items()} for k2, v2 in v1.items()}
+        for k1, v1 in mock_verisure_config_flow.get_installations.return_value.items()
+    }
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -58,7 +50,7 @@ async def test_full_user_flow_single_installation(
     await hass.async_block_till_done()
 
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
-    assert result2.get("title") == "ascending"
+    assert result2.get("title") == "ascending (12345th street)"
     assert result2.get("data") == {
         CONF_GIID: "12345",
         CONF_EMAIL: "verisure_my_pages@example.com",
@@ -101,7 +93,7 @@ async def test_full_user_flow_multiple_installations(
     await hass.async_block_till_done()
 
     assert result3.get("type") == FlowResultType.CREATE_ENTRY
-    assert result3.get("title") == "descending"
+    assert result3.get("title") == "descending (54321th street)"
     assert result3.get("data") == {
         CONF_GIID: "54321",
         CONF_EMAIL: "verisure_my_pages@example.com",
@@ -142,19 +134,10 @@ async def test_full_user_flow_single_installation_with_mfa(
     assert result2.get("step_id") == "mfa"
 
     mock_verisure_config_flow.login.side_effect = None
-
-    def func():
-        return {
-            "data": {
-                "account": {
-                    "installations": [
-                        {"giid": "12345", "alias": "ascending"},
-                    ]
-                }
-            }
-        }
-
-    mock_verisure_config_flow.get_installations = func
+    mock_verisure_config_flow.get_installations.return_value = {
+        k1: {k2: {k3: [v3[0]] for k3, v3 in v2.items()} for k2, v2 in v1.items()}
+        for k1, v1 in mock_verisure_config_flow.get_installations.return_value.items()
+    }
 
     result3 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -165,7 +148,7 @@ async def test_full_user_flow_single_installation_with_mfa(
     await hass.async_block_till_done()
 
     assert result3.get("type") == FlowResultType.CREATE_ENTRY
-    assert result3.get("title") == "ascending"
+    assert result3.get("title") == "ascending (12345th street)"
     assert result3.get("data") == {
         CONF_GIID: "12345",
         CONF_EMAIL: "verisure_my_pages@example.com",
@@ -227,7 +210,7 @@ async def test_full_user_flow_multiple_installations_with_mfa(
     await hass.async_block_till_done()
 
     assert result4.get("type") == FlowResultType.CREATE_ENTRY
-    assert result4.get("title") == "descending"
+    assert result4.get("title") == "descending (54321th street)"
     assert result4.get("data") == {
         CONF_GIID: "54321",
         CONF_EMAIL: "verisure_my_pages@example.com",
@@ -317,19 +300,10 @@ async def test_verisure_errors(
     assert result5.get("step_id") == "mfa"
     assert result5.get("errors") == {"base": error}
 
-    def func():
-        return {
-            "data": {
-                "account": {
-                    "installations": [
-                        {"giid": "12345", "alias": "ascending"},
-                    ]
-                }
-            }
-        }
-
-    mock_verisure_config_flow.get_installations = func
-
+    mock_verisure_config_flow.get_installations.return_value = {
+        k1: {k2: {k3: [v3[0]] for k3, v3 in v2.items()} for k2, v2 in v1.items()}
+        for k1, v1 in mock_verisure_config_flow.get_installations.return_value.items()
+    }
     mock_verisure_config_flow.validate_mfa.side_effect = None
     mock_verisure_config_flow.login.side_effect = None
 
@@ -342,7 +316,7 @@ async def test_verisure_errors(
     await hass.async_block_till_done()
 
     assert result6.get("type") == FlowResultType.CREATE_ENTRY
-    assert result6.get("title") == "ascending"
+    assert result6.get("title") == "ascending (12345th street)"
     assert result6.get("data") == {
         CONF_GIID: "12345",
         CONF_EMAIL: "verisure_my_pages@example.com",
@@ -562,19 +536,10 @@ async def test_reauth_flow_errors(
 
     mock_verisure_config_flow.validate_mfa.side_effect = None
     mock_verisure_config_flow.login.side_effect = None
-
-    def func():
-        return {
-            "data": {
-                "account": {
-                    "installations": [
-                        {"giid": "12345", "alias": "ascending"},
-                    ]
-                }
-            }
-        }
-
-    mock_verisure_config_flow.get_installations = func
+    mock_verisure_config_flow.get_installations.return_value = {
+        k1: {k2: {k3: [v3[0]] for k3, v3 in v2.items()} for k2, v2 in v1.items()}
+        for k1, v1 in mock_verisure_config_flow.get_installations.return_value.items()
+    }
 
     await hass.config_entries.flow.async_configure(
         result5["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Verisure integration needs to be re-authenticated after the update because the integration is build on a new API.
Mouse detectors have been removed due to a lack of available testers with these types of devices.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The python-verisure pakcage has been updated to work with the new GraphQL API instead of the old REST API. New Verisure devices like the Danalock Smartlock and cameras with motion detection are only supported in the new API.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes #79411, #76620 and #76306
- Link to the documentation pull request: [24654](https://github.com/home-assistant/home-assistant.io/pull/24654)
- Link to the compare between versions: https://github.com/persandstrom/python-verisure/compare/version-1...version-2

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
