### PR TITLE
Cache improvements [ci]

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,23 @@
+name: Delete Caches
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "Closed PR number"
+        type: string
+        required: true
+
+jobs:
+  delete:
+    name: "Delete unused caches (PR #${{ github.event.inputs.pr-number || github.event.number }})"
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: snnaplab/delete-branch-cache-action@v1.0.0
+        with:
+          ref: refs/pull/${{ github.event.inputs.pr-number || github.event.number }}/merge

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -18,6 +18,39 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: snnaplab/delete-branch-cache-action@v1.0.0
-        with:
-          ref: refs/pull/${{ github.event.inputs.pr-number || github.event.number }}/merge
+      - name: Delete caches
+        run: |
+          ref="refs/pull/${{ github.event.inputs.pr-number || github.event.number }}/merge"
+
+          page=1
+          per_page=100
+          del_count=0
+
+          while true; do
+            res=$(curl -fsS \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: token ${{ github.token }}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/caches?per_page=$per_page&page=$page")
+
+            res_count=$(echo $res | jq '.actions_caches | length')
+            if [ $res_count -eq 0 ]; then break; fi
+
+            targets=$(echo $res | jq \
+              --arg ref "$ref" \
+              '.actions_caches[] | select(.ref == $ref) | del(.created_at, .size_in_bytes, .version)')
+            echo "$targets"
+
+            for id in $(echo $targets | jq '.id'); do
+              curl -fsS \
+                -X DELETE \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: token ${{ github.token }}" \
+                "https://api.github.com/repos/${{ github.repository }}/actions/caches/$id"
+              ((del_count+=1))
+            done
+
+            if [ $res_count -lt $per_page ]; then break; fi
+            ((page+=1))
+          done
+
+          echo "Delete $del_count caches."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -551,6 +551,70 @@ jobs:
           pip install --cache-dir=$PIP_CACHE -r requirements_test.txt --use-deprecated=legacy-resolver
           pip install -e .
 
+  cleanup-cache:
+    name: Cleanup old pip caches
+    runs-on: ubuntu-20.04
+    needs:
+      - base
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup
+        run: |
+          sort="last_accessed_at"
+          page=1
+          per_page=100
+          del_count=0
+          index=0
+
+          all_versions=($(echo $ALL_PYTHON_VERSIONS | tr -d \',[]))
+
+          if [[ "${{ github.ref }}" == "refs/heads/dev" ]] \
+            || [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci-keep-cache') }}" == "true" ]]
+          then
+            index=1
+            echo "Keep one entry per Python version"
+          fi
+
+          while true; do
+            res=$(curl -fsS \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: token ${{ github.token }}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/caches?sort=$sort&per_page=$per_page&page=$page")
+
+            res_count=$(echo $res | jq '.actions_caches | length')
+            if [ $res_count -eq 0 ]; then break; fi
+
+            echo "Check ref: ${{ github.ref }}"
+            for version in ${all_versions[@]}; do
+              key="${{ runner.os }}-$version.+-pip"
+              echo "Check key regex: $key"
+
+              # Select all cache keys which match the ref and key regex
+              # Keep the first entry for 'ref/heads/dev'
+              targets=$(echo $res | jq \
+                --arg ref "${{ github.ref }}" --arg key "$key" --arg index $index \
+                '[.actions_caches[] | select(.ref == $ref) | select(.key | test($key))][$index | fromjson:][] | del(.created_at, .size_in_bytes, .version)')
+
+              if [ $(echo $targets | jq -s 'length') -eq 0 ]; then continue; fi
+              echo "$targets"
+
+              for id in $(echo $targets | jq '.id'); do
+                curl -fsS \
+                  -X DELETE \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: token ${{ github.token }}" \
+                  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$id"
+                ((del_count += 1))
+              done
+            done
+
+            if [ $res_count -lt $per_page ]; then break; fi
+            ((page += 1))
+          done
+
+          echo "Deleted $del_count caches."
+
   hassfest:
     name: Check hassfest
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Proposed change
A few days ago Github added the option to manage Action caches from a web interface.
https://github.blog/changelog/2022-10-20-manage-caches-in-your-actions-workflows-from-web-interface/

Looking at our cache list: https://github.com/home-assistant/core/actions/caches
it is rather obvious that we are well above the soft limit, 10GB, set by Github. It's regularly in the 20-40GB range, I've even seen 70GB. That isn't a direct issue as Github will automatically evict old entries. However, there is still room for improvement.

In particular:
* Github doesn't care if a cache is useful or not, it will just evict the oldest (accessed) ones first.
* Being over the limit of 10GB can have (small) performance impacts when accessing / storing cache entries.
> The cache eviction process may cause cache thrashing, where caches are created and deleted at a high frequency.

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy

### Changes
* After a PR is merged / closed, delete all cache entries from that branch / ref. Github won't reuse them anyway.
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
* Delete all pip caches for PRs. The venv cache still kept. If it shouldn't be available, the fallback will be the last pip cache from the `dev` branch which is close enough. In almost all cases only one or two new dependencies are installed per PR. In special cases, like adding support for the next Python version, a new label can be added `ci-keep-cache` to bypass deletion and keep the last cache entry (per Python version).
* Delete all but the latest pip cache entries for the `dev` branch.

### Improvements
* With less cache entries taking up space, there will be more space available for venv caches. I.e. it might not need to be rebuild quite that often if a PR doesn't target the most up-to-date version of `dev`. E.g. at the moment the oldest cache entry is from 8h ago.
* (Maybe) Small performance improvments when accessing / storing cache entries.

### Example output

<details>
<summary>Example output if cache entries are deleted (from my fork)</summary>

```
Keep one entry per Python version
Check ref: refs/heads/dev
Check key regex: Linux-3.9.+-pip
{
  "id": 4944,
  "ref": "refs/heads/dev",
  "key": "Linux-3.9.15-pip-3-2022.11-2022-10-24T08:13:1666599238",
  "last_accessed_at": "2022-10-24T15:28:31.530000000Z"
}
Check key regex: Linux-3.10.+-pip
{
  "id": 4942,
  "ref": "refs/heads/dev",
  "key": "Linux-3.10.8-pip-3-2022.11-2022-10-24T08:13:1666599237",
  "last_accessed_at": "2022-10-24T15:28:33.986666700Z"
}
Deleted 2 caches.
```
</details>

### Notes
* ~~I've used https://github.com/snnaplab/delete-branch-cache-action to delete old caches for closed PRs. The action might need to be added to the list of allowed actions (depending on the repo settings).~~
* A new label should be added: `ci-keep-cache`.

### Refs
* https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
* https://docs.github.com/en/rest/actions/cache#list-github-actions-caches-for-a-repository
* https://github.com/marketplace/actions/delete-branch-cache-action

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
