### PR TITLE
Rewrite UniFi block client switch

### DIFF
--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -400,7 +400,7 @@ class UnifiBlockClientSwitch(SwitchEntity):
     @property
     def icon(self) -> str:
         """Return the icon to use in the frontend."""
-        if not self._attr_is_on:
+        if not self.is_on:
             return "mdi:network-off"
         return "mdi:network"
 
@@ -502,7 +502,7 @@ class UnifiDPIRestrictionSwitch(SwitchEntity):
     @property
     def icon(self):
         """Return the icon to use in the frontend."""
-        if self._attr_is_on:
+        if self.is_on:
             return "mdi:network"
         return "mdi:network-off"
 

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1027,21 +1027,13 @@ async def test_new_client_discovered_on_block_control(
     )
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
-
-    blocked = hass.states.get("switch.block_client_1")
-    assert blocked is None
+    assert hass.states.get("switch.block_client_1") is None
 
     mock_unifi_websocket(message=MessageKey.CLIENT, data=BLOCKED)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
-
-    mock_unifi_websocket(message=MessageKey.EVENT, data=EVENT_BLOCKED_CLIENT_CONNECTED)
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
-    blocked = hass.states.get("switch.block_client_1")
-    assert blocked is not None
+    assert hass.states.get("switch.block_client_1") is not None
 
 
 async def test_option_block_clients(hass, aioclient_mock):

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -54,7 +54,7 @@ CLIENT_1 = {
     "mac": "00:00:00:00:00:01",
     "name": "POE Client 1",
     "oui": "Producer",
-    "sw_mac": "00:00:00:00:01:01",
+    "sw_mac": "10:00:00:00:01:01",
     "sw_port": 1,
     "wired-rx_bytes": 1234000000,
     "wired-tx_bytes": 5678000000,
@@ -67,7 +67,7 @@ CLIENT_2 = {
     "mac": "00:00:00:00:00:02",
     "name": "POE Client 2",
     "oui": "Producer",
-    "sw_mac": "00:00:00:00:01:01",
+    "sw_mac": "10:00:00:00:01:01",
     "sw_port": 2,
     "wired-rx_bytes": 1234000000,
     "wired-tx_bytes": 5678000000,
@@ -80,7 +80,7 @@ CLIENT_3 = {
     "mac": "00:00:00:00:00:03",
     "name": "Non-POE Client 3",
     "oui": "Producer",
-    "sw_mac": "00:00:00:00:01:01",
+    "sw_mac": "10:00:00:00:01:01",
     "sw_port": 3,
     "wired-rx_bytes": 1234000000,
     "wired-tx_bytes": 5678000000,
@@ -93,7 +93,7 @@ CLIENT_4 = {
     "mac": "00:00:00:00:00:04",
     "name": "Non-POE Client 4",
     "oui": "Producer",
-    "sw_mac": "00:00:00:00:01:01",
+    "sw_mac": "10:00:00:00:01:01",
     "sw_port": 4,
     "wired-rx_bytes": 1234000000,
     "wired-tx_bytes": 5678000000,
@@ -107,7 +107,7 @@ POE_SWITCH_CLIENTS = [
         "mac": "00:00:00:00:00:01",
         "name": "POE Client 1",
         "oui": "Producer",
-        "sw_mac": "00:00:00:00:01:01",
+        "sw_mac": "10:00:00:00:01:01",
         "sw_port": 1,
         "wired-rx_bytes": 1234000000,
         "wired-tx_bytes": 5678000000,
@@ -120,7 +120,7 @@ POE_SWITCH_CLIENTS = [
         "mac": "00:00:00:00:00:02",
         "name": "POE Client 2",
         "oui": "Producer",
-        "sw_mac": "00:00:00:00:01:01",
+        "sw_mac": "10:00:00:00:01:01",
         "sw_port": 1,
         "wired-rx_bytes": 1234000000,
         "wired-tx_bytes": 5678000000,
@@ -131,7 +131,7 @@ DEVICE_1 = {
     "board_rev": 2,
     "device_id": "mock-id",
     "ip": "10.0.1.1",
-    "mac": "00:00:00:00:01:01",
+    "mac": "10:00:00:00:01:01",
     "last_seen": 1562600145,
     "model": "US16P150",
     "name": "mock-name",
@@ -650,7 +650,7 @@ async def test_switches(hass, aioclient_mock):
     assert switch_1 is not None
     assert switch_1.state == "on"
     assert switch_1.attributes["power"] == "2.56"
-    assert switch_1.attributes[SWITCH_DOMAIN] == "00:00:00:00:01:01"
+    assert switch_1.attributes[SWITCH_DOMAIN] == "10:00:00:00:01:01"
     assert switch_1.attributes["port"] == 1
     assert switch_1.attributes["poe_mode"] == "auto"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify the block client switch entity implementation. Shares the same design as https://github.com/home-assistant/core/pull/80566 and https://github.com/home-assistant/core/pull/80738 and https://github.com/home-assistant/core/pull/80752 and https://github.com/home-assistant/core/pull/80761

The refactoring breaks away from old dependencies as to simplify the overall refactoring compared to the deCONZ one which took way too long by keeping all relations intact.
Once entity refactoring is in place I can start working on consolidating logic once more.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
