### PR TITLE
Include esphome device name in BLE logs

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -249,6 +249,8 @@ async def async_setup_entry(  # noqa: C901
 
     async def on_disconnect() -> None:
         """Run disconnect callbacks on API disconnect."""
+        name = entry_data.device_info.name if entry_data.device_info else host
+        _LOGGER.debug("%s: %s disconnected, running disconnected callbacks", name, host)
         for disconnect_cb in entry_data.disconnect_callbacks:
             disconnect_cb()
         entry_data.disconnect_callbacks = []

--- a/homeassistant/components/esphome/bluetooth/__init__.py
+++ b/homeassistant/components/esphome/bluetooth/__init__.py
@@ -30,13 +30,15 @@ def _async_can_connect_factory(
     @hass_callback
     def _async_can_connect() -> bool:
         """Check if a given source can make another connection."""
+        can_connect = bool(entry_data.available and entry_data.ble_connections_free)
         _LOGGER.debug(
-            "Checking if %s can connect, available=%s, ble_connections_free=%s",
+            "%s: Checking can connect, available=%s, ble_connections_free=%s result=%s",
             source,
             entry_data.available,
             entry_data.ble_connections_free,
+            can_connect,
         )
-        return bool(entry_data.available and entry_data.ble_connections_free)
+        return can_connect
 
     return _async_can_connect
 
@@ -55,7 +57,7 @@ async def async_connect_scanner(
     version = entry_data.device_info.bluetooth_proxy_version
     connectable = version >= 2
     _LOGGER.debug(
-        "Connecting scanner for %s, version=%s, connectable=%s",
+        "%s: Connecting scanner version=%s, connectable=%s",
         source,
         version,
         connectable,

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -61,7 +61,7 @@ def verify_connected(func: _WrapFuncType) -> _WrapFuncType:
         if disconnected_event.is_set():
             task.cancel()
             raise BleakError(
-                f"{self._ble_device.name} ({self._ble_device.address}): "  # pylint: disable=protected-access
+                f"{self._source}: {self._ble_device.name} - {self._ble_device.address}: "  # pylint: disable=protected-access
                 "Disconnected during operation"
             )
         return next(iter(done)).result()
@@ -120,14 +120,22 @@ class ESPHomeClient(BaseBleakClient):
             self._cancel_connection_state()
         except (AssertionError, ValueError) as ex:
             _LOGGER.debug(
-                "Failed to unsubscribe from connection state (likely connection dropped): %s",
+                "%s: %s - %s: Failed to unsubscribe from connection state (likely connection dropped): %s",
+                self._source,
+                self._ble_device.name,
+                self._ble_device.address,
                 ex,
             )
         self._cancel_connection_state = None
 
     def _async_ble_device_disconnected(self) -> None:
         """Handle the BLE device disconnecting from the ESP."""
-        _LOGGER.debug("%s: BLE device disconnected", self._source)
+        _LOGGER.debug(
+            "%s: %s - %s: BLE device disconnected",
+            self._source,
+            self._ble_device.name,
+            self._ble_device.address,
+        )
         self._is_connected = False
         self.services = BleakGATTServiceCollection()  # type: ignore[no-untyped-call]
         if self._disconnected_event:
@@ -138,7 +146,12 @@ class ESPHomeClient(BaseBleakClient):
 
     def _async_esp_disconnected(self) -> None:
         """Handle the esp32 client disconnecting from hass."""
-        _LOGGER.debug("%s: ESP device disconnected", self._source)
+        _LOGGER.debug(
+            "%s: %s - %s: ESP device disconnected",
+            self._source,
+            self._ble_device.name,
+            self._ble_device.address,
+        )
         self.entry_data.disconnect_callbacks.remove(self._async_esp_disconnected)
         self._async_ble_device_disconnected()
 
@@ -168,7 +181,10 @@ class ESPHomeClient(BaseBleakClient):
         ) -> None:
             """Handle a connect or disconnect."""
             _LOGGER.debug(
-                "Connection state changed: connected=%s mtu=%s error=%s",
+                "%s: %s - %s: Connection state changed to connected=%s mtu=%s error=%s",
+                self._source,
+                self._ble_device.name,
+                self._ble_device.address,
                 connected,
                 mtu,
                 error,
@@ -201,6 +217,12 @@ class ESPHomeClient(BaseBleakClient):
                 connected_future.set_exception(BleakError("Disconnected"))
                 return
 
+            _LOGGER.debug(
+                "%s: %s - %s: connected, registering for disconnected callbacks",
+                self._source,
+                self._ble_device.name,
+                self._ble_device.address,
+            )
             self.entry_data.disconnect_callbacks.append(self._async_esp_disconnected)
             connected_future.set_result(connected)
 
@@ -228,7 +250,10 @@ class ESPHomeClient(BaseBleakClient):
         if self.entry_data.ble_connections_free:
             return
         _LOGGER.debug(
-            "%s: Out of connection slots, waiting for a free one", self._source
+            "%s: %s - %s: Out of connection slots, waiting for a free one",
+            self._source,
+            self._ble_device.name,
+            self._ble_device.address,
         )
         async with async_timeout.timeout(timeout):
             await self.entry_data.wait_for_ble_connections_free()
@@ -270,19 +295,28 @@ class ESPHomeClient(BaseBleakClient):
             cached_services := entry_data.get_gatt_services_cache(address_as_int)
         ):
             _LOGGER.debug(
-                "Cached services hit for %s - %s",
+                "%s: %s - %s: Cached services hit",
+                self._source,
                 self._ble_device.name,
                 self._ble_device.address,
             )
             self.services = cached_services
             return self.services
         _LOGGER.debug(
-            "Cached services miss for %s - %s",
+            "%s: %s - %s: Cached services miss",
+            self._source,
             self._ble_device.name,
             self._ble_device.address,
         )
         esphome_services = await self._client.bluetooth_gatt_get_services(
             address_as_int
+        )
+        _LOGGER.debug(
+            "%s: %s - %s: Got services: %s",
+            self._source,
+            self._ble_device.name,
+            self._ble_device.address,
+            esphome_services,
         )
         max_write_without_response = self.mtu_size - GATT_HEADER_SIZE
         services = BleakGATTServiceCollection()  # type: ignore[no-untyped-call]
@@ -307,7 +341,8 @@ class ESPHomeClient(BaseBleakClient):
                     )
         self.services = services
         _LOGGER.debug(
-            "Cached services saved for %s - %s",
+            "%s: %s - %s: Cached services saved",
+            self._source,
             self._ble_device.name,
             self._ble_device.address,
         )

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -99,6 +99,11 @@ class RuntimeEntryData:
         default_factory=lambda: LRU(MAX_CACHED_SERVICES)  # type: ignore[no-any-return]
     )
 
+    @property
+    def name(self) -> str:
+        """Return the name of the device."""
+        return self.device_info.name if self.device_info else self.entry_id
+
     def get_gatt_services_cache(
         self, address: int
     ) -> BleakGATTServiceCollection | None:
@@ -114,13 +119,19 @@ class RuntimeEntryData:
     @callback
     def async_update_ble_connection_limits(self, free: int, limit: int) -> None:
         """Update the BLE connection limits."""
-        name = self.device_info.name if self.device_info else self.entry_id
-        _LOGGER.debug("%s: BLE connection limits: %s/%s", name, free, limit)
+        _LOGGER.debug(
+            "%s: BLE connection limits: used=%s free=%s limit=%s",
+            self.name,
+            limit - free,
+            free,
+            limit,
+        )
         self.ble_connections_free = free
         self.ble_connections_limit = limit
         if free:
             for fut in self._ble_connection_free_futures:
-                fut.set_result(free)
+                if not fut.done():
+                    fut.set_result(free)
             self._ble_connection_free_futures.clear()
 
     async def wait_for_ble_connections_free(self) -> int:
@@ -186,7 +197,8 @@ class RuntimeEntryData:
         subscription_key = (type(state), state.key)
         self.state[type(state)][state.key] = state
         _LOGGER.debug(
-            "Dispatching update with key %s: %s",
+            "%s: dispatching update with key %s: %s",
+            self.name,
             subscription_key,
             state,
         )

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -130,8 +130,7 @@ class RuntimeEntryData:
         self.ble_connections_limit = limit
         if free:
             for fut in self._ble_connection_free_futures:
-                if not fut.done():
-                    fut.set_result(free)
+                fut.set_result(free)
             self._ble_connection_free_futures.clear()
 
     async def wait_for_ble_connections_free(self) -> int:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes it easier to debug what is going on when there are multiple esphome proxies

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
