### PR TITLE
Add support for Netatmo noise sensor to homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     POWER_WATT,
     PRESSURE_HPA,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    SOUND_PRESSURE_DB,
     TEMP_CELSIUS,
     Platform,
 )
@@ -308,6 +309,12 @@ SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {
         device_class="homekit_controller__thread_status",
         entity_category=EntityCategory.DIAGNOSTIC,
         format=thread_status_to_str,
+    ),
+    CharacteristicsTypes.VENDOR_NETATMO_NOISE: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_NETATMO_NOISE,
+        name="Noise",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=SOUND_PRESSURE_DB,
     ),
 }
 

--- a/tests/components/homekit_controller/fixtures/netatmo_home_coach.json
+++ b/tests/components/homekit_controller/fixtures/netatmo_home_coach.json
@@ -1,0 +1,298 @@
+[
+    {
+        "aid": 1,
+        "services": [
+            {
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291",
+                "characteristics": [
+                    {
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "iid": 2,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "Healthy Home Coach",
+                        "description": "Name",
+                        "maxLen": 64
+                    },
+                    {
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "Netatmo",
+                        "description": "Manufacturer",
+                        "maxLen": 64
+                    },
+                    {
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "Healthy Home Coach",
+                        "description": "Model",
+                        "maxLen": 64
+                    },
+                    {
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "AAAAAAAAAAAAA",
+                        "description": "Serial Number",
+                        "maxLen": 64
+                    },
+                    {
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "iid": 6,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "59",
+                        "description": "Firmware Revision",
+                        "maxLen": 64
+                    },
+                    {
+                        "type": "00000014-0000-1000-8000-0026BB765291",
+                        "iid": 7,
+                        "perms": [
+                            "pw"
+                        ],
+                        "format": "bool",
+                        "description": "Identify"
+                    }
+                ]
+            },
+            {
+                "iid": 25,
+                "type": "000000A2-0000-1000-8000-0026BB765291",
+                "characteristics": [
+                    {
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "iid": 26,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "1.1.0",
+                        "description": "Version",
+                        "maxLen": 64
+                    }
+                ]
+            },
+            {
+                "iid": 27,
+                "type": "EA22EA53-6227-55EA-AC24-73ACF3EEA0E8",
+                "characteristics": [
+                    {
+                        "type": "4D05AE82-5A22-5BD6-A730-B7F8B4F3218D",
+                        "iid": 28,
+                        "perms": [
+                            "pw"
+                        ],
+                        "format": "bool"
+                    },
+                    {
+                        "type": "00F44C18-042E-5C4E-9A4C-561D44DCD804",
+                        "iid": 29,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "g262d1a",
+                        "maxLen": 64
+                    }
+                ]
+            },
+            {
+                "iid": 24,
+                "type": "0000008D-0000-1000-8000-0026BB765291",
+                "characteristics": [
+                    {
+                        "type": "00000095-0000-1000-8000-0026BB765291",
+                        "iid": 8,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "format": "uint8",
+                        "value": 1,
+                        "description": "Air Quality",
+                        "minValue": 0,
+                        "maxValue": 5
+                    },
+                    {
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "iid": 9,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "Air quality sensor",
+                        "description": "Name",
+                        "maxLen": 64
+                    }
+                ]
+            },
+            {
+                "iid": 10,
+                "type": "00000097-0000-1000-8000-0026BB765291",
+                "characteristics": [
+                    {
+                        "type": "00000092-0000-1000-8000-0026BB765291",
+                        "iid": 11,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "format": "uint8",
+                        "value": 0,
+                        "description": "Carbon Dioxide Detected",
+                        "minValue": 0,
+                        "maxValue": 1
+                    },
+                    {
+                        "type": "00000093-0000-1000-8000-0026BB765291",
+                        "iid": 12,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "format": "float",
+                        "value": 804,
+                        "description": "Carbon Dioxide Level",
+                        "minValue": 0,
+                        "maxValue": 10000
+                    },
+                    {
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "iid": 13,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "Carbon Dioxide sensor",
+                        "description": "Name",
+                        "maxLen": 64
+                    }
+                ]
+            },
+            {
+                "iid": 14,
+                "type": "00000082-0000-1000-8000-0026BB765291",
+                "characteristics": [
+                    {
+                        "type": "00000010-0000-1000-8000-0026BB765291",
+                        "iid": 15,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "format": "float",
+                        "value": 59,
+                        "description": "Current Relative Humidity",
+                        "unit": "percentage",
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "minStep": 1
+                    },
+                    {
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "iid": 16,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "Humidity sensor",
+                        "description": "Name",
+                        "maxLen": 64
+                    }
+                ]
+            },
+            {
+                "iid": 17,
+                "type": "0000008A-0000-1000-8000-0026BB765291",
+                "characteristics": [
+                    {
+                        "type": "00000011-0000-1000-8000-0026BB765291",
+                        "iid": 18,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "format": "float",
+                        "value": 22.9,
+                        "description": "Current Temperature",
+                        "unit": "celsius",
+                        "minValue": 0,
+                        "maxValue": 50,
+                        "minStep": 0.1
+                    },
+                    {
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "iid": 19,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "Temperature sensor",
+                        "description": "Name",
+                        "maxLen": 64
+                    }
+                ]
+            },
+            {
+                "iid": 20,
+                "type": "6237CEFC-9F4D-54B2-8033-2EDA0053B811",
+                "characteristics": [
+                    {
+                        "type": "B3BBFABC-D78C-5B8D-948C-5DAC1EE2CDE5",
+                        "iid": 21,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "format": "uint8",
+                        "value": 0,
+                        "minValue": 0,
+                        "maxValue": 200,
+                        "minStep": 1
+                    },
+                    {
+                        "type": "627EA399-29D9-5DC8-9A02-08AE928F73D8",
+                        "iid": 22,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "format": "uint8",
+                        "value": 0,
+                        "minValue": 0,
+                        "maxValue": 5,
+                        "minStep": 1
+                    },
+                    {
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "iid": 23,
+                        "perms": [
+                            "pr"
+                        ],
+                        "format": "string",
+                        "value": "Noise sensor",
+                        "description": "Name",
+                        "maxLen": 64
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/tests/components/homekit_controller/fixtures/netatmo_home_coach.json
+++ b/tests/components/homekit_controller/fixtures/netatmo_home_coach.json
@@ -1,298 +1,249 @@
 [
-    {
-        "aid": 1,
-        "services": [
-            {
-                "iid": 1,
-                "type": "0000003E-0000-1000-8000-0026BB765291",
-                "characteristics": [
-                    {
-                        "type": "00000023-0000-1000-8000-0026BB765291",
-                        "iid": 2,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "Healthy Home Coach",
-                        "description": "Name",
-                        "maxLen": 64
-                    },
-                    {
-                        "type": "00000020-0000-1000-8000-0026BB765291",
-                        "iid": 3,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "Netatmo",
-                        "description": "Manufacturer",
-                        "maxLen": 64
-                    },
-                    {
-                        "type": "00000021-0000-1000-8000-0026BB765291",
-                        "iid": 4,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "Healthy Home Coach",
-                        "description": "Model",
-                        "maxLen": 64
-                    },
-                    {
-                        "type": "00000030-0000-1000-8000-0026BB765291",
-                        "iid": 5,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "AAAAAAAAAAAAA",
-                        "description": "Serial Number",
-                        "maxLen": 64
-                    },
-                    {
-                        "type": "00000052-0000-1000-8000-0026BB765291",
-                        "iid": 6,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "59",
-                        "description": "Firmware Revision",
-                        "maxLen": 64
-                    },
-                    {
-                        "type": "00000014-0000-1000-8000-0026BB765291",
-                        "iid": 7,
-                        "perms": [
-                            "pw"
-                        ],
-                        "format": "bool",
-                        "description": "Identify"
-                    }
-                ]
-            },
-            {
-                "iid": 25,
-                "type": "000000A2-0000-1000-8000-0026BB765291",
-                "characteristics": [
-                    {
-                        "type": "00000037-0000-1000-8000-0026BB765291",
-                        "iid": 26,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "1.1.0",
-                        "description": "Version",
-                        "maxLen": 64
-                    }
-                ]
-            },
-            {
-                "iid": 27,
-                "type": "EA22EA53-6227-55EA-AC24-73ACF3EEA0E8",
-                "characteristics": [
-                    {
-                        "type": "4D05AE82-5A22-5BD6-A730-B7F8B4F3218D",
-                        "iid": 28,
-                        "perms": [
-                            "pw"
-                        ],
-                        "format": "bool"
-                    },
-                    {
-                        "type": "00F44C18-042E-5C4E-9A4C-561D44DCD804",
-                        "iid": 29,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "g262d1a",
-                        "maxLen": 64
-                    }
-                ]
-            },
-            {
-                "iid": 24,
-                "type": "0000008D-0000-1000-8000-0026BB765291",
-                "characteristics": [
-                    {
-                        "type": "00000095-0000-1000-8000-0026BB765291",
-                        "iid": 8,
-                        "perms": [
-                            "pr",
-                            "ev"
-                        ],
-                        "format": "uint8",
-                        "value": 1,
-                        "description": "Air Quality",
-                        "minValue": 0,
-                        "maxValue": 5
-                    },
-                    {
-                        "type": "00000023-0000-1000-8000-0026BB765291",
-                        "iid": 9,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "Air quality sensor",
-                        "description": "Name",
-                        "maxLen": 64
-                    }
-                ]
-            },
-            {
-                "iid": 10,
-                "type": "00000097-0000-1000-8000-0026BB765291",
-                "characteristics": [
-                    {
-                        "type": "00000092-0000-1000-8000-0026BB765291",
-                        "iid": 11,
-                        "perms": [
-                            "pr",
-                            "ev"
-                        ],
-                        "format": "uint8",
-                        "value": 0,
-                        "description": "Carbon Dioxide Detected",
-                        "minValue": 0,
-                        "maxValue": 1
-                    },
-                    {
-                        "type": "00000093-0000-1000-8000-0026BB765291",
-                        "iid": 12,
-                        "perms": [
-                            "pr",
-                            "ev"
-                        ],
-                        "format": "float",
-                        "value": 804,
-                        "description": "Carbon Dioxide Level",
-                        "minValue": 0,
-                        "maxValue": 10000
-                    },
-                    {
-                        "type": "00000023-0000-1000-8000-0026BB765291",
-                        "iid": 13,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "Carbon Dioxide sensor",
-                        "description": "Name",
-                        "maxLen": 64
-                    }
-                ]
-            },
-            {
-                "iid": 14,
-                "type": "00000082-0000-1000-8000-0026BB765291",
-                "characteristics": [
-                    {
-                        "type": "00000010-0000-1000-8000-0026BB765291",
-                        "iid": 15,
-                        "perms": [
-                            "pr",
-                            "ev"
-                        ],
-                        "format": "float",
-                        "value": 59,
-                        "description": "Current Relative Humidity",
-                        "unit": "percentage",
-                        "minValue": 0,
-                        "maxValue": 100,
-                        "minStep": 1
-                    },
-                    {
-                        "type": "00000023-0000-1000-8000-0026BB765291",
-                        "iid": 16,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "Humidity sensor",
-                        "description": "Name",
-                        "maxLen": 64
-                    }
-                ]
-            },
-            {
-                "iid": 17,
-                "type": "0000008A-0000-1000-8000-0026BB765291",
-                "characteristics": [
-                    {
-                        "type": "00000011-0000-1000-8000-0026BB765291",
-                        "iid": 18,
-                        "perms": [
-                            "pr",
-                            "ev"
-                        ],
-                        "format": "float",
-                        "value": 22.9,
-                        "description": "Current Temperature",
-                        "unit": "celsius",
-                        "minValue": 0,
-                        "maxValue": 50,
-                        "minStep": 0.1
-                    },
-                    {
-                        "type": "00000023-0000-1000-8000-0026BB765291",
-                        "iid": 19,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "Temperature sensor",
-                        "description": "Name",
-                        "maxLen": 64
-                    }
-                ]
-            },
-            {
-                "iid": 20,
-                "type": "6237CEFC-9F4D-54B2-8033-2EDA0053B811",
-                "characteristics": [
-                    {
-                        "type": "B3BBFABC-D78C-5B8D-948C-5DAC1EE2CDE5",
-                        "iid": 21,
-                        "perms": [
-                            "pr",
-                            "ev"
-                        ],
-                        "format": "uint8",
-                        "value": 0,
-                        "minValue": 0,
-                        "maxValue": 200,
-                        "minStep": 1
-                    },
-                    {
-                        "type": "627EA399-29D9-5DC8-9A02-08AE928F73D8",
-                        "iid": 22,
-                        "perms": [
-                            "pr",
-                            "ev"
-                        ],
-                        "format": "uint8",
-                        "value": 0,
-                        "minValue": 0,
-                        "maxValue": 5,
-                        "minStep": 1
-                    },
-                    {
-                        "type": "00000023-0000-1000-8000-0026BB765291",
-                        "iid": 23,
-                        "perms": [
-                            "pr"
-                        ],
-                        "format": "string",
-                        "value": "Noise sensor",
-                        "description": "Name",
-                        "maxLen": 64
-                    }
-                ]
-            }
+  {
+    "aid": 1,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Healthy Home Coach",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Netatmo",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Healthy Home Coach",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "AAAAAAAAAAAAA",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "59",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 7,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
         ]
-    }
+      },
+      {
+        "iid": 25,
+        "type": "000000A2-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000037-0000-1000-8000-0026BB765291",
+            "iid": 26,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.1.0",
+            "description": "Version",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 27,
+        "type": "EA22EA53-6227-55EA-AC24-73ACF3EEA0E8",
+        "characteristics": [
+          {
+            "type": "4D05AE82-5A22-5BD6-A730-B7F8B4F3218D",
+            "iid": 28,
+            "perms": ["pw"],
+            "format": "bool"
+          },
+          {
+            "type": "00F44C18-042E-5C4E-9A4C-561D44DCD804",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "g262d1a",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 24,
+        "type": "0000008D-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000095-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 1,
+            "description": "Air Quality",
+            "minValue": 0,
+            "maxValue": 5
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 9,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Air quality sensor",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 10,
+        "type": "00000097-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000092-0000-1000-8000-0026BB765291",
+            "iid": 11,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Carbon Dioxide Detected",
+            "minValue": 0,
+            "maxValue": 1
+          },
+          {
+            "type": "00000093-0000-1000-8000-0026BB765291",
+            "iid": 12,
+            "perms": ["pr", "ev"],
+            "format": "float",
+            "value": 804,
+            "description": "Carbon Dioxide Level",
+            "minValue": 0,
+            "maxValue": 10000
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 13,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Carbon Dioxide sensor",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 14,
+        "type": "00000082-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000010-0000-1000-8000-0026BB765291",
+            "iid": 15,
+            "perms": ["pr", "ev"],
+            "format": "float",
+            "value": 59,
+            "description": "Current Relative Humidity",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 16,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Humidity sensor",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 17,
+        "type": "0000008A-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000011-0000-1000-8000-0026BB765291",
+            "iid": 18,
+            "perms": ["pr", "ev"],
+            "format": "float",
+            "value": 22.9,
+            "description": "Current Temperature",
+            "unit": "celsius",
+            "minValue": 0,
+            "maxValue": 50,
+            "minStep": 0.1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 19,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Temperature sensor",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 20,
+        "type": "6237CEFC-9F4D-54B2-8033-2EDA0053B811",
+        "characteristics": [
+          {
+            "type": "B3BBFABC-D78C-5B8D-948C-5DAC1EE2CDE5",
+            "iid": 21,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "minValue": 0,
+            "maxValue": 200,
+            "minStep": 1
+          },
+          {
+            "type": "627EA399-29D9-5DC8-9A02-08AE928F73D8",
+            "iid": 22,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "minValue": 0,
+            "maxValue": 5,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 23,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Noise sensor",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/tests/components/homekit_controller/specific_devices/test_netatmo_home_coach.py
+++ b/tests/components/homekit_controller/specific_devices/test_netatmo_home_coach.py
@@ -1,0 +1,45 @@
+"""
+Regression tests for Netamo Healthy Home Coach.
+
+https://github.com/home-assistant/core/issues/73360
+"""
+from homeassistant.components.sensor import SensorStateClass
+
+from ..common import (
+    HUB_TEST_ACCESSORY_ID,
+    DeviceTestInfo,
+    EntityTestInfo,
+    assert_devices_and_entities_created,
+    setup_accessories_from_file,
+    setup_test_accessories,
+)
+
+
+async def test_netamo_smart_co_alarm_setup(hass):
+    """Test that a Netamo Smart CO Alarm can be correctly setup in HA."""
+    accessories = await setup_accessories_from_file(hass, "netatmo_home_coach.json")
+    await setup_test_accessories(hass, accessories)
+
+    await assert_devices_and_entities_created(
+        hass,
+        DeviceTestInfo(
+            unique_id=HUB_TEST_ACCESSORY_ID,
+            name="Healthy Home Coach",
+            model="Healthy Home Coach",
+            manufacturer="Netatmo",
+            sw_version="59",
+            hw_version="",
+            serial_number="1234",
+            devices=[],
+            entities=[
+                EntityTestInfo(
+                    entity_id="sensor.healthy_home_coach_noise",
+                    friendly_name="Healthy Home Coach Noise",
+                    unique_id="00:00:00:00:00:00_1_20_21",
+                    state="0",
+                    unit_of_measurement="dB",
+                    capabilities={"state_class": SensorStateClass.MEASUREMENT},
+                ),
+            ],
+        ),
+    )


### PR DESCRIPTION
## Proposed change

Add support for the vendor specific "noise" characteristic on Netatmo devices like the Healthy Home Coach.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #73360
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
