### PR TITLE
Cleanup Shelly update platform

### DIFF
--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -14,13 +14,11 @@ from aioshelly.rpc_device import RpcDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_DEVICE_ID, CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    ATTR_BETA,
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
     ATTR_DEVICE,
@@ -249,43 +247,6 @@ class ShellyBlockCoordinator(DataUpdateCoordinator):
         self.device_id = entry.id
         self.device.subscribe_updates(self.async_set_updated_data)
 
-    async def async_trigger_ota_update(self, beta: bool = False) -> None:
-        """Trigger or schedule an ota update."""
-        update_data = self.device.status["update"]
-        LOGGER.debug("OTA update service - update_data: %s", update_data)
-
-        if not update_data["has_update"] and not beta:
-            LOGGER.warning("No OTA update available for device %s", self.name)
-            return
-
-        if beta and not update_data.get("beta_version"):
-            LOGGER.warning(
-                "No OTA update on beta channel available for device %s", self.name
-            )
-            return
-
-        if update_data["status"] == "updating":
-            LOGGER.warning("OTA update already in progress for %s", self.name)
-            return
-
-        new_version = update_data["new_version"]
-        if beta:
-            new_version = update_data["beta_version"]
-        LOGGER.info(
-            "Start OTA update of device %s from '%s' to '%s'",
-            self.name,
-            self.device.firmware_version,
-            new_version,
-        )
-        try:
-            result = await self.device.trigger_ota_update(beta=beta)
-        except DeviceConnectionError as err:
-            raise HomeAssistantError(f"Error starting OTA update: {repr(err)}") from err
-        except InvalidAuthError:
-            self.entry.async_start_reauth(self.hass)
-        else:
-            LOGGER.debug("Result of OTA update call: %s", result)
-
     def shutdown(self) -> None:
         """Shutdown the coordinator."""
         self.device.shutdown()
@@ -479,46 +440,6 @@ class ShellyRpcCoordinator(DataUpdateCoordinator):
         )
         self.device_id = entry.id
         self.device.subscribe_updates(self.async_set_updated_data)
-
-    async def async_trigger_ota_update(self, beta: bool = False) -> None:
-        """Trigger an ota update."""
-
-        update_data = self.device.status["sys"]["available_updates"]
-        LOGGER.debug("OTA update service - update_data: %s", update_data)
-
-        if not bool(update_data) or (not update_data.get("stable") and not beta):
-            LOGGER.warning("No OTA update available for device %s", self.name)
-            return
-
-        if beta and not update_data.get(ATTR_BETA):
-            LOGGER.warning(
-                "No OTA update on beta channel available for device %s", self.name
-            )
-            return
-
-        new_version = update_data.get("stable", {"version": ""})["version"]
-        if beta:
-            new_version = update_data.get(ATTR_BETA, {"version": ""})["version"]
-
-        assert self.device.shelly
-        LOGGER.info(
-            "Start OTA update of device %s from '%s' to '%s'",
-            self.name,
-            self.device.firmware_version,
-            new_version,
-        )
-        try:
-            await self.device.trigger_ota_update(beta=beta)
-        except DeviceConnectionError as err:
-            raise HomeAssistantError(
-                f"OTA update connection error: {repr(err)}"
-            ) from err
-        except RpcCallError as err:
-            raise HomeAssistantError(f"OTA update request error: {repr(err)}") from err
-        except InvalidAuthError:
-            self.entry.async_start_reauth(self.hass)
-        else:
-            LOGGER.debug("OTA update call successful")
 
     async def shutdown(self) -> None:
         """Shutdown the coordinator."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Cleanup Shelly update platform, coordinator and add tests**

Shelly started with providing service for OTA which was updated to button + binary sensor and recently to update platform, this left behind many legacy code, most of the code which handle the OTA was placed in `coordinator.py` instead of in the update platform. By this, big parts of the OTA code where not tested since `coordinator.py` is excluded from tests (although it looked like `update` had 100% test coverage)

By placing all the relevant code in `update.py` we make sure update is fully checked up to the library calls.
After moving the code many legacy checks which are now covered by the update base entity removed.
Tests added to cover states that were not tested before.

Right now there are multiple firmware updates and beta, both for Shelly Gen1 and Gen2, tested the changes on multiple devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
