### PR TITLE
Add attachments to simplepush

### DIFF
--- a/homeassistant/components/simplepush/const.py
+++ b/homeassistant/components/simplepush/const.py
@@ -6,6 +6,7 @@ DOMAIN: Final = "simplepush"
 DEFAULT_NAME: Final = "simplepush"
 DATA_HASS_CONFIG: Final = "simplepush_hass_config"
 
+ATTR_ATTACHMENTS: Final = "attachments"
 ATTR_ENCRYPTED: Final = "encrypted"
 ATTR_EVENT: Final = "event"
 

--- a/homeassistant/components/simplepush/notify.py
+++ b/homeassistant/components/simplepush/notify.py
@@ -68,24 +68,17 @@ class SimplePushNotificationService(BaseNotificationService):
             event = data.get(ATTR_EVENT)
 
             attachments_data = data.get(ATTR_ATTACHMENTS)
-            if isinstance(attachments_data, list) and attachments_data:
-                attachments = []
+            if isinstance(attachments_data, list):
                 for attachment in attachments_data:
-                    if (
+                    if not (
                         isinstance(attachment, dict)
                         and "video" in attachment.keys()
                         and "thumbnail" in attachment.keys()
-                    ):
-                        attachments.append(
-                            {
-                                "video": attachment["video"],
-                                "thumbnail": attachment["thumbnail"],
-                            }
-                        )
-                    elif isinstance(attachment, dict) and "video" in attachment.keys():
-                        attachments.append(attachment["video"])
-                    else:
-                        attachments.append(attachment)
+                    ) and not isinstance(attachment, str):
+                        _LOGGER.error("Attachment format is incorrect")
+                        return
+
+                attachments = attachments_data
 
         # use event from config until YAML config is removed
         event = event or self._event

--- a/homeassistant/components/simplepush/notify.py
+++ b/homeassistant/components/simplepush/notify.py
@@ -72,17 +72,20 @@ class SimplePushNotificationService(BaseNotificationService):
                 attachments = []
                 for attachment in attachments_data:
                     if (
-                        "attachment" in attachment.keys()
+                        isinstance(attachment, dict)
+                        and "video" in attachment.keys()
                         and "thumbnail" in attachment.keys()
                     ):
                         attachments.append(
                             {
-                                "video": attachment["attachment"],
+                                "video": attachment["video"],
                                 "thumbnail": attachment["thumbnail"],
                             }
                         )
-                    elif "attachment" in attachment.keys():
-                        attachments.append(attachment["attachment"])
+                    elif isinstance(attachment, dict) and "video" in attachment.keys():
+                        attachments.append(attachment["video"])
+                    else:
+                        attachments.append(attachment)
 
         # use event from config until YAML config is removed
         event = event or self._event

--- a/homeassistant/components/simplepush/notify.py
+++ b/homeassistant/components/simplepush/notify.py
@@ -71,14 +71,17 @@ class SimplePushNotificationService(BaseNotificationService):
             if isinstance(attachments_data, list) and attachments_data:
                 attachments = []
                 for attachment in attachments_data:
-                    if "attachment" in attachment and "thumbnail" in attachment:
+                    if (
+                        "attachment" in attachment.keys()
+                        and "thumbnail" in attachment.keys()
+                    ):
                         attachments.append(
                             {
                                 "video": attachment["attachment"],
                                 "thumbnail": attachment["thumbnail"],
                             }
                         )
-                    elif "attachment" in attachment:
+                    elif "attachment" in attachment.keys():
                         attachments.append(attachment["attachment"])
 
         # use event from config until YAML config is removed

--- a/homeassistant/components/simplepush/notify.py
+++ b/homeassistant/components/simplepush/notify.py
@@ -69,16 +69,25 @@ class SimplePushNotificationService(BaseNotificationService):
 
             attachments_data = data.get(ATTR_ATTACHMENTS)
             if isinstance(attachments_data, list):
+                attachments = []
                 for attachment in attachments_data:
                     if not (
                         isinstance(attachment, dict)
-                        and "video" in attachment
-                        and "thumbnail" in attachment
-                    ) and not isinstance(attachment, str):
+                        and (
+                            "image" in attachment
+                            or "video" in attachment
+                            or ("video" in attachment and "thumbnail" in attachment)
+                        )
+                    ):
                         _LOGGER.error("Attachment format is incorrect")
                         return
 
-                attachments = attachments_data
+                    if "video" in attachment and "thumbnail" in attachment:
+                        attachments.append(attachment)
+                    elif "video" in attachment:
+                        attachments.append(attachment["video"])
+                    elif "image" in attachment:
+                        attachments.append(attachment["image"])
 
         # use event from config until YAML config is removed
         event = event or self._event

--- a/homeassistant/components/simplepush/notify.py
+++ b/homeassistant/components/simplepush/notify.py
@@ -72,8 +72,8 @@ class SimplePushNotificationService(BaseNotificationService):
                 for attachment in attachments_data:
                     if not (
                         isinstance(attachment, dict)
-                        and "video" in attachment.keys()
-                        and "thumbnail" in attachment.keys()
+                        and "video" in attachment
+                        and "thumbnail" in attachment
                     ) and not isinstance(attachment, str):
                         _LOGGER.error("Attachment format is incorrect")
                         return


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds attachments for the Simplepush component.
Attachments can be pictures, GIFs or video files defined by an URL.

I will update the documentation (https://www.home-assistant.io/integrations/simplepush/), after this PR gets merged. If preferred I can also do it beforehand.

The new functionality can be tested with the following automation:
```
alias: Test
description: >-
  Send a notification with two attachments
trigger: []
condition: []
action:
  - service: notify.simplepush
    data:
      message: test
      data:
        attachments:
          - image: https://upload.wikimedia.org/wikipedia/commons/e/ee/Sample_abc.jpg
          - video: http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4
            thumbnail: http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerEscapes.jpg
mode: restart
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #80744
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
