### PR TITLE
Change `UnitOfEnergy` to `UnitEnergy`

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     VOLUME_CUBIC_FEET,
     VOLUME_CUBIC_METERS,
-    UnitOfEnergy,
+    UnitEnergy,
 )
 from homeassistant.core import (
     HomeAssistant,
@@ -43,10 +43,10 @@ SUPPORTED_STATE_CLASSES = [
     SensorStateClass.TOTAL_INCREASING,
 ]
 VALID_ENERGY_UNITS = [
-    UnitOfEnergy.WATT_HOUR,
-    UnitOfEnergy.KILO_WATT_HOUR,
-    UnitOfEnergy.MEGA_WATT_HOUR,
-    UnitOfEnergy.GIGA_JOULE,
+    UnitEnergy.WATT_HOUR,
+    UnitEnergy.KILO_WATT_HOUR,
+    UnitEnergy.MEGA_WATT_HOUR,
+    UnitEnergy.GIGA_JOULE,
 ]
 VALID_ENERGY_UNITS_GAS = [VOLUME_CUBIC_FEET, VOLUME_CUBIC_METERS] + VALID_ENERGY_UNITS
 _LOGGER = logging.getLogger(__name__)
@@ -283,17 +283,17 @@ class EnergyCostSensor(SensorEntity):
                 return
 
             if energy_price_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, "").endswith(
-                f"/{UnitOfEnergy.WATT_HOUR}"
+                f"/{UnitEnergy.WATT_HOUR}"
             ):
                 energy_price *= 1000.0
 
             if energy_price_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, "").endswith(
-                f"/{UnitOfEnergy.MEGA_WATT_HOUR}"
+                f"/{UnitEnergy.MEGA_WATT_HOUR}"
             ):
                 energy_price /= 1000.0
 
             if energy_price_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, "").endswith(
-                f"/{UnitOfEnergy.GIGA_JOULE}"
+                f"/{UnitEnergy.GIGA_JOULE}"
             ):
                 energy_price /= 1000 / 3.6
 
@@ -316,11 +316,11 @@ class EnergyCostSensor(SensorEntity):
             if energy_unit not in VALID_ENERGY_UNITS_GAS:
                 energy_unit = None
 
-        if energy_unit == UnitOfEnergy.WATT_HOUR:
+        if energy_unit == UnitEnergy.WATT_HOUR:
             energy_price /= 1000
-        elif energy_unit == UnitOfEnergy.MEGA_WATT_HOUR:
+        elif energy_unit == UnitEnergy.MEGA_WATT_HOUR:
             energy_price *= 1000
-        elif energy_unit == UnitOfEnergy.GIGA_JOULE:
+        elif energy_unit == UnitEnergy.GIGA_JOULE:
             energy_price *= 1000 / 3.6
 
         if energy_unit is None:

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     VOLUME_CUBIC_FEET,
     VOLUME_CUBIC_METERS,
-    UnitOfEnergy,
+    UnitEnergy,
 )
 from homeassistant.core import HomeAssistant, callback, valid_entity_id
 
@@ -23,10 +23,10 @@ from .const import DOMAIN
 ENERGY_USAGE_DEVICE_CLASSES = (sensor.SensorDeviceClass.ENERGY,)
 ENERGY_USAGE_UNITS = {
     sensor.SensorDeviceClass.ENERGY: (
-        UnitOfEnergy.KILO_WATT_HOUR,
-        UnitOfEnergy.MEGA_WATT_HOUR,
-        UnitOfEnergy.WATT_HOUR,
-        UnitOfEnergy.GIGA_JOULE,
+        UnitEnergy.KILO_WATT_HOUR,
+        UnitEnergy.MEGA_WATT_HOUR,
+        UnitEnergy.WATT_HOUR,
+        UnitEnergy.GIGA_JOULE,
     )
 }
 ENERGY_PRICE_UNITS = tuple(
@@ -40,10 +40,10 @@ GAS_USAGE_DEVICE_CLASSES = (
 )
 GAS_USAGE_UNITS = {
     sensor.SensorDeviceClass.ENERGY: (
-        UnitOfEnergy.WATT_HOUR,
-        UnitOfEnergy.KILO_WATT_HOUR,
-        UnitOfEnergy.MEGA_WATT_HOUR,
-        UnitOfEnergy.GIGA_JOULE,
+        UnitEnergy.WATT_HOUR,
+        UnitEnergy.KILO_WATT_HOUR,
+        UnitEnergy.MEGA_WATT_HOUR,
+        UnitEnergy.GIGA_JOULE,
     ),
     sensor.SensorDeviceClass.GAS: (VOLUME_CUBIC_METERS, VOLUME_CUBIC_FEET),
 }

--- a/homeassistant/components/energy/websocket_api.py
+++ b/homeassistant/components/energy/websocket_api.py
@@ -13,7 +13,7 @@ from typing import Any, cast
 import voluptuous as vol
 
 from homeassistant.components import recorder, websocket_api
-from homeassistant.const import UnitOfEnergy
+from homeassistant.const import UnitEnergy
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.integration_platform import (
     async_process_integration_platforms,
@@ -273,7 +273,7 @@ async def ws_get_fossil_energy_consumption(
         statistic_ids,
         "hour",
         True,
-        {"energy": UnitOfEnergy.KILO_WATT_HOUR},
+        {"energy": UnitEnergy.KILO_WATT_HOUR},
     )
 
     def _combine_sum_statistics(

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -488,7 +488,7 @@ POWER_VOLT_AMPERE_REACTIVE: Final = "var"
 
 
 # Energy units
-class UnitOfEnergy(StrEnum):
+class UnitEnergy(StrEnum):
     """Energy units."""
 
     GIGA_JOULE = "GJ"
@@ -498,11 +498,11 @@ class UnitOfEnergy(StrEnum):
 
 
 ENERGY_KILO_WATT_HOUR: Final = "kWh"
-"""Deprecated: please use UnitOfEnergy.KILO_WATT_HOUR."""
+"""Deprecated: please use UnitEnergy.KILO_WATT_HOUR."""
 ENERGY_MEGA_WATT_HOUR: Final = "MWh"
-"""Deprecated: please use UnitOfEnergy.MEGA_WATT_HOUR."""
+"""Deprecated: please use UnitEnergy.MEGA_WATT_HOUR."""
 ENERGY_WATT_HOUR: Final = "Wh"
-"""Deprecated: please use UnitOfEnergy.WATT_HOUR."""
+"""Deprecated: please use UnitEnergy.WATT_HOUR."""
 
 # Electric_current units
 ELECTRIC_CURRENT_MILLIAMPERE: Final = "mA"

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -42,7 +42,7 @@ from homeassistant.const import (
     VOLUME_GALLONS,
     VOLUME_LITERS,
     VOLUME_MILLILITERS,
-    UnitOfEnergy,
+    UnitEnergy,
     UnitOfVolumetricFlux,
 )
 from homeassistant.exceptions import HomeAssistantError
@@ -148,18 +148,18 @@ class EnergyConverter(BaseUnitConverter):
     """Utility to convert energy values."""
 
     UNIT_CLASS = "energy"
-    NORMALIZED_UNIT = UnitOfEnergy.KILO_WATT_HOUR
+    NORMALIZED_UNIT = UnitEnergy.KILO_WATT_HOUR
     _UNIT_CONVERSION: dict[str, float] = {
-        UnitOfEnergy.WATT_HOUR: 1 * 1000,
-        UnitOfEnergy.KILO_WATT_HOUR: 1,
-        UnitOfEnergy.MEGA_WATT_HOUR: 1 / 1000,
-        UnitOfEnergy.GIGA_JOULE: 3.6 / 1000,
+        UnitEnergy.WATT_HOUR: 1 * 1000,
+        UnitEnergy.KILO_WATT_HOUR: 1,
+        UnitEnergy.MEGA_WATT_HOUR: 1 / 1000,
+        UnitEnergy.GIGA_JOULE: 3.6 / 1000,
     }
     VALID_UNITS = {
-        UnitOfEnergy.WATT_HOUR,
-        UnitOfEnergy.KILO_WATT_HOUR,
-        UnitOfEnergy.MEGA_WATT_HOUR,
-        UnitOfEnergy.GIGA_JOULE,
+        UnitEnergy.WATT_HOUR,
+        UnitEnergy.KILO_WATT_HOUR,
+        UnitEnergy.MEGA_WATT_HOUR,
+        UnitEnergy.GIGA_JOULE,
     }
 
 

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     VOLUME_CUBIC_FEET,
     VOLUME_CUBIC_METERS,
-    UnitOfEnergy,
+    UnitEnergy,
 )
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -140,7 +140,7 @@ async def test_cost_sensor_price_entity_total_increasing(
         return compile_statistics(hass, now, now + timedelta(seconds=1)).platform_stats
 
     energy_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
     }
 
@@ -344,7 +344,7 @@ async def test_cost_sensor_price_entity_total(
         return compile_statistics(hass, now, now + timedelta(seconds=1)).platform_stats
 
     energy_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: energy_state_class,
     }
 
@@ -550,7 +550,7 @@ async def test_cost_sensor_price_entity_total_no_reset(
         return compile_statistics(hass, now, now + timedelta(seconds=1)).platform_stats
 
     energy_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: energy_state_class,
     }
 
@@ -698,10 +698,10 @@ async def test_cost_sensor_price_entity_total_no_reset(
 @pytest.mark.parametrize(
     "energy_unit,factor",
     [
-        (UnitOfEnergy.WATT_HOUR, 1000),
-        (UnitOfEnergy.KILO_WATT_HOUR, 1),
-        (UnitOfEnergy.MEGA_WATT_HOUR, 0.001),
-        (UnitOfEnergy.GIGA_JOULE, 0.001 * 3.6),
+        (UnitEnergy.WATT_HOUR, 1000),
+        (UnitEnergy.KILO_WATT_HOUR, 1),
+        (UnitEnergy.MEGA_WATT_HOUR, 0.001),
+        (UnitEnergy.GIGA_JOULE, 0.001 * 3.6),
     ],
 )
 async def test_cost_sensor_handle_energy_units(
@@ -764,10 +764,10 @@ async def test_cost_sensor_handle_energy_units(
 @pytest.mark.parametrize(
     "price_unit,factor",
     [
-        (f"EUR/{UnitOfEnergy.WATT_HOUR}", 0.001),
-        (f"EUR/{UnitOfEnergy.KILO_WATT_HOUR}", 1),
-        (f"EUR/{UnitOfEnergy.MEGA_WATT_HOUR}", 1000),
-        (f"EUR/{UnitOfEnergy.GIGA_JOULE}", 1000 / 3.6),
+        (f"EUR/{UnitEnergy.WATT_HOUR}", 0.001),
+        (f"EUR/{UnitEnergy.KILO_WATT_HOUR}", 1),
+        (f"EUR/{UnitEnergy.MEGA_WATT_HOUR}", 1000),
+        (f"EUR/{UnitEnergy.GIGA_JOULE}", 1000 / 3.6),
     ],
 )
 async def test_cost_sensor_handle_price_units(
@@ -775,7 +775,7 @@ async def test_cost_sensor_handle_price_units(
 ) -> None:
     """Test energy cost price from sensor entity."""
     energy_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
     }
     price_attributes = {
@@ -888,7 +888,7 @@ async def test_cost_sensor_handle_gas_kwh(
 ) -> None:
     """Test gas cost price from sensor entity."""
     energy_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
     }
     energy_data = data.EnergyManager.default_preferences()
@@ -939,7 +939,7 @@ async def test_cost_sensor_wrong_state_class(
 ) -> None:
     """Test energy sensor rejects sensor with wrong state_class."""
     energy_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: state_class,
     }
     energy_data = data.EnergyManager.default_preferences()
@@ -1000,7 +1000,7 @@ async def test_cost_sensor_state_class_measurement_no_reset(
 ) -> None:
     """Test energy sensor rejects state_class measurement with no last_reset."""
     energy_attributes = {
-        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: UnitEnergy.KILO_WATT_HOUR,
         ATTR_STATE_CLASS: state_class,
     }
     energy_data = data.EnergyManager.default_preferences()

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.energy import async_get_manager, validate
-from homeassistant.const import UnitOfEnergy
+from homeassistant.const import UnitEnergy
 from homeassistant.helpers.json import JSON_DUMP
 from homeassistant.setup import async_setup_component
 
@@ -63,13 +63,13 @@ async def test_validation_empty_config(hass):
 @pytest.mark.parametrize(
     "state_class, energy_unit, extra",
     [
-        ("total_increasing", UnitOfEnergy.KILO_WATT_HOUR, {}),
-        ("total_increasing", UnitOfEnergy.MEGA_WATT_HOUR, {}),
-        ("total_increasing", UnitOfEnergy.WATT_HOUR, {}),
-        ("total", UnitOfEnergy.KILO_WATT_HOUR, {}),
-        ("total", UnitOfEnergy.KILO_WATT_HOUR, {"last_reset": "abc"}),
-        ("measurement", UnitOfEnergy.KILO_WATT_HOUR, {"last_reset": "abc"}),
-        ("total_increasing", UnitOfEnergy.GIGA_JOULE, {}),
+        ("total_increasing", UnitEnergy.KILO_WATT_HOUR, {}),
+        ("total_increasing", UnitEnergy.MEGA_WATT_HOUR, {}),
+        ("total_increasing", UnitEnergy.WATT_HOUR, {}),
+        ("total", UnitEnergy.KILO_WATT_HOUR, {}),
+        ("total", UnitEnergy.KILO_WATT_HOUR, {"last_reset": "abc"}),
+        ("measurement", UnitEnergy.KILO_WATT_HOUR, {"last_reset": "abc"}),
+        ("total_increasing", UnitEnergy.GIGA_JOULE, {}),
     ],
 )
 async def test_validation(

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -40,7 +40,7 @@ from homeassistant.const import (
     VOLUME_GALLONS,
     VOLUME_LITERS,
     VOLUME_MILLILITERS,
-    UnitOfEnergy,
+    UnitEnergy,
     UnitOfVolumetricFlux,
 )
 from homeassistant.exceptions import HomeAssistantError
@@ -70,10 +70,10 @@ INVALID_SYMBOL = "bob"
         (DistanceConverter, LENGTH_YARD),
         (DistanceConverter, LENGTH_FEET),
         (DistanceConverter, LENGTH_INCHES),
-        (EnergyConverter, UnitOfEnergy.WATT_HOUR),
-        (EnergyConverter, UnitOfEnergy.KILO_WATT_HOUR),
-        (EnergyConverter, UnitOfEnergy.MEGA_WATT_HOUR),
-        (EnergyConverter, UnitOfEnergy.GIGA_JOULE),
+        (EnergyConverter, UnitEnergy.WATT_HOUR),
+        (EnergyConverter, UnitEnergy.KILO_WATT_HOUR),
+        (EnergyConverter, UnitEnergy.MEGA_WATT_HOUR),
+        (EnergyConverter, UnitEnergy.GIGA_JOULE),
         (MassConverter, MASS_GRAMS),
         (MassConverter, MASS_KILOGRAMS),
         (MassConverter, MASS_MICROGRAMS),
@@ -117,7 +117,7 @@ def test_convert_same_unit(converter: type[BaseUnitConverter], valid_unit: str) 
     "converter,valid_unit",
     [
         (DistanceConverter, LENGTH_KILOMETERS),
-        (EnergyConverter, UnitOfEnergy.KILO_WATT_HOUR),
+        (EnergyConverter, UnitEnergy.KILO_WATT_HOUR),
         (MassConverter, MASS_GRAMS),
         (PowerConverter, POWER_WATT),
         (PressureConverter, PRESSURE_PA),
@@ -143,7 +143,7 @@ def test_convert_invalid_unit(
     "converter,from_unit,to_unit",
     [
         (DistanceConverter, LENGTH_KILOMETERS, LENGTH_METERS),
-        (EnergyConverter, UnitOfEnergy.WATT_HOUR, UnitOfEnergy.KILO_WATT_HOUR),
+        (EnergyConverter, UnitEnergy.WATT_HOUR, UnitEnergy.KILO_WATT_HOUR),
         (MassConverter, MASS_GRAMS, MASS_KILOGRAMS),
         (PowerConverter, POWER_WATT, POWER_KILO_WATT),
         (PressureConverter, PRESSURE_HPA, PRESSURE_INHG),
@@ -164,7 +164,7 @@ def test_convert_nonnumeric_value(
     "converter,from_unit,to_unit,expected",
     [
         (DistanceConverter, LENGTH_KILOMETERS, LENGTH_METERS, 1 / 1000),
-        (EnergyConverter, UnitOfEnergy.WATT_HOUR, UnitOfEnergy.KILO_WATT_HOUR, 1000),
+        (EnergyConverter, UnitEnergy.WATT_HOUR, UnitEnergy.KILO_WATT_HOUR, 1000),
         (PowerConverter, POWER_WATT, POWER_KILO_WATT, 1000),
         (PressureConverter, PRESSURE_HPA, PRESSURE_INHG, pytest.approx(33.86389)),
         (
@@ -258,14 +258,14 @@ def test_distance_convert(
 @pytest.mark.parametrize(
     "value,from_unit,expected,to_unit",
     [
-        (10, UnitOfEnergy.WATT_HOUR, 0.01, UnitOfEnergy.KILO_WATT_HOUR),
-        (10, UnitOfEnergy.WATT_HOUR, 0.00001, UnitOfEnergy.MEGA_WATT_HOUR),
-        (10, UnitOfEnergy.KILO_WATT_HOUR, 10000, UnitOfEnergy.WATT_HOUR),
-        (10, UnitOfEnergy.KILO_WATT_HOUR, 0.01, UnitOfEnergy.MEGA_WATT_HOUR),
-        (10, UnitOfEnergy.MEGA_WATT_HOUR, 10000000, UnitOfEnergy.WATT_HOUR),
-        (10, UnitOfEnergy.MEGA_WATT_HOUR, 10000, UnitOfEnergy.KILO_WATT_HOUR),
-        (10, UnitOfEnergy.GIGA_JOULE, 10000 / 3.6, UnitOfEnergy.KILO_WATT_HOUR),
-        (10, UnitOfEnergy.GIGA_JOULE, 10 / 3.6, UnitOfEnergy.MEGA_WATT_HOUR),
+        (10, UnitEnergy.WATT_HOUR, 0.01, UnitEnergy.KILO_WATT_HOUR),
+        (10, UnitEnergy.WATT_HOUR, 0.00001, UnitEnergy.MEGA_WATT_HOUR),
+        (10, UnitEnergy.KILO_WATT_HOUR, 10000, UnitEnergy.WATT_HOUR),
+        (10, UnitEnergy.KILO_WATT_HOUR, 0.01, UnitEnergy.MEGA_WATT_HOUR),
+        (10, UnitEnergy.MEGA_WATT_HOUR, 10000000, UnitEnergy.WATT_HOUR),
+        (10, UnitEnergy.MEGA_WATT_HOUR, 10000, UnitEnergy.KILO_WATT_HOUR),
+        (10, UnitEnergy.GIGA_JOULE, 10000 / 3.6, UnitEnergy.KILO_WATT_HOUR),
+        (10, UnitEnergy.GIGA_JOULE, 10 / 3.6, UnitEnergy.MEGA_WATT_HOUR),
     ],
 )
 def test_energy_convert(


### PR DESCRIPTION
## Proposed change
Following the discussion in https://github.com/home-assistant/core/pull/81011#pullrequestreview-1156386742 and on discord.

I think it could make sense to remove the `Of` from the Unit enum names. It's two fewer characters to type each time and it will still be obvious what the name is referring to.

This PR is only for `UnitEnergy` to show the difference and help us decide what do choose. If accepted, the other once will be updated, too.

/CC @epenet

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
