### PR TITLE
Update pynuki to 1.6.0

### DIFF
--- a/homeassistant/components/nuki/manifest.json
+++ b/homeassistant/components/nuki/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nuki",
   "name": "Nuki",
   "documentation": "https://www.home-assistant.io/integrations/nuki",
-  "requirements": ["pynuki==1.5.2"],
+  "requirements": ["pynuki==1.5.3"],
   "codeowners": ["@pschmitt", "@pvizeli", "@pree"],
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/nuki/manifest.json
+++ b/homeassistant/components/nuki/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nuki",
   "name": "Nuki",
   "documentation": "https://www.home-assistant.io/integrations/nuki",
-  "requirements": ["pynuki==1.5.3"],
+  "requirements": ["pynuki==1.6.0"],
   "codeowners": ["@pschmitt", "@pvizeli", "@pree"],
   "config_flow": true,
   "dhcp": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1748,7 +1748,7 @@ pynina==0.1.8
 pynobo==1.6.0
 
 # homeassistant.components.nuki
-pynuki==1.5.2
+pynuki==1.5.3
 
 # homeassistant.components.nut
 pynut2==2.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1748,7 +1748,7 @@ pynina==0.1.8
 pynobo==1.6.0
 
 # homeassistant.components.nuki
-pynuki==1.5.3
+pynuki==1.6.0
 
 # homeassistant.components.nut
 pynut2==2.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1234,7 +1234,7 @@ pynina==0.1.8
 pynobo==1.6.0
 
 # homeassistant.components.nuki
-pynuki==1.5.2
+pynuki==1.5.3
 
 # homeassistant.components.nut
 pynut2==2.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1234,7 +1234,7 @@ pynina==0.1.8
 pynobo==1.6.0
 
 # homeassistant.components.nuki
-pynuki==1.5.3
+pynuki==1.6.0
 
 # homeassistant.components.nut
 pynut2==2.1.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update pynuki to `1.6.0`, this changes the token for communication with the bridge API from hashed to encrypted. Hashed tokens are deprecated and will be removed from the API end of this year. This is not a breaking change, since all bridges (even the old hardware revision) got this update in June.

GitHub compare: https://github.com/pschmitt/pynuki/compare/1.5.2...1.6.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR depends on the PR in the pynuki repo: https://github.com/pschmitt/pynuki/pull/85

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
