### PR TITLE
Remove previously-deprecated Guardian services and binary sensor

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -44,15 +44,11 @@ from .util import GuardianDataUpdateCoordinator
 
 DATA_PAIRED_SENSOR_MANAGER = "paired_sensor_manager"
 
-SERVICE_NAME_DISABLE_AP = "disable_ap"
-SERVICE_NAME_ENABLE_AP = "enable_ap"
 SERVICE_NAME_PAIR_SENSOR = "pair_sensor"
 SERVICE_NAME_UNPAIR_SENSOR = "unpair_sensor"
 SERVICE_NAME_UPGRADE_FIRMWARE = "upgrade_firmware"
 
 SERVICES = (
-    SERVICE_NAME_DISABLE_AP,
-    SERVICE_NAME_ENABLE_AP,
     SERVICE_NAME_PAIR_SENSOR,
     SERVICE_NAME_UNPAIR_SENSOR,
     SERVICE_NAME_UPGRADE_FIRMWARE,
@@ -232,30 +228,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return wrapper
 
     @call_with_data
-    async def async_disable_ap(call: ServiceCall, data: GuardianData) -> None:
-        """Disable the onboard AP."""
-        async_log_deprecated_service_call(
-            hass,
-            call,
-            "switch.turn_off",
-            f"switch.guardian_valve_controller_{entry.data[CONF_UID]}_onboard_ap",
-            "2022.12.0",
-        )
-        await data.client.wifi.disable_ap()
-
-    @call_with_data
-    async def async_enable_ap(call: ServiceCall, data: GuardianData) -> None:
-        """Enable the onboard AP."""
-        async_log_deprecated_service_call(
-            hass,
-            call,
-            "switch.turn_on",
-            f"switch.guardian_valve_controller_{entry.data[CONF_UID]}_onboard_ap",
-            "2022.12.0",
-        )
-        await data.client.wifi.enable_ap()
-
-    @call_with_data
     async def async_pair_sensor(call: ServiceCall, data: GuardianData) -> None:
         """Add a new paired sensor."""
         uid = call.data[CONF_UID]
@@ -279,8 +251,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     for service_name, schema, method in (
-        (SERVICE_NAME_DISABLE_AP, SERVICE_BASE_SCHEMA, async_disable_ap),
-        (SERVICE_NAME_ENABLE_AP, SERVICE_BASE_SCHEMA, async_enable_ap),
         (
             SERVICE_NAME_PAIR_SENSOR,
             SERVICE_PAIR_UNPAIR_SENSOR_SCHEMA,

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -23,7 +23,6 @@ from . import (
 )
 from .const import (
     API_SYSTEM_ONBOARD_SENSOR_STATUS,
-    API_WIFI_STATUS,
     CONF_UID,
     DOMAIN,
     SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED,
@@ -36,7 +35,6 @@ from .util import (
 
 ATTR_CONNECTED_CLIENTS = "connected_clients"
 
-SENSOR_KIND_AP_INFO = "ap_enabled"
 SENSOR_KIND_LEAK_DETECTED = "leak_detected"
 SENSOR_KIND_MOVED = "moved"
 
@@ -69,13 +67,6 @@ VALVE_CONTROLLER_DESCRIPTIONS = (
         device_class=BinarySensorDeviceClass.MOISTURE,
         api_category=API_SYSTEM_ONBOARD_SENSOR_STATUS,
     ),
-    ValveControllerBinarySensorDescription(
-        key=SENSOR_KIND_AP_INFO,
-        name="Onboard AP enabled",
-        device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        api_category=API_WIFI_STATUS,
-    ),
 )
 
 
@@ -95,7 +86,7 @@ async def async_setup_entry(
                 f"{uid}_ap_enabled",
                 f"switch.guardian_valve_controller_{uid}_onboard_ap",
                 "2022.12.0",
-                remove_old_entity=False,
+                remove_old_entity=True,
             ),
         ),
     )
@@ -183,10 +174,5 @@ class ValveControllerBinarySensor(ValveControllerEntity, BinarySensorEntity):
     @callback
     def _async_update_from_latest_data(self) -> None:
         """Update the entity."""
-        if self.entity_description.key == SENSOR_KIND_AP_INFO:
-            self._attr_is_on = self.coordinator.data["station_connected"]
-            self._attr_extra_state_attributes[
-                ATTR_CONNECTED_CLIENTS
-            ] = self.coordinator.data.get("ap_clients")
-        elif self.entity_description.key == SENSOR_KIND_LEAK_DETECTED:
+        if self.entity_description.key == SENSOR_KIND_LEAK_DETECTED:
             self._attr_is_on = self.coordinator.data["wet"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `guardian.disable_ap` service, `guardian.enable_ap` service, and corresponding binary sensor (all deprecated in 2022.10.0) have now been fully removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In https://github.com/home-assistant/core/pull/75034, we deprecated the `guardian.disable_ap` service, the `guardian.enable_ap` service, and the corresponding binary sensor. Now that two versions have passed, it's time to remove it fully.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/pull/75283
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
