### PR TITLE
Add API key validation for Forecast.Solar

### DIFF
--- a/homeassistant/components/forecast_solar/strings.json
+++ b/homeassistant/components/forecast_solar/strings.json
@@ -15,6 +15,9 @@
     }
   },
   "options": {
+    "error": {
+      "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]"
+    },
     "step": {
       "init": {
         "description": "These values allow tweaking the Forecast.Solar result. Please refer to the documentation if a field is unclear.",

--- a/homeassistant/components/forecast_solar/translations/en.json
+++ b/homeassistant/components/forecast_solar/translations/en.json
@@ -15,6 +15,9 @@
         }
     },
     "options": {
+        "error": {
+            "invalid_api_key": "Invalid API key"
+        },
         "step": {
             "init": {
                 "data": {

--- a/tests/components/forecast_solar/conftest.py
+++ b/tests/components/forecast_solar/conftest.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from forecast_solar import models
 import pytest
@@ -20,6 +20,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[None, AsyncMock, None]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
+    ) as mock_setup:
+        yield mock_setup
 
 
 @pytest.fixture

--- a/tests/components/forecast_solar/conftest.py
+++ b/tests/components/forecast_solar/conftest.py
@@ -23,7 +23,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, AsyncMock, None]:
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.forecast_solar.async_setup_entry", return_value=True

--- a/tests/components/forecast_solar/test_config_flow.py
+++ b/tests/components/forecast_solar/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Forecast.Solar config flow."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock
 
 from homeassistant.components.forecast_solar.const import (
     CONF_AZIMUTH,
@@ -17,7 +17,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-async def test_user_flow(hass: HomeAssistant) -> None:
+async def test_user_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     """Test the full user configuration flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -27,20 +27,17 @@ async def test_user_flow(hass: HomeAssistant) -> None:
     assert result.get("step_id") == SOURCE_USER
     assert "flow_id" in result
 
-    with patch(
-        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_NAME: "Name",
-                CONF_LATITUDE: 52.42,
-                CONF_LONGITUDE: 4.42,
-                CONF_AZIMUTH: 142,
-                CONF_DECLINATION: 42,
-                CONF_MODULES_POWER: 4242,
-            },
-        )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_NAME: "Name",
+            CONF_LATITUDE: 52.42,
+            CONF_LONGITUDE: 4.42,
+            CONF_AZIMUTH: 142,
+            CONF_DECLINATION: 42,
+            CONF_MODULES_POWER: 4242,
+        },
+    )
 
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
     assert result2.get("title") == "Name"
@@ -58,63 +55,67 @@ async def test_user_flow(hass: HomeAssistant) -> None:
 
 
 async def test_options_flow_invalid_api(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test options config flow when API key is invalid."""
-    result = await hass.config_entries.options.async_init(init_integration.entry_id)
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
     assert "flow_id" in result
 
-    with patch(
-        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_API_KEY: "solarPOWER!",
-                CONF_DECLINATION: 21,
-                CONF_AZIMUTH: 22,
-                CONF_MODULES_POWER: 2122,
-                CONF_DAMPING: 0.25,
-                CONF_INVERTER_SIZE: 2000,
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_API_KEY: "solarPOWER!",
+            CONF_DECLINATION: 21,
+            CONF_AZIMUTH: 22,
+            CONF_MODULES_POWER: 2122,
+            CONF_DAMPING: 0.25,
+            CONF_INVERTER_SIZE: 2000,
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result2.get("type") == FlowResultType.FORM
     assert result2["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
-    assert len(mock_setup_entry.mock_calls) == 0
-
 
 async def test_options_flow(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test config flow options."""
-    result = await hass.config_entries.options.async_init(init_integration.entry_id)
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
     assert "flow_id" in result
 
     # With the API key
-    with patch(
-        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_API_KEY: "SolarForecast150",
-                CONF_DECLINATION: 21,
-                CONF_AZIMUTH: 22,
-                CONF_MODULES_POWER: 2122,
-                CONF_DAMPING: 0.25,
-                CONF_INVERTER_SIZE: 2000,
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_API_KEY: "SolarForecast150",
+            CONF_DECLINATION: 21,
+            CONF_AZIMUTH: 22,
+            CONF_MODULES_POWER: 2122,
+            CONF_DAMPING: 0.25,
+            CONF_INVERTER_SIZE: 2000,
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
     assert result2.get("data") == {
@@ -126,34 +127,35 @@ async def test_options_flow(
         CONF_INVERTER_SIZE: 2000,
     }
 
-    assert len(mock_setup_entry.mock_calls) == 1
-
 
 async def test_options_flow_without_key(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test config flow options."""
-    result = await hass.config_entries.options.async_init(init_integration.entry_id)
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
     assert "flow_id" in result
 
     # Without the API key
-    with patch(
-        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_DECLINATION: 21,
-                CONF_AZIMUTH: 22,
-                CONF_MODULES_POWER: 2122,
-                CONF_DAMPING: 0.25,
-                CONF_INVERTER_SIZE: 2000,
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_DECLINATION: 21,
+            CONF_AZIMUTH: 22,
+            CONF_MODULES_POWER: 2122,
+            CONF_DAMPING: 0.25,
+            CONF_INVERTER_SIZE: 2000,
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
     assert result2.get("data") == {
@@ -164,5 +166,3 @@ async def test_options_flow_without_key(
         CONF_DAMPING: 0.25,
         CONF_INVERTER_SIZE: 2000,
     }
-
-    assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/forecast_solar/test_config_flow.py
+++ b/tests/components/forecast_solar/test_config_flow.py
@@ -58,66 +58,63 @@ async def test_user_flow(hass: HomeAssistant) -> None:
 
 
 async def test_options_flow_invalid_api(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test options config flow when API key is invalid."""
-    mock_config_entry.add_to_hass(hass)
-    with patch(
-        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    result = await hass.config_entries.options.async_init(init_integration.entry_id)
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
     assert "flow_id" in result
 
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_API_KEY: "solarPOWER!",
-            CONF_DECLINATION: 21,
-            CONF_AZIMUTH: 22,
-            CONF_MODULES_POWER: 2122,
-            CONF_DAMPING: 0.25,
-            CONF_INVERTER_SIZE: 2000,
-        },
-    )
+    with patch(
+        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_API_KEY: "solarPOWER!",
+                CONF_DECLINATION: 21,
+                CONF_AZIMUTH: 22,
+                CONF_MODULES_POWER: 2122,
+                CONF_DAMPING: 0.25,
+                CONF_INVERTER_SIZE: 2000,
+            },
+        )
+        await hass.async_block_till_done()
 
     assert result2.get("type") == FlowResultType.FORM
     assert result2["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
+    assert len(mock_setup_entry.mock_calls) == 0
+
 
 async def test_options_flow(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test config flow options."""
-    mock_config_entry.add_to_hass(hass)
-    with patch(
-        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    result = await hass.config_entries.options.async_init(init_integration.entry_id)
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
     assert "flow_id" in result
 
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_API_KEY: "SolarForecast150",
-            CONF_DECLINATION: 21,
-            CONF_AZIMUTH: 22,
-            CONF_MODULES_POWER: 2122,
-            CONF_DAMPING: 0.25,
-            CONF_INVERTER_SIZE: 2000,
-        },
-    )
+    # With the API key
+    with patch(
+        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_API_KEY: "SolarForecast150",
+                CONF_DECLINATION: 21,
+                CONF_AZIMUTH: 22,
+                CONF_MODULES_POWER: 2122,
+                CONF_DAMPING: 0.25,
+                CONF_INVERTER_SIZE: 2000,
+            },
+        )
+        await hass.async_block_till_done()
 
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
     assert result2.get("data") == {
@@ -129,35 +126,34 @@ async def test_options_flow(
         CONF_INVERTER_SIZE: 2000,
     }
 
+    assert len(mock_setup_entry.mock_calls) == 1
+
 
 async def test_options_flow_without_key(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test config flow options."""
-    mock_config_entry.add_to_hass(hass)
-    with patch(
-        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    result = await hass.config_entries.options.async_init(init_integration.entry_id)
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
     assert "flow_id" in result
 
     # Without the API key
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_DECLINATION: 21,
-            CONF_AZIMUTH: 22,
-            CONF_MODULES_POWER: 2122,
-            CONF_DAMPING: 0.25,
-            CONF_INVERTER_SIZE: 2000,
-        },
-    )
+    with patch(
+        "homeassistant.components.forecast_solar.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_DECLINATION: 21,
+                CONF_AZIMUTH: 22,
+                CONF_MODULES_POWER: 2122,
+                CONF_DAMPING: 0.25,
+                CONF_INVERTER_SIZE: 2000,
+            },
+        )
+        await hass.async_block_till_done()
 
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
     assert result2.get("data") == {
@@ -168,3 +164,5 @@ async def test_options_flow_without_key(
         CONF_DAMPING: 0.25,
         CONF_INVERTER_SIZE: 2000,
     }
+
+    assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/forecast_solar/test_config_flow.py
+++ b/tests/components/forecast_solar/test_config_flow.py
@@ -87,7 +87,7 @@ async def test_options_flow_invalid_api(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_api_key"}
+    assert result2["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
 
 async def test_options_flow(
@@ -161,6 +161,7 @@ async def test_options_flow_without_key(
 
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
     assert result2.get("data") == {
+        CONF_API_KEY: None,
         CONF_DECLINATION: 21,
         CONF_AZIMUTH: 22,
         CONF_MODULES_POWER: 2122,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A validation check to ensure that only the correct format of API keys are entered in the options flow. I also tested additionally whether this works well when a user leaves the api key empty.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
