### PR TITLE
Handle HTTPError on nuki integration

### DIFF
--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -8,13 +8,13 @@ from pynuki.bridge import InvalidCredentialsException
 from requests.exceptions import RequestException
 import voluptuous as vol
 
-from homeassistant import config_entries, exceptions
+from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
-from .helpers import parse_id
+from .helpers import CannotConnect, InvalidAuth, parse_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -153,11 +153,3 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=data_schema, errors=errors
         )
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(exceptions.HomeAssistantError):
-    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/nuki/helpers.py
+++ b/homeassistant/components/nuki/helpers.py
@@ -1,6 +1,15 @@
 """nuki integration helpers."""
+from homeassistant import exceptions
 
 
 def parse_id(hardware_id):
     """Parse Nuki ID."""
     return hex(hardware_id).split("x")[-1].upper()
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pynuki import NukiLock, NukiOpener
 from pynuki.constants import MODE_OPENER_CONTINUOUS
+from requests.exceptions import RequestException
 import voluptuous as vol
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
@@ -26,6 +27,7 @@ from .const import (
     DOMAIN as NUKI_DOMAIN,
     ERROR_STATES,
 )
+from .helpers import CannotConnect
 
 
 async def async_setup_entry(
@@ -114,15 +116,24 @@ class NukiLockEntity(NukiDeviceEntity):
 
     def lock(self, **kwargs: Any) -> None:
         """Lock the device."""
-        self._nuki_device.lock()
+        try:
+            self._nuki_device.lock()
+        except RequestException as err:
+            raise CannotConnect from err
 
     def unlock(self, **kwargs: Any) -> None:
         """Unlock the device."""
-        self._nuki_device.unlock()
+        try:
+            self._nuki_device.unlock()
+        except RequestException as err:
+            raise CannotConnect from err
 
     def open(self, **kwargs: Any) -> None:
         """Open the door latch."""
-        self._nuki_device.unlatch()
+        try:
+            self._nuki_device.unlatch()
+        except RequestException as err:
+            raise CannotConnect from err
 
     def lock_n_go(self, unlatch: bool) -> None:
         """Lock and go.
@@ -130,7 +141,10 @@ class NukiLockEntity(NukiDeviceEntity):
         This will first unlock the door, then wait for 20 seconds (or another
         amount of time depending on the lock settings) and relock.
         """
-        self._nuki_device.lock_n_go(unlatch)
+        try:
+            self._nuki_device.lock_n_go(unlatch)
+        except RequestException as err:
+            raise CannotConnect from err
 
 
 class NukiOpenerEntity(NukiDeviceEntity):
@@ -148,15 +162,24 @@ class NukiOpenerEntity(NukiDeviceEntity):
 
     def lock(self, **kwargs: Any) -> None:
         """Disable ring-to-open."""
-        self._nuki_device.deactivate_rto()
+        try:
+            self._nuki_device.deactivate_rto()
+        except RequestException as err:
+            raise CannotConnect from err
 
     def unlock(self, **kwargs: Any) -> None:
         """Enable ring-to-open."""
-        self._nuki_device.activate_rto()
+        try:
+            self._nuki_device.activate_rto()
+        except RequestException as err:
+            raise CannotConnect from err
 
     def open(self, **kwargs: Any) -> None:
         """Buzz open the door."""
-        self._nuki_device.electric_strike_actuation()
+        try:
+            self._nuki_device.electric_strike_actuation()
+        except RequestException as err:
+            raise CannotConnect from err
 
     def lock_n_go(self, unlatch: bool) -> None:
         """Stub service."""
@@ -168,7 +191,10 @@ class NukiOpenerEntity(NukiDeviceEntity):
         rings the bell. This is similar to ring-to-open, except that it does
         not automatically deactivate
         """
-        if enable:
-            self._nuki_device.activate_continuous_mode()
-        else:
-            self._nuki_device.deactivate_continuous_mode()
+        try:
+            if enable:
+                self._nuki_device.activate_continuous_mode()
+            else:
+                self._nuki_device.deactivate_continuous_mode()
+        except RequestException as err:
+            raise CannotConnect from err


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Catches HTTPErrors when doing API-requests and raises HomeAssistant-Errors instead.
This will enable the `continue_on_error` functionality.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #73344
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
