### PR TITLE
Add optional support for users with multiple ovo accounts

### DIFF
--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
+from .const import ACCOUNT, DATA_CLIENT, DATA_COORDINATOR, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         authenticated = await client.authenticate(
-            entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
+            entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD], entry.data[ACCOUNT]
         )
     except aiohttp.ClientError as exception:
         _LOGGER.warning(exception)
@@ -49,7 +49,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async with async_timeout.timeout(10):
             try:
                 authenticated = await client.authenticate(
-                    entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
+                    entry.data[CONF_USERNAME],
+                    entry.data[CONF_PASSWORD],
+                    entry.data[ACCOUNT],
                 )
             except aiohttp.ClientError as exception:
                 raise UpdateFailed(exception) from exception

--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import ACCOUNT, DATA_CLIENT, DATA_COORDINATOR, DOMAIN
+from .const import CONF_ACCOUNT, DATA_CLIENT, DATA_COORDINATOR, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         authenticated = await client.authenticate(
-            entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD], entry.data[ACCOUNT]
+            entry.data[CONF_USERNAME],
+            entry.data[CONF_PASSWORD],
+            entry.data[CONF_ACCOUNT],
         )
     except aiohttp.ClientError as exception:
         _LOGGER.warning(exception)
@@ -51,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 authenticated = await client.authenticate(
                     entry.data[CONF_USERNAME],
                     entry.data[CONF_PASSWORD],
-                    entry.data[ACCOUNT],
+                    entry.data[CONF_ACCOUNT],
                 )
             except aiohttp.ClientError as exception:
                 raise UpdateFailed(exception) from exception

--- a/homeassistant/components/ovo_energy/config_flow.py
+++ b/homeassistant/components/ovo_energy/config_flow.py
@@ -34,9 +34,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
             client = OVOEnergy()
             try:
                 authenticated = await client.authenticate(
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PASSWORD],
-                    user_input.get(CONF_ACCOUNT, None),
+                    user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
                 )
             except aiohttp.ClientError:
                 errors["base"] = "cannot_connect"
@@ -87,7 +85,6 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
                         data={
                             CONF_USERNAME: self.username,
                             CONF_PASSWORD: user_input[CONF_PASSWORD],
-                            CONF_ACCOUNT: user_input.get(CONF_ACCOUNT, None),
                         },
                     )
                     return self.async_abort(reason="reauth_successful")

--- a/homeassistant/components/ovo_energy/config_flow.py
+++ b/homeassistant/components/ovo_energy/config_flow.py
@@ -6,11 +6,15 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import ACCOUNT, DOMAIN
+from .const import CONF_ACCOUNT, DOMAIN
 
 REAUTH_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 USER_SCHEMA = vol.Schema(
-    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str, ACCOUNT: str}
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_ACCOUNT): str,
+    }
 )
 
 
@@ -32,7 +36,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
                 authenticated = await client.authenticate(
                     user_input[CONF_USERNAME],
                     user_input[CONF_PASSWORD],
-                    user_input.get(ACCOUNT, None),
+                    user_input.get(CONF_ACCOUNT, None),
                 )
             except aiohttp.ClientError:
                 errors["base"] = "cannot_connect"
@@ -46,7 +50,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
                         data={
                             CONF_USERNAME: user_input[CONF_USERNAME],
                             CONF_PASSWORD: user_input[CONF_PASSWORD],
-                            ACCOUNT: user_input.get(ACCOUNT, None),
+                            CONF_ACCOUNT: user_input.get(CONF_ACCOUNT, None),
                         },
                     )
 
@@ -71,7 +75,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
                 authenticated = await client.authenticate(
                     self.username,
                     user_input[CONF_PASSWORD],
-                    user_input.get(ACCOUNT, None),
+                    user_input.get(CONF_ACCOUNT, None),
                 )
             except aiohttp.ClientError:
                 errors["base"] = "connection_error"
@@ -83,7 +87,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
                         data={
                             CONF_USERNAME: self.username,
                             CONF_PASSWORD: user_input[CONF_PASSWORD],
-                            ACCOUNT: user_input.get(ACCOUNT, None),
+                            CONF_ACCOUNT: user_input.get(CONF_ACCOUNT, None),
                         },
                     )
                     return self.async_abort(reason="reauth_successful")

--- a/homeassistant/components/ovo_energy/config_flow.py
+++ b/homeassistant/components/ovo_energy/config_flow.py
@@ -26,6 +26,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Initialize the flow."""
         self.username = None
+        self.account = None
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
@@ -65,13 +66,16 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input and user_input.get(CONF_USERNAME):
             self.username = user_input[CONF_USERNAME]
 
+        if user_input and user_input.get(CONF_ACCOUNT):
+            self.account = user_input[CONF_ACCOUNT]
+
         self.context["title_placeholders"] = {CONF_USERNAME: self.username}
 
         if user_input is not None and user_input.get(CONF_PASSWORD) is not None:
             client = OVOEnergy()
             try:
                 authenticated = await client.authenticate(
-                    self.username, user_input[CONF_PASSWORD]
+                    self.username, user_input[CONF_PASSWORD], self.account
                 )
             except aiohttp.ClientError:
                 errors["base"] = "connection_error"
@@ -83,6 +87,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
                         data={
                             CONF_USERNAME: self.username,
                             CONF_PASSWORD: user_input[CONF_PASSWORD],
+                            CONF_ACCOUNT: self.account,
                         },
                     )
                     return self.async_abort(reason="reauth_successful")

--- a/homeassistant/components/ovo_energy/config_flow.py
+++ b/homeassistant/components/ovo_energy/config_flow.py
@@ -71,9 +71,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
             client = OVOEnergy()
             try:
                 authenticated = await client.authenticate(
-                    self.username,
-                    user_input[CONF_PASSWORD],
-                    user_input.get(CONF_ACCOUNT, None),
+                    self.username, user_input[CONF_PASSWORD]
                 )
             except aiohttp.ClientError:
                 errors["base"] = "connection_error"

--- a/homeassistant/components/ovo_energy/config_flow.py
+++ b/homeassistant/components/ovo_energy/config_flow.py
@@ -35,7 +35,9 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
             client = OVOEnergy()
             try:
                 authenticated = await client.authenticate(
-                    user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                    user_input.get(CONF_ACCOUNT, None),
                 )
             except aiohttp.ClientError:
                 errors["base"] = "cannot_connect"

--- a/homeassistant/components/ovo_energy/config_flow.py
+++ b/homeassistant/components/ovo_energy/config_flow.py
@@ -6,11 +6,11 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import DOMAIN
+from .const import ACCOUNT, DOMAIN
 
 REAUTH_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 USER_SCHEMA = vol.Schema(
-    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str, ACCOUNT: str}
 )
 
 
@@ -30,7 +30,9 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
             client = OVOEnergy()
             try:
                 authenticated = await client.authenticate(
-                    user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                    user_input.get(ACCOUNT, None),
                 )
             except aiohttp.ClientError:
                 errors["base"] = "cannot_connect"
@@ -44,6 +46,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
                         data={
                             CONF_USERNAME: user_input[CONF_USERNAME],
                             CONF_PASSWORD: user_input[CONF_PASSWORD],
+                            ACCOUNT: user_input.get(ACCOUNT, None),
                         },
                     )
 
@@ -66,7 +69,9 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
             client = OVOEnergy()
             try:
                 authenticated = await client.authenticate(
-                    self.username, user_input[CONF_PASSWORD]
+                    self.username,
+                    user_input[CONF_PASSWORD],
+                    user_input.get(ACCOUNT, None),
                 )
             except aiohttp.ClientError:
                 errors["base"] = "connection_error"
@@ -78,6 +83,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
                         data={
                             CONF_USERNAME: self.username,
                             CONF_PASSWORD: user_input[CONF_PASSWORD],
+                            ACCOUNT: user_input.get(ACCOUNT, None),
                         },
                     )
                     return self.async_abort(reason="reauth_successful")

--- a/homeassistant/components/ovo_energy/config_flow.py
+++ b/homeassistant/components/ovo_energy/config_flow.py
@@ -49,7 +49,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
                         data={
                             CONF_USERNAME: user_input[CONF_USERNAME],
                             CONF_PASSWORD: user_input[CONF_PASSWORD],
-                            CONF_ACCOUNT: user_input.get(CONF_ACCOUNT, None),
+                            CONF_ACCOUNT: client.account_id,
                         },
                     )
 

--- a/homeassistant/components/ovo_energy/const.py
+++ b/homeassistant/components/ovo_energy/const.py
@@ -3,4 +3,4 @@ DOMAIN = "ovo_energy"
 
 DATA_CLIENT = "ovo_client"
 DATA_COORDINATOR = "coordinator"
-ACCOUNT = "account"
+CONF_ACCOUNT = "account"

--- a/homeassistant/components/ovo_energy/const.py
+++ b/homeassistant/components/ovo_energy/const.py
@@ -3,3 +3,4 @@ DOMAIN = "ovo_energy"
 
 DATA_CLIENT = "ovo_client"
 DATA_COORDINATOR = "coordinator"
+ACCOUNT = "account"

--- a/homeassistant/components/ovo_energy/strings.json
+++ b/homeassistant/components/ovo_energy/strings.json
@@ -10,7 +10,8 @@
       "user": {
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "account": "OVO account id (only add if you have multiple accounts)"
         },
         "description": "Set up an OVO Energy instance to access your energy usage.",
         "title": "Add OVO Energy Account"

--- a/homeassistant/components/ovo_energy/translations/en.json
+++ b/homeassistant/components/ovo_energy/translations/en.json
@@ -17,7 +17,8 @@
             "user": {
                 "data": {
                     "password": "Password",
-                    "username": "Username"
+                    "username": "Username",
+                    "account": "OVO account id (only add if you have multiple accounts)"
                 },
                 "description": "Set up an OVO Energy instance to access your energy usage.",
                 "title": "Add OVO Energy Account"


### PR DESCRIPTION
## Proposed change
This change adds support for specifying the OVO account id during component setup. This resolves issues for users who have multiple OVO accounts as the current code selects the first account and does not allow this to be overridden. This issue was reported in https://github.com/home-assistant/core/issues/73375


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: https://github.com/home-assistant/core/issues/73375

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

_Unsure how Black works? Existing tests cover the changes from what I can see._

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

_I'm new to this so happy to update docs if someone can guide me_

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

_Being so new I would not be confident reviewing PRs at the moment_

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

