### PR TITLE
Strict typing for shared MQTT modules

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -182,7 +182,7 @@ MQTT_PUBLISH_SCHEMA = vol.All(
 
 
 async def _async_setup_discovery(
-    hass: HomeAssistant, conf: ConfigType, config_entry
+    hass: HomeAssistant, conf: ConfigType, config_entry: ConfigEntry
 ) -> None:
     """Try to start the discovery of MQTT devices.
 
@@ -377,7 +377,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         retain: bool = call.data[ATTR_RETAIN]
         if msg_topic_template is not None:
             try:
-                rendered_topic = template.Template(
+                rendered_topic: Any = template.Template(
                     msg_topic_template, hass
                 ).async_render(parse_result=False)
                 msg_topic = valid_publish_topic(rendered_topic)
@@ -620,12 +620,12 @@ def async_subscribe_connection_status(
     """Subscribe to MQTT connection changes."""
     connection_status_callback_job = HassJob(connection_status_callback)
 
-    async def connected():
+    async def connected() -> None:
         task = hass.async_run_hass_job(connection_status_callback_job, True)
         if task:
             await task
 
-    async def disconnected():
+    async def disconnected() -> None:
         task = hass.async_run_hass_job(connection_status_callback_job, False)
         if task:
             await task
@@ -636,7 +636,7 @@ def async_subscribe_connection_status(
     }
 
     @callback
-    def unsubscribe():
+    def unsubscribe() -> None:
         subscriptions["connect"]()
         subscriptions["disconnect"]()
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -678,7 +678,7 @@ class MQTT:
         _mqttc: mqtt.Client,
         _userdata: None,
         mid: int,
-        _granted_qos: tuple[Any] | None = None,
+        _granted_qos: tuple[Any, ...] | None = None,
     ) -> None:
         """Publish / Subscribe / Unsubscribe callback."""
         self.hass.add_job(self._mqtt_handle_mid, mid)

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -341,7 +341,7 @@ class MQTT:
         self._ha_started = asyncio.Event()
         self._last_subscribe = time.time()
         self._mqttc: mqtt.Client = None
-        self._cleanup_on_unload: list[Callable] = []
+        self._cleanup_on_unload: list[Callable[[], None]] = []
 
         self._paho_lock = asyncio.Lock()  # Prevents parallel calls to the MQTT client
         self._pending_operations: dict[int, asyncio.Event] = {}

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -674,7 +674,11 @@ class MQTT:
         self._mqtt_data.state_write_requests.process_write_state_requests()
 
     def _mqtt_on_callback(
-        self, _mqttc: mqtt.Client, _userdata: None, mid: int, _granted_qos: tuple[Any]
+        self,
+        _mqttc: mqtt.Client,
+        _userdata: None,
+        mid: int,
+        _granted_qos: tuple[Any] | None = None,
     ) -> None:
         """Publish / Subscribe / Unsubscribe callback."""
         self.hass.add_job(self._mqtt_handle_mid, mid)

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -555,7 +555,13 @@ class MQTT:
         if errors:
             _raise_on_errors(errors)
 
-    def _mqtt_on_connect(self, _mqttc, _userdata, _flags, result_code: int) -> None:
+    def _mqtt_on_connect(
+        self,
+        _mqttc: mqtt.Client,
+        _userdata: None,
+        _flags: dict[str, Any],
+        result_code: int,
+    ) -> None:
         """On connect callback.
 
         Resubscribe to all topics we were subscribed to and publish birth
@@ -613,7 +619,9 @@ class MQTT:
                 publish_birth_message(birth_message), self.hass.loop
             )
 
-    def _mqtt_on_message(self, _mqttc, _userdata, msg: MQTTMessage) -> None:
+    def _mqtt_on_message(
+        self, _mqttc: mqtt.Client, _userdata: None, msg: MQTTMessage
+    ) -> None:
         """Message received callback."""
         self.hass.add_job(self._mqtt_handle_message, msg)
 
@@ -665,7 +673,9 @@ class MQTT:
             )
         self._mqtt_data.state_write_requests.process_write_state_requests()
 
-    def _mqtt_on_callback(self, _mqttc, _userdata, mid: int, _granted_qos=None) -> None:
+    def _mqtt_on_callback(
+        self, _mqttc: mqtt.Client, _userdata: None, mid: int, _granted_qos: tuple[Any]
+    ) -> None:
         """Publish / Subscribe / Unsubscribe callback."""
         self.hass.add_job(self._mqtt_handle_mid, mid)
 
@@ -681,7 +691,9 @@ class MQTT:
             if mid not in self._pending_operations:
                 self._pending_operations[mid] = asyncio.Event()
 
-    def _mqtt_on_disconnect(self, _mqttc, _userdata, result_code: int) -> None:
+    def _mqtt_on_disconnect(
+        self, _mqttc: mqtt.Client, _userdata: None, result_code: int
+    ) -> None:
         """Disconnected callback."""
         self.connected = False
         dispatcher_send(self.hass, MQTT_DISCONNECTED)

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -682,7 +682,9 @@ def try_connection(
 
     result: queue.Queue[bool] = queue.Queue(maxsize=1)
 
-    def on_connect(client_, userdata, flags, result_code: int) -> None:
+    def on_connect(
+        client_: mqtt.Client, userdata: None, flags: dict[str, Any], result_code: int
+    ) -> None:
         """Handle connection result."""
         result.put(result_code == mqtt.CONNACK_ACCEPTED)
 

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -287,7 +287,7 @@ class MQTTOptionsFlowHandler(config_entries.OptionsFlow):
         options_config: dict[str, Any] = {}
         bad_input: bool = False
 
-        def _birth_will(birt_or_will: str) -> dict:
+        def _birth_will(birt_or_will: str) -> dict[str, Any]:
             """Return the user input for birth or will."""
             assert user_input
             return {
@@ -298,7 +298,10 @@ class MQTTOptionsFlowHandler(config_entries.OptionsFlow):
             }
 
         def _validate(
-            field: str, values: dict[str, Any], error_code: str, schema: Callable
+            field: str,
+            values: dict[str, Any],
+            error_code: str,
+            schema: Callable[[Any], Any],
         ):
             """Validate the user input."""
             nonlocal bad_input

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -302,7 +302,7 @@ class MQTTOptionsFlowHandler(config_entries.OptionsFlow):
             values: dict[str, Any],
             error_code: str,
             schema: Callable[[Any], Any],
-        ):
+        ) -> None:
             """Validate the user input."""
             nonlocal bad_input
             try:
@@ -682,7 +682,7 @@ def try_connection(
 
     result: queue.Queue[bool] = queue.Queue(maxsize=1)
 
-    def on_connect(client_, userdata, flags, result_code):
+    def on_connect(client_, userdata, flags, result_code: int) -> None:
         """Handle connection result."""
         result.put(result_code == mqtt.CONNACK_ACCEPTED)
 

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -287,6 +287,7 @@ async def async_get_platform_config_from_yaml(
     config_yaml: ConfigType | None = None,
 ) -> list[ConfigType]:
     """Return a list of validated configurations for the domain."""
+    platform_configs: Any | None
     mqtt_data = get_mqtt_data(hass)
     if config_yaml is None:
         config_yaml = mqtt_data.config
@@ -294,6 +295,7 @@ async def async_get_platform_config_from_yaml(
         return []
     if not (platform_configs := config_yaml.get(platform_domain)):
         return []
+    assert isinstance(platform_configs, list)
     return platform_configs
 
 

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -662,7 +662,9 @@ def stop_discovery_updates(
     clear_discovery_hash(hass, discovery_hash)
 
 
-async def async_remove_discovery_payload(hass: HomeAssistant, discovery_data: dict):
+async def async_remove_discovery_payload(
+    hass: HomeAssistant, discovery_data: DiscoveryInfoType
+) -> None:
     """Clear retained discovery topic in broker to avoid rediscovery after a restart of HA."""
     discovery_topic = discovery_data[ATTR_DISCOVERY_TOPIC]
     await async_publish(hass, discovery_topic, "", retain=True)
@@ -820,7 +822,7 @@ class MqttDiscoveryUpdate(Entity):
         """Initialize the discovery update mixin."""
         self._discovery_data = discovery_data
         self._discovery_update = discovery_update
-        self._remove_discovery_updated: Callable | None = None
+        self._remove_discovery_updated: Callable[[], None] | None = None
         self._removed_from_hass = False
         if discovery_data is None:
             return
@@ -1169,7 +1171,7 @@ def update_device(
     device_info = device_info_from_specifications(config[CONF_DEVICE])
 
     if config_entry_id is not None and device_info is not None:
-        update_device_info = cast(dict, device_info)
+        update_device_info = cast(dict[str, Any], device_info)
         update_device_info["config_entry_id"] = config_entry_id
         device = device_registry.async_get_or_create(**update_device_info)
 

--- a/homeassistant/components/mqtt/subscription.py
+++ b/homeassistant/components/mqtt/subscription.py
@@ -21,7 +21,7 @@ class EntitySubscription:
     hass: HomeAssistant = attr.ib()
     topic: str = attr.ib()
     message_callback: MessageCallbackType = attr.ib()
-    subscribe_task: Coroutine | None = attr.ib()
+    subscribe_task: Coroutine[Any, Any, Callable[[], None]] | None = attr.ib()
     unsubscribe_callback: Callable[[], None] | None = attr.ib()
     qos: int = attr.ib(default=0)
     encoding: str = attr.ib(default="utf-8")
@@ -53,7 +53,7 @@ class EntitySubscription:
             hass, self.topic, self.message_callback, self.qos, self.encoding
         )
 
-    async def subscribe(self):
+    async def subscribe(self) -> None:
         """Subscribe to a topic."""
         if not self.subscribe_task:
             return

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -40,58 +40,58 @@ def mqtt_config_entry_enabled(hass: HomeAssistant) -> bool | None:
     return not bool(hass.config_entries.async_entries(DOMAIN)[0].disabled_by)
 
 
-def valid_topic(value: Any) -> str:
+def valid_topic(topic: Any) -> str:
     """Validate that this is a valid topic name/filter."""
-    value = cv.string(value)
+    validated_topic = cv.string(topic)
     try:
-        raw_value = value.encode("utf-8")
+        raw_validated_topic = validated_topic.encode("utf-8")
     except UnicodeError as err:
         raise vol.Invalid("MQTT topic name/filter must be valid UTF-8 string.") from err
-    if not raw_value:
+    if not raw_validated_topic:
         raise vol.Invalid("MQTT topic name/filter must not be empty.")
-    if len(raw_value) > 65535:
+    if len(raw_validated_topic) > 65535:
         raise vol.Invalid(
             "MQTT topic name/filter must not be longer than 65535 encoded bytes."
         )
-    if "\0" in value:
+    if "\0" in validated_topic:
         raise vol.Invalid("MQTT topic name/filter must not contain null character.")
-    if any(char <= "\u001F" for char in value):
+    if any(char <= "\u001F" for char in validated_topic):
         raise vol.Invalid("MQTT topic name/filter must not contain control characters.")
-    if any("\u007f" <= char <= "\u009F" for char in value):
+    if any("\u007f" <= char <= "\u009F" for char in validated_topic):
         raise vol.Invalid("MQTT topic name/filter must not contain control characters.")
-    if any("\ufdd0" <= char <= "\ufdef" for char in value):
+    if any("\ufdd0" <= char <= "\ufdef" for char in validated_topic):
         raise vol.Invalid("MQTT topic name/filter must not contain non-characters.")
-    if any((ord(char) & 0xFFFF) in (0xFFFE, 0xFFFF) for char in value):
+    if any((ord(char) & 0xFFFF) in (0xFFFE, 0xFFFF) for char in validated_topic):
         raise vol.Invalid("MQTT topic name/filter must not contain noncharacters.")
 
-    return value
+    return validated_topic
 
 
-def valid_subscribe_topic(value: Any) -> str:
+def valid_subscribe_topic(topic: Any) -> str:
     """Validate that we can subscribe using this MQTT topic."""
-    value = valid_topic(value)
-    for i in (i for i, c in enumerate(value) if c == "+"):
-        if (i > 0 and value[i - 1] != "/") or (
-            i < len(value) - 1 and value[i + 1] != "/"
+    validated_topic = valid_topic(topic)
+    for i in (i for i, c in enumerate(validated_topic) if c == "+"):
+        if (i > 0 and validated_topic[i - 1] != "/") or (
+            i < len(validated_topic) - 1 and validated_topic[i + 1] != "/"
         ):
             raise vol.Invalid(
                 "Single-level wildcard must occupy an entire level of the filter"
             )
 
-    index = value.find("#")
+    index = validated_topic.find("#")
     if index != -1:
-        if index != len(value) - 1:
+        if index != len(validated_topic) - 1:
             # If there are multiple wildcards, this will also trigger
             raise vol.Invalid(
                 "Multi-level wildcard must be the last "
                 "character in the topic filter."
             )
-        if len(value) > 1 and value[index - 1] != "/":
+        if len(validated_topic) > 1 and validated_topic[index - 1] != "/":
             raise vol.Invalid(
                 "Multi-level wildcard must be after a topic level separator."
             )
 
-    return value
+    return validated_topic
 
 
 def valid_subscribe_topic_template(value: Any) -> template.Template:
@@ -104,12 +104,12 @@ def valid_subscribe_topic_template(value: Any) -> template.Template:
     return tpl
 
 
-def valid_publish_topic(value: Any) -> str:
+def valid_publish_topic(topic: Any) -> str:
     """Validate that we can publish using this MQTT topic."""
-    value = valid_topic(value)
-    if "+" in value or "#" in value:
+    validated_topic = valid_topic(topic)
+    if "+" in validated_topic or "#" in validated_topic:
         raise vol.Invalid("Wildcards can not be used in topic names")
-    return value
+    return validated_topic
 
 
 _VALID_QOS_SCHEMA = vol.All(vol.Coerce(int), vol.In([0, 1, 2]))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Corrects the typing of some missed code elements/attributes of shared MQTT modules:
`__init__.py`, `models.py`, `client.py`, `config_flow.py`, `mixins.py`, `subscription.py` and `util.py`.

These modules are corrected before the improvement is stated for the platform modules.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
