### PR TITLE
Fix SSDP/UPnP server after testing

### DIFF
--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -3,7 +3,7 @@
   "name": "DLNA Digital Media Renderer",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
-  "requirements": ["async-upnp-client==0.32.0"],
+  "requirements": ["async-upnp-client==0.32.1"],
   "dependencies": ["ssdp"],
   "after_dependencies": ["media_source"],
   "ssdp": [

--- a/homeassistant/components/dlna_dms/manifest.json
+++ b/homeassistant/components/dlna_dms/manifest.json
@@ -3,7 +3,7 @@
   "name": "DLNA Digital Media Server",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dlna_dms",
-  "requirements": ["async-upnp-client==0.32.0"],
+  "requirements": ["async-upnp-client==0.32.1"],
   "dependencies": ["ssdp"],
   "after_dependencies": ["media_source"],
   "ssdp": [

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -7,7 +7,7 @@
     "samsungctl[websocket]==0.7.1",
     "samsungtvws[async,encrypted]==2.5.0",
     "wakeonlan==2.1.0",
-    "async-upnp-client==0.32.0"
+    "async-upnp-client==0.32.1"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -29,7 +29,12 @@ from async_upnp_client.server import (
     UpnpServerDevice,
     UpnpServerService,
 )
-from async_upnp_client.ssdp import SSDP_PORT, determine_source_target, is_ipv4_address
+from async_upnp_client.ssdp import (
+    SSDP_PORT,
+    determine_source_target,
+    fix_ipv6_address_scope_id,
+    is_ipv4_address,
+)
 from async_upnp_client.ssdp_listener import SsdpDevice, SsdpDeviceTracker, SsdpListener
 from async_upnp_client.utils import CaseInsensitiveDict
 
@@ -722,6 +727,7 @@ class Server:
             else:
                 source_tuple = (source_ip_str, 0)
             source, target = determine_source_target(source_tuple)
+            source = fix_ipv6_address_scope_id(source) or source
             http_port = await _async_find_next_available_port(source)
             _LOGGER.debug("Binding UPnP HTTP server to: %s:%s", source_ip, http_port)
             self._upnp_servers.append(

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -420,6 +420,7 @@ class Scanner:
             else:
                 source_tuple = (source_ip_str, 0)
             source, target = determine_source_target(source_tuple)
+            source = fix_ipv6_address_scope_id(source) or source
             self._ssdp_listeners.append(
                 SsdpListener(
                     async_callback=self._ssdp_listener_callback,

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -219,8 +219,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         UPNP_SERVER: server,
     }
 
-    await hass.async_create_task(scanner.async_start())
-    await hass.async_create_task(server.async_start())
+    await scanner.async_start()
+    await server.async_start()
 
     return True
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -218,8 +218,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         UPNP_SERVER: server,
     }
 
-    hass.create_task(scanner.async_start())
-    hass.create_task(server.async_start())
+    await hass.async_create_task(scanner.async_start())
+    await hass.async_create_task(server.async_start())
 
     return True
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -9,6 +9,7 @@ from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
 import logging
 import socket
+from time import time
 from typing import Any
 from urllib.parse import urljoin
 import xml.etree.ElementTree as ET
@@ -716,6 +717,7 @@ class Server:
             )
 
         # Start a server on all source IPs.
+        boot_id = int(time())
         for source_ip in await async_build_source_set(self.hass):
             source_ip_str = str(source_ip)
             if source_ip.version == 6:
@@ -737,6 +739,7 @@ class Server:
                     target=target,
                     http_port=http_port,
                     server_device=HassUpnpServiceDevice,
+                    boot_id=boot_id,
                     options={
                         SSDP_SEARCH_RESPONDER_OPTIONS: {
                             SSDP_SEARCH_RESPONDER_OPTION_ALWAYS_REPLY_WITH_ROOT_DEVICE: True

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["async-upnp-client==0.32.0"],
+  "requirements": ["async-upnp-client==0.32.1"],
   "dependencies": ["network"],
   "after_dependencies": ["zeroconf"],
   "codeowners": [],

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -3,7 +3,7 @@
   "name": "UPnP/IGD",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
-  "requirements": ["async-upnp-client==0.32.0", "getmac==0.8.2"],
+  "requirements": ["async-upnp-client==0.32.1", "getmac==0.8.2"],
   "dependencies": ["network", "ssdp"],
   "codeowners": ["@StevenLooman"],
   "ssdp": [

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -2,7 +2,7 @@
   "domain": "yeelight",
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
-  "requirements": ["yeelight==0.7.10", "async-upnp-client==0.32.0"],
+  "requirements": ["yeelight==0.7.10", "async-upnp-client==0.32.1"],
   "codeowners": ["@zewelor", "@shenxn", "@starkillerOG", "@alexyao2015"],
   "config_flow": true,
   "dependencies": ["network"],

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,7 +4,7 @@ aiodiscover==1.4.13
 aiohttp==3.8.1
 aiohttp_cors==0.7.0
 astral==2.2
-async-upnp-client==0.32.0
+async-upnp-client==0.32.1
 async_timeout==4.0.2
 atomicwrites-homeassistant==1.4.1
 attrs==21.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -353,7 +353,7 @@ asterisk_mbox==0.5.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.32.0
+async-upnp-client==0.32.1
 
 # homeassistant.components.supla
 asyncpysupla==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -307,7 +307,7 @@ arcam-fmj==0.12.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.32.0
+async-upnp-client==0.32.1
 
 # homeassistant.components.sleepiq
 asyncsleepiq==1.2.3

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -671,7 +671,7 @@ async def test_async_detect_interfaces_setting_empty_route(
 
     ssdp_listeners = hass.data[ssdp.DOMAIN][ssdp.SSDP_SCANNER]._ssdp_listeners
     sources = {ssdp_listener.source for ssdp_listener in ssdp_listeners}
-    assert sources == {("2001:db8::%1", 0, 0, 1), ("192.168.1.5", 0)}
+    assert sources == {("2001:db8::", 0, 0, 1), ("192.168.1.5", 0)}
 
 
 @pytest.mark.usefixtures("mock_get_source_ip")
@@ -695,7 +695,7 @@ async def test_bind_failure_skips_adapter(
     """Test that an adapter with a bind failure is skipped."""
 
     async def _async_start(self):
-        if self.source == ("2001:db8::%1", 0, 0, 1):
+        if self.source == ("2001:db8::", 0, 0, 1):
             raise OSError
 
     SsdpListener.async_start = _async_start


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes after testing by @oyvindwe the new ssdp/upnp server. Includes a fix for the race condition reported in #80400 as well.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80400
- This PR is related to issue: https://github.com/StevenLooman/async_upnp_client/issues/147
- Link to documentation pull request: 

Changes to `async-upnp-client` `0.32.1`:
- Commits: https://github.com/StevenLooman/async_upnp_client/compare/0.32.0...0.32.1
- Changelog: https://github.com/StevenLooman/async_upnp_client/blob/0.32.1/CHANGES.rst#async_upnp_client-0321-2022-10-23

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
