### PR TITLE
Allow empty string for filters for waze_travel_time

### DIFF
--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -52,7 +52,7 @@ class WazeOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(
                 title="",
-                data={k: v for k, v in user_input.items() if v not in (None, "")},
+                data=user_input,
             )
 
         return self.async_show_form(

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -185,14 +185,14 @@ class WazeTravelTimeData:
                 )
                 routes = params.calc_all_routes_info(real_time=realtime)
 
-                if incl_filter is not None:
+                if incl_filter not in (None, ""):
                     routes = {
                         k: v
                         for k, v in routes.items()
                         if incl_filter.lower() in k.lower()
                     }
 
-                if excl_filter is not None:
+                if excl_filter not in (None, ""):
                     routes = {
                         k: v
                         for k, v in routes.items()

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -185,14 +185,14 @@ class WazeTravelTimeData:
                 )
                 routes = params.calc_all_routes_info(real_time=realtime)
 
-                if incl_filter not in (None, ""):
+                if incl_filter not in {None, ""}:
                     routes = {
                         k: v
                         for k, v in routes.items()
                         if incl_filter.lower() in k.lower()
                     }
 
-                if excl_filter not in (None, ""):
+                if excl_filter not in {None, ""}:
                     routes = {
                         k: v
                         for k, v in routes.items()

--- a/tests/components/waze_travel_time/test_config_flow.py
+++ b/tests/components/waze_travel_time/test_config_flow.py
@@ -139,7 +139,9 @@ async def test_dupe(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("invalidate_config_entry")
-async def test_invalid_config_entry(hass: HomeAssistant, caplog) -> None:
+async def test_invalid_config_entry(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -164,7 +166,7 @@ async def test_reset_filters(hass: HomeAssistant) -> None:
     options[CONF_INCL_FILTER] = "test"
     options[CONF_EXCL_FILTER] = "test"
     config_entry = MockConfigEntry(
-        domain=DOMAIN, data=MOCK_CONFIG, options=DEFAULT_OPTIONS, entry_id="test"
+        domain=DOMAIN, data=MOCK_CONFIG, options=options, entry_id="test"
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/waze_travel_time/test_config_flow.py
+++ b/tests/components/waze_travel_time/test_config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.components.waze_travel_time.const import (
     IMPERIAL_UNITS,
 )
 from homeassistant.const import CONF_NAME, CONF_REGION
+from homeassistant.core import HomeAssistant
 
 from .const import MOCK_CONFIG
 
@@ -26,7 +27,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("validate_config_entry")
-async def test_minimum_fields(hass):
+async def test_minimum_fields(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -50,7 +51,7 @@ async def test_minimum_fields(hass):
     }
 
 
-async def test_options(hass):
+async def test_options(hass: HomeAssistant) -> None:
     """Test options flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -105,7 +106,7 @@ async def test_options(hass):
 
 
 @pytest.mark.usefixtures("validate_config_entry")
-async def test_dupe(hass):
+async def test_dupe(hass: HomeAssistant) -> None:
     """Test setting up the same entry data twice is OK."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -138,7 +139,7 @@ async def test_dupe(hass):
 
 
 @pytest.mark.usefixtures("invalidate_config_entry")
-async def test_invalid_config_entry(hass, caplog):
+async def test_invalid_config_entry(hass: HomeAssistant, caplog) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -154,3 +155,46 @@ async def test_invalid_config_entry(hass, caplog):
     assert result2["errors"] == {"base": "cannot_connect"}
 
     assert "Error trying to validate entry" in caplog.text
+
+
+@pytest.mark.usefixtures("mock_update")
+async def test_reset_filters(hass: HomeAssistant) -> None:
+    """Test resetting inclusive and exclusive filters to empty string."""
+    options = {**DEFAULT_OPTIONS}
+    options[CONF_INCL_FILTER] = "test"
+    options[CONF_EXCL_FILTER] = "test"
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, options=DEFAULT_OPTIONS, entry_id="test"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id, data=None
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_AVOID_FERRIES: True,
+            CONF_AVOID_SUBSCRIPTION_ROADS: True,
+            CONF_AVOID_TOLL_ROADS: True,
+            CONF_EXCL_FILTER: "",
+            CONF_INCL_FILTER: "",
+            CONF_REALTIME: False,
+            CONF_UNITS: IMPERIAL_UNITS,
+            CONF_VEHICLE_TYPE: "taxi",
+        },
+    )
+
+    assert config_entry.options == {
+        CONF_AVOID_FERRIES: True,
+        CONF_AVOID_SUBSCRIPTION_ROADS: True,
+        CONF_AVOID_TOLL_ROADS: True,
+        CONF_EXCL_FILTER: "",
+        CONF_INCL_FILTER: "",
+        CONF_REALTIME: False,
+        CONF_UNITS: IMPERIAL_UNITS,
+        CONF_VEHICLE_TYPE: "taxi",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In the OptionFlow allow setting `incl_filter` and `excl_filter` to an empty string when it was not empty before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80757
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
