### PR TITLE
Handle sending ZCL commands with empty bitmap options

### DIFF
--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -14,7 +14,6 @@ import enum
 import functools
 import itertools
 import logging
-import operator
 from random import uniform
 import re
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -163,25 +162,16 @@ def convert_to_zcl_values(
         if field.name not in fields:
             continue
         value = fields[field.name]
-        if issubclass(field.type, enum.Flag):
-            if isinstance(value, list):
-                value = field.type(
-                    functools.reduce(
-                        operator.ior,
-                        [
-                            field.type[flag.replace(" ", "_")]
-                            if isinstance(flag, str)
-                            else field.type(flag)
-                            for flag in value
-                        ],
-                    )
-                )
-            else:
-                value = (
-                    field.type[value.replace(" ", "_")]
-                    if isinstance(value, str)
-                    else field.type(value)
-                )
+        if issubclass(field.type, enum.Flag) and isinstance(value, list):
+            new_value = 0
+
+            for flag in value:
+                if isinstance(flag, str):
+                    new_value |= field.type[flag.replace(" ", "_")]
+                else:
+                    new_value |= flag
+
+            value = field.type(new_value)
         elif issubclass(field.type, enum.Enum):
             value = (
                 field.type[value.replace(" ", "_")]

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -195,3 +195,17 @@ async def test_zcl_schema_conversions(hass, device_light):
 
     assert isinstance(converted_data["start_hue"], uint16_t)
     assert converted_data["start_hue"] == 196
+
+    # This time, the update flags bitmap is empty
+    raw_data = {
+        "update_flags": [],
+        "action": 0x02,
+        "direction": 0x01,
+        "time": 20,
+        "start_hue": 196,
+    }
+
+    converted_data = convert_to_zcl_values(raw_data, command_schema)
+
+    # No flags are passed through
+    assert converted_data["update_flags"] == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
ZHA fails to send commands that include empty bitfields:

```Python
2022-10-26 20:32:37.243 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140024940356912] reduce() of empty iterable with no initial value
Traceback (most recent call last):
  File "/opt/homeassistant/homeassistant/components/websocket_api/commands.py", line 200, in handle_call_service
    await hass.services.async_call(
  File "/opt/homeassistant/homeassistant/core.py", line 1744, in async_call
    task.result()
  File "/opt/homeassistant/homeassistant/core.py", line 1781, in _execute_service
    await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
  File "/opt/homeassistant/homeassistant/helpers/service.py", line 748, in admin_handler
    await result
  File "/opt/homeassistant/homeassistant/components/zha/api.py", line 1324, in issue_zigbee_cluster_command
    await zha_device.issue_cluster_command(
  File "/opt/homeassistant/homeassistant/components/zha/core/device.py", line 704, in issue_cluster_command
    **convert_to_zcl_values(params, commands[command].schema)
  File "/opt/homeassistant/homeassistant/components/zha/core/helpers.py", line 169, in convert_to_zcl_values
    functools.reduce(
TypeError: reduce() of empty iterable with no initial value
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
