### PR TITLE
Fix HKC exceptions during BLE startup not being caught

### DIFF
--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -1,6 +1,12 @@
 """Constants for the homekit_controller component."""
+import asyncio
 from typing import Final
 
+from aiohomekit.exceptions import (
+    AccessoryDisconnectedError,
+    AccessoryNotFoundError,
+    EncryptionError,
+)
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
@@ -94,3 +100,10 @@ CHARACTERISTIC_PLATFORMS = {
 
 # Device classes
 DEVICE_CLASS_ECOBEE_MODE: Final = "homekit_controller__ecobee_mode"
+
+STARTUP_EXCEPTIONS = (
+    asyncio.TimeoutError,
+    AccessoryNotFoundError,
+    EncryptionError,
+    AccessoryDisconnectedError,
+)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Noticed this while doing some testing with an esp32 proxy
when it runs out of slots.

Fixes
```
2022-10-23 22:10:52.625 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved:   File "/Users/bdraco/home-assistant/venv/bin/hass", line 33, in <module>
    sys.exit(load_entry_point(homeassistant, console_scripts, hass)())
  File "/Users/bdraco/home-assistant/homeassistant/__main__.py", line 191, in main
    exit_code = runner.run(runtime_conf)
  File "/Users/bdraco/home-assistant/homeassistant/runner.py", line 119, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/base_events.py", line 633, in run_until_complete
    self.run_forever()
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/base_events.py", line 600, in run_forever
    self._run_once()
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/base_events.py", line 1888, in _run_once
    handle._run()
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/bdraco/home-assistant/homeassistant/core.py", line 1050, in _onetime_listener
    self._hass.async_run_job(listener, event)
  File "/Users/bdraco/home-assistant/homeassistant/core.py", line 621, in async_run_job
    return self.async_run_hass_job(HassJob(target), *args)
  File "/Users/bdraco/home-assistant/homeassistant/core.py", line 576, in async_run_hass_job
    return self.async_add_hass_job(hassjob, *args)
  File "/Users/bdraco/home-assistant/homeassistant/core.py", line 479, in async_add_hass_job
    task = self.loop.create_task(hassjob.target(*args))
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/bleak_retry_connector/__init__.py", line 491, in establish_connection
    await client.connect(
  File "/Users/bdraco/home-assistant/homeassistant/components/bluetooth/models.py", line 289, in connect
    self._async_get_backend() or self._async_get_fallback_backend()
  File "/Users/bdraco/home-assistant/homeassistant/components/bluetooth/models.py", line 362, in _async_get_fallback_backend
    raise BleakError(
bleak.exc.BleakError: No backend with an available connection slot that can reach address CA:D5:1A:5B:E3:A9 was found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/connection.py", line 47, in establish_connection
    return await retry_establish_connection(
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/bleak_retry_connector/__init__.py", line 564, in establish_connection
    _raise_if_needed(name, description, exc)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/bleak_retry_connector/__init__.py", line 442, in _raise_if_needed
    raise BleakConnectionError(msg) from exc
bleak_retry_connector.BleakConnectionError: Eve Motion 41A4 [CA:D5:1A:5B:E3:A9] (id=4B:10:3C:BB:EF:8E) - CA:D5:1A:5B:E3:A9: Failed to connect: No backend with an available connection slot that can reach address CA:D5:1A:5B:E3:A9 was found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/components/homekit_controller/connection.py", line 189, in _async_retry_populate_ble_accessory_state
    await self.pairing.async_populate_accessories_state(force_update=True)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 813, in async_populate_accessories_state
    await self._async_populate_accessories_state(force_update, attempts)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 162, in _async_operation_lock_wrap
    return await func(self, *args, **kwargs)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/bleak_retry_connector/__init__.py", line 600, in _async_wrap_bluetooth_connection_error_retry
    return await func(*args, **kwargs)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 825, in _async_populate_accessories_state
    await self._populate_accessories_and_characteristics(force_update, attempts)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 859, in _populate_accessories_and_characteristics
    await self._ensure_connected(attempts)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 398, in _ensure_connected
    self.client = await establish_connection(
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/connection.py", line 57, in establish_connection
    raise AccessoryDisconnectedError(ex) from ex
aiohomekit.exceptions.AccessoryDisconnectedError: Eve Motion 41A4 [CA:D5:1A:5B:E3:A9] (id=4B:10:3C:BB:EF:8E) - CA:D5:1A:5B:E3:A9: Failed to connect: No backend with an available connection slot that can reach address CA:D5:1A:5B:E3:A9 was found
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
