### PR TITLE
Adjust formatting in unit system tests

### DIFF
--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -388,46 +388,59 @@ def test_get_unit_system_invalid(key: str) -> None:
         _ = get_unit_system(key)
 
 
-# fmt: off
 @pytest.mark.parametrize(
-    "unit_system, device_class, original_unit, state_unit",
+    "device_class, original_unit, state_unit",
     (
         # Test distance conversion
-        (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_FEET, LENGTH_METERS),
-        (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_INCHES, LENGTH_MILLIMETERS),
-        (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_MILES, LENGTH_KILOMETERS),
-        (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_YARD, LENGTH_METERS),
-        (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_KILOMETERS, None),
-        (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, "very_long", None),
+        (SensorDeviceClass.DISTANCE, LENGTH_FEET, LENGTH_METERS),
+        (SensorDeviceClass.DISTANCE, LENGTH_INCHES, LENGTH_MILLIMETERS),
+        (SensorDeviceClass.DISTANCE, LENGTH_MILES, LENGTH_KILOMETERS),
+        (SensorDeviceClass.DISTANCE, LENGTH_YARD, LENGTH_METERS),
+        (SensorDeviceClass.DISTANCE, LENGTH_KILOMETERS, None),
+        (SensorDeviceClass.DISTANCE, "very_long", None),
         # Test speed conversion
-        (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_FEET_PER_SECOND, SPEED_KILOMETERS_PER_HOUR),
-        (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_MILES_PER_HOUR, SPEED_KILOMETERS_PER_HOUR),
-        (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_KILOMETERS_PER_HOUR, None),
-        (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_KNOTS, None),
-        (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_METERS_PER_SECOND, None),
-        (METRIC_SYSTEM, SensorDeviceClass.SPEED, "very_fast", None),
-        # Test distance conversion
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_CENTIMETERS, LENGTH_INCHES),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_KILOMETERS, LENGTH_MILES),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_METERS, LENGTH_FEET),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_MILLIMETERS, LENGTH_INCHES),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_MILES, None),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, "very_long", None),
-        # Test speed conversion
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_METERS_PER_SECOND, SPEED_MILES_PER_HOUR),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_KILOMETERS_PER_HOUR, SPEED_MILES_PER_HOUR),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_FEET_PER_SECOND, None),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_KNOTS, None),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_MILES_PER_HOUR, None),
-        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, "very_fast", None),
+        (SensorDeviceClass.SPEED, SPEED_FEET_PER_SECOND, SPEED_KILOMETERS_PER_HOUR),
+        (SensorDeviceClass.SPEED, SPEED_MILES_PER_HOUR, SPEED_KILOMETERS_PER_HOUR),
+        (SensorDeviceClass.SPEED, SPEED_KILOMETERS_PER_HOUR, None),
+        (SensorDeviceClass.SPEED, SPEED_KNOTS, None),
+        (SensorDeviceClass.SPEED, SPEED_METERS_PER_SECOND, None),
+        (SensorDeviceClass.SPEED, "very_fast", None),
     ),
 )
-# fmt: on
-def test_get_converted_unit(
-    unit_system: UnitSystem,
+def test_get_metric_converted_unit_(
     device_class: SensorDeviceClass,
     original_unit: str,
     state_unit: str | None,
 ) -> None:
     """Test unit conversion rules."""
+    unit_system = METRIC_SYSTEM
+    assert unit_system.get_converted_unit(device_class, original_unit) == state_unit
+
+
+@pytest.mark.parametrize(
+    "device_class, original_unit, state_unit",
+    (
+        # Test distance conversion
+        (SensorDeviceClass.DISTANCE, LENGTH_CENTIMETERS, LENGTH_INCHES),
+        (SensorDeviceClass.DISTANCE, LENGTH_KILOMETERS, LENGTH_MILES),
+        (SensorDeviceClass.DISTANCE, LENGTH_METERS, LENGTH_FEET),
+        (SensorDeviceClass.DISTANCE, LENGTH_MILLIMETERS, LENGTH_INCHES),
+        (SensorDeviceClass.DISTANCE, LENGTH_MILES, None),
+        (SensorDeviceClass.DISTANCE, "very_long", None),
+        # Test speed conversion
+        (SensorDeviceClass.SPEED, SPEED_METERS_PER_SECOND, SPEED_MILES_PER_HOUR),
+        (SensorDeviceClass.SPEED, SPEED_KILOMETERS_PER_HOUR, SPEED_MILES_PER_HOUR),
+        (SensorDeviceClass.SPEED, SPEED_FEET_PER_SECOND, None),
+        (SensorDeviceClass.SPEED, SPEED_KNOTS, None),
+        (SensorDeviceClass.SPEED, SPEED_MILES_PER_HOUR, None),
+        (SensorDeviceClass.SPEED, "very_fast", None),
+    ),
+)
+def test_get_us_converted_unit(
+    device_class: SensorDeviceClass,
+    original_unit: str,
+    state_unit: str | None,
+) -> None:
+    """Test unit conversion rules."""
+    unit_system = US_CUSTOMARY_SYSTEM
     assert unit_system.get_converted_unit(device_class, original_unit) == state_unit

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -388,9 +388,11 @@ def test_get_unit_system_invalid(key: str) -> None:
         _ = get_unit_system(key)
 
 
+# fmt: off
 @pytest.mark.parametrize(
     "unit_system, device_class, original_unit, state_unit",
     (
+        # Test distance conversion
         (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_FEET, LENGTH_METERS),
         (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_INCHES, LENGTH_MILLIMETERS),
         (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_MILES, LENGTH_KILOMETERS),
@@ -398,62 +400,29 @@ def test_get_unit_system_invalid(key: str) -> None:
         (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_KILOMETERS, None),
         (METRIC_SYSTEM, SensorDeviceClass.DISTANCE, "very_long", None),
         # Test speed conversion
-        (
-            METRIC_SYSTEM,
-            SensorDeviceClass.SPEED,
-            SPEED_FEET_PER_SECOND,
-            SPEED_KILOMETERS_PER_HOUR,
-        ),
-        (
-            METRIC_SYSTEM,
-            SensorDeviceClass.SPEED,
-            SPEED_MILES_PER_HOUR,
-            SPEED_KILOMETERS_PER_HOUR,
-        ),
+        (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_FEET_PER_SECOND, SPEED_KILOMETERS_PER_HOUR),
+        (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_MILES_PER_HOUR, SPEED_KILOMETERS_PER_HOUR),
         (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_KILOMETERS_PER_HOUR, None),
         (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_KNOTS, None),
         (METRIC_SYSTEM, SensorDeviceClass.SPEED, SPEED_METERS_PER_SECOND, None),
         (METRIC_SYSTEM, SensorDeviceClass.SPEED, "very_fast", None),
-        (
-            US_CUSTOMARY_SYSTEM,
-            SensorDeviceClass.DISTANCE,
-            LENGTH_CENTIMETERS,
-            LENGTH_INCHES,
-        ),
-        (
-            US_CUSTOMARY_SYSTEM,
-            SensorDeviceClass.DISTANCE,
-            LENGTH_KILOMETERS,
-            LENGTH_MILES,
-        ),
+        # Test distance conversion
+        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_CENTIMETERS, LENGTH_INCHES),
+        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_KILOMETERS, LENGTH_MILES),
         (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_METERS, LENGTH_FEET),
-        (
-            US_CUSTOMARY_SYSTEM,
-            SensorDeviceClass.DISTANCE,
-            LENGTH_MILLIMETERS,
-            LENGTH_INCHES,
-        ),
+        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_MILLIMETERS, LENGTH_INCHES),
         (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, LENGTH_MILES, None),
         (US_CUSTOMARY_SYSTEM, SensorDeviceClass.DISTANCE, "very_long", None),
         # Test speed conversion
-        (
-            US_CUSTOMARY_SYSTEM,
-            SensorDeviceClass.SPEED,
-            SPEED_METERS_PER_SECOND,
-            SPEED_MILES_PER_HOUR,
-        ),
-        (
-            US_CUSTOMARY_SYSTEM,
-            SensorDeviceClass.SPEED,
-            SPEED_KILOMETERS_PER_HOUR,
-            SPEED_MILES_PER_HOUR,
-        ),
+        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_METERS_PER_SECOND, SPEED_MILES_PER_HOUR),
+        (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_KILOMETERS_PER_HOUR, SPEED_MILES_PER_HOUR),
         (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_FEET_PER_SECOND, None),
         (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_KNOTS, None),
         (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, SPEED_MILES_PER_HOUR, None),
         (US_CUSTOMARY_SYSTEM, SensorDeviceClass.SPEED, "very_fast", None),
     ),
 )
+# fmt: on
 def test_get_converted_unit(
     unit_system: UnitSystem,
     device_class: SensorDeviceClass,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust black formatting in unit system tests
I think this is way more readable, but it goes against black standard rules so maybe it is not wanted?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
