### PR TITLE
Clean-up Shelly legacy update entities

### DIFF
--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -19,9 +19,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
 
 from .const import CONF_SLEEP_PERIOD
-from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
+from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .entity import (
     RestEntityDescription,
     RpcEntityDescription,
@@ -30,7 +31,12 @@ from .entity import (
     async_setup_entry_rest,
     async_setup_entry_rpc,
 )
-from .utils import get_device_entry_gen
+from .utils import (
+    async_remove_shelly_entity,
+    get_block_device_name,
+    get_device_entry_gen,
+    get_rpc_device_name,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -117,9 +123,27 @@ async def async_setup_entry(
 ) -> None:
     """Set up update entities for Shelly component."""
     if get_device_entry_gen(config_entry) == 2:
+        # Remove legacy update binary sensors, remove in 2023.2.0
+        rpc_coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
+        assert rpc_coordinator
+        mac = rpc_coordinator.mac
+        async_remove_shelly_entity(hass, "binary_sensor", f"{mac}-sys-fwupdate")
+        device_name = slugify(get_rpc_device_name(rpc_coordinator.device))
+        async_remove_shelly_entity(hass, "button", f"{device_name}_ota_update")
+        async_remove_shelly_entity(hass, "button", f"{device_name}_ota_update_beta")
+
         return async_setup_entry_rpc(
             hass, config_entry, async_add_entities, RPC_UPDATES, RpcUpdateEntity
         )
+
+    # Remove legacy update binary sensors, remove in 2023.2.0
+    block_coordinator = get_entry_data(hass)[config_entry.entry_id].block
+    assert block_coordinator
+    mac = block_coordinator.mac
+    async_remove_shelly_entity(hass, "binary_sensor", f"{mac}-fwupdate")
+    device_name = slugify(get_block_device_name(block_coordinator.device))
+    async_remove_shelly_entity(hass, "button", f"{device_name}_ota_update")
+    async_remove_shelly_entity(hass, "button", f"{device_name}_ota_update_beta")
 
     if not config_entry.data[CONF_SLEEP_PERIOD]:
         async_setup_entry_rest(

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -123,7 +123,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up update entities for Shelly component."""
     if get_device_entry_gen(config_entry) == 2:
-        # Remove legacy update binary sensors, remove in 2023.2.0
+        # Remove legacy update binary sensor & buttons, remove in 2023.2.0
         rpc_coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
         assert rpc_coordinator
         mac = rpc_coordinator.mac
@@ -136,7 +136,7 @@ async def async_setup_entry(
             hass, config_entry, async_add_entities, RPC_UPDATES, RpcUpdateEntity
         )
 
-    # Remove legacy update binary sensors, remove in 2023.2.0
+    # Remove legacy update binary sensor & buttons, remove in 2023.2.0
     block_coordinator = get_entry_data(hass)[config_entry.entry_id].block
     assert block_coordinator
     mac = block_coordinator.mac

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -46,7 +46,6 @@ async def test_remove_legacy_entities(
     object_id,
     mock_block_device,
     mock_rpc_device,
-    caplog,
 ):
     """Test removes legacy update entities."""
     entity_id = f"{domain}.test_name_{object_id}"
@@ -63,7 +62,6 @@ async def test_remove_legacy_entities(
 
     await init_integration(hass, gen)
 
-    assert f"Removing entity: {entity_id}" in caplog.text
     assert entity_registry.async_get(entity_id) is None
 
 

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError
 import pytest
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.shelly.const import DOMAIN, REST_SENSORS_UPDATE_INTERVAL
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
@@ -23,6 +25,46 @@ from homeassistant.util import dt
 from . import MOCK_MAC, init_integration
 
 from tests.common import async_fire_time_changed
+
+
+@pytest.mark.parametrize(
+    "gen, domain, unique_id, object_id",
+    [
+        (1, BINARY_SENSOR_DOMAIN, f"{MOCK_MAC}-fwupdate", "firmware_update"),
+        (1, BUTTON_DOMAIN, "test_name_ota_update", "ota_update"),
+        (1, BUTTON_DOMAIN, "test_name_ota_update_beta", "ota_update_beta"),
+        (2, BINARY_SENSOR_DOMAIN, f"{MOCK_MAC}-sys-fwupdate", "firmware_update"),
+        (2, BUTTON_DOMAIN, "test_name_ota_update", "ota_update"),
+        (2, BUTTON_DOMAIN, "test_name_ota_update_beta", "ota_update_beta"),
+    ],
+)
+async def test_remove_legacy_entities(
+    hass: HomeAssistant,
+    gen,
+    domain,
+    unique_id,
+    object_id,
+    mock_block_device,
+    mock_rpc_device,
+    caplog,
+):
+    """Test removes legacy update entities."""
+    entity_id = f"{domain}.test_name_{object_id}"
+    entity_registry = async_get(hass)
+    entity_registry.async_get_or_create(
+        domain,
+        DOMAIN,
+        unique_id,
+        suggested_object_id=f"test_name_{object_id}",
+        disabled_by=None,
+    )
+
+    assert entity_registry.async_get(entity_id) is not None
+
+    await init_integration(hass, gen)
+
+    assert f"Removing entity: {entity_id}" in caplog.text
+    assert entity_registry.async_get(entity_id) is None
 
 
 async def test_block_update(hass: HomeAssistant, mock_block_device, monkeypatch):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove 3 leftover update sensors that were migrated to `update` platform in https://github.com/home-assistant/core/pull/78305

Verified on Gen1 & Gen2 devices

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/80878
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
