### PR TITLE
Significantly reduce clock_gettime syscalls on platforms with broken vdso

### DIFF
--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 import logging
-import time
 from typing import Any, Generic, TypeVar
 
 from bleak import BleakError
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.debounce import Debouncer
+from homeassistant.util.dt import monotonic_time_course
 
 from . import BluetoothChange, BluetoothScanningMode, BluetoothServiceInfoBleak
 from .passive_update_processor import PassiveBluetoothProcessorCoordinator
@@ -94,7 +94,7 @@ class ActiveBluetoothProcessorCoordinator(
         """Return true if time to try and poll."""
         poll_age: float | None = None
         if self._last_poll:
-            poll_age = time.monotonic() - self._last_poll
+            poll_age = monotonic_time_course() - self._last_poll
         return self._needs_poll_method(service_info, poll_age)
 
     async def _async_poll_data(
@@ -124,7 +124,7 @@ class ActiveBluetoothProcessorCoordinator(
                 self.last_poll_successful = False
             return
         finally:
-            self._last_poll = time.monotonic()
+            self._last_poll = monotonic_time_course()
 
         if not self.last_poll_successful:
             self.logger.debug("%s: Polling recovered")

--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -9,7 +9,7 @@ from bleak import BleakError
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.debounce import Debouncer
-from homeassistant.util.dt import monotonic_time_course
+from homeassistant.util.dt import monotonic_time_coarse
 
 from . import BluetoothChange, BluetoothScanningMode, BluetoothServiceInfoBleak
 from .passive_update_processor import PassiveBluetoothProcessorCoordinator
@@ -94,7 +94,7 @@ class ActiveBluetoothProcessorCoordinator(
         """Return true if time to try and poll."""
         poll_age: float | None = None
         if self._last_poll:
-            poll_age = monotonic_time_course() - self._last_poll
+            poll_age = monotonic_time_coarse() - self._last_poll
         return self._needs_poll_method(service_info, poll_age)
 
     async def _async_poll_data(
@@ -124,7 +124,7 @@ class ActiveBluetoothProcessorCoordinator(
                 self.last_poll_successful = False
             return
         finally:
-            self._last_poll = monotonic_time_course()
+            self._last_poll = monotonic_time_coarse()
 
         if not self.last_poll_successful:
             self.logger.debug("%s: Polling recovered")

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -21,7 +21,7 @@ from homeassistant.core import (
 )
 from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.util.dt import monotonic_time_course
+from homeassistant.util.dt import monotonic_time_coarse
 
 from .advertisement_tracker import AdvertisementTracker
 from .const import (
@@ -69,7 +69,7 @@ APPLE_START_BYTES_WANTED: Final = {
     APPLE_DEVICE_ID_START_BYTE,
 }
 
-MONOTONIC_TIME: Final = monotonic_time_course
+MONOTONIC_TIME: Final = monotonic_time_coarse
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -7,7 +7,6 @@ from dataclasses import replace
 from datetime import datetime, timedelta
 import itertools
 import logging
-import time
 from typing import TYPE_CHECKING, Any, Final
 
 from bleak.backends.scanner import AdvertisementDataCallback
@@ -22,6 +21,7 @@ from homeassistant.core import (
 )
 from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util.dt import monotonic_time_course
 
 from .advertisement_tracker import AdvertisementTracker
 from .const import (
@@ -69,7 +69,7 @@ APPLE_START_BYTES_WANTED: Final = {
     APPLE_DEVICE_ID_START_BYTE,
 }
 
-MONOTONIC_TIME: Final = time.monotonic
+MONOTONIC_TIME: Final = monotonic_time_course
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bluetooth/scanner.py
+++ b/homeassistant/components/bluetooth/scanner.py
@@ -6,7 +6,6 @@ from collections.abc import Callable
 from datetime import datetime
 import logging
 import platform
-import time
 from typing import Any
 
 import async_timeout
@@ -22,6 +21,7 @@ from dbus_fast import InvalidMessageError
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback as hass_callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util.dt import monotonic_time_course
 from homeassistant.util.package import is_docker_env
 
 from .const import (
@@ -35,7 +35,7 @@ from .models import BaseHaScanner, BluetoothScanningMode, BluetoothServiceInfoBl
 from .util import adapter_human_name, async_reset_adapter
 
 OriginalBleakScanner = bleak.BleakScanner
-MONOTONIC_TIME = time.monotonic
+MONOTONIC_TIME = monotonic_time_course
 
 # or_patterns is a workaround for the fact that passive scanning
 # needs at least one matcher to be set. The below matcher

--- a/homeassistant/components/bluetooth/scanner.py
+++ b/homeassistant/components/bluetooth/scanner.py
@@ -21,7 +21,7 @@ from dbus_fast import InvalidMessageError
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback as hass_callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.util.dt import monotonic_time_course
+from homeassistant.util.dt import monotonic_time_coarse
 from homeassistant.util.package import is_docker_env
 
 from .const import (
@@ -35,7 +35,7 @@ from .models import BaseHaScanner, BluetoothScanningMode, BluetoothServiceInfoBl
 from .util import adapter_human_name, async_reset_adapter
 
 OriginalBleakScanner = bleak.BleakScanner
-MONOTONIC_TIME = monotonic_time_course
+MONOTONIC_TIME = monotonic_time_coarse
 
 # or_patterns is a workaround for the fact that passive scanning
 # needs at least one matcher to be set. The below matcher

--- a/homeassistant/components/bluetooth/util.py
+++ b/homeassistant/components/bluetooth/util.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import platform
-import time
 
 from bluetooth_auto_recovery import recover_adapter
 
 from homeassistant.core import callback
+from homeassistant.util.dt import monotonic_time_course
 
 from .const import (
     DEFAULT_ADAPTER_BY_PLATFORM,
@@ -29,7 +29,7 @@ async def async_load_history_from_system() -> dict[str, BluetoothServiceInfoBlea
 
     bluez_dbus = BlueZDBusObjects()
     await bluez_dbus.load()
-    now = time.monotonic()
+    now = monotonic_time_course()
     return {
         address: BluetoothServiceInfoBleak(
             name=history.advertisement_data.local_name

--- a/homeassistant/components/bluetooth/util.py
+++ b/homeassistant/components/bluetooth/util.py
@@ -6,7 +6,7 @@ import platform
 from bluetooth_auto_recovery import recover_adapter
 
 from homeassistant.core import callback
-from homeassistant.util.dt import monotonic_time_course
+from homeassistant.util.dt import monotonic_time_coarse
 
 from .const import (
     DEFAULT_ADAPTER_BY_PLATFORM,
@@ -29,7 +29,7 @@ async def async_load_history_from_system() -> dict[str, BluetoothServiceInfoBlea
 
     bluez_dbus = BlueZDBusObjects()
     await bluez_dbus.load()
-    now = monotonic_time_course()
+    now = monotonic_time_coarse()
     return {
         address: BluetoothServiceInfoBleak(
             name=history.advertisement_data.local_name

--- a/homeassistant/components/esphome/bluetooth/scanner.py
+++ b/homeassistant/components/esphome/bluetooth/scanner.py
@@ -19,7 +19,7 @@ from homeassistant.components.bluetooth import (
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.util.dt import monotonic_time_course
+from homeassistant.util.dt import monotonic_time_coarse
 
 TWO_CHAR = re.compile("..")
 
@@ -85,7 +85,7 @@ class ESPHomeScanner(BaseHaScanner):
     @callback
     def async_on_advertisement(self, adv: BluetoothLEAdvertisement) -> None:
         """Call the registered callback."""
-        now = monotonic_time_course()
+        now = monotonic_time_coarse()
         address = ":".join(TWO_CHAR.findall("%012X" % adv.address))  # must be upper
         name = adv.name
         if prev_discovery := self._discovered_device_advertisement_datas.get(address):

--- a/homeassistant/components/esphome/bluetooth/scanner.py
+++ b/homeassistant/components/esphome/bluetooth/scanner.py
@@ -19,6 +19,7 @@ from homeassistant.components.bluetooth import (
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util.dt import monotonic_time_course
 
 TWO_CHAR = re.compile("..")
 
@@ -84,7 +85,7 @@ class ESPHomeScanner(BaseHaScanner):
     @callback
     def async_on_advertisement(self, adv: BluetoothLEAdvertisement) -> None:
         """Call the registered callback."""
-        now = time.monotonic()
+        now = monotonic_time_course()
         address = ":".join(TWO_CHAR.findall("%012X" % adv.address))  # must be upper
         name = adv.name
         if prev_discovery := self._discovered_device_advertisement_datas.get(address):

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -466,7 +466,7 @@ def _datetime_ambiguous(dattim: dt.datetime) -> bool:
     return _datetime_exists(dattim) and dattim.utcoffset() != opposite_fold.utcoffset()
 
 
-def __monotonic_time_course() -> float:
+def __monotonic_time_coarse() -> float:
     """Return a monotonic time in seconds.
 
     This is the course version of time_monotonic, which is faster but less accurate.
@@ -483,12 +483,12 @@ def __monotonic_time_course() -> float:
 try:
     HAS_COARSE_TIME = (
         platform.system() == "Linux"
-        and abs(time.monotonic() - __monotonic_time_course()) < 1
+        and abs(time.monotonic() - __monotonic_time_coarse()) < 1
     )
 except Exception:  # pylint: disable=broad-except
     HAS_COARSE_TIME = False
 
 if HAS_COARSE_TIME:
-    monotonic_time_course = __monotonic_time_course
+    monotonic_time_coarse = __monotonic_time_coarse
 else:
-    monotonic_time_course = time.monotonic
+    monotonic_time_coarse = time.monotonic

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import bisect
 from contextlib import suppress
 import datetime as dt
+import platform
 import re
+import time
 from typing import Any
 import zoneinfo
 
@@ -13,6 +15,7 @@ import ciso8601
 DATE_STR_FORMAT = "%Y-%m-%d"
 UTC = dt.timezone.utc
 DEFAULT_TIME_ZONE: dt.tzinfo = dt.timezone.utc
+CLOCK_MONOTONIC_COARSE = 6
 
 # EPOCHORDINAL is not exposed as a constant
 # https://github.com/python/cpython/blob/3.10/Lib/zoneinfo/_zoneinfo.py#L12
@@ -461,3 +464,31 @@ def _datetime_ambiguous(dattim: dt.datetime) -> bool:
     assert dattim.tzinfo is not None
     opposite_fold = dattim.replace(fold=not dattim.fold)
     return _datetime_exists(dattim) and dattim.utcoffset() != opposite_fold.utcoffset()
+
+
+def __monotonic_time_course() -> float:
+    """Return a monotonic time in seconds.
+
+    This is the course version of time_monotonic, which is faster but less accurate.
+
+    Since many arm64 and 32-bit platforms don't support VDSO with time.monotonic
+    because of errata, we can't rely on the kernel to provide a fast
+    monotonic time.
+
+    https://lore.kernel.org/lkml/20170404171826.25030-1-marc.zyngier@arm.com/
+    """
+    return time.clock_gettime(CLOCK_MONOTONIC_COARSE)
+
+
+try:
+    HAS_COARSE_TIME = (
+        platform.system() == "Linux"
+        and abs(time.monotonic() - __monotonic_time_course()) < 1
+    )
+except Exception:  # pylint: disable=broad-except
+    HAS_COARSE_TIME = False
+
+if HAS_COARSE_TIME:
+    monotonic_time_course = __monotonic_time_course
+else:
+    monotonic_time_course = time.monotonic

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -469,7 +469,7 @@ def _datetime_ambiguous(dattim: dt.datetime) -> bool:
 def __monotonic_time_coarse() -> float:
     """Return a monotonic time in seconds.
 
-    This is the course version of time_monotonic, which is faster but less accurate.
+    This is the coarse version of time_monotonic, which is faster but less accurate.
 
     Since many arm64 and 32-bit platforms don't support VDSO with time.monotonic
     because of errata, we can't rely on the kernel to provide a fast

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -480,15 +480,10 @@ def __monotonic_time_coarse() -> float:
     return time.clock_gettime(CLOCK_MONOTONIC_COARSE)
 
 
-try:
-    HAS_COARSE_TIME = (
+monotonic_time_coarse = time.monotonic
+with suppress(Exception):
+    if (
         platform.system() == "Linux"
         and abs(time.monotonic() - __monotonic_time_coarse()) < 1
-    )
-except Exception:  # pylint: disable=broad-except
-    HAS_COARSE_TIME = False
-
-if HAS_COARSE_TIME:
-    monotonic_time_coarse = __monotonic_time_coarse
-else:
-    monotonic_time_coarse = time.monotonic
+    ):
+        monotonic_time_coarse = __monotonic_time_coarse

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+import time
 
 import pytest
 
@@ -719,3 +720,8 @@ def test_find_next_time_expression_tenth_second_pattern_does_not_drift_entering_
         assert (next_target - prev_target).total_seconds() == 60
         assert next_target.second == 10
         prev_target = next_target
+
+
+def test_monotonic_time_coarse():
+    """Test monotonic time coarse."""
+    assert abs(time.monotonic() - dt_util.monotonic_time_coarse()) < 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We found that on some ARM64 and 32-bit platforms that fetching monotonic time is an order of magnitude slow than expected because vdso does not work or disabled on those platforms due to errata (HA Blue / Odroid n2+). For bluetooth and likely some other places CLOCK_MONOTONIC_COARSE is good enough and does not incur the syscall overhead.

See https://lore.kernel.org/lkml/20170404171826.25030-1-marc.zyngier@arm.com/


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
