### PR TITLE
Add ZHA StartUpColorTemperature configuration entity

### DIFF
--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -44,6 +44,7 @@ class ColorChannel(ZigbeeChannel):
         "color_temp_physical_max": True,
         "color_capabilities": True,
         "color_loop_active": False,
+        "start_up_color_temperature" : True,
     }
 
     @cached_property

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -44,7 +44,7 @@ class ColorChannel(ZigbeeChannel):
         "color_temp_physical_max": True,
         "color_capabilities": True,
         "color_loop_active": False,
-        "start_up_color_temperature" : True,
+        "start_up_color_temperature": True,
     }
 
     @cached_property

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -528,16 +528,31 @@ class StartUpCurrentLevelConfigurationEntity(
     _zcl_attribute: str = "start_up_current_level"
     _attr_name = "Start-up current level"
 
+
 @CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_COLOR)
 class StartUpColorTemperatureConfigurationEntity(
     ZHANumberConfigurationEntity, id_suffix="start_up_color_temperature"
 ):
     """Representation of a ZHA startup color temperature configuration entity."""
 
-    _attr_native_min_value: float = 0x0000
-    _attr_native_max_value: float = 0xFFFF
+    _attr_native_min_value: float = 153
+    _attr_native_max_value: float = 500
     _zcl_attribute: str = "start_up_color_temperature"
     _attr_name = "Start-up color temperature"
+
+    def __init__(
+        self,
+        unique_id: str,
+        zha_device: ZHADevice,
+        channels: list[ZigbeeChannel],
+        **kwargs: Any,
+    ) -> None:
+        """Init this ZHA startup color temperature entity."""
+        super().__init__(unique_id, zha_device, channels, **kwargs)
+        if self._channel:
+            self._attr_native_min_value: float = self._channel.min_mireds
+            self._attr_native_max_value: float = self._channel.max_mireds
+
 
 @CONFIG_DIAGNOSTIC_MATCH(
     channel_names="tuya_manufacturer",

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .core import discovery
 from .core.const import (
     CHANNEL_ANALOG_OUTPUT,
+    CHANNEL_COLOR,
     CHANNEL_INOVELLI,
     CHANNEL_LEVEL,
     DATA_ZHA,
@@ -527,6 +528,16 @@ class StartUpCurrentLevelConfigurationEntity(
     _zcl_attribute: str = "start_up_current_level"
     _attr_name = "Start-up current level"
 
+@CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_COLOR)
+class StartUpColorTemperatureConfigurationEntity(
+    ZHANumberConfigurationEntity, id_suffix="start_up_color_temperature"
+):
+    """Representation of a ZHA startup color temperature configuration entity."""
+
+    _attr_native_min_value: float = 0x0000
+    _attr_native_max_value: float = 0xFFFF
+    _zcl_attribute: str = "start_up_color_temperature"
+    _attr_name = "Start-up color temperature"
 
 @CONFIG_DIAGNOSTIC_MATCH(
     channel_names="tuya_manufacturer",

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -5,6 +5,7 @@ import pytest
 from zigpy.exceptions import ZigbeeException
 from zigpy.profiles import zha
 import zigpy.zcl.clusters.general as general
+import zigpy.zcl.clusters.lighting as lighting
 import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
@@ -64,12 +65,13 @@ async def light(zigpy_device_mock):
         {
             1: {
                 SIG_EP_PROFILE: zha.PROFILE_ID,
-                SIG_EP_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                SIG_EP_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
                 SIG_EP_INPUT: [
                     general.Basic.cluster_id,
                     general.Identify.cluster_id,
                     general.OnOff.cluster_id,
                     general.LevelControl.cluster_id,
+                    lighting.Color.cluster_id,
                 ],
                 SIG_EP_OUTPUT: [general.Ota.cluster_id],
             }
@@ -319,6 +321,116 @@ async def test_level_control_number(
 
     assert level_control_cluster.write_attributes.call_count == 1
     assert level_control_cluster.write_attributes.call_args[0][0] == {
+        attr: new_value,
+    }
+    assert hass.states.get(entity_id).state == str(initial_value)
+
+
+@pytest.mark.parametrize(
+    "attr, initial_value, new_value",
+    (("start_up_color_temperature", 500, 350),),
+)
+async def test_color_number(
+    hass, light, zha_device_joined, attr, initial_value, new_value
+):
+    """Test zha color number entities - new join."""
+
+    entity_registry = er.async_get(hass)
+    color_cluster = light.endpoints[1].light_color
+    color_cluster.PLUGGED_ATTR_READS = {
+        attr: initial_value,
+    }
+    zha_device = await zha_device_joined(light)
+
+    entity_id = await find_entity_id(
+        Platform.NUMBER,
+        zha_device,
+        hass,
+        qualifier=attr,
+    )
+    assert entity_id is not None
+
+    assert color_cluster.read_attributes.call_count == 3
+    assert (
+        call(
+            [
+                "color_temp_physical_min",
+                "color_temp_physical_max",
+                "color_capabilities",
+                "start_up_color_temperature",
+            ],
+            allow_cache=True,
+            only_cache=False,
+            manufacturer=None,
+        )
+        in color_cluster.read_attributes.call_args_list
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == str(initial_value)
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry
+    assert entity_entry.entity_category == EntityCategory.CONFIG
+
+    # Test number set_value
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {
+            "entity_id": entity_id,
+            "value": new_value,
+        },
+        blocking=True,
+    )
+
+    assert color_cluster.write_attributes.call_count == 1
+    assert color_cluster.write_attributes.call_args[0][0] == {
+        attr: new_value,
+    }
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == str(new_value)
+
+    color_cluster.read_attributes.reset_mock()
+    await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "homeassistant", "update_entity", {"entity_id": entity_id}, blocking=True
+    )
+    # the mocking doesn't update the attr cache so this flips back to initial value
+    assert hass.states.get(entity_id).state == str(initial_value)
+    assert color_cluster.read_attributes.call_count == 1
+    assert (
+        call(
+            [
+                attr,
+            ],
+            allow_cache=False,
+            only_cache=False,
+            manufacturer=None,
+        )
+        in color_cluster.read_attributes.call_args_list
+    )
+
+    color_cluster.write_attributes.reset_mock()
+    color_cluster.write_attributes.side_effect = ZigbeeException
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {
+            "entity_id": entity_id,
+            "value": new_value,
+        },
+        blocking=True,
+    )
+
+    assert color_cluster.write_attributes.call_count == 1
+    assert color_cluster.write_attributes.call_args[0][0] == {
         attr: new_value,
     }
     assert hass.states.get(entity_id).state == str(initial_value)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Some Zigbee color lights also feature a start up color temperature configuration, besides the already available start up level and OnOff configuration. This PR adds support for exposing this feature as Entity as well.

Tested with an Philips Hue Infuse ceiling lamp:
![Screenshot 2022-10-23 235631](https://user-images.githubusercontent.com/4631548/197420471-46246af2-8be1-4afa-98a3-0254e8688911.png)
![Screenshot 2022-10-23 235614](https://user-images.githubusercontent.com/4631548/197420473-c239c615-e603-4688-be66-7700062fb979.png)

I assume due to the `153-500` value range, the UI unfortunately uses a number input instead of a slider. If there's an easy way to give the UI a hint to use a slider (or even the color temperature slider), that would be great.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: _none_
- This PR is related to issue: _none_
- Link to documentation pull request: _none_

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
