### PR TITLE
Use EntityDescription in Freebox switch

### DIFF
--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -51,16 +51,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up the switch."""
     router: FreeboxRouter = hass.data[DOMAIN][entry.unique_id]
-    async_add_entities(
-        [
-            FreeboxSwitch(
-                router,
-                entity_description,
-            )
-            for entity_description in SWITCH_DESCRIPTIONS
-        ],
-        True,
-    )
+    entities = [
+        FreeboxSwitch(router, entity_description)
+        for entity_description in SWITCH_DESCRIPTIONS
+    ]
+    async_add_entities(entities, True)
 
 
 class FreeboxSwitch(SwitchEntity):

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -76,7 +76,7 @@ class FreeboxSwitch(SwitchEntity):
         self.entity_description = entity_description
         self._router = router
         self._attr_device_info = self._router.device_info
-        self._attr_unique_id = f"{self._router.mac} {self.entity_description.key}"
+        self._attr_unique_id = f"{self._router.mac} {self.entity_description.name}"
 
     async def _async_set_state(self, enabled: bool):
         """Turn the switch on or off."""

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -38,8 +38,7 @@ class FreeboxSwitchEntityDescription(
 SWITCH_DESCRIPTIONS = [
     FreeboxSwitchEntityDescription(
         key="wifi",
-        name="WiFi",
-        has_entity_name=True,
+        name="Freebox WiFi",
         entity_category=EntityCategory.CONFIG,
         state_fn=lambda router: router.wifi.get_global_config,
         on_off_fn=lambda router: router.wifi.set_global_config,

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -1,15 +1,17 @@
 """Support for Freebox Delta, Revolution and Mini 4K."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 import logging
 from typing import Any
 
 from freebox_api.exceptions import InsufficientPermissionsError
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -18,49 +20,68 @@ from .router import FreeboxRouter
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass
+class FreeboxSwitchRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    state_fn: Callable[[FreeboxRouter], Any]
+    on_off_fn: Callable[[FreeboxRouter], Any]
+
+
+@dataclass
+class FreeboxSwitchEntityDescription(
+    SwitchEntityDescription, FreeboxSwitchRequiredKeysMixin
+):
+    """Describes Freebox switch entity."""
+
+
+SWITCH_DESCRIPTIONS = [
+    FreeboxSwitchEntityDescription(
+        key="wifi",
+        name="WiFi",
+        has_entity_name=True,
+        entity_category=EntityCategory.CONFIG,
+        state_fn=lambda router: router.wifi.get_global_config,
+        on_off_fn=lambda router: router.wifi.set_global_config,
+    )
+]
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the switch."""
     router: FreeboxRouter = hass.data[DOMAIN][entry.unique_id]
-    async_add_entities([FreeboxWifiSwitch(router)], True)
+    async_add_entities(
+        [
+            FreeboxSwitch(
+                router,
+                entity_description,
+            )
+            for entity_description in SWITCH_DESCRIPTIONS
+        ],
+        True,
+    )
 
 
-class FreeboxWifiSwitch(SwitchEntity):
-    """Representation of a freebox wifi switch."""
+class FreeboxSwitch(SwitchEntity):
+    """Representation of a freebox switch."""
 
-    def __init__(self, router: FreeboxRouter) -> None:
-        """Initialize the Wifi switch."""
-        self._name = "Freebox WiFi"
-        self._state: bool | None = None
+    entity_description: FreeboxSwitchEntityDescription
+
+    def __init__(
+        self, router: FreeboxRouter, entity_description: FreeboxSwitchEntityDescription
+    ) -> None:
+        """Initialize the switch."""
+        self.entity_description = entity_description
         self._router = router
-        self._unique_id = f"{self._router.mac} {self._name}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return self._unique_id
-
-    @property
-    def name(self) -> str:
-        """Return the name of the switch."""
-        return self._name
-
-    @property
-    def is_on(self) -> bool | None:
-        """Return true if device is on."""
-        return self._state
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        return self._router.device_info
+        self._attr_device_info = self._router.device_info
+        self._attr_unique_id = f"{self._router.mac} {self.entity_description.key}"
 
     async def _async_set_state(self, enabled: bool):
         """Turn the switch on or off."""
-        wifi_config = {"enabled": enabled}
         try:
-            await self._router.wifi.set_global_config(wifi_config)
+            await self.entity_description.on_off_fn(self._router)({"enabled": enabled})
         except InsufficientPermissionsError:
             _LOGGER.warning(
                 "Home Assistant does not have permissions to modify the Freebox settings. Please refer to documentation"
@@ -76,6 +97,5 @@ class FreeboxWifiSwitch(SwitchEntity):
 
     async def async_update(self) -> None:
         """Get the state and update it."""
-        datas = await self._router.wifi.get_global_config()
-        active = datas["enabled"]
-        self._state = bool(active)
+        datas = await self.entity_description.state_fn(self._router)()
+        self._attr_is_on = bool(datas["enabled"])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleaning the code before adding new sensors, use SwitchEntityDescriptor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
