### PR TITLE
Add support for oralb IO Series 4

### DIFF
--- a/homeassistant/components/oralb/manifest.json
+++ b/homeassistant/components/oralb/manifest.json
@@ -8,7 +8,7 @@
       "manufacturer_id": 220
     }
   ],
-  "requirements": ["oralb-ble==0.5.0"],
+  "requirements": ["oralb-ble==0.6.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@bdraco"],
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1238,7 +1238,7 @@ openwrt-luci-rpc==1.1.11
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.oralb
-oralb-ble==0.5.0
+oralb-ble==0.6.0
 
 # homeassistant.components.oru
 oru==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -883,7 +883,7 @@ open-meteo==0.2.1
 openerz-api==0.1.0
 
 # homeassistant.components.oralb
-oralb-ble==0.5.0
+oralb-ble==0.6.0
 
 # homeassistant.components.ovo_energy
 ovoenergy==1.2.0

--- a/tests/components/oralb/__init__.py
+++ b/tests/components/oralb/__init__.py
@@ -22,3 +22,14 @@ ORALB_SERVICE_INFO = BluetoothServiceInfo(
     service_data={},
     source="local",
 )
+
+
+ORALB_IO_SERIES_4_SERVICE_INFO = BluetoothServiceInfo(
+    name="GXB772CD\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x074\x0c\x038\x00\x00\x02\x01\x00\x04"},
+    service_uuids=[],
+    service_data={},
+    source="local",
+)

--- a/tests/components/oralb/test_config_flow.py
+++ b/tests/components/oralb/test_config_flow.py
@@ -6,7 +6,7 @@ from homeassistant import config_entries
 from homeassistant.components.oralb.const import DOMAIN
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import NOT_ORALB_SERVICE_INFO, ORALB_SERVICE_INFO
+from . import NOT_ORALB_SERVICE_INFO, ORALB_IO_SERIES_4_SERVICE_INFO, ORALB_SERVICE_INFO
 
 from tests.common import MockConfigEntry
 
@@ -26,6 +26,25 @@ async def test_async_step_bluetooth_valid_device(hass):
         )
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Smart Series 7000 48BE"
+    assert result2["data"] == {}
+    assert result2["result"].unique_id == "78:DB:2F:C2:48:BE"
+
+
+async def test_async_step_bluetooth_valid_io_series4_device(hass):
+    """Test discovery via bluetooth with a valid device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=ORALB_IO_SERIES_4_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+    with patch("homeassistant.components.oralb.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "IO Series 4 48BE"
     assert result2["data"] == {}
     assert result2["result"].unique_id == "78:DB:2F:C2:48:BE"
 

--- a/tests/components/oralb/test_sensor.py
+++ b/tests/components/oralb/test_sensor.py
@@ -4,7 +4,7 @@
 from homeassistant.components.oralb.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
 
-from . import ORALB_SERVICE_INFO
+from . import ORALB_IO_SERIES_4_SERVICE_INFO, ORALB_SERVICE_INFO
 
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
@@ -35,6 +35,31 @@ async def test_sensors(hass, entity_registry_enabled_by_default):
         toothbrush_sensor_attrs[ATTR_FRIENDLY_NAME]
         == "Smart Series 7000 48BE Toothbrush State"
     )
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_sensors_io_series_4(hass, entity_registry_enabled_by_default):
+    """Test setting up creates the sensors with an io series 4."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=ORALB_IO_SERIES_4_SERVICE_INFO.address,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all("sensor")) == 0
+    inject_bluetooth_service_info(hass, ORALB_IO_SERIES_4_SERVICE_INFO)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all("sensor")) == 8
+
+    toothbrush_sensor = hass.states.get("sensor.io_series_4_48be_mode")
+    toothbrush_sensor_attrs = toothbrush_sensor.attributes
+    assert toothbrush_sensor.state == "gum care"
+    assert toothbrush_sensor_attrs[ATTR_FRIENDLY_NAME] == "IO Series 4 48BE Mode"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for oralb IO Series 4
changelog: https://github.com/Bluetooth-Devices/oralb-ble/compare/v0.5.0...v0.6.0
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
