### PR TITLE
Migrate volume units to an enum

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -635,9 +635,13 @@ class UnitOfVolume(StrEnum):
     LITERS = "L"
     MILLILITERS = "mL"
     GALLONS = "gal"
-    """US gallon (British/Imperial gallon is not yet supported)"""
+    """Assumed to be US gallon in conversion utilities.
+
+    British/Imperial gallon is not yet supported"""
     FLUID_OUNCES = "fl. oz."
-    """US fluid ounce (British/Imperial fluid ounce is not yet supported)"""
+    """Assumed to be US fluid ounce in conversion utilities.
+
+    British/Imperial fluid ounce is not yet supported"""
 
 
 VOLUME_LITERS: Final = "L"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -645,18 +645,18 @@ class UnitOfVolume(StrEnum):
 
 
 VOLUME_LITERS: Final = "L"
-"""Deprecate: please use UnitOfVolume.LITERS"""
+"""Deprecated: please use UnitOfVolume.LITERS"""
 VOLUME_MILLILITERS: Final = "mL"
-"""Deprecate: please use UnitOfVolume.MILLILITERS"""
+"""Deprecated: please use UnitOfVolume.MILLILITERS"""
 VOLUME_CUBIC_METERS: Final = "m³"
-"""Deprecate: please use UnitOfVolume.CUBIC_METERS"""
+"""Deprecated: please use UnitOfVolume.CUBIC_METERS"""
 VOLUME_CUBIC_FEET: Final = "ft³"
-"""Deprecate: please use UnitOfVolume.CUBIC_FEET"""
+"""Deprecated: please use UnitOfVolume.CUBIC_FEET"""
 
 VOLUME_GALLONS: Final = "gal"
-"""Deprecate: please use UnitOfVolume.GALLONS"""
+"""Deprecated: please use UnitOfVolume.GALLONS"""
 VOLUME_FLUID_OUNCE: Final = "fl. oz."
-"""Deprecate: please use UnitOfVolume.FLUID_OUNCES"""
+"""Deprecated: please use UnitOfVolume.FLUID_OUNCES"""
 
 # Volume Flow Rate units
 VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR: Final = "m³/h"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -625,17 +625,34 @@ PRESSURE_PSI: Final = "psi"
 SOUND_PRESSURE_DB: Final = "dB"
 SOUND_PRESSURE_WEIGHTED_DBA: Final = "dBa"
 
+
 # Volume units
+class UnitOfVolume(StrEnum):
+    """Volume units."""
+
+    CUBIC_FEET = "ft³"
+    CUBIC_METERS = "m³"
+    LITERS = "L"
+    MILLILITERS = "mL"
+    GALLONS = "gal"
+    """US gallon (British/Imperial gallon is not yet supported)"""
+    FLUID_OUNCES = "fl. oz."
+    """US fluid ounce (British/Imperial fluid ounce is not yet supported)"""
+
+
 VOLUME_LITERS: Final = "L"
+"""Deprecate: please use UnitOfVolume.LITERS"""
 VOLUME_MILLILITERS: Final = "mL"
+"""Deprecate: please use UnitOfVolume.MILLILITERS"""
 VOLUME_CUBIC_METERS: Final = "m³"
+"""Deprecate: please use UnitOfVolume.CUBIC_METERS"""
 VOLUME_CUBIC_FEET: Final = "ft³"
+"""Deprecate: please use UnitOfVolume.CUBIC_FEET"""
 
 VOLUME_GALLONS: Final = "gal"
-"""US gallon (British gallon is not yet supported)"""
-
+"""Deprecate: please use UnitOfVolume.GALLONS"""
 VOLUME_FLUID_OUNCE: Final = "fl. oz."
-"""US fluid ounce (British fluid ounce is not yet supported)"""
+"""Deprecate: please use UnitOfVolume.FLUID_OUNCES"""
 
 # Volume Flow Rate units
 VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR: Final = "m³/h"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -635,13 +635,13 @@ class UnitOfVolume(StrEnum):
     LITERS = "L"
     MILLILITERS = "mL"
     GALLONS = "gal"
-    """Assumed to be US gallon in conversion utilities.
+    """Assumed to be US gallons in conversion utilities.
 
-    British/Imperial gallon is not yet supported"""
+    British/Imperial gallons are not yet supported"""
     FLUID_OUNCES = "fl. oz."
-    """Assumed to be US fluid ounce in conversion utilities.
+    """Assumed to be US fluid ounces in conversion utilities.
 
-    British/Imperial fluid ounce is not yet supported"""
+    British/Imperial fluid ounces are not yet supported"""
 
 
 VOLUME_LITERS: Final = "L"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: VOLUME_*** units are now deprecated. Please use UnitOfVolume enum instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add UnitOfVolume enum, to replace VOLUME_*** units

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1511

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
