### PR TITLE
Refactor zwave_js add-on manager

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -854,24 +854,24 @@ async def async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) ->
     s2_unauthenticated_key: str = entry.data.get(CONF_S2_UNAUTHENTICATED_KEY, "")
     addon_state = addon_info.state
 
+    addon_config = {
+        CONF_ADDON_DEVICE: usb_path,
+        CONF_ADDON_S0_LEGACY_KEY: s0_legacy_key,
+        CONF_ADDON_S2_ACCESS_CONTROL_KEY: s2_access_control_key,
+        CONF_ADDON_S2_AUTHENTICATED_KEY: s2_authenticated_key,
+        CONF_ADDON_S2_UNAUTHENTICATED_KEY: s2_unauthenticated_key,
+    }
+
     if addon_state == AddonState.NOT_INSTALLED:
         addon_manager.async_schedule_install_setup_addon(
-            usb_path,
-            s0_legacy_key,
-            s2_access_control_key,
-            s2_authenticated_key,
-            s2_unauthenticated_key,
+            addon_config,
             catch_error=True,
         )
         raise ConfigEntryNotReady
 
     if addon_state == AddonState.NOT_RUNNING:
         addon_manager.async_schedule_setup_addon(
-            usb_path,
-            s0_legacy_key,
-            s2_access_control_key,
-            s2_authenticated_key,
-            s2_unauthenticated_key,
+            addon_config,
             catch_error=True,
         )
         raise ConfigEntryNotReady

--- a/homeassistant/components/zwave_js/addon.py
+++ b/homeassistant/components/zwave_js/addon.py
@@ -5,10 +5,10 @@ import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from enum import Enum
-from functools import partial
+from functools import partial, wraps
 from typing import Any, TypeVar
 
-from typing_extensions import ParamSpec
+from typing_extensions import Concatenate, ParamSpec
 
 from homeassistant.components.hassio import (
     async_create_backup,
@@ -28,17 +28,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.singleton import singleton
 
-from .const import (
-    ADDON_SLUG,
-    CONF_ADDON_DEVICE,
-    CONF_ADDON_S0_LEGACY_KEY,
-    CONF_ADDON_S2_ACCESS_CONTROL_KEY,
-    CONF_ADDON_S2_AUTHENTICATED_KEY,
-    CONF_ADDON_S2_UNAUTHENTICATED_KEY,
-    DOMAIN,
-    LOGGER,
-)
+from .const import ADDON_SLUG, DOMAIN, LOGGER
 
+_AddonManagerT = TypeVar("_AddonManagerT", bound="AddonManager")
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
 
@@ -49,25 +41,33 @@ DATA_ADDON_MANAGER = f"{DOMAIN}_addon_manager"
 @callback
 def get_addon_manager(hass: HomeAssistant) -> AddonManager:
     """Get the add-on manager."""
-    return AddonManager(hass, ADDON_SLUG)
+    return AddonManager(hass, "Z-Wave JS", ADDON_SLUG)
 
 
 def api_error(
     error_message: str,
-) -> Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Coroutine[Any, Any, _R]]]:
+) -> Callable[
+    [Callable[Concatenate[_AddonManagerT, _P], Awaitable[_R]]],
+    Callable[Concatenate[_AddonManagerT, _P], Coroutine[Any, Any, _R]],
+]:
     """Handle HassioAPIError and raise a specific AddonError."""
 
     def handle_hassio_api_error(
-        func: Callable[_P, Awaitable[_R]]
-    ) -> Callable[_P, Coroutine[Any, Any, _R]]:
+        func: Callable[Concatenate[_AddonManagerT, _P], Awaitable[_R]]
+    ) -> Callable[Concatenate[_AddonManagerT, _P], Coroutine[Any, Any, _R]]:
         """Handle a HassioAPIError."""
 
-        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        @wraps(func)
+        async def wrapper(
+            self: _AddonManagerT, *args: _P.args, **kwargs: _P.kwargs
+        ) -> _R:
             """Wrap an add-on manager method."""
             try:
-                return_value = await func(*args, **kwargs)
+                return_value = await func(self, *args, **kwargs)
             except HassioAPIError as err:
-                raise AddonError(f"{error_message}: {err}") from err
+                raise AddonError(
+                    f"{error_message.format(addon_name=self.addon_name)}: {err}"
+                ) from err
 
             return return_value
 
@@ -100,12 +100,13 @@ class AddonManager:
     """Manage the add-on.
 
     Methods may raise AddonError.
-    Only one instance of this class may exist
+    Only one instance of this class may exist per add-on
     to keep track of running add-on tasks.
     """
 
-    def __init__(self, hass: HomeAssistant, addon_slug: str) -> None:
+    def __init__(self, hass: HomeAssistant, addon_name: str, addon_slug: str) -> None:
         """Set up the add-on manager."""
+        self.addon_name = addon_name
         self.addon_slug = addon_slug
         self._hass = hass
         self._install_task: asyncio.Task | None = None
@@ -124,7 +125,7 @@ class AddonManager:
             )
         )
 
-    @api_error("Failed to get Z-Wave JS add-on discovery info")
+    @api_error("Failed to get {addon_name} add-on discovery info")
     async def async_get_addon_discovery_info(self) -> dict:
         """Return add-on discovery info."""
         discovery_info = await async_get_addon_discovery_info(
@@ -132,14 +133,14 @@ class AddonManager:
         )
 
         if not discovery_info:
-            raise AddonError("Failed to get Z-Wave JS add-on discovery info")
+            raise AddonError(f"Failed to get {self.addon_name} add-on discovery info")
 
         discovery_info_config: dict = discovery_info["config"]
         return discovery_info_config
 
-    @api_error("Failed to get the Z-Wave JS add-on info")
+    @api_error("Failed to get the {addon_name} add-on info")
     async def async_get_addon_info(self) -> AddonInfo:
-        """Return and cache Z-Wave JS add-on info."""
+        """Return and cache manager add-on info."""
         addon_store_info = await async_get_addon_store_info(self._hass, self.addon_slug)
         LOGGER.debug("Add-on store info: %s", addon_store_info)
         if not addon_store_info["installed"]:
@@ -161,7 +162,7 @@ class AddonManager:
 
     @callback
     def async_get_addon_state(self, addon_info: dict[str, Any]) -> AddonState:
-        """Return the current state of the Z-Wave JS add-on."""
+        """Return the current state of the manager add-on."""
         addon_state = AddonState.NOT_RUNNING
 
         if addon_info["state"] == "started":
@@ -173,25 +174,27 @@ class AddonManager:
 
         return addon_state
 
-    @api_error("Failed to set the Z-Wave JS add-on options")
+    @api_error("Failed to set the {addon_name} add-on options")
     async def async_set_addon_options(self, config: dict) -> None:
-        """Set Z-Wave JS add-on options."""
+        """Set manager add-on options."""
         options = {"options": config}
         await async_set_addon_options(self._hass, self.addon_slug, options)
 
-    @api_error("Failed to install the Z-Wave JS add-on")
+    @api_error("Failed to install the {addon_name} add-on")
     async def async_install_addon(self) -> None:
-        """Install the Z-Wave JS add-on."""
+        """Install the manager add-on."""
         await async_install_addon(self._hass, self.addon_slug)
 
     @callback
     def async_schedule_install_addon(self, catch_error: bool = False) -> asyncio.Task:
-        """Schedule a task that installs the Z-Wave JS add-on.
+        """Schedule a task that installs the manager add-on.
 
         Only schedule a new install task if the there's no running task.
         """
         if not self._install_task or self._install_task.done():
-            LOGGER.info("Z-Wave JS add-on is not installed. Installing add-on")
+            LOGGER.info(
+                "%s add-on is not installed. Installing add-on", self.addon_name
+            )
             self._install_task = self._async_schedule_addon_operation(
                 self.async_install_addon, catch_error=catch_error
             )
@@ -200,46 +203,40 @@ class AddonManager:
     @callback
     def async_schedule_install_setup_addon(
         self,
-        usb_path: str,
-        s0_legacy_key: str,
-        s2_access_control_key: str,
-        s2_authenticated_key: str,
-        s2_unauthenticated_key: str,
+        addon_config: dict[str, Any],
         catch_error: bool = False,
     ) -> asyncio.Task:
-        """Schedule a task that installs and sets up the Z-Wave JS add-on.
+        """Schedule a task that installs and sets up the manager add-on.
 
         Only schedule a new install task if the there's no running task.
         """
         if not self._install_task or self._install_task.done():
-            LOGGER.info("Z-Wave JS add-on is not installed. Installing add-on")
+            LOGGER.info(
+                "%s add-on is not installed. Installing add-on", self.addon_name
+            )
             self._install_task = self._async_schedule_addon_operation(
                 self.async_install_addon,
                 partial(
                     self.async_configure_addon,
-                    usb_path,
-                    s0_legacy_key,
-                    s2_access_control_key,
-                    s2_authenticated_key,
-                    s2_unauthenticated_key,
+                    addon_config,
                 ),
                 self.async_start_addon,
                 catch_error=catch_error,
             )
         return self._install_task
 
-    @api_error("Failed to uninstall the Z-Wave JS add-on")
+    @api_error("Failed to uninstall the {addon_name} add-on")
     async def async_uninstall_addon(self) -> None:
-        """Uninstall the Z-Wave JS add-on."""
+        """Uninstall the manager add-on."""
         await async_uninstall_addon(self._hass, self.addon_slug)
 
-    @api_error("Failed to update the Z-Wave JS add-on")
+    @api_error("Failed to update the {addon_name} add-on")
     async def async_update_addon(self) -> None:
-        """Update the Z-Wave JS add-on if needed."""
+        """Update the manager add-on if needed."""
         addon_info = await self.async_get_addon_info()
 
         if addon_info.state is AddonState.NOT_INSTALLED:
-            raise AddonError("Z-Wave JS add-on is not installed")
+            raise AddonError(f"{self.addon_name} add-on is not installed")
 
         if not addon_info.update_available:
             return
@@ -249,36 +246,36 @@ class AddonManager:
 
     @callback
     def async_schedule_update_addon(self, catch_error: bool = False) -> asyncio.Task:
-        """Schedule a task that updates and sets up the Z-Wave JS add-on.
+        """Schedule a task that updates and sets up the manager add-on.
 
         Only schedule a new update task if the there's no running task.
         """
         if not self._update_task or self._update_task.done():
-            LOGGER.info("Trying to update the Z-Wave JS add-on")
+            LOGGER.info("Trying to update the %s add-on", self.addon_name)
             self._update_task = self._async_schedule_addon_operation(
                 self.async_update_addon,
                 catch_error=catch_error,
             )
         return self._update_task
 
-    @api_error("Failed to start the Z-Wave JS add-on")
+    @api_error("Failed to start the {addon_name} add-on")
     async def async_start_addon(self) -> None:
-        """Start the Z-Wave JS add-on."""
+        """Start the manager add-on."""
         await async_start_addon(self._hass, self.addon_slug)
 
-    @api_error("Failed to restart the Z-Wave JS add-on")
+    @api_error("Failed to restart the {addon_name} add-on")
     async def async_restart_addon(self) -> None:
-        """Restart the Z-Wave JS add-on."""
+        """Restart the manager add-on."""
         await async_restart_addon(self._hass, self.addon_slug)
 
     @callback
     def async_schedule_start_addon(self, catch_error: bool = False) -> asyncio.Task:
-        """Schedule a task that starts the Z-Wave JS add-on.
+        """Schedule a task that starts the manager add-on.
 
         Only schedule a new start task if the there's no running task.
         """
         if not self._start_task or self._start_task.done():
-            LOGGER.info("Z-Wave JS add-on is not running. Starting add-on")
+            LOGGER.info("%s add-on is not running. Starting add-on", self.addon_name)
             self._start_task = self._async_schedule_addon_operation(
                 self.async_start_addon, catch_error=catch_error
             )
@@ -286,80 +283,60 @@ class AddonManager:
 
     @callback
     def async_schedule_restart_addon(self, catch_error: bool = False) -> asyncio.Task:
-        """Schedule a task that restarts the Z-Wave JS add-on.
+        """Schedule a task that restarts the manager add-on.
 
         Only schedule a new restart task if the there's no running task.
         """
         if not self._restart_task or self._restart_task.done():
-            LOGGER.info("Restarting Z-Wave JS add-on")
+            LOGGER.info("Restarting %s add-on", self.addon_name)
             self._restart_task = self._async_schedule_addon_operation(
                 self.async_restart_addon, catch_error=catch_error
             )
         return self._restart_task
 
-    @api_error("Failed to stop the Z-Wave JS add-on")
+    @api_error("Failed to stop the {addon_name} add-on")
     async def async_stop_addon(self) -> None:
-        """Stop the Z-Wave JS add-on."""
+        """Stop the manager add-on."""
         await async_stop_addon(self._hass, self.addon_slug)
 
     async def async_configure_addon(
         self,
-        usb_path: str,
-        s0_legacy_key: str,
-        s2_access_control_key: str,
-        s2_authenticated_key: str,
-        s2_unauthenticated_key: str,
+        addon_config: dict[str, Any],
     ) -> None:
-        """Configure and start Z-Wave JS add-on."""
+        """Configure and start manager add-on."""
         addon_info = await self.async_get_addon_info()
 
         if addon_info.state is AddonState.NOT_INSTALLED:
-            raise AddonError("Z-Wave JS add-on is not installed")
+            raise AddonError(f"{self.addon_name} add-on is not installed")
 
-        new_addon_options = {
-            CONF_ADDON_DEVICE: usb_path,
-            CONF_ADDON_S0_LEGACY_KEY: s0_legacy_key,
-            CONF_ADDON_S2_ACCESS_CONTROL_KEY: s2_access_control_key,
-            CONF_ADDON_S2_AUTHENTICATED_KEY: s2_authenticated_key,
-            CONF_ADDON_S2_UNAUTHENTICATED_KEY: s2_unauthenticated_key,
-        }
-
-        if new_addon_options != addon_info.options:
-            await self.async_set_addon_options(new_addon_options)
+        if addon_config != addon_info.options:
+            await self.async_set_addon_options(addon_config)
 
     @callback
     def async_schedule_setup_addon(
         self,
-        usb_path: str,
-        s0_legacy_key: str,
-        s2_access_control_key: str,
-        s2_authenticated_key: str,
-        s2_unauthenticated_key: str,
+        addon_config: dict[str, Any],
         catch_error: bool = False,
     ) -> asyncio.Task:
-        """Schedule a task that configures and starts the Z-Wave JS add-on.
+        """Schedule a task that configures and starts the manager add-on.
 
         Only schedule a new setup task if the there's no running task.
         """
         if not self._start_task or self._start_task.done():
-            LOGGER.info("Z-Wave JS add-on is not running. Starting add-on")
+            LOGGER.info("%s add-on is not running. Starting add-on", self.addon_name)
             self._start_task = self._async_schedule_addon_operation(
                 partial(
                     self.async_configure_addon,
-                    usb_path,
-                    s0_legacy_key,
-                    s2_access_control_key,
-                    s2_authenticated_key,
-                    s2_unauthenticated_key,
+                    addon_config,
                 ),
                 self.async_start_addon,
                 catch_error=catch_error,
             )
         return self._start_task
 
-    @api_error("Failed to create a backup of the Z-Wave JS add-on.")
+    @api_error("Failed to create a backup of the {addon_name} add-on.")
     async def async_create_backup(self) -> None:
-        """Create a partial backup of the Z-Wave JS add-on."""
+        """Create a partial backup of the manager add-on."""
         addon_info = await self.async_get_addon_info()
         name = f"addon_{self.addon_slug}_{addon_info.version}"
 
@@ -391,4 +368,4 @@ class AddonManager:
 
 
 class AddonError(HomeAssistantError):
-    """Represent an error with Z-Wave JS add-on."""
+    """Represent an error with the manager add-on."""

--- a/homeassistant/components/zwave_js/addon.py
+++ b/homeassistant/components/zwave_js/addon.py
@@ -162,7 +162,7 @@ class AddonManager:
 
     @callback
     def async_get_addon_state(self, addon_info: dict[str, Any]) -> AddonState:
-        """Return the current state of the manager add-on."""
+        """Return the current state of the managed add-on."""
         addon_state = AddonState.NOT_RUNNING
 
         if addon_info["state"] == "started":
@@ -182,12 +182,12 @@ class AddonManager:
 
     @api_error("Failed to install the {addon_name} add-on")
     async def async_install_addon(self) -> None:
-        """Install the manager add-on."""
+        """Install the managed add-on."""
         await async_install_addon(self._hass, self.addon_slug)
 
     @callback
     def async_schedule_install_addon(self, catch_error: bool = False) -> asyncio.Task:
-        """Schedule a task that installs the manager add-on.
+        """Schedule a task that installs the managed add-on.
 
         Only schedule a new install task if the there's no running task.
         """
@@ -206,7 +206,7 @@ class AddonManager:
         addon_config: dict[str, Any],
         catch_error: bool = False,
     ) -> asyncio.Task:
-        """Schedule a task that installs and sets up the manager add-on.
+        """Schedule a task that installs and sets up the managed add-on.
 
         Only schedule a new install task if the there's no running task.
         """
@@ -227,12 +227,12 @@ class AddonManager:
 
     @api_error("Failed to uninstall the {addon_name} add-on")
     async def async_uninstall_addon(self) -> None:
-        """Uninstall the manager add-on."""
+        """Uninstall the managed add-on."""
         await async_uninstall_addon(self._hass, self.addon_slug)
 
     @api_error("Failed to update the {addon_name} add-on")
     async def async_update_addon(self) -> None:
-        """Update the manager add-on if needed."""
+        """Update the managed add-on if needed."""
         addon_info = await self.async_get_addon_info()
 
         if addon_info.state is AddonState.NOT_INSTALLED:
@@ -246,7 +246,7 @@ class AddonManager:
 
     @callback
     def async_schedule_update_addon(self, catch_error: bool = False) -> asyncio.Task:
-        """Schedule a task that updates and sets up the manager add-on.
+        """Schedule a task that updates and sets up the managed add-on.
 
         Only schedule a new update task if the there's no running task.
         """
@@ -260,17 +260,17 @@ class AddonManager:
 
     @api_error("Failed to start the {addon_name} add-on")
     async def async_start_addon(self) -> None:
-        """Start the manager add-on."""
+        """Start the managed add-on."""
         await async_start_addon(self._hass, self.addon_slug)
 
     @api_error("Failed to restart the {addon_name} add-on")
     async def async_restart_addon(self) -> None:
-        """Restart the manager add-on."""
+        """Restart the managed add-on."""
         await async_restart_addon(self._hass, self.addon_slug)
 
     @callback
     def async_schedule_start_addon(self, catch_error: bool = False) -> asyncio.Task:
-        """Schedule a task that starts the manager add-on.
+        """Schedule a task that starts the managed add-on.
 
         Only schedule a new start task if the there's no running task.
         """
@@ -283,7 +283,7 @@ class AddonManager:
 
     @callback
     def async_schedule_restart_addon(self, catch_error: bool = False) -> asyncio.Task:
-        """Schedule a task that restarts the manager add-on.
+        """Schedule a task that restarts the managed add-on.
 
         Only schedule a new restart task if the there's no running task.
         """
@@ -296,7 +296,7 @@ class AddonManager:
 
     @api_error("Failed to stop the {addon_name} add-on")
     async def async_stop_addon(self) -> None:
-        """Stop the manager add-on."""
+        """Stop the managed add-on."""
         await async_stop_addon(self._hass, self.addon_slug)
 
     async def async_configure_addon(
@@ -318,9 +318,9 @@ class AddonManager:
         addon_config: dict[str, Any],
         catch_error: bool = False,
     ) -> asyncio.Task:
-        """Schedule a task that configures and starts the manager add-on.
+        """Schedule a task that configures and starts the managed add-on.
 
-        Only schedule a new setup task if the there's no running task.
+        Only schedule a new setup task if there's no running task.
         """
         if not self._start_task or self._start_task.done():
             LOGGER.info("%s add-on is not running. Starting add-on", self.addon_name)
@@ -336,7 +336,7 @@ class AddonManager:
 
     @api_error("Failed to create a backup of the {addon_name} add-on.")
     async def async_create_backup(self) -> None:
-        """Create a partial backup of the manager add-on."""
+        """Create a partial backup of the managed add-on."""
         addon_info = await self.async_get_addon_info()
         name = f"addon_{self.addon_slug}_{addon_info.version}"
 
@@ -368,4 +368,4 @@ class AddonManager:
 
 
 class AddonError(HomeAssistantError):
-    """Represent an error with the manager add-on."""
+    """Represent an error with the managed add-on."""

--- a/tests/components/zwave_js/test_addon.py
+++ b/tests/components/zwave_js/test_addon.py
@@ -2,14 +2,29 @@
 import pytest
 
 from homeassistant.components.zwave_js.addon import AddonError, get_addon_manager
+from homeassistant.components.zwave_js.const import (
+    CONF_ADDON_DEVICE,
+    CONF_ADDON_S0_LEGACY_KEY,
+    CONF_ADDON_S2_ACCESS_CONTROL_KEY,
+    CONF_ADDON_S2_AUTHENTICATED_KEY,
+    CONF_ADDON_S2_UNAUTHENTICATED_KEY,
+)
 
 
 async def test_not_installed_raises_exception(hass, addon_not_installed):
     """Test addon not installed raises exception."""
     addon_manager = get_addon_manager(hass)
 
+    addon_config = {
+        CONF_ADDON_DEVICE: "/test",
+        CONF_ADDON_S0_LEGACY_KEY: "123",
+        CONF_ADDON_S2_ACCESS_CONTROL_KEY: "456",
+        CONF_ADDON_S2_AUTHENTICATED_KEY: "789",
+        CONF_ADDON_S2_UNAUTHENTICATED_KEY: "012",
+    }
+
     with pytest.raises(AddonError):
-        await addon_manager.async_configure_addon("/test", "123", "456", "789", "012")
+        await addon_manager.async_configure_addon(addon_config)
 
     with pytest.raises(AddonError):
         await addon_manager.async_update_addon()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Make the add-on manager class abstract in regards to what add-on it manages.
- The plan is to move the add-on manager class to the hassio integration so that other integrations that need to manage an add-on can leverage the manager. This will be done in follow up PRs. The matter integration will be first in line to use the manager.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
