### PR TITLE
Bump aiogithubapi from 22.2.4 to 22.10.1

### DIFF
--- a/homeassistant/components/github/manifest.json
+++ b/homeassistant/components/github/manifest.json
@@ -2,7 +2,7 @@
   "domain": "github",
   "name": "GitHub",
   "documentation": "https://www.home-assistant.io/integrations/github",
-  "requirements": ["aiogithubapi==22.2.4"],
+  "requirements": ["aiogithubapi==22.10.1"],
   "codeowners": ["@timmo001", "@ludeeus"],
   "iot_class": "cloud_polling",
   "config_flow": true,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -162,7 +162,7 @@ aioflo==2021.11.0
 aioftp==0.21.3
 
 # homeassistant.components.github
-aiogithubapi==22.2.4
+aiogithubapi==22.10.1
 
 # homeassistant.components.guardian
 aioguardian==2022.07.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -146,7 +146,7 @@ aioesphomeapi==11.2.0
 aioflo==2021.11.0
 
 # homeassistant.components.github
-aiogithubapi==22.2.4
+aiogithubapi==22.10.1
 
 # homeassistant.components.guardian
 aioguardian==2022.07.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I have published a new version of [`aiogithubapi`](https://github.com/ludeeus/aiogithubapi), the new version is [`22.10.1`](https://pypi.org/project/aiogithubapi/22.10.1/).
This is used by the [GitHub integration](https://www.home-assistant.io/integrations/github/) and I wish to update the `manifest.json` file for that integration as shown in this PR from the old `22.2.4` version to use the new version (`22.10.1`).

- [The release notes of the new release can be found here](https://github.com/ludeeus/aiogithubapi/releases/tag/22.10.0)
- [The release notes of in-between release `22.3.0` can be found here](https://github.com/ludeeus/aiogithubapi/releases/tag/22.3.0)
- [The release notes of in-between release `22.3.1` can be found here](https://github.com/ludeeus/aiogithubapi/releases/tag/22.3.1)
- [The release notes of in-between release `22.10.0` can be found here](https://github.com/ludeeus/aiogithubapi/releases/tag/22.10.0)
- [The complete diff between `22.2.4` and `22.10.1` can be found here](https://github.com/ludeeus/aiogithubapi/compare/22.2.4...22.10.1#files_bucket)

If there are any questions add a comment to this PR or reach out to me on the [Home Assistant Discord server](https://discord.gg/c5DvZ4e) (`Ludeeus#4212`)
Thanks for considering!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
