### PR TITLE
Fix `integrations.json` creation, make `iot_standards` a list

### DIFF
--- a/homeassistant/components/ultraloq/__init__.py
+++ b/homeassistant/components/ultraloq/__init__.py
@@ -1,0 +1,1 @@
+"""Virtual integration: Ultraloq."""

--- a/homeassistant/components/ultraloq/manifest.json
+++ b/homeassistant/components/ultraloq/manifest.json
@@ -2,5 +2,5 @@
   "domain": "ultraloq",
   "name": "Ultraloq",
   "integration_type": "virtual",
-  "iot_standard": "zwave"
+  "iot_standards": ["zwave"]
 }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2368,6 +2368,7 @@
       "integrations": {
         "symfonisk": {
           "integration_type": "virtual",
+          "supported_by": "sonos",
           "name": "IKEA SYMFONISK"
         },
         "tradfri": {
@@ -5607,6 +5608,9 @@
       "integrations": {
         "ultraloq": {
           "integration_type": "virtual",
+          "iot_standards": [
+            "zwave"
+          ],
           "name": "Ultraloq"
         }
       }

--- a/script/hassfest/config_flow.py
+++ b/script/hassfest/config_flow.py
@@ -113,6 +113,10 @@ def _populate_brand_integrations(
             metadata["config_flow"] = integration.config_flow
         if integration.iot_class:
             metadata["iot_class"] = integration.iot_class
+        if integration.supported_by:
+            metadata["supported_by"] = integration.supported_by
+        if integration.iot_standards:
+            metadata["iot_standards"] = integration.iot_standards
         if integration.translated_name:
             integration_data["translated_name"].add(domain)
         else:
@@ -185,8 +189,8 @@ def _generate_integrations(
             if integration.integration_type == "virtual":
                 if integration.supported_by:
                     metadata["supported_by"] = integration.supported_by
-                if integration.iot_standard:
-                    metadata["iot_standard"] = integration.iot_standard
+                if integration.iot_standards:
+                    metadata["iot_standards"] = integration.iot_standards
             else:
                 metadata["config_flow"] = integration.config_flow
                 if integration.iot_class:

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -263,9 +263,9 @@ VIRTUAL_INTEGRATION_MANIFEST_SCHEMA = vol.Schema(
         vol.Required("domain"): str,
         vol.Required("name"): str,
         vol.Required("integration_type"): "virtual",
-        vol.Exclusive("iot_standard", "virtual_integration"): vol.Any(
-            "homekit", "zigbee", "zwave"
-        ),
+        vol.Exclusive("iot_standards", "virtual_integration"): [
+            vol.Any("homekit", "zigbee", "zwave")
+        ],
         vol.Exclusive("supported_by", "virtual_integration"): str,
     }
 )

--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -186,9 +186,9 @@ class Integration:
         return self.manifest.get("iot_class")
 
     @property
-    def iot_standard(self) -> str:
+    def iot_standards(self) -> list[str]:
         """Return the IoT standard supported by this virtual integration."""
-        return self.manifest.get("iot_standard", {})
+        return self.manifest.get("iot_standards", [])
 
     def add_error(self, *args: Any, **kwargs: Any) -> None:
         """Add an error."""


### PR DESCRIPTION

## Proposed change

Some fields where left out of the `integration.json` file the frontend uses to check what an integration supports.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1510

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
