### PR TITLE
Add Switcher button platform

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -29,7 +29,13 @@ from .const import (
 )
 from .utils import async_start_bridge, async_stop_bridge
 
-PLATFORMS = [Platform.CLIMATE, Platform.COVER, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BUTTON,
+    Platform.CLIMATE,
+    Platform.COVER,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switcher_kis/button.py
+++ b/homeassistant/components/switcher_kis/button.py
@@ -1,0 +1,159 @@
+"""Switcher integration Button platform."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from aioswitcher.api import (
+    DeviceState,
+    SwitcherBaseResponse,
+    SwitcherType2Api,
+    ThermostatSwing,
+)
+from aioswitcher.api.remotes import SwitcherBreezeRemote
+from aioswitcher.device import DeviceCategory
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import SwitcherDataUpdateCoordinator
+from .const import SIGNAL_DEVICE_ADD
+from .utils import get_breeze_remote_manager
+
+
+@dataclass
+class SwitcherThermostatButtonDescriptionMixin:
+    """Mixin to describe a Switcher Thermostat Button entity."""
+
+    press_fn: Callable[[SwitcherType2Api, SwitcherBreezeRemote], SwitcherBaseResponse]
+    supported: Callable[[SwitcherBreezeRemote], bool]
+
+
+@dataclass
+class SwitcherThermostatButtonEntityDescription(
+    ButtonEntityDescription, SwitcherThermostatButtonDescriptionMixin
+):
+    """Class to describe a Switcher Thermostat Button entity."""
+
+
+THERMOSTAT_BUTTONS = [
+    SwitcherThermostatButtonEntityDescription(
+        key="assume_on",
+        name="Assume on",
+        icon="mdi:fan",
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda api, remote: api.control_breeze_device(
+            remote, state=DeviceState.ON, update_state=True
+        ),
+        supported=lambda remote: bool(remote.on_off_type),
+    ),
+    SwitcherThermostatButtonEntityDescription(
+        key="assume_off",
+        name="Assume off",
+        icon="mdi:fan-off",
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda api, remote: api.control_breeze_device(
+            remote, state=DeviceState.OFF, update_state=True
+        ),
+        supported=lambda remote: bool(remote.on_off_type),
+    ),
+    SwitcherThermostatButtonEntityDescription(
+        key="vertical_swing_on",
+        name="Vertical swing on",
+        icon="mdi:autorenew",
+        press_fn=lambda api, remote: api.control_breeze_device(
+            remote, swing=ThermostatSwing.ON
+        ),
+        supported=lambda remote: bool(remote.separated_swing_command),
+    ),
+    SwitcherThermostatButtonEntityDescription(
+        key="vertical_swing_off",
+        name="Vertical swing off",
+        icon="mdi:autorenew-off",
+        press_fn=lambda api, remote: api.control_breeze_device(
+            remote, swing=ThermostatSwing.OFF
+        ),
+        supported=lambda remote: bool(remote.separated_swing_command),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Switcher button from config entry."""
+
+    @callback
+    async def async_add_buttons(coordinator: SwitcherDataUpdateCoordinator) -> None:
+        """Get remote and add button from Switcher device."""
+        if coordinator.data.device_type.category == DeviceCategory.THERMOSTAT:
+            remote: SwitcherBreezeRemote = await hass.async_add_executor_job(
+                get_breeze_remote_manager(hass).get_remote, coordinator.data.remote_id
+            )
+            async_add_entities(
+                SwitcherThermostatButtonEntity(coordinator, description, remote)
+                for description in THERMOSTAT_BUTTONS
+                if description.supported(remote)
+            )
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_DEVICE_ADD, async_add_buttons)
+    )
+
+
+class SwitcherThermostatButtonEntity(
+    CoordinatorEntity[SwitcherDataUpdateCoordinator], ButtonEntity
+):
+    """Representation of a Switcher climate entity."""
+
+    entity_description: SwitcherThermostatButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: SwitcherDataUpdateCoordinator,
+        description: SwitcherThermostatButtonEntityDescription,
+        remote: SwitcherBreezeRemote,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._remote = remote
+
+        self._attr_name = f"{coordinator.name} {description.name}"
+        self._attr_unique_id = f"{coordinator.mac_address}-{description.key}"
+        self._attr_device_info = DeviceInfo(
+            connections={
+                (device_registry.CONNECTION_NETWORK_MAC, coordinator.mac_address)
+            }
+        )
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        response: SwitcherBaseResponse = None
+        error = None
+
+        try:
+            async with SwitcherType2Api(
+                self.coordinator.data.ip_address, self.coordinator.data.device_id
+            ) as swapi:
+                response = await self.entity_description.press_fn(swapi, self._remote)
+        except (asyncio.TimeoutError, OSError, RuntimeError) as err:
+            error = repr(err)
+
+        if error or not response or not response.successful:
+            self.coordinator.last_update_success = False
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                f"Call api for {self.name} failed, "
+                f"response/error: {response or error}"
+            )

--- a/homeassistant/components/switcher_kis/climate.py
+++ b/homeassistant/components/switcher_kis/climate.py
@@ -5,7 +5,7 @@ import asyncio
 from typing import Any, cast
 
 from aioswitcher.api import SwitcherBaseResponse, SwitcherType2Api
-from aioswitcher.api.remotes import SwitcherBreezeRemote, SwitcherBreezeRemoteManager
+from aioswitcher.api.remotes import SwitcherBreezeRemote
 from aioswitcher.device import (
     DeviceCategory,
     DeviceState,
@@ -37,6 +37,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import SwitcherDataUpdateCoordinator
 from .const import SIGNAL_DEVICE_ADD
+from .utils import get_breeze_remote_manager
 
 DEVICE_MODE_TO_HA = {
     ThermostatMode.COOL: HVACMode.COOL,
@@ -64,13 +65,12 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Switcher climate from config entry."""
-    remote_manager = SwitcherBreezeRemoteManager()
 
     async def async_add_climate(coordinator: SwitcherDataUpdateCoordinator) -> None:
         """Get remote and add climate from Switcher device."""
         if coordinator.data.device_type.category == DeviceCategory.THERMOSTAT:
             remote: SwitcherBreezeRemote = await hass.async_add_executor_job(
-                remote_manager.get_remote, coordinator.data.remote_id
+                get_breeze_remote_manager(hass).get_remote, coordinator.data.remote_id
             )
             async_add_entities([SwitcherClimateEntity(coordinator, remote)])
 

--- a/homeassistant/components/switcher_kis/manifest.json
+++ b/homeassistant/components/switcher_kis/manifest.json
@@ -3,7 +3,7 @@
   "name": "Switcher",
   "documentation": "https://www.home-assistant.io/integrations/switcher_kis/",
   "codeowners": ["@tomerfi", "@thecode"],
-  "requirements": ["aioswitcher==3.1.0"],
+  "requirements": ["aioswitcher==3.2.0"],
   "quality_scale": "platinum",
   "iot_class": "local_push",
   "config_flow": true,

--- a/homeassistant/components/switcher_kis/utils.py
+++ b/homeassistant/components/switcher_kis/utils.py
@@ -6,9 +6,11 @@ from collections.abc import Callable
 import logging
 from typing import Any
 
+from aioswitcher.api.remotes import SwitcherBreezeRemoteManager
 from aioswitcher.bridge import SwitcherBase, SwitcherBridge
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import singleton
 
 from .const import DATA_BRIDGE, DISCOVERY_TIME_SEC, DOMAIN
 
@@ -53,3 +55,9 @@ async def async_discover_devices() -> dict[str, SwitcherBase]:
 
     _LOGGER.debug("Finished discovery, discovered devices: %s", len(discovered_devices))
     return discovered_devices
+
+
+@singleton.singleton("switcher_breeze_remote_manager")
+def get_breeze_remote_manager(hass: HomeAssistant) -> SwitcherBreezeRemoteManager:
+    """Get Switcher Breeze remote manager."""
+    return SwitcherBreezeRemoteManager()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -267,7 +267,7 @@ aioslimproto==2.1.1
 aiosteamist==0.3.2
 
 # homeassistant.components.switcher_kis
-aioswitcher==3.1.0
+aioswitcher==3.2.0
 
 # homeassistant.components.syncthing
 aiosyncthing==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -242,7 +242,7 @@ aioslimproto==2.1.1
 aiosteamist==0.3.2
 
 # homeassistant.components.switcher_kis
-aioswitcher==3.1.0
+aioswitcher==3.2.0
 
 # homeassistant.components.syncthing
 aiosyncthing==0.5.1

--- a/tests/components/switcher_kis/test_button.py
+++ b/tests/components/switcher_kis/test_button.py
@@ -1,0 +1,150 @@
+"""Tests for Switcher button platform."""
+from unittest.mock import ANY, patch
+
+from aioswitcher.api import DeviceState, SwitcherBaseResponse, ThermostatSwing
+import pytest
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import slugify
+
+from . import init_integration
+from .consts import DUMMY_THERMOSTAT_DEVICE as DEVICE
+
+BASE_ENTITY_ID = f"{BUTTON_DOMAIN}.{slugify(DEVICE.name)}"
+ASSUME_ON_EID = BASE_ENTITY_ID + "_assume_on"
+ASSUME_OFF_EID = BASE_ENTITY_ID + "_assume_off"
+SWING_ON_EID = BASE_ENTITY_ID + "_vertical_swing_on"
+SWING_OFF_EID = BASE_ENTITY_ID + "_vertical_swing_off"
+
+
+@pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
+async def test_assume_button(hass: HomeAssistant, mock_bridge, mock_api):
+    """Test assume on/off button."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    assert hass.states.get(ASSUME_ON_EID) is not None
+    assert hass.states.get(ASSUME_OFF_EID) is not None
+    assert hass.states.get(SWING_ON_EID) is None
+    assert hass.states.get(SWING_OFF_EID) is None
+
+    with patch(
+        "homeassistant.components.switcher_kis.climate.SwitcherType2Api.control_breeze_device",
+    ) as mock_control_device:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: ASSUME_ON_EID},
+            blocking=True,
+        )
+        assert mock_api.call_count == 2
+        mock_control_device.assert_called_once_with(
+            ANY, state=DeviceState.ON, update_state=True
+        )
+
+        mock_control_device.reset_mock()
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: ASSUME_OFF_EID},
+            blocking=True,
+        )
+        assert mock_api.call_count == 4
+        mock_control_device.assert_called_once_with(
+            ANY, state=DeviceState.OFF, update_state=True
+        )
+
+
+@pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
+async def test_swing_button(hass: HomeAssistant, mock_bridge, mock_api, monkeypatch):
+    """Test vertical swing on/off button."""
+    monkeypatch.setattr(DEVICE, "remote_id", "ELEC7022")
+    await init_integration(hass)
+    assert mock_bridge
+
+    assert hass.states.get(ASSUME_ON_EID) is None
+    assert hass.states.get(ASSUME_OFF_EID) is None
+    assert hass.states.get(SWING_ON_EID) is not None
+    assert hass.states.get(SWING_OFF_EID) is not None
+
+    with patch(
+        "homeassistant.components.switcher_kis.climate.SwitcherType2Api.control_breeze_device",
+    ) as mock_control_device:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: SWING_ON_EID},
+            blocking=True,
+        )
+        assert mock_api.call_count == 2
+        mock_control_device.assert_called_once_with(ANY, swing=ThermostatSwing.ON)
+
+        mock_control_device.reset_mock()
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: SWING_OFF_EID},
+            blocking=True,
+        )
+        assert mock_api.call_count == 4
+        mock_control_device.assert_called_once_with(ANY, swing=ThermostatSwing.OFF)
+
+
+@pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
+async def test_control_device_fail(hass, mock_bridge, mock_api, monkeypatch):
+    """Test control device fail."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    assert hass.states.get(ASSUME_ON_EID) is not None
+
+    # Test exception during set hvac mode
+    with patch(
+        "homeassistant.components.switcher_kis.climate.SwitcherType2Api.control_breeze_device",
+        side_effect=RuntimeError("fake error"),
+    ) as mock_control_device:
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                BUTTON_DOMAIN,
+                SERVICE_PRESS,
+                {ATTR_ENTITY_ID: ASSUME_ON_EID},
+                blocking=True,
+            )
+
+        assert mock_api.call_count == 2
+        mock_control_device.assert_called_once_with(
+            ANY, state=DeviceState.ON, update_state=True
+        )
+
+        state = hass.states.get(ASSUME_ON_EID)
+        assert state.state == STATE_UNAVAILABLE
+
+    # Make device available again
+    mock_bridge.mock_callbacks([DEVICE])
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ASSUME_ON_EID) is not None
+
+    # Test error response during turn on
+    with patch(
+        "homeassistant.components.switcher_kis.climate.SwitcherType2Api.control_breeze_device",
+        return_value=SwitcherBaseResponse(None),
+    ) as mock_control_device:
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                BUTTON_DOMAIN,
+                SERVICE_PRESS,
+                {ATTR_ENTITY_ID: ASSUME_ON_EID},
+                blocking=True,
+            )
+
+        assert mock_api.call_count == 4
+        mock_control_device.assert_called_once_with(
+            ANY, state=DeviceState.ON, update_state=True
+        )
+
+        state = hass.states.get(ASSUME_ON_EID)
+        assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Add Switcher button platform**

 - Add buttons to sync the device state for toggle AC types, for these types the AC state can be out of sync with the device state (similar to Sensibo: https://www.home-assistant.io/integrations/sensibo/#assume-state)
 - Add buttons to control Vertical swing for AC types that does not have a feedback for the swing on/off mode, for these devices the manufacture App provides two buttons to control on/off without feedback. For ACs that provide status we already control the swing using the climate entity.

Bump `aioswitcher` to 3.2.0 which is required for this PR (https://github.com/TomerFi/aioswitcher/pull/584)

GitHub diff: https://github.com/TomerFi/aioswitcher/compare/3.1.0...3.2.0
Release notes: https://github.com/TomerFi/aioswitcher/releases/tag/3.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24749

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
