### PR TITLE
Modernize rest switch tests

### DIFF
--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -6,22 +6,45 @@ import aiohttp
 import pytest
 
 from homeassistant.components.rest import DOMAIN
-import homeassistant.components.rest.switch as rest
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchDeviceClass
+from homeassistant.components.rest.switch import (
+    CONF_BODY_OFF,
+    CONF_BODY_ON,
+    CONF_STATE_RESOURCE,
+)
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SCAN_INTERVAL,
+    SwitchDeviceClass,
+)
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
+    ATTR_ENTITY_PICTURE,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
     CONF_DEVICE_CLASS,
     CONF_HEADERS,
+    CONF_ICON,
+    CONF_METHOD,
     CONF_NAME,
     CONF_PARAMS,
     CONF_PLATFORM,
     CONF_RESOURCE,
+    CONF_UNIQUE_ID,
     CONTENT_TYPE_JSON,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.template_entity import CONF_PICTURE
 from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
 
-from tests.common import assert_setup_component
+from tests.common import assert_setup_component, async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 NAME = "foo"
@@ -34,16 +57,10 @@ async def test_setup_missing_config(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test setup with configuration missing required entries."""
-    assert await async_setup_component(
-        hass,
-        SWITCH_DOMAIN,
-        {
-            SWITCH_DOMAIN: {
-                CONF_PLATFORM: DOMAIN,
-            }
-        },
-    )
+    config = {SWITCH_DOMAIN: {CONF_PLATFORM: DOMAIN}}
+    assert await async_setup_component(hass, SWITCH_DOMAIN, config)
     await hass.async_block_till_done()
+    assert_setup_component(0, SWITCH_DOMAIN)
     assert "Invalid config for [switch.rest]: required key not provided" in caplog.text
 
 
@@ -51,14 +68,10 @@ async def test_setup_missing_schema(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test setup with resource missing schema."""
-    assert await async_setup_component(
-        hass,
-        SWITCH_DOMAIN,
-        {
-            SWITCH_DOMAIN: {CONF_PLATFORM: DOMAIN, CONF_RESOURCE: "localhost"},
-        },
-    )
+    config = {SWITCH_DOMAIN: {CONF_PLATFORM: DOMAIN, CONF_RESOURCE: "localhost"}}
+    assert await async_setup_component(hass, SWITCH_DOMAIN, config)
     await hass.async_block_till_done()
+    assert_setup_component(0, SWITCH_DOMAIN)
     assert "Invalid config for [switch.rest]: invalid url" in caplog.text
 
 
@@ -68,15 +81,11 @@ async def test_setup_failed_connect(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test setup when connection error occurs."""
-    aioclient_mock.get("http://localhost", exc=aiohttp.ClientError)
-    assert await async_setup_component(
-        hass,
-        SWITCH_DOMAIN,
-        {
-            SWITCH_DOMAIN: {CONF_PLATFORM: DOMAIN, CONF_RESOURCE: "http://localhost"},
-        },
-    )
+    aioclient_mock.get(RESOURCE, exc=aiohttp.ClientError)
+    config = {SWITCH_DOMAIN: {CONF_PLATFORM: DOMAIN, CONF_RESOURCE: RESOURCE}}
+    assert await async_setup_component(hass, SWITCH_DOMAIN, config)
     await hass.async_block_till_done()
+    assert_setup_component(0, SWITCH_DOMAIN)
     assert "No route to resource/endpoint" in caplog.text
 
 
@@ -86,15 +95,11 @@ async def test_setup_timeout(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test setup when connection timeout occurs."""
-    aioclient_mock.get("http://localhost", exc=asyncio.TimeoutError())
-    assert await async_setup_component(
-        hass,
-        SWITCH_DOMAIN,
-        {
-            SWITCH_DOMAIN: {CONF_PLATFORM: DOMAIN, CONF_RESOURCE: "http://localhost"},
-        },
-    )
+    aioclient_mock.get(RESOURCE, exc=asyncio.TimeoutError())
+    config = {SWITCH_DOMAIN: {CONF_PLATFORM: DOMAIN, CONF_RESOURCE: RESOURCE}}
+    assert await async_setup_component(hass, SWITCH_DOMAIN, config)
     await hass.async_block_till_done()
+    assert_setup_component(0, SWITCH_DOMAIN)
     assert "No route to resource/endpoint" in caplog.text
 
 
@@ -102,18 +107,10 @@ async def test_setup_minimum(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test setup with minimum configuration."""
-    aioclient_mock.get("http://localhost", status=HTTPStatus.OK)
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    config = {SWITCH_DOMAIN: {CONF_PLATFORM: DOMAIN, CONF_RESOURCE: RESOURCE}}
     with assert_setup_component(1, SWITCH_DOMAIN):
-        assert await async_setup_component(
-            hass,
-            SWITCH_DOMAIN,
-            {
-                SWITCH_DOMAIN: {
-                    CONF_PLATFORM: DOMAIN,
-                    CONF_RESOURCE: "http://localhost",
-                }
-            },
-        )
+        assert await async_setup_component(hass, SWITCH_DOMAIN, config)
         await hass.async_block_till_done()
     assert aioclient_mock.call_count == 1
 
@@ -123,18 +120,15 @@ async def test_setup_query_params(
 ) -> None:
     """Test setup with query params."""
     aioclient_mock.get("http://localhost/?search=something", status=HTTPStatus.OK)
+    config = {
+        SWITCH_DOMAIN: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_RESOURCE: RESOURCE,
+            CONF_PARAMS: {"search": "something"},
+        }
+    }
     with assert_setup_component(1, SWITCH_DOMAIN):
-        assert await async_setup_component(
-            hass,
-            SWITCH_DOMAIN,
-            {
-                SWITCH_DOMAIN: {
-                    CONF_PLATFORM: DOMAIN,
-                    CONF_RESOURCE: "http://localhost",
-                    CONF_PARAMS: {"search": "something"},
-                }
-            },
-        )
+        assert await async_setup_component(hass, SWITCH_DOMAIN, config)
         await hass.async_block_till_done()
 
     assert aioclient_mock.call_count == 1
@@ -142,21 +136,18 @@ async def test_setup_query_params(
 
 async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test setup with valid configuration."""
-    aioclient_mock.get("http://localhost", status=HTTPStatus.OK)
-    assert await async_setup_component(
-        hass,
-        SWITCH_DOMAIN,
-        {
-            SWITCH_DOMAIN: {
-                CONF_PLATFORM: DOMAIN,
-                CONF_NAME: "foo",
-                CONF_RESOURCE: "http://localhost",
-                CONF_HEADERS: {"Content-type": CONTENT_TYPE_JSON},
-                rest.CONF_BODY_ON: "custom on text",
-                rest.CONF_BODY_OFF: "custom off text",
-            }
-        },
-    )
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    config = {
+        SWITCH_DOMAIN: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "foo",
+            CONF_RESOURCE: RESOURCE,
+            CONF_HEADERS: {"Content-type": CONTENT_TYPE_JSON},
+            CONF_BODY_ON: "custom on text",
+            CONF_BODY_OFF: "custom off text",
+        }
+    }
+    assert await async_setup_component(hass, SWITCH_DOMAIN, config)
     await hass.async_block_till_done()
     assert aioclient_mock.call_count == 1
     assert_setup_component(1, SWITCH_DOMAIN)
@@ -166,23 +157,20 @@ async def test_setup_with_state_resource(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test setup with valid configuration."""
-    aioclient_mock.get("http://localhost", status=HTTPStatus.NOT_FOUND)
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.NOT_FOUND)
     aioclient_mock.get("http://localhost/state", status=HTTPStatus.OK)
-    assert await async_setup_component(
-        hass,
-        SWITCH_DOMAIN,
-        {
-            SWITCH_DOMAIN: {
-                CONF_PLATFORM: DOMAIN,
-                CONF_NAME: "foo",
-                CONF_RESOURCE: "http://localhost",
-                rest.CONF_STATE_RESOURCE: "http://localhost/state",
-                CONF_HEADERS: {"Content-type": CONTENT_TYPE_JSON},
-                rest.CONF_BODY_ON: "custom on text",
-                rest.CONF_BODY_OFF: "custom off text",
-            }
-        },
-    )
+    config = {
+        SWITCH_DOMAIN: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "foo",
+            CONF_RESOURCE: RESOURCE,
+            CONF_STATE_RESOURCE: "http://localhost/state",
+            CONF_HEADERS: {"Content-type": CONTENT_TYPE_JSON},
+            CONF_BODY_ON: "custom on text",
+            CONF_BODY_OFF: "custom off text",
+        }
+    }
+    assert await async_setup_component(hass, SWITCH_DOMAIN, config)
     await hass.async_block_till_done()
     assert aioclient_mock.call_count == 1
     assert_setup_component(1, SWITCH_DOMAIN)
@@ -192,26 +180,23 @@ async def test_setup_with_templated_headers_params(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test setup with valid configuration."""
-    aioclient_mock.get("http://localhost", status=HTTPStatus.OK)
-    assert await async_setup_component(
-        hass,
-        SWITCH_DOMAIN,
-        {
-            SWITCH_DOMAIN: {
-                CONF_PLATFORM: DOMAIN,
-                CONF_NAME: "foo",
-                CONF_RESOURCE: "http://localhost",
-                CONF_HEADERS: {
-                    "Accept": CONTENT_TYPE_JSON,
-                    "User-Agent": "Mozilla/{{ 3 + 2 }}.0",
-                },
-                CONF_PARAMS: {
-                    "start": 0,
-                    "end": "{{ 3 + 2 }}",
-                },
-            }
-        },
-    )
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    config = {
+        SWITCH_DOMAIN: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "foo",
+            CONF_RESOURCE: "http://localhost",
+            CONF_HEADERS: {
+                "Accept": CONTENT_TYPE_JSON,
+                "User-Agent": "Mozilla/{{ 3 + 2 }}.0",
+            },
+            CONF_PARAMS: {
+                "start": 0,
+                "end": "{{ 3 + 2 }}",
+            },
+        }
+    }
+    assert await async_setup_component(hass, SWITCH_DOMAIN, config)
     await hass.async_block_till_done()
     assert aioclient_mock.call_count == 1
     assert aioclient_mock.mock_calls[-1][3].get("Accept") == CONTENT_TYPE_JSON
@@ -221,156 +206,234 @@ async def test_setup_with_templated_headers_params(
     assert_setup_component(1, SWITCH_DOMAIN)
 
 
-"""Tests for REST switch platform."""
+# Tests for REST switch platform.
 
 
-def _setup_test_switch(hass: HomeAssistant) -> None:
+async def _async_setup_test_switch(hass: HomeAssistant) -> None:
     headers = {"Content-type": CONTENT_TYPE_JSON}
-    config = rest.PLATFORM_SCHEMA(
-        {
-            CONF_PLATFORM: "switch",
-            CONF_NAME: NAME,
-            CONF_DEVICE_CLASS: DEVICE_CLASS,
-            CONF_RESOURCE: RESOURCE,
-            rest.CONF_STATE_RESOURCE: STATE_RESOURCE,
-            rest.CONF_HEADERS: headers,
-        }
-    )
-    switch = rest.RestSwitch(hass, config, None)
-    switch.hass = hass
-    return switch, config[rest.CONF_BODY_ON], config[rest.CONF_BODY_OFF]
+    config = {
+        CONF_PLATFORM: DOMAIN,
+        CONF_NAME: NAME,
+        CONF_DEVICE_CLASS: DEVICE_CLASS,
+        CONF_RESOURCE: RESOURCE,
+        CONF_STATE_RESOURCE: STATE_RESOURCE,
+        CONF_HEADERS: headers,
+    }
+
+    assert await async_setup_component(hass, SWITCH_DOMAIN, {SWITCH_DOMAIN: config})
+    await hass.async_block_till_done()
+    assert_setup_component(1, SWITCH_DOMAIN)
 
 
-def test_name(hass: HomeAssistant) -> None:
+async def test_name(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test the name."""
-    switch, body_on, body_off = _setup_test_switch(hass)
-    assert switch.name == NAME
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    await _async_setup_test_switch(hass)
+
+    state = hass.states.get("switch.foo")
+    assert state.attributes[ATTR_FRIENDLY_NAME] == NAME
 
 
-def test_device_class(hass: HomeAssistant) -> None:
-    """Test the name."""
-    switch, body_on, body_off = _setup_test_switch(hass)
-    assert switch.device_class == DEVICE_CLASS
+async def test_device_class(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the device class."""
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    await _async_setup_test_switch(hass)
+
+    state = hass.states.get("switch.foo")
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS
 
 
-def test_is_on_before_update(hass: HomeAssistant) -> None:
+async def test_is_on_before_update(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test is_on in initial state."""
-    switch, body_on, body_off = _setup_test_switch(hass)
-    assert switch.is_on is None
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    await _async_setup_test_switch(hass)
+
+    state = hass.states.get("switch.foo")
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_turn_on_success(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test turn_on."""
-    aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
-    switch, body_on, body_off = _setup_test_switch(hass)
-    await switch.async_turn_on()
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    await _async_setup_test_switch(hass)
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
-    assert body_on.template == aioclient_mock.mock_calls[-1][2].decode()
-    assert switch.is_on
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: "switch.foo"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert aioclient_mock.mock_calls[-1][2].decode() == "ON"
+    assert hass.states.get("switch.foo").state == STATE_ON
 
 
 async def test_turn_on_status_not_ok(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test turn_on when error status returned."""
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
     aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
-    switch, body_on, body_off = _setup_test_switch(hass)
-    await switch.async_turn_on()
+    await _async_setup_test_switch(hass)
 
-    assert body_on.template == aioclient_mock.mock_calls[-1][2].decode()
-    assert switch.is_on is None
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: "switch.foo"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert aioclient_mock.mock_calls[-1][2].decode() == "ON"
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
 
 async def test_turn_on_timeout(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test turn_on when timeout occurs."""
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
     aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
-    switch, body_on, body_off = _setup_test_switch(hass)
-    await switch.async_turn_on()
+    await _async_setup_test_switch(hass)
 
-    assert switch.is_on is None
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: "switch.foo"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
 
 async def test_turn_off_success(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test turn_off."""
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
     aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
-    switch, body_on, body_off = _setup_test_switch(hass)
-    await switch.async_turn_off()
+    await _async_setup_test_switch(hass)
 
-    assert body_off.template == aioclient_mock.mock_calls[-1][2].decode()
-    assert not switch.is_on
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: "switch.foo"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert aioclient_mock.mock_calls[-1][2].decode() == "OFF"
+
+    assert hass.states.get("switch.foo").state == STATE_OFF
 
 
 async def test_turn_off_status_not_ok(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test turn_off when error status returned."""
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
     aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
-    switch, body_on, body_off = _setup_test_switch(hass)
-    await switch.async_turn_off()
+    await _async_setup_test_switch(hass)
 
-    assert body_off.template == aioclient_mock.mock_calls[-1][2].decode()
-    assert switch.is_on is None
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: "switch.foo"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert aioclient_mock.mock_calls[-1][2].decode() == "OFF"
+
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
 
 async def test_turn_off_timeout(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test turn_off when timeout occurs."""
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
     aioclient_mock.post(RESOURCE, exc=asyncio.TimeoutError())
-    switch, body_on, body_off = _setup_test_switch(hass)
-    await switch.async_turn_on()
+    await _async_setup_test_switch(hass)
 
-    assert switch.is_on is None
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: "switch.foo"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
 
 async def test_update_when_on(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test update when switch is on."""
-    switch, body_on, body_off = _setup_test_switch(hass)
-    aioclient_mock.get(RESOURCE, text=body_on.template)
-    await switch.async_update()
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    await _async_setup_test_switch(hass)
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
-    assert switch.is_on
+    aioclient_mock.clear_requests()
+    aioclient_mock.get(RESOURCE, text="ON")
+    async_fire_time_changed(
+        hass,
+        utcnow() + SCAN_INTERVAL,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.foo").state == STATE_ON
 
 
 async def test_update_when_off(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test update when switch is off."""
-    switch, body_on, body_off = _setup_test_switch(hass)
-    aioclient_mock.get(RESOURCE, text=body_off.template)
-    await switch.async_update()
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    await _async_setup_test_switch(hass)
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
-    assert not switch.is_on
+    aioclient_mock.clear_requests()
+    aioclient_mock.get(RESOURCE, text="OFF")
+    async_fire_time_changed(
+        hass,
+        utcnow() + SCAN_INTERVAL,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.foo").state == STATE_OFF
 
 
 async def test_update_when_unknown(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test update when unknown status returned."""
-    aioclient_mock.get(RESOURCE, text="unknown status")
-    switch, body_on, body_off = _setup_test_switch(hass)
-    await switch.async_update()
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    await _async_setup_test_switch(hass)
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
-    assert switch.is_on is None
+    aioclient_mock.clear_requests()
+    aioclient_mock.get(RESOURCE, text="unknown status")
+    async_fire_time_changed(
+        hass,
+        utcnow() + SCAN_INTERVAL,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
 
 async def test_update_timeout(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test update when timeout occurs."""
-    aioclient_mock.get(RESOURCE, exc=asyncio.TimeoutError())
-    switch, body_on, body_off = _setup_test_switch(hass)
-    await switch.async_update()
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
+    await _async_setup_test_switch(hass)
 
-    assert switch.is_on is None
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.get(RESOURCE, exc=asyncio.TimeoutError())
+    async_fire_time_changed(
+        hass,
+        utcnow() + SCAN_INTERVAL,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
 
 async def test_entity_config(
@@ -378,18 +441,18 @@ async def test_entity_config(
 ) -> None:
     """Test entity configuration."""
 
-    aioclient_mock.get("http://localhost", status=HTTPStatus.OK)
+    aioclient_mock.get(RESOURCE, status=HTTPStatus.OK)
     config = {
         SWITCH_DOMAIN: {
             # REST configuration
-            "platform": "rest",
-            "method": "POST",
-            "resource": "http://localhost",
+            CONF_PLATFORM: "rest",
+            CONF_METHOD: "POST",
+            CONF_RESOURCE: "http://localhost",
             # Entity configuration
-            "icon": "{{'mdi:one_two_three'}}",
-            "picture": "{{'blabla.png'}}",
-            "name": "{{'REST' + ' ' + 'Switch'}}",
-            "unique_id": "very_unique",
+            CONF_ICON: "{{'mdi:one_two_three'}}",
+            CONF_PICTURE: "{{'blabla.png'}}",
+            CONF_NAME: "{{'REST' + ' ' + 'Switch'}}",
+            CONF_UNIQUE_ID: "very_unique",
         },
     }
 
@@ -402,7 +465,7 @@ async def test_entity_config(
     state = hass.states.get("switch.rest_switch")
     assert state.state == "unknown"
     assert state.attributes == {
-        "entity_picture": "blabla.png",
-        "friendly_name": "REST Switch",
-        "icon": "mdi:one_two_three",
+        ATTR_ENTITY_PICTURE: "blabla.png",
+        ATTR_FRIENDLY_NAME: "REST Switch",
+        ATTR_ICON: "mdi:one_two_three",
     }

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -1,7 +1,6 @@
 """The tests for the REST switch platform."""
 import asyncio
 from http import HTTPStatus
-from unittest.mock import patch
 
 import aiohttp
 import pytest
@@ -267,17 +266,17 @@ async def test_turn_on_success(
     """Test turn_on."""
     await _async_setup_test_switch(hass, aioclient_mock)
 
-    with patch("homeassistant.components.rest.switch.RestSwitch.async_update"):
-        aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
-        assert await hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "switch.foo"},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
+    aioclient_mock.get(RESOURCE, text="ON")
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.foo"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-    assert aioclient_mock.mock_calls[-1][2].decode() == "ON"
+    assert aioclient_mock.mock_calls[-2][2].decode() == "ON"
     assert hass.states.get("switch.foo").state == STATE_ON
 
 
@@ -287,15 +286,14 @@ async def test_turn_on_status_not_ok(
     """Test turn_on when error status returned."""
     await _async_setup_test_switch(hass, aioclient_mock)
 
-    with patch("homeassistant.components.rest.switch.RestSwitch.async_update"):
-        aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
-        assert await hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "switch.foo"},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.foo"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
     assert aioclient_mock.mock_calls[-1][2].decode() == "ON"
     assert hass.states.get("switch.foo").state == STATE_UNKNOWN
@@ -307,15 +305,14 @@ async def test_turn_on_timeout(
     """Test turn_on when timeout occurs."""
     await _async_setup_test_switch(hass, aioclient_mock)
 
-    with patch("homeassistant.components.rest.switch.RestSwitch.async_update"):
-        aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
-        assert await hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "switch.foo"},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.foo"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
     assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
@@ -326,17 +323,17 @@ async def test_turn_off_success(
     """Test turn_off."""
     await _async_setup_test_switch(hass, aioclient_mock)
 
-    with patch("homeassistant.components.rest.switch.RestSwitch.async_update"):
-        aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
-        assert await hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: "switch.foo"},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
+    aioclient_mock.get(RESOURCE, text="OFF")
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.foo"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-    assert aioclient_mock.mock_calls[-1][2].decode() == "OFF"
+    assert aioclient_mock.mock_calls[-2][2].decode() == "OFF"
 
     assert hass.states.get("switch.foo").state == STATE_OFF
 
@@ -347,15 +344,14 @@ async def test_turn_off_status_not_ok(
     """Test turn_off when error status returned."""
     await _async_setup_test_switch(hass, aioclient_mock)
 
-    with patch("homeassistant.components.rest.switch.RestSwitch.async_update"):
-        aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
-        assert await hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: "switch.foo"},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.foo"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
     assert aioclient_mock.mock_calls[-1][2].decode() == "OFF"
 
@@ -368,15 +364,14 @@ async def test_turn_off_timeout(
     """Test turn_off when timeout occurs."""
     await _async_setup_test_switch(hass, aioclient_mock)
 
-    with patch("homeassistant.components.rest.switch.RestSwitch.async_update"):
-        aioclient_mock.post(RESOURCE, exc=asyncio.TimeoutError())
-        assert await hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: "switch.foo"},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
+    aioclient_mock.post(RESOURCE, exc=asyncio.TimeoutError())
+    assert await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.foo"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
     assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -267,7 +267,7 @@ async def test_turn_on_success(
     await _async_setup_test_switch(hass, aioclient_mock)
 
     aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
-    aioclient_mock.get(RESOURCE, text="ON")
+    aioclient_mock.get(RESOURCE, exc=aiohttp.ClientError)
     assert await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON,
@@ -324,7 +324,7 @@ async def test_turn_off_success(
     await _async_setup_test_switch(hass, aioclient_mock)
 
     aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
-    aioclient_mock.get(RESOURCE, text="OFF")
+    aioclient_mock.get(RESOURCE, exc=aiohttp.ClientError)
     assert await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -28,10 +28,8 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 NAME = "foo"
 DEVICE_CLASS = SwitchDeviceClass.SWITCH
-METHOD = "post"
 RESOURCE = "http://localhost/"
 STATE_RESOURCE = RESOURCE
-PARAMS = None
 
 
 async def test_setup_missing_config(hass: HomeAssistant) -> None:
@@ -207,8 +205,6 @@ async def test_setup_with_templated_headers_params(
 
 
 def _setup_test_switch(hass: HomeAssistant) -> None:
-    body_on = "on"
-    body_off = "off"
     headers = {"Content-type": CONTENT_TYPE_JSON}
     config = rest.PLATFORM_SCHEMA(
         {
@@ -217,12 +213,7 @@ def _setup_test_switch(hass: HomeAssistant) -> None:
             CONF_DEVICE_CLASS: DEVICE_CLASS,
             CONF_RESOURCE: RESOURCE,
             rest.CONF_STATE_RESOURCE: STATE_RESOURCE,
-            rest.CONF_METHOD: METHOD,
             rest.CONF_HEADERS: headers,
-            rest.CONF_BODY_ON: body_on,
-            rest.CONF_BODY_OFF: body_off,
-            rest.CONF_TIMEOUT: 10,
-            rest.CONF_VERIFY_SSL: True,
         }
     )
     switch = rest.RestSwitch(hass, config, None)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust rest switch tests to use schema validation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
