### PR TITLE
TP-Link Omada integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1267,6 +1267,10 @@ omit =
     homeassistant/components/totalconnect/binary_sensor.py
     homeassistant/components/touchline/climate.py
     homeassistant/components/tplink_lte/*
+    homeassistant/components/tplink_omada/__init__.py
+    homeassistant/components/tplink_omada/coordinator.py
+    homeassistant/components/tplink_omada/entity.py
+    homeassistant/components/tplink_omada/switch.py
     homeassistant/components/traccar/device_tracker.py
     homeassistant/components/tractive/__init__.py
     homeassistant/components/tractive/binary_sensor.py

--- a/.strict-typing
+++ b/.strict-typing
@@ -298,6 +298,7 @@ homeassistant.components.tile.*
 homeassistant.components.tilt_ble.*
 homeassistant.components.tolo.*
 homeassistant.components.tplink.*
+homeassistant.components.tplink_omada.*
 homeassistant.components.tractive.*
 homeassistant.components.tradfri.*
 homeassistant.components.trafikverket_ferry.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1229,6 +1229,8 @@ build.json @home-assistant/supervisor
 /tests/components/totalconnect/ @austinmroczek
 /homeassistant/components/tplink/ @rytilahti @thegardenmonkey
 /tests/components/tplink/ @rytilahti @thegardenmonkey
+/homeassistant/components/tplink_omada/ @MarkGodwin
+/tests/components/tplink_omada/ @MarkGodwin
 /homeassistant/components/traccar/ @ludeeus
 /tests/components/traccar/ @ludeeus
 /homeassistant/components/trace/ @home-assistant/core

--- a/homeassistant/brands/tplink.json
+++ b/homeassistant/brands/tplink.json
@@ -1,0 +1,5 @@
+{
+  "domain": "tplink",
+  "name": "TP-Link",
+  "integrations": ["tplink", "tplink_omada", "tplink_lte"]
+}

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -1,12 +1,17 @@
 """The TP-Link Omada integration."""
 from __future__ import annotations
 
+from tplink_omada_client.exceptions import (
+    ConnectionFailed,
+    LoginFailed,
+    UnsupportedControllerVersion,
+)
 from tplink_omada_client.omadaclient import OmadaSite
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
@@ -23,9 +28,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client = await create_omada_client(hass, entry.data)
         await client.login()
 
+    except (LoginFailed, UnsupportedControllerVersion) as ex:
+        raise ConfigEntryAuthFailed(
+            f"Omada controller refused login attempt: {ex}"
+        ) from ex
+    except ConnectionFailed as ex:
+        raise ConfigEntryAuthFailed(
+            f"Omada controller could not be reached: {ex}"
+        ) from ex
+
     except Exception as ex:
         raise ConfigEntryNotReady(
-            f"Omada controller could not be reached: {ex}"
+            f"Unexpected error connecting to Omada controller: {ex}"
         ) from ex
 
     site_client = await client.get_site_client(OmadaSite(None, entry.data[CONF_SITE]))

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -25,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"Omada controller could not be reached: {ex}"
         ) from ex
 
-    hass.data[DOMAIN][entry.entry_id] = await hub.get_client()
+    hass.data[DOMAIN][entry.entry_id] = hub.get_client()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -1,0 +1,40 @@
+"""The TP-Link Omada integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .config_flow import OmadaHub
+from .const import DOMAIN
+
+PLATFORMS: list[Platform] = [Platform.SWITCH]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up TP-Link Omada from a config entry."""
+
+    hass.data.setdefault(DOMAIN, {})
+
+    try:
+        hub = OmadaHub(hass, entry.data)
+        await hub.authenticate()
+    except Exception as ex:
+        raise ConfigEntryNotReady(
+            f"Omada controller could not be reached: {ex}"
+        ) from ex
+
+    hass.data[DOMAIN][entry.entry_id] = await hub.get_client()
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
     LoginFailed,
+    OmadaClientException,
     UnsupportedControllerVersion,
 )
 from tplink_omada_client.omadaclient import OmadaSite
@@ -33,11 +34,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"Omada controller refused login attempt: {ex}"
         ) from ex
     except ConnectionFailed as ex:
-        raise ConfigEntryAuthFailed(
+        raise ConfigEntryNotReady(
             f"Omada controller could not be reached: {ex}"
         ) from ex
 
-    except Exception as ex:
+    except OmadaClientException as ex:
         raise ConfigEntryNotReady(
             f"Unexpected error connecting to Omada controller: {ex}"
         ) from ex

--- a/homeassistant/components/tplink_omada/config_flow.py
+++ b/homeassistant/components/tplink_omada/config_flow.py
@@ -51,7 +51,7 @@ async def create_omada_client(
 
 
 class HubInfo(NamedTuple):
-    """Basic controller information."""
+    """Discovered controller information."""
 
     controller_id: str
     name: str

--- a/homeassistant/components/tplink_omada/config_flow.py
+++ b/homeassistant/components/tplink_omada/config_flow.py
@@ -1,0 +1,118 @@
+"""Config flow for TP-Link Omada integration."""
+from __future__ import annotations
+
+import logging
+from types import MappingProxyType
+from typing import Any
+
+from tplink_omada_client.exceptions import (
+    ConnectionFailed,
+    OmadaClientException,
+    RequestFailed,
+    UnsupportedControllerVersion,
+)
+from tplink_omada_client.omadaclient import OmadaClient
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_VERIFY_SSL, default=True): bool,
+        vol.Required("site", default="Default"): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+
+class OmadaHub:
+    """Omada Controller hub."""
+
+    def __init__(self, hass: HomeAssistant, data: MappingProxyType[str, Any]) -> None:
+        """Initialize."""
+        self.hass = hass
+        self.host = data[CONF_HOST]
+        self.site = data["site"]
+        self.verify_ssl = bool(data[CONF_VERIFY_SSL])
+        self.username = data[CONF_USERNAME]
+        self.password = data[CONF_PASSWORD]
+        self.client = None
+
+    async def get_client(self) -> OmadaClient:
+        """Get the client api for the hub."""
+        if not self.client:
+            websession = async_get_clientsession(self.hass, verify_ssl=self.verify_ssl)
+            self.client = OmadaClient(
+                self.host,
+                self.username,
+                self.password,
+                websession=websession,
+                site=self.site,
+            )
+        return self.client
+
+    async def authenticate(self) -> bool:
+        """Test if we can authenticate with the host."""
+
+        client = await self.get_client()
+        await client.login()
+
+        return True
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect."""
+
+    hub = OmadaHub(hass, MappingProxyType(data))
+
+    await hub.authenticate()
+
+    # Return info that you want to store in the config entry.
+    return {"title": f"Omada Controller ({data['site']})"}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for TP-Link Omada."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        errors = {}
+
+        try:
+            info = await validate_input(self.hass, user_input)
+        except ConnectionFailed:
+            errors["base"] = "cannot_connect"
+        except RequestFailed:
+            errors["base"] = "invalid_auth"
+        except UnsupportedControllerVersion:
+            errors["base"] = "unsupported_controller"
+        except OmadaClientException:
+            errors["base"] = "unknown"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )

--- a/homeassistant/components/tplink_omada/config_flow.py
+++ b/homeassistant/components/tplink_omada/config_flow.py
@@ -139,7 +139,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
         """Perform reauth upon an API authentication error."""
         self._omada_opts = dict(entry_data)
-        return await self.async_step_reauth_confirm(dict(entry_data))
+        return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -157,12 +157,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 entry = self.hass.config_entries.async_get_entry(
                     self.context["entry_id"]
                 )
-                if entry is not None:
-                    self.hass.config_entries.async_update_entry(
-                        entry, data=self._omada_opts
-                    )
-                    await self.hass.config_entries.async_reload(entry.entry_id)
-                    return self.async_abort(reason="reauth_successful")
+                assert entry is not None
+                self.hass.config_entries.async_update_entry(
+                    entry, data=self._omada_opts
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
 
         return self.async_show_form(
             step_id="reauth_confirm",
@@ -191,7 +191,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except UnsupportedControllerVersion:
             errors["base"] = "unsupported_controller"
         except OmadaClientException as ex:
-            _LOGGER.exception("Unexpected API error: %s", ex)
+            _LOGGER.error("Unexpected API error: %s", ex)
             errors["base"] = "unknown"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/tplink_omada/config_flow.py
+++ b/homeassistant/components/tplink_omada/config_flow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from types import MappingProxyType
-from typing import Any
+from typing import Any, NamedTuple
 
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
@@ -11,87 +11,73 @@ from tplink_omada_client.exceptions import (
     OmadaClientException,
     UnsupportedControllerVersion,
 )
-from tplink_omada_client.omadaclient import OmadaClient
+from tplink_omada_client.omadaclient import OmadaClient, OmadaSite
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_SITE = "site"
+
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_VERIFY_SSL, default=True): bool,
-        vol.Required("site", default="Default"): str,
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
     }
 )
 
 
-class OmadaHub:
-    """Omada Controller hub."""
-
-    def __init__(self, hass: HomeAssistant, data: MappingProxyType[str, Any]) -> None:
-        """Initialize."""
-        self.hass = hass
-        self.host = data[CONF_HOST]
-        self.site = data["site"]
-        self.verify_ssl = bool(data[CONF_VERIFY_SSL])
-        self.username = data[CONF_USERNAME]
-        self.password = data[CONF_PASSWORD]
-        self.client = None
-
-    def get_client(self) -> OmadaClient:
-        """Get the client api for the hub."""
-        if not self.client:
-            websession = async_get_clientsession(self.hass, verify_ssl=self.verify_ssl)
-            self.client = OmadaClient(
-                self.host,
-                self.username,
-                self.password,
-                websession=websession,
-                site=self.site,
-            )
-        return self.client
-
-    async def authenticate(self) -> bool:
-        """Test if we can authenticate with the host."""
-
-        client = self.get_client()
-        await client.login()
-
-        return True
-
-    async def get_controller_name(self) -> str:
-        """Get the display name of the controller."""
-        client = self.get_client()
-        name = await client.get_controller_name()
-        return str(name)
+async def create_omada_client(
+    hass: HomeAssistant, data: MappingProxyType[str, Any]
+) -> OmadaClient:
+    """Create a TP-Link Omada client API for the given config entry."""
+    host = data[CONF_HOST]
+    verify_ssl = bool(data[CONF_VERIFY_SSL])
+    username = data[CONF_USERNAME]
+    password = data[CONF_PASSWORD]
+    websession = async_get_clientsession(hass, verify_ssl=verify_ssl)
+    return OmadaClient(host, username, password, websession=websession)
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+class HubInfo(NamedTuple):
+    """Basic controller information."""
+
+    controller_id: str
+    name: str
+    sites: list[OmadaSite]
+
+
+async def _validate_input(hass: HomeAssistant, data: dict[str, Any]) -> HubInfo:
     """Validate the user input allows us to connect."""
 
-    hub = OmadaHub(hass, MappingProxyType(data))
+    client = await create_omada_client(hass, MappingProxyType(data))
+    controller_id = await client.login()
+    name = await client.get_controller_name()
+    sites = await client.get_sites()
 
-    await hub.authenticate()
-    name = await hub.get_controller_name()
-
-    # Return info that you want to store in the config entry.
-    return {"title": f"TP-Link Omada {name} ({data['site']})"}
+    return HubInfo(controller_id, name, sites)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for TP-Link Omada."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        """Create the config flow for a new integration."""
+        self._omada_opts: dict[str, Any] = {}
+        self._sites: list[OmadaSite] = []
+        self._display_name: str = ""
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -105,7 +91,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         try:
-            info = await validate_input(self.hass, user_input)
+            info = await _validate_input(self.hass, user_input)
         except ConnectionFailed:
             errors["base"] = "cannot_connect"
         except LoginFailed:
@@ -119,8 +105,42 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            return self.async_create_entry(title=info["title"], data=user_input)
+            self._omada_opts.update(user_input)
+            self._display_name = f"{info.name} ({info.sites[0].name})"
+            if len(info.sites) < 1:
+                errors["base"] = "no_sites_found"
+            else:
+                self._sites = info.sites
+                if len(self._sites) > 1:
+                    return await self.async_step_site()
+                return await self.async_step_site({CONF_SITE: self._sites[0].id})
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
+
+    async def async_step_site(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle step to select site to manage."""
+
+        if user_input is None:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_SITE, "site"): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                selector.SelectOptionDict(value=s.id, label=s.name)
+                                for s in self._sites
+                            ],
+                            multiple=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+
+            return self.async_show_form(step_id="site", data_schema=schema)
+
+        self._omada_opts.update(user_input)
+        return self.async_create_entry(title=self._display_name, data=self._omada_opts)

--- a/homeassistant/components/tplink_omada/const.py
+++ b/homeassistant/components/tplink_omada/const.py
@@ -1,0 +1,3 @@
+"""Constants for the TP-Link Omada integration."""
+
+DOMAIN = "tplink_omada"

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -1,0 +1,44 @@
+"""Generic Omada API coordinator."""
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+import logging
+from typing import Generic, TypeVar
+
+import async_timeout
+from tplink_omada_client.exceptions import OmadaClientException
+from tplink_omada_client.omadaclient import OmadaClient
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+_LOGGER = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class OmadaCoordinator(DataUpdateCoordinator[dict[str, T]], Generic[T]):
+    """Coordinator for synchronizing bulk Omada data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        omada_client: OmadaClient,
+        update_func: Callable[[OmadaClient], Awaitable[dict[str, T]]],
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Omada API Data",
+            update_interval=timedelta(seconds=300),
+        )
+        self.omada_client = omada_client
+        self._update_func = update_func
+
+    async def _async_update_data(self) -> dict[str, T]:
+        """Fetch data from API endpoint."""
+        try:
+            async with async_timeout.timeout(10):
+                return await self._update_func(self.omada_client)
+        except OmadaClientException as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err

--- a/homeassistant/components/tplink_omada/entity.py
+++ b/homeassistant/components/tplink_omada/entity.py
@@ -1,0 +1,33 @@
+"""Base entity definitions."""
+from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
+
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import OmadaCoordinator
+
+
+class OmadaSwitchDeviceEntity(
+    CoordinatorEntity[OmadaCoordinator[OmadaSwitchPortDetails]]
+):
+    """Common base class for all entities attached to Omada network switches."""
+
+    def __init__(
+        self, coordinator: OmadaCoordinator[OmadaSwitchPortDetails], device: OmadaSwitch
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self.device = device
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return information about the device."""
+        return DeviceInfo(
+            connections={(device_registry.CONNECTION_NETWORK_MAC, self.device.mac)},
+            identifiers={(DOMAIN, (self.device.mac))},
+            manufacturer="TP-Link",
+            model=self.device.model_display_name,
+            name=self.device.name,
+        )

--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "tplink_omada",
+  "name": "TP-Link Omada",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/tplink_omada",
+  "requirements": ["tplink-omada-client==1.0.0"],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": ["@MarkGodwin"],
+  "iot_class": "local_polling"
+}

--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -5,10 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/tplink_omada",
   "integration_type": "hub",
   "requirements": ["tplink-omada-client==1.1.0"],
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
-  "dependencies": [],
   "codeowners": ["@MarkGodwin"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tplink_omada",
   "integration_type": "hub",
-  "requirements": ["tplink-omada-client==1.0.1"],
+  "requirements": ["tplink-omada-client==1.1.0"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -3,6 +3,7 @@
   "name": "TP-Link Omada",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tplink_omada",
+  "integration_type": "hub",
   "requirements": ["tplink-omada-client==1.0.1"],
   "ssdp": [],
   "zeroconf": [],

--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -3,7 +3,7 @@
   "name": "TP-Link Omada",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tplink_omada",
-  "requirements": ["tplink-omada-client==1.0.0"],
+  "requirements": ["tplink-omada-client==1.0.1"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -5,17 +5,25 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
-          "site": "Site",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
-        }
+        },
+        "title": "TP-Link Omada Controller",
+        "description": "Enter the connection details for the Omada controller. Cloud controllers aren't supported."
+      },
+      "site": {
+        "data": {
+          "site": "Site"
+        },
+        "title": "Choose which site(s) to manage"
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unsupported_controller": "Omada Controller version not supported.",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "no_sites_found": "No sites found which the user can manage."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
+          "site": "Site",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unsupported_controller": "Omada Controller version not supported.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -16,6 +16,14 @@
           "site": "Site"
         },
         "title": "Choose which site(s) to manage"
+      },
+      "reauth_confirm": {
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "title": "Update TP-Link Omada Credentials",
+        "description": "The provided credentials have stopped working. Please update them."
       }
     },
     "error": {
@@ -26,7 +34,8 @@
       "no_sites_found": "No sites found which the user can manage."
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -1,0 +1,126 @@
+"""Support for TPLink Omada device toggle options."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from tplink_omada_client.definitions import PoEMode
+from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
+from tplink_omada_client.omadaclient import OmadaClient, SwitchPortOverrides
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import OmadaCoordinator
+from .entity import OmadaSwitchDeviceEntity
+
+POE_SWITCH_ICON = "mdi:ethernet"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switches."""
+    omada_client: OmadaClient = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Naming fun. Omada switches, as in the network hardware
+    network_switches = await omada_client.get_switches()
+
+    entities: list = []
+    for switch in network_switches:
+
+        def make_update_func(
+            network_switch: OmadaSwitch,
+        ) -> Callable[[OmadaClient], Awaitable[dict[str, OmadaSwitchPortDetails]]]:
+            async def update_func(
+                client: OmadaClient,
+            ) -> dict[str, OmadaSwitchPortDetails]:
+                ports = await client.get_switch_ports(network_switch)
+                return {p.port_id: p for p in ports}
+
+            return update_func
+
+        coordinator = OmadaCoordinator[OmadaSwitchPortDetails](
+            hass, omada_client, make_update_func(switch)
+        )
+
+        await coordinator.async_config_entry_first_refresh()
+
+        for port_id in coordinator.data:
+            entities.append(
+                OmadaNetworkSwitchPortPoEControl(
+                    coordinator, switch, omada_client, port_id
+                )
+            )
+
+    async_add_entities(entities)
+
+
+def get_port_base_name(port: OmadaSwitchPortDetails) -> str:
+    """Get display name for a switch port."""
+
+    if port.name == f"Port{port.port}":
+        return f"Port {port.port}"
+    return f"Port {port.port} ({port.name})"
+
+
+class OmadaNetworkSwitchPortPoEControl(OmadaSwitchDeviceEntity, SwitchEntity):
+    """Representation of a PoE control toggle on a single network port on a switch."""
+
+    def __init__(
+        self,
+        coordinator: OmadaCoordinator[OmadaSwitchPortDetails],
+        device: OmadaSwitch,
+        omada_client: OmadaClient,
+        port_id: str,
+    ) -> None:
+        """Initialize the PoE switch."""
+        super().__init__(coordinator, device)
+        self.port_id = port_id
+        self.port_details = self.coordinator.data[port_id]
+        self.omada_client = omada_client
+        self._attr_unique_id = f"{device.mac}_{port_id}_poe"
+
+        port_name = f"{get_port_base_name(self.port_details)} PoE"
+
+        self.entity_description = SwitchEntityDescription(
+            f"PoE Enabled Port {self.port_details.port}",
+            name=port_name,
+            has_entity_name=True,
+            entity_category=EntityCategory.CONFIG,
+            icon=POE_SWITCH_ICON,
+        )
+        self._refresh_state()
+
+    async def _async_turn_on_off_poe(self, enable: bool) -> None:
+        self.port_details = await self.omada_client.update_switch_port(
+            self.device,
+            self.port_details,
+            overrides=SwitchPortOverrides(enable_poe=enable),
+        )
+        self._refresh_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self._async_turn_on_off_poe(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self._async_turn_on_off_poe(False)
+
+    def _refresh_state(self) -> None:
+        self._attr_is_on = self.port_details.poe_mode != PoEMode.DISABLED
+        if self.hass:
+            self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.port_details = self.coordinator.data[self.port_id]
+        self._refresh_state()

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from tplink_omada_client.definitions import PoEMode
 from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
-from tplink_omada_client.omadaclient import OmadaClient, SwitchPortOverrides
+from tplink_omada_client.omadasiteclient import OmadaSiteClient, SwitchPortOverrides
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -27,7 +27,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up switches."""
-    omada_client: OmadaClient = hass.data[DOMAIN][config_entry.entry_id]
+    omada_client: OmadaSiteClient = hass.data[DOMAIN][config_entry.entry_id]
 
     # Naming fun. Omada switches, as in the network hardware
     network_switches = await omada_client.get_switches()
@@ -39,9 +39,9 @@ async def async_setup_entry(
 
         def make_update_func(
             network_switch: OmadaSwitch,
-        ) -> Callable[[OmadaClient], Awaitable[dict[str, OmadaSwitchPortDetails]]]:
+        ) -> Callable[[OmadaSiteClient], Awaitable[dict[str, OmadaSwitchPortDetails]]]:
             async def update_func(
-                client: OmadaClient,
+                client: OmadaSiteClient,
             ) -> dict[str, OmadaSwitchPortDetails]:
                 ports = await client.get_switch_ports(network_switch)
                 return {p.port_id: p for p in ports}
@@ -80,7 +80,7 @@ class OmadaNetworkSwitchPortPoEControl(OmadaSwitchDeviceEntity, SwitchEntity):
         self,
         coordinator: OmadaCoordinator[OmadaSwitchPortDetails],
         device: OmadaSwitch,
-        omada_client: OmadaClient,
+        omada_client: OmadaSiteClient,
         port_id: str,
     ) -> None:
         """Initialize the PoE switch."""

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -44,7 +44,6 @@ async def async_setup_entry(
     for switch in [
         ns for ns in network_switches if ns.device_capabilities.supports_poe
     ]:
-
         coordinator = OmadaCoordinator[OmadaSwitchPortDetails](
             hass, omada_client, partial(poll_switch_state, network_switch=switch)
         )

--- a/homeassistant/components/tplink_omada/translations/en.json
+++ b/homeassistant/components/tplink_omada/translations/en.json
@@ -1,0 +1,23 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "site": "Site",
+                    "verify_ssl": "Verify SSL certificate",
+                    "password": "Password",
+                    "username": "Username"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/components/tplink_omada/translations/en.json
+++ b/homeassistant/components/tplink_omada/translations/en.json
@@ -26,6 +26,14 @@
                     "site": "Site"
                 },
                 "title": "Choose which site(s) to manage"
+            },
+            "reauth_confirm": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username"
+                },
+                "title": "Update TP-Link Omada Credentials",
+                "description": "The provided username and password have stopped working. Please update them."
             }
         }
     }

--- a/homeassistant/components/tplink_omada/translations/en.json
+++ b/homeassistant/components/tplink_omada/translations/en.json
@@ -5,18 +5,27 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
+            "unsupported_controller": "Omada Controller version not supported.",
             "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
+            "unknown": "Unexpected error",
+            "no_sites_found": "No sites found which the user can manage."
         },
         "step": {
             "user": {
                 "data": {
                     "host": "Host",
-                    "site": "Site",
                     "verify_ssl": "Verify SSL certificate",
                     "password": "Password",
                     "username": "Username"
-                }
+                },
+                "title": "TP-Link Omada Controller",
+                "description": "Enter the connection details for the Omada controller. Cloud controllers aren't supported."
+            },
+            "site": {
+                "data": {
+                    "site": "Site"
+                },
+                "title": "Choose which site(s) to manage"
             }
         }
     }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -442,6 +442,7 @@ FLOWS = {
         "toon",
         "totalconnect",
         "tplink",
+        "tplink_omada",
         "traccar",
         "tractive",
         "tradfri",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5674,22 +5674,26 @@
       "iot_class": "local_polling"
     },
     "tplink": {
-      "name": "TP-Link Kasa Smart",
-      "integration_type": "hub",
-      "config_flow": true,
-      "iot_class": "local_polling"
-    },
-    "tplink_lte": {
-      "name": "TP-Link LTE",
-      "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "local_polling"
-    },
-    "tplink_omada": {
-      "name": "TP-Link Omada",
-      "integration_type": "hub",
-      "config_flow": true,
-      "iot_class": "local_polling"
+      "name": "TP-Link",
+      "integrations": {
+        "tplink": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "local_polling",
+          "name": "TP-Link Kasa Smart"
+        },
+        "tplink_omada": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "local_polling",
+          "name": "TP-Link Omada"
+        },
+        "tplink_lte": {
+          "integration_type": "hub",
+          "iot_class": "local_polling",
+          "name": "TP-Link LTE"
+        }
+      }
     },
     "traccar": {
       "name": "Traccar",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5685,6 +5685,12 @@
       "config_flow": false,
       "iot_class": "local_polling"
     },
+    "tplink_omada": {
+      "name": "TP-Link Omada",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "traccar": {
       "name": "Traccar",
       "integration_type": "hub",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5690,6 +5690,7 @@
         },
         "tplink_lte": {
           "integration_type": "hub",
+          "config_flow": false,
           "iot_class": "local_polling",
           "name": "TP-Link LTE"
         }

--- a/mypy.ini
+++ b/mypy.ini
@@ -2735,6 +2735,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.tplink_omada.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.tractive.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2514,7 +2514,7 @@ total_connect_client==2023.1
 tp-connected==0.0.4
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.0.0
+tplink-omada-client==1.0.1
 
 # homeassistant.components.transmission
 transmission-rpc==3.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2513,6 +2513,9 @@ total_connect_client==2023.1
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4
 
+# homeassistant.components.tplink_omada
+tplink-omada-client==1.0.0
+
 # homeassistant.components.transmission
 transmission-rpc==3.4.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2514,7 +2514,7 @@ total_connect_client==2023.1
 tp-connected==0.0.4
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.0.1
+tplink-omada-client==1.1.0
 
 # homeassistant.components.transmission
 transmission-rpc==3.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1763,7 +1763,7 @@ toonapi==0.2.1
 total_connect_client==2023.1
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.0.1
+tplink-omada-client==1.1.0
 
 # homeassistant.components.transmission
 transmission-rpc==3.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1762,6 +1762,9 @@ toonapi==0.2.1
 # homeassistant.components.totalconnect
 total_connect_client==2023.1
 
+# homeassistant.components.tplink_omada
+tplink-omada-client==1.0.0
+
 # homeassistant.components.transmission
 transmission-rpc==3.4.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1763,7 +1763,7 @@ toonapi==0.2.1
 total_connect_client==2023.1
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.0.0
+tplink-omada-client==1.0.1
 
 # homeassistant.components.transmission
 transmission-rpc==3.4.0

--- a/tests/components/tplink_omada/__init__.py
+++ b/tests/components/tplink_omada/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the TP-Link Omada integration."""

--- a/tests/components/tplink_omada/test_config_flow.py
+++ b/tests/components/tplink_omada/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Test the TP-Link Omada config flow."""
+"""Test the TP-Link Omada config flows."""
 from unittest.mock import patch
 
 from tplink_omada_client.exceptions import (
@@ -10,8 +10,8 @@ from tplink_omada_client.exceptions import (
 from tplink_omada_client.omadaclient import OmadaSite
 
 from homeassistant import config_entries
-from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.config_flow import HubInfo
+from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 

--- a/tests/components/tplink_omada/test_config_flow.py
+++ b/tests/components/tplink_omada/test_config_flow.py
@@ -1,0 +1,98 @@
+"""Test the TP-Link Omada config flow."""
+from unittest.mock import patch
+
+from tplink_omada_client.exceptions import ConnectionFailed, RequestFailed
+
+from homeassistant import config_entries
+from homeassistant.components.tplink_omada.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.tplink_omada.config_flow.OmadaHub.authenticate",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.tplink_omada.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "verify_ssl": True,
+                "site": "Test",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Omada Controller (Test)"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "verify_ssl": True,
+        "site": "Test",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.tplink_omada.config_flow.PlaceholderHub.authenticate",
+        side_effect=RequestFailed,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "site": "Test",
+                "verify_ssl": False,
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.tplink_omada.config_flow.PlaceholderHub.authenticate",
+        side_effect=ConnectionFailed,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "site": "Test",
+                "verify_ssl": True,
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
Basic TP-Link Omada SDN Controller integration.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
[TP-Link Omada SDN](https://www.tp-link.com/us/omada-sdn/) has a suite of managed devices controlled by a software or hardware controller. The API for this allows configuration and monitoring of the SDN. The SDN has some fairly powerful features, which I don't propose to expose in HA. We'll only expose basic status and configuration - i.e. things that might be used in automations.

The integration adds a device for every network switch managed by the controller, and adds a toggle switch entity for each network port with PoE capability.

Currently this integration only supports PoE config of network switch ports (as the instructions said not to add multiple domains in the first PR). I will be adding features to add sensors for monitoring switches (port speed, connectivity, PoE power drain, etc..) and wifi access points, plus device tracking on the WiFi access points. Entities will share a small number of coordinators which will poll the Omada API for updates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # 
- This PR is related to issue: 
- Link to documentation pull request: [Documentation PR](https://github.com/home-assistant/home-assistant.io/pull/24753)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
