### PR TITLE
Add diagnostics to webostv

### DIFF
--- a/homeassistant/components/webostv/diagnostics.py
+++ b/homeassistant/components/webostv/diagnostics.py
@@ -1,0 +1,52 @@
+"""Diagnostics support for LG webOS Smart TV."""
+from __future__ import annotations
+
+from typing import Any
+
+from aiowebostv import WebOsClient
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST, CONF_UNIQUE_ID
+from homeassistant.core import HomeAssistant
+
+from .const import DATA_CONFIG_ENTRY, DOMAIN
+
+TO_REDACT = {
+    CONF_CLIENT_SECRET,
+    CONF_UNIQUE_ID,
+    CONF_HOST,
+    "device_id",
+    "deviceUUID",
+    "icon",
+    "largeIcon",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    client: WebOsClient = hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id].client
+
+    client_data = {
+        "is_registered": client.is_registered(),
+        "is_connected": client.is_connected(),
+        "current_app_id": client.current_app_id,
+        "current_channel": client.current_channel,
+        "apps": client.apps,
+        "inputs": client.inputs,
+        "system_info": client.system_info,
+        "software_info": client.software_info,
+        "hello_info": client.hello_info,
+        "sound_output": client.sound_output,
+        "is_on": client.is_on,
+    }
+
+    return async_redact_data(
+        {
+            "entry": entry.as_dict(),
+            "client": client_data,
+        },
+        TO_REDACT,
+    )

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -39,6 +39,8 @@ def client_fixture():
         client.sound_output = "speaker"
         client.muted = False
         client.is_on = True
+        client.is_registered = Mock(return_value=True)
+        client.is_connected = Mock(return_value=True)
 
         async def mock_state_update_callback():
             await client.register_state_update_callback.call_args[0][0](client)

--- a/tests/components/webostv/test_diagnostics.py
+++ b/tests/components/webostv/test_diagnostics.py
@@ -1,0 +1,61 @@
+"""Tests for the diagnostics data provided by LG webOS Smart TV."""
+from aiohttp import ClientSession
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
+
+from . import setup_webostv
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSession, client
+) -> None:
+    """Test diagnostics."""
+    entry = await setup_webostv(hass)
+    assert await get_diagnostics_for_config_entry(hass, hass_client, entry) == {
+        "client": {
+            "is_registered": True,
+            "is_connected": True,
+            "current_app_id": "com.webos.app.livetv",
+            "current_channel": {
+                "channelId": "ch1id",
+                "channelName": "Channel 1",
+                "channelNumber": "1",
+            },
+            "apps": {
+                "com.webos.app.livetv": {
+                    "icon": REDACTED,
+                    "id": "com.webos.app.livetv",
+                    "largeIcon": REDACTED,
+                    "title": "Live TV",
+                }
+            },
+            "inputs": {
+                "in1": {"appId": "app0", "id": "in1", "label": "Input01"},
+                "in2": {"appId": "app1", "id": "in2", "label": "Input02"},
+            },
+            "system_info": {"modelName": "TVFAKE"},
+            "software_info": {"major_ver": "major", "minor_ver": "minor"},
+            "hello_info": {"deviceUUID": "**REDACTED**"},
+            "sound_output": "speaker",
+            "is_on": True,
+        },
+        "entry": {
+            "entry_id": entry.entry_id,
+            "version": 1,
+            "domain": "webostv",
+            "title": "fake_webos",
+            "data": {
+                "client_secret": "**REDACTED**",
+                "host": "**REDACTED**",
+            },
+            "options": {},
+            "pref_disable_new_entities": False,
+            "pref_disable_polling": False,
+            "source": "user",
+            "unique_id": REDACTED,
+            "disabled_by": None,
+        },
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds diagnostics to `webostv`:
```json
{
  "home_assistant": {
    "installation_type": "Unsupported Third Party Container",
    "version": "2022.12.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.9.14",
    "docker": true,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.10.102.1-microsoft-standard-WSL2",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "webostv",
    "name": "LG webOS Smart TV",
    "config_flow": true,
    "documentation": "https://www.home-assistant.io/integrations/webostv",
    "requirements": [
      "aiowebostv==0.2.1"
    ],
    "codeowners": [
      "@bendavid",
      "@thecode"
    ],
    "ssdp": [
      {
        "st": "urn:lge-com:service:webos-second-screen:1"
      }
    ],
    "quality_scale": "platinum",
    "iot_class": "local_push",
    "loggers": [
      "aiowebostv"
    ],
    "is_built_in": true
  },
  "data": {
    "entry": {
      "entry_id": "f1c99abb848b58b11f088a36dade47ea",
      "version": 1,
      "domain": "webostv",
      "title": "LG webOS Smart TV",
      "data": {
        "host": "**REDACTED**",
        "client_secret": "**REDACTED**"
      },
      "options": {
        "sources": [
          "Netflix",
          "YouTube",
          "HDMI 1"
        ]
      },
      "pref_disable_new_entities": false,
      "pref_disable_polling": false,
      "source": "user",
      "unique_id": "**REDACTED**",
      "disabled_by": null
    },
    "client": {
      "is_registered": true,
      "is_connected": true,
      "current_app_id": "com.webos.app.hdmi1",
      "current_channel": null,
      "channels": null,
      "apps": {
        "com.webos.app.livetv": {
          "systemApp": true,
          "removable": false,
          "relaunch": false,
          "largeIcon": "**REDACTED**",
          "bgImages": [],
          "userData": "",
          "id": "com.webos.app.livetv",
          "bgColor": "",
          "title": "\u05e2\u05e8\u05d5\u05e6\u05d9 \u05e2\u05d9\u05d3\u05df +",
          "iconColor": "#a3c125",
          "appDescription": "",
          "lptype": "default",
          "params": {},
          "bgImage": "/usr/palm/applications/com.webos.app.livetv/assets/livetv.png",
          "unmovable": false,
          "miniicon": "assets/icon_antenna.png",
          "icon": "**REDACTED**",
          "launchPointId": "com.webos.app.livetv_default",
          "favicon": "",
          "imageForRecents": "",
          "tileSize": "normal"
        },
        "netflix": {
          "systemApp": false,
          "removable": true,
          "relaunch": false,
          "largeIcon": "**REDACTED**",
          "bgImages": [],
          "userData": "",
          "id": "netflix",
          "bgColor": "",
          "title": "Netflix",
          "iconColor": "#ffffff",
          "appDescription": "",
          "lptype": "default",
          "params": {},
          "bgImage": "/media/cryptofs/apps/usr/palm/applications/netflix/50482506074077809_launcher_background_image.png",
          "unmovable": false,
          "miniicon": "SMALL_APP_ICON.png",
          "icon": "**REDACTED**",
          "launchPointId": "netflix_default",
          "favicon": "",
          "imageForRecents": "/media/cryptofs/apps/usr/palm/applications/netflix/RECENTS.png",
          "tileSize": "normal"
        }
      },
      "inputs": {
        "com.webos.app.externalinput.av1": {
          "id": "AV_1",
          "label": "AV",
          "port": 1,
          "appId": "com.webos.app.externalinput.av1",
          "icon": "**REDACTED**",
          "modified": false,
          "subList": [],
          "subCount": 0,
          "connected": false,
          "favorite": false
        },
        "com.webos.app.hdmi1": {
          "id": "HDMI_1",
          "label": "HDMI 1",
          "port": 1,
          "appId": "com.webos.app.hdmi1",
          "icon": "**REDACTED**",
          "modified": false,
          "lastUniqueId": 255,
          "subList": [],
          "subCount": 0,
          "connected": false,
          "favorite": true
        },
        "com.webos.app.hdmi2": {
          "id": "HDMI_2",
          "label": "HDMI 2",
          "port": 2,
          "appId": "com.webos.app.hdmi2",
          "icon": "**REDACTED**",
          "modified": false,
          "lastUniqueId": 255,
          "subList": [],
          "subCount": 0,
          "connected": false,
          "favorite": true
        }
      },
      "system_info": {
        "returnValue": true,
        "features": {
          "3d": false,
          "dvr": true
        },
        "receiverType": "dvb",
        "modelName": "55SK8500YVA",
        "programMode": "true"
      },
      "software_info": {
        "returnValue": true,
        "product_name": "webOSTV 4.0",
        "model_name": "HE_DTV_W18H_AFADABAA",
        "sw_type": "FIRMWARE",
        "major_ver": "05",
        "minor_ver": "50.10",
        "device_id": "**REDACTED**",
        "auth_flag": "N",
        "ignore_disable": "N",
        "eco_info": "01",
        "config_key": "00",
        "language_code": "he-IL"
      },
      "hello_info": {
        "protocolVersion": 1,
        "deviceType": "tv",
        "deviceOS": "webOS",
        "deviceOSVersion": "4.1.0",
        "deviceOSReleaseVersion": "4.4.2",
        "deviceUUID": "**REDACTED**",
        "pairingTypes": [
          "PIN",
          "PROMPT",
          "COMBINED"
        ]
      },
      "sound_output": "tv_external_speaker",
      "is_on": true
    }
  }
}
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
