### PR TITLE
Remove previously-deprecated RainMachine sensors

### DIFF
--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -14,20 +14,14 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS, VOLUME_CUBIC_METERS, VOLUME_LITERS
+from homeassistant.const import VOLUME_CUBIC_METERS, VOLUME_LITERS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utc_from_timestamp, utcnow
 
 from . import RainMachineData, RainMachineEntity
-from .const import (
-    DATA_PROGRAMS,
-    DATA_PROVISION_SETTINGS,
-    DATA_RESTRICTIONS_UNIVERSAL,
-    DATA_ZONES,
-    DOMAIN,
-)
+from .const import DATA_PROGRAMS, DATA_PROVISION_SETTINGS, DATA_ZONES, DOMAIN
 from .model import (
     RainMachineEntityDescription,
     RainMachineEntityDescriptionMixinDataKey,
@@ -49,7 +43,6 @@ TYPE_FLOW_SENSOR_LEAK_CLICKS = "flow_sensor_leak_clicks"
 TYPE_FLOW_SENSOR_LEAK_VOLUME = "flow_sensor_leak_volume"
 TYPE_FLOW_SENSOR_START_INDEX = "flow_sensor_start_index"
 TYPE_FLOW_SENSOR_WATERING_CLICKS = "flow_sensor_watering_clicks"
-TYPE_FREEZE_TEMP = "freeze_protect_temp"
 TYPE_LAST_LEAK_DETECTED = "last_leak_detected"
 TYPE_PROGRAM_RUN_COMPLETION_TIME = "program_run_completion_time"
 TYPE_RAIN_SENSOR_RAIN_START = "rain_sensor_rain_start"
@@ -141,17 +134,6 @@ SENSOR_DESCRIPTIONS = (
         data_key="flowSensorWateringClicks",
     ),
     RainMachineSensorDataDescription(
-        key=TYPE_FREEZE_TEMP,
-        name="Freeze protect temperature",
-        icon="mdi:thermometer",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement=TEMP_CELSIUS,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        api_category=DATA_RESTRICTIONS_UNIVERSAL,
-        data_key="freezeProtectTemp",
-    ),
-    RainMachineSensorDataDescription(
         key=TYPE_LAST_LEAK_DETECTED,
         name="Last leak detected",
         icon="mdi:pipe-leak",
@@ -191,17 +173,16 @@ async def async_setup_entry(
                 f"{data.controller.mac}_freeze_protect_temp",
                 f"select.{data.controller.name.lower()}_freeze_protect_temperature",
                 breaks_in_ha_version="2022.12.0",
-                remove_old_entity=False,
+                remove_old_entity=True,
             ),
         ),
     )
 
     api_category_sensor_map = {
         DATA_PROVISION_SETTINGS: ProvisionSettingsSensor,
-        DATA_RESTRICTIONS_UNIVERSAL: UniversalRestrictionsSensor,
     }
 
-    sensors = [
+    sensors: list[ProvisionSettingsSensor | TimeRemainingSensor] = [
         api_category_sensor_map[description.api_category](entry, data, description)
         for description in SENSOR_DESCRIPTIONS
         if (
@@ -371,18 +352,6 @@ class ProvisionSettingsSensor(RainMachineEntity, SensorEntity):
 
         # Return all other sensor values or None
         self._attr_native_value = new_value
-
-
-class UniversalRestrictionsSensor(RainMachineEntity, SensorEntity):
-    """Define a sensor that handles universal restrictions data."""
-
-    entity_description: RainMachineSensorDataDescription
-
-    @callback
-    def update_from_latest_data(self) -> None:
-        """Update the state."""
-        if self.entity_description.key == TYPE_FREEZE_TEMP:
-            self._attr_native_value = self.coordinator.data.get("freezeProtectTemp")
 
 
 class ZoneTimeRemainingSensor(TimeRemainingSensor):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `extra_water_on_hot_days` binary sensor, `freeze_protection` binary sensor, and `freeze_protection_temperature` sensor (all deprecated in 2022.10.0) have now been fully removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In https://github.com/home-assistant/core/pull/76478 and https://github.com/home-assistant/core/pull/76484, we deprecated two RainMachine binary sensors and one sensor. Now that two versions have passed, it's time to remove them fully.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/pull/76478, https://github.com/home-assistant/core/pull/76484
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
