### PR TITLE
Provide a human readable error when an esphome ble proxy connection fails

### DIFF
--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any, TypeVar, cast
 import uuid
 
+from aioesphomeapi import BLEConnectionError
 from aioesphomeapi.connection import APIConnectionError, TimeoutAPIError
 import async_timeout
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -182,8 +183,12 @@ class ESPHomeClient(BaseBleakClient):
                 return
 
             if error:
+                try:
+                    human_error = BLEConnectionError(error)
+                except ValueError:
+                    human_error = f"Unknown error code {error}"
                 connected_future.set_exception(
-                    BleakError(f"Error while connecting: {error}")
+                    BleakError(f"Error code {error} while connecting: {human_error}")
                 )
                 return
 

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any, TypeVar, cast
 import uuid
 
-from aioesphomeapi import BLEConnectionError
+from aioesphomeapi import ESP_CONNECTION_ERROR_DESCRIPTION, BLEConnectionError
 from aioesphomeapi.connection import APIConnectionError, TimeoutAPIError
 import async_timeout
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -184,11 +184,16 @@ class ESPHomeClient(BaseBleakClient):
 
             if error:
                 try:
-                    human_error = BLEConnectionError(error)
-                except ValueError:
+                    ble_connection_error = BLEConnectionError(error)
+                    ble_connection_error_name = ble_connection_error.name
+                    human_error = ESP_CONNECTION_ERROR_DESCRIPTION[ble_connection_error]
+                except (KeyError, ValueError):
+                    ble_connection_error_name = str(error)
                     human_error = f"Unknown error code {error}"
                 connected_future.set_exception(
-                    BleakError(f"Error code {error} while connecting: {human_error}")
+                    BleakError(
+                        f"Error {ble_connection_error_name} while connecting: {human_error}"
+                    )
                 )
                 return
 

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "requirements": ["aioesphomeapi==11.2.1"],
+  "requirements": ["aioesphomeapi==11.3.0"],
   "zeroconf": ["_esphomelib._tcp.local."],
   "dhcp": [{ "registered_devices": true }],
   "codeowners": ["@OttoWinter", "@jesserockz"],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "requirements": ["aioesphomeapi==11.2.0"],
+  "requirements": ["aioesphomeapi==11.2.1"],
   "zeroconf": ["_esphomelib._tcp.local."],
   "dhcp": [{ "registered_devices": true }],
   "codeowners": ["@OttoWinter", "@jesserockz"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -153,7 +153,7 @@ aioecowitt==2022.09.3
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==11.2.0
+aioesphomeapi==11.3.0
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -140,7 +140,7 @@ aioecowitt==2022.09.3
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==11.2.0
+aioesphomeapi==11.3.0
 
 # homeassistant.components.flo
 aioflo==2021.11.0


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changelog: https://github.com/esphome/aioesphomeapi/releases/tag/v11.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
