### PR TITLE
Add diagnostics to Switcher

### DIFF
--- a/homeassistant/components/switcher_kis/diagnostics.py
+++ b/homeassistant/components/switcher_kis/diagnostics.py
@@ -1,0 +1,28 @@
+"""Diagnostics support for Switcher."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DATA_DEVICE, DOMAIN
+
+TO_REDACT = {"device_id", "ip_address", "mac_address"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    devices = hass.data[DOMAIN][DATA_DEVICE]
+
+    return async_redact_data(
+        {
+            "entry": entry.as_dict(),
+            "devices": [asdict(devices[d].data) for d in devices],
+        },
+        TO_REDACT,
+    )

--- a/tests/components/switcher_kis/test_diagnostics.py
+++ b/tests/components/switcher_kis/test_diagnostics.py
@@ -1,0 +1,59 @@
+"""Tests for the diagnostics data provided by Switcher."""
+from aiohttp import ClientSession
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
+
+from . import init_integration
+from .consts import DUMMY_WATER_HEATER_DEVICE
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSession, mock_bridge, monkeypatch
+) -> None:
+    """Test diagnostics."""
+    entry = await init_integration(hass)
+    device = DUMMY_WATER_HEATER_DEVICE
+    monkeypatch.setattr(device, "last_data_update", "2022-09-28T16:42:12.706017")
+    mock_bridge.mock_callbacks([device])
+    await hass.async_block_till_done()
+
+    assert await get_diagnostics_for_config_entry(hass, hass_client, entry) == {
+        "devices": [
+            {
+                "auto_shutdown": "02:00:00",
+                "device_id": REDACTED,
+                "device_state": {
+                    "__type": "<enum 'DeviceState'>",
+                    "repr": "<DeviceState.ON: ('01', 'on')>",
+                },
+                "device_type": {
+                    "__type": "<enum 'DeviceType'>",
+                    "repr": "<DeviceType.V4: ('Switcher V4', '0317', "
+                    "1, <DeviceCategory.WATER_HEATER: 1>)>",
+                },
+                "electric_current": 12.8,
+                "ip_address": REDACTED,
+                "last_data_update": "2022-09-28T16:42:12.706017",
+                "mac_address": REDACTED,
+                "name": "Heater FE12",
+                "power_consumption": 2780,
+                "remaining_time": "01:29:32",
+            }
+        ],
+        "entry": {
+            "entry_id": entry.entry_id,
+            "version": 1,
+            "domain": "switcher_kis",
+            "title": "Mock Title",
+            "data": {},
+            "options": {},
+            "pref_disable_new_entities": False,
+            "pref_disable_polling": False,
+            "source": "user",
+            "unique_id": "switcher_kis",
+            "disabled_by": None,
+        },
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds diagnostics to `switcher_kis`:
```json
{
  "home_assistant": {
    "installation_type": "Unsupported Third Party Container",
    "version": "2022.12.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.9.14",
    "docker": true,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.10.102.1-microsoft-standard-WSL2",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "switcher_kis",
    "name": "Switcher",
    "documentation": "https://www.home-assistant.io/integrations/switcher_kis/",
    "codeowners": [
      "@tomerfi",
      "@thecode"
    ],
    "requirements": [
      "aioswitcher==3.1.0"
    ],
    "quality_scale": "platinum",
    "iot_class": "local_push",
    "config_flow": true,
    "loggers": [
      "aioswitcher"
    ],
    "is_built_in": true
  },
  "data": {
    "entry": {
      "entry_id": "7f602b3014d45028402633a9ef594d9f",
      "version": 1,
      "domain": "switcher_kis",
      "title": "Switcher",
      "data": {},
      "options": {},
      "pref_disable_new_entities": false,
      "pref_disable_polling": false,
      "source": "user",
      "unique_id": null,
      "disabled_by": null
    },
    "devices": [
      {
        "device_type": {
          "__type": "<enum 'DeviceType'>",
          "repr": "<DeviceType.V2_QCA: ('Switcher V2 (qualcomm)', '01a1', 1, <DeviceCategory.WATER_HEATER: 1>)>"
        },
        "device_state": {
          "__type": "<enum 'DeviceState'>",
          "repr": "<DeviceState.OFF: ('00', 'off')>"
        },
        "device_id": "**REDACTED**",
        "ip_address": "**REDACTED**",
        "mac_address": "**REDACTED**",
        "name": "Washing Machine",
        "last_data_update": "2022-10-28T12:54:18.052107",
        "power_consumption": 0,
        "electric_current": 0.0,
        "remaining_time": "00:00:00",
        "auto_shutdown": "03:00:00"
      },
      {
        "device_type": {
          "__type": "<enum 'DeviceType'>",
          "repr": "<DeviceType.V2_ESP: ('Switcher V2 (esp)', '01a7', 1, <DeviceCategory.WATER_HEATER: 1>)>"
        },
        "device_state": {
          "__type": "<enum 'DeviceState'>",
          "repr": "<DeviceState.OFF: ('00', 'off')>"
        },
        "device_id": "**REDACTED**",
        "ip_address": "**REDACTED**",
        "mac_address": "**REDACTED**",
        "name": "Switcher Boiler 2CE2",
        "last_data_update": "2022-10-28T12:54:13.956263",
        "power_consumption": 0,
        "electric_current": 0.0,
        "remaining_time": "00:00:00",
        "auto_shutdown": "03:00:00"
      }
    ]
  }
}
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
