### PR TITLE
Update pymonoprice version to 0.4.0

### DIFF
--- a/homeassistant/components/monoprice/manifest.json
+++ b/homeassistant/components/monoprice/manifest.json
@@ -2,7 +2,7 @@
   "domain": "monoprice",
   "name": "Monoprice 6-Zone Amplifier",
   "documentation": "https://www.home-assistant.io/integrations/monoprice",
-  "requirements": ["pymonoprice==0.3"],
+  "requirements": ["pymonoprice==0.4"],
   "codeowners": ["@etsinko", "@OnFreund"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1724,7 +1724,7 @@ pymochad==0.2.0
 pymodbus==2.5.3
 
 # homeassistant.components.monoprice
-pymonoprice==0.3
+pymonoprice==0.4
 
 # homeassistant.components.msteams
 pymsteams==0.1.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1216,7 +1216,7 @@ pymochad==0.2.0
 pymodbus==2.5.3
 
 # homeassistant.components.monoprice
-pymonoprice==0.3
+pymonoprice==0.4
 
 # homeassistant.components.myq
 pymyq==3.1.4


### PR DESCRIPTION
## Proposed change

Bump the pymonoprice version to 0.4.0. In addition to updating the use of async to the latest syntax, this new release includes new APIs that can be used to query all of the zones on a given controller unit, and has greatly improved mypy typing.

https://github.com/etsinko/pymonoprice/releases/tag/0.4

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
