### PR TITLE
Add field descriptions for nibe heat pump

### DIFF
--- a/homeassistant/components/nibe_heatpump/config_flow.py
+++ b/homeassistant/components/nibe_heatpump/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import selector
 
 from .const import (
     CONF_CONNECTION_TYPE,
@@ -27,13 +27,22 @@ from .const import (
     LOGGER,
 )
 
+PORT_SELECTOR = vol.All(
+    selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=1, step=1, max=65535, mode=selector.NumberSelectorMode.BOX
+        )
+    ),
+    vol.Coerce(int),
+)
+
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_MODEL): vol.In(list(Model.__members__)),
-        vol.Required(CONF_IP_ADDRESS): str,
-        vol.Required(CONF_LISTENING_PORT, default=9999): cv.port,
-        vol.Required(CONF_REMOTE_READ_PORT, default=9999): cv.port,
-        vol.Required(CONF_REMOTE_WRITE_PORT, default=10000): cv.port,
+        vol.Required(CONF_IP_ADDRESS): selector.TextSelector(),
+        vol.Required(CONF_LISTENING_PORT, default=9999): PORT_SELECTOR,
+        vol.Required(CONF_REMOTE_READ_PORT, default=9999): PORT_SELECTOR,
+        vol.Required(CONF_REMOTE_WRITE_PORT, default=10000): PORT_SELECTOR,
     }
 )
 

--- a/homeassistant/components/nibe_heatpump/strings.json
+++ b/homeassistant/components/nibe_heatpump/strings.json
@@ -2,11 +2,18 @@
   "config": {
     "step": {
       "user": {
+        "description": "Before attempting to configure the integration, verify that:\n - The NibeGW unit is connected to a heat pump.\n - The MODBUS40 accessory has been enabled in the heat pump configuration.\n - The pump has not gone into an alarm state about missing MODBUS40 accessory.",
         "data": {
           "ip_address": "Remote address",
           "remote_read_port": "Remote read port",
           "remote_write_port": "Remote write port",
           "listening_port": "Local listening port"
+        },
+        "data_description": {
+          "ip_address": "The address of the NibeGW unit. The device should have been configured with a static address.",
+          "remote_read_port": "The port the NibeGW unit is listening for read requests on.",
+          "remote_write_port": "The port the NibeGW unit is listening for write requests on.",
+          "listening_port": "The local port on this system, that the NibeGW unit is configured to send data to."
         }
       }
     },

--- a/homeassistant/components/nibe_heatpump/translations/en.json
+++ b/homeassistant/components/nibe_heatpump/translations/en.json
@@ -15,7 +15,14 @@
                     "listening_port": "Local listening port",
                     "remote_read_port": "Remote read port",
                     "remote_write_port": "Remote write port"
-                }
+                },
+                "data_description": {
+                    "ip_address": "The address of the NibeGW unit. The device should have been configured with a static address.",
+                    "listening_port": "The local port on this system, that the NibeGW unit is configured to send data to.",
+                    "remote_read_port": "The port the NibeGW unit is listening for read requests on.",
+                    "remote_write_port": "The port the NibeGW unit is listening for write requests on."
+                },
+                "description": "Before attempting to configure the integration, verify that:\n - The NibeGW unit is connected to a heat pump.\n - The MODBUS40 accessory has been enabled in the heat pump configuration.\n - The pump has not gone into an alarm state about missing MODBUS40 accessory."
             }
         }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve description strings for fields during configuration flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #14164

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
