### PR TITLE
Fix ignored upnp discoveries not being matched when device changes its unique identifier

### DIFF
--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -3,7 +3,7 @@
   "name": "DLNA Digital Media Renderer",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
-  "requirements": ["async-upnp-client==0.32.1"],
+  "requirements": ["async-upnp-client==0.32.2"],
   "dependencies": ["ssdp"],
   "after_dependencies": ["media_source"],
   "ssdp": [

--- a/homeassistant/components/dlna_dms/manifest.json
+++ b/homeassistant/components/dlna_dms/manifest.json
@@ -3,7 +3,7 @@
   "name": "DLNA Digital Media Server",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dlna_dms",
-  "requirements": ["async-upnp-client==0.32.1"],
+  "requirements": ["async-upnp-client==0.32.2"],
   "dependencies": ["ssdp"],
   "after_dependencies": ["media_source"],
   "ssdp": [

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -8,7 +8,7 @@
     "samsungctl[websocket]==0.7.1",
     "samsungtvws[async,encrypted]==2.5.0",
     "wakeonlan==2.1.0",
-    "async-upnp-client==0.32.1"
+    "async-upnp-client==0.32.2"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["async-upnp-client==0.32.1"],
+  "requirements": ["async-upnp-client==0.32.2"],
   "dependencies": ["network"],
   "after_dependencies": ["zeroconf"],
   "codeowners": [],

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -169,6 +169,7 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONFIG_ENTRY_MAC_ADDRESS: mac_address,
                 CONFIG_ENTRY_LOCATION: discovery_info.ssdp_location,
                 CONFIG_ENTRY_HOST: host,
+                CONFIG_ENTRY_ST: discovery_info.ssdp_st,
             },
         )
 

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -20,6 +20,7 @@ from .const import (
     CONFIG_ENTRY_ST,
     CONFIG_ENTRY_UDN,
     DOMAIN,
+    DOMAIN_DISCOVERIES,
     LOGGER,
     ST_IGD_V1,
     ST_IGD_V2,
@@ -47,7 +48,7 @@ def _is_complete_discovery(discovery_info: ssdp.SsdpServiceInfo) -> bool:
     )
 
 
-async def _async_discover_igd_devices(
+async def _async_discovered_igd_devices(
     hass: HomeAssistant,
 ) -> list[ssdp.SsdpServiceInfo]:
     """Discovery IGD devices."""
@@ -79,9 +80,19 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     # - ssdp(discovery_info) --> ssdp_confirm(None) --> ssdp_confirm({}) --> create_entry()
     # - user(None): scan --> user({...}) --> create_entry()
 
-    def __init__(self) -> None:
-        """Initialize the UPnP/IGD config flow."""
-        self._discoveries: list[SsdpServiceInfo] | None = None
+    @property
+    def _discoveries(self) -> dict[str, SsdpServiceInfo]:
+        """Get current discoveries."""
+        domain_data: dict = self.hass.data.setdefault(DOMAIN, {})
+        return domain_data.setdefault(DOMAIN_DISCOVERIES, {})
+
+    def _add_discovery(self, discovery: SsdpServiceInfo) -> None:
+        """Add a discovery."""
+        self._discoveries[discovery.ssdp_usn] = discovery
+
+    def _remove_discovery(self, usn: str) -> SsdpServiceInfo:
+        """Remove a discovery by its USN/unique_id."""
+        return self._discoveries.pop(usn)
 
     async def async_step_user(
         self, user_input: Mapping[str, Any] | None = None
@@ -95,7 +106,7 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             discovery = next(
                 iter(
                     discovery
-                    for discovery in self._discoveries
+                    for discovery in self._discoveries.values()
                     if discovery.ssdp_usn == user_input["unique_id"]
                 )
             )
@@ -103,21 +114,20 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._async_create_entry_from_discovery(discovery)
 
         # Discover devices.
-        discoveries = await _async_discover_igd_devices(self.hass)
+        discoveries = await _async_discovered_igd_devices(self.hass)
 
         # Store discoveries which have not been configured.
         current_unique_ids = {
             entry.unique_id for entry in self._async_current_entries()
         }
-        self._discoveries = [
-            discovery
-            for discovery in discoveries
-            if (
+        for discovery in discoveries:
+            if not (
                 _is_complete_discovery(discovery)
                 and _is_igd_device(discovery)
                 and discovery.ssdp_usn not in current_unique_ids
-            )
-        ]
+            ):
+                continue
+            self._add_discovery(discovery)
 
         # Ensure anything to add.
         if not self._discoveries:
@@ -128,7 +138,7 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required("unique_id"): vol.In(
                     {
                         discovery.ssdp_usn: _friendly_name_from_discovery(discovery)
-                        for discovery in self._discoveries
+                        for discovery in self._discoveries.values()
                     }
                 ),
             }
@@ -163,7 +173,7 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         mac_address = await _async_mac_address_from_discovery(self.hass, discovery_info)
         host = discovery_info.ssdp_headers["_host"]
         self._abort_if_unique_id_configured(
-            # Store mac address for older entries.
+            # Store mac address and other data for older entries.
             # The location is stored in the config entry such that when the location changes, the entry is reloaded.
             updates={
                 CONFIG_ENTRY_MAC_ADDRESS: mac_address,
@@ -205,7 +215,7 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="config_entry_updated")
 
         # Store discovery.
-        self._discoveries = [discovery_info]
+        self._add_discovery(discovery_info)
 
         # Ensure user recognizable.
         self.context["title_placeholders"] = {
@@ -222,9 +232,26 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(step_id="ssdp_confirm")
 
-        assert self._discoveries
-        discovery = self._discoveries[0]
+        assert self.unique_id
+        discovery = self._remove_discovery(self.unique_id)
         return await self._async_create_entry_from_discovery(discovery)
+
+    async def async_step_ignore(self, user_input: dict[str, Any]) -> FlowResult:
+        """Ignore this config flow."""
+        usn = user_input["unique_id"]
+        discovery = self._remove_discovery(usn)
+        mac_address = await _async_mac_address_from_discovery(self.hass, discovery)
+        data = {
+            CONFIG_ENTRY_UDN: discovery.upnp[ssdp.ATTR_UPNP_UDN],
+            CONFIG_ENTRY_ST: discovery.ssdp_st,
+            CONFIG_ENTRY_ORIGINAL_UDN: discovery.upnp[ssdp.ATTR_UPNP_UDN],
+            CONFIG_ENTRY_MAC_ADDRESS: mac_address,
+            CONFIG_ENTRY_HOST: discovery.ssdp_headers["_host"],
+            CONFIG_ENTRY_LOCATION: discovery.ssdp_location,
+        }
+
+        await self.async_set_unique_id(user_input["unique_id"], raise_on_progress=False)
+        return self.async_create_entry(title=user_input["title"], data=data)
 
     async def _async_create_entry_from_discovery(
         self,

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -244,5 +244,6 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             CONFIG_ENTRY_ORIGINAL_UDN: discovery.upnp[ssdp.ATTR_UPNP_UDN],
             CONFIG_ENTRY_LOCATION: discovery.ssdp_location,
             CONFIG_ENTRY_MAC_ADDRESS: mac_address,
+            CONFIG_ENTRY_HOST: discovery.ssdp_headers["_host"],
         }
         return self.async_create_entry(title=title, data=data)

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -121,13 +121,12 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             entry.unique_id for entry in self._async_current_entries()
         }
         for discovery in discoveries:
-            if not (
+            if (
                 _is_complete_discovery(discovery)
                 and _is_igd_device(discovery)
                 and discovery.ssdp_usn not in current_unique_ids
             ):
-                continue
-            self._add_discovery(discovery)
+                self._add_discovery(discovery)
 
         # Ensure anything to add.
         if not self._discoveries:

--- a/homeassistant/components/upnp/const.py
+++ b/homeassistant/components/upnp/const.py
@@ -7,6 +7,7 @@ from homeassistant.const import TIME_SECONDS
 LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "upnp"
+DOMAIN_DISCOVERIES = "discoveries"
 BYTES_RECEIVED = "bytes_received"
 BYTES_SENT = "bytes_sent"
 PACKETS_RECEIVED = "packets_received"

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -3,7 +3,7 @@
   "name": "UPnP/IGD",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
-  "requirements": ["async-upnp-client==0.32.1", "getmac==0.8.2"],
+  "requirements": ["async-upnp-client==0.32.2", "getmac==0.8.2"],
   "dependencies": ["network", "ssdp"],
   "codeowners": ["@StevenLooman"],
   "ssdp": [

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -2,7 +2,7 @@
   "domain": "yeelight",
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
-  "requirements": ["yeelight==0.7.10", "async-upnp-client==0.32.1"],
+  "requirements": ["yeelight==0.7.10", "async-upnp-client==0.32.2"],
   "codeowners": ["@zewelor", "@shenxn", "@starkillerOG", "@alexyao2015"],
   "config_flow": true,
   "dependencies": ["network"],

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,7 +4,7 @@ aiodiscover==1.4.13
 aiohttp==3.8.1
 aiohttp_cors==0.7.0
 astral==2.2
-async-upnp-client==0.32.1
+async-upnp-client==0.32.2
 async_timeout==4.0.2
 atomicwrites-homeassistant==1.4.1
 attrs==21.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -353,7 +353,7 @@ asterisk_mbox==0.5.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.32.1
+async-upnp-client==0.32.2
 
 # homeassistant.components.supla
 asyncpysupla==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -307,7 +307,7 @@ arcam-fmj==0.12.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.32.1
+async-upnp-client==0.32.2
 
 # homeassistant.components.sleepiq
 asyncsleepiq==1.2.3

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -63,6 +63,7 @@ async def test_flow_ssdp(hass: HomeAssistant):
         CONFIG_ENTRY_ORIGINAL_UDN: TEST_UDN,
         CONFIG_ENTRY_LOCATION: TEST_LOCATION,
         CONFIG_ENTRY_MAC_ADDRESS: TEST_MAC_ADDRESS,
+        CONFIG_ENTRY_HOST: TEST_HOST,
     }
 
 
@@ -138,6 +139,7 @@ async def test_flow_ssdp_no_mac_address(hass: HomeAssistant):
         CONFIG_ENTRY_ORIGINAL_UDN: TEST_UDN,
         CONFIG_ENTRY_LOCATION: TEST_LOCATION,
         CONFIG_ENTRY_MAC_ADDRESS: None,
+        CONFIG_ENTRY_HOST: TEST_HOST,
     }
 
 
@@ -382,6 +384,7 @@ async def test_flow_user(hass: HomeAssistant):
         CONFIG_ENTRY_ORIGINAL_UDN: TEST_UDN,
         CONFIG_ENTRY_LOCATION: TEST_LOCATION,
         CONFIG_ENTRY_MAC_ADDRESS: TEST_MAC_ADDRESS,
+        CONFIG_ENTRY_HOST: TEST_HOST,
     }
 
 

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -67,6 +67,41 @@ async def test_flow_ssdp(hass: HomeAssistant):
     }
 
 
+@pytest.mark.usefixtures(
+    "ssdp_instant_discovery",
+    "mock_setup_entry",
+    "mock_get_source_ip",
+    "mock_mac_address_from_host",
+)
+async def test_flow_ssdp_ignore(hass: HomeAssistant):
+    """Test config flow: discovered + ignore through ssdp."""
+    # Discovered via step ssdp.
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data=TEST_DISCOVERY,
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "ssdp_confirm"
+
+    # Ignore entry.
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IGNORE},
+        data={"unique_id": TEST_USN, "title": TEST_FRIENDLY_NAME},
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == TEST_FRIENDLY_NAME
+    assert result["data"] == {
+        CONFIG_ENTRY_ST: TEST_ST,
+        CONFIG_ENTRY_UDN: TEST_UDN,
+        CONFIG_ENTRY_ORIGINAL_UDN: TEST_UDN,
+        CONFIG_ENTRY_LOCATION: TEST_LOCATION,
+        CONFIG_ENTRY_MAC_ADDRESS: TEST_MAC_ADDRESS,
+        CONFIG_ENTRY_HOST: TEST_HOST,
+    }
+
+
 @pytest.mark.usefixtures("mock_get_source_ip")
 async def test_flow_ssdp_incomplete_discovery(hass: HomeAssistant):
     """Test config flow: incomplete discovery through ssdp."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This better handles ignored upnp-config entries when the router/device changes its unique identifier (unique device name, UDN, in UPnP terms).

Fixes #78454:
1. When an ignored entry is matched, make sure to properly update it with additional data (`st`-key)
2. When a config entry is ignored, store additional data used for matching new discoveries

Discoveries are now stored at the integration/domain data instead of the individual config flow. When a discovery is ignored, a new flow is created instead of the existing flow for that discovery being used. As a result, the specific discovery is not available to the flow, only its unique key. This gets the original discovery using the unique key from the (shared) discoveries.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #78454
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
