### PR TITLE
Add type hints to template helper

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -559,8 +559,11 @@ class Template:
 
     @callback
     def async_render_with_possible_json_value(
-        self, value, error_value=_SENTINEL, variables=None
-    ):
+        self,
+        value: Any,
+        error_value: object | None = _SENTINEL,
+        variables: dict[str, Any] | None = None,
+    ) -> Any:
         """Render template with value exposed.
 
         If valid JSON will expose value_json too.
@@ -571,7 +574,7 @@ class Template:
             return self.template
 
         if self._compiled is None:
-            self._ensure_compiled()
+            self._compiled = self._ensure_compiled()
 
         variables = dict(variables or {})
         variables["value"] = value

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -573,8 +573,7 @@ class Template:
         if self.is_static:
             return self.template
 
-        if self._compiled is None:
-            self._compiled = self._ensure_compiled()
+        compiled = self._compiled or self._ensure_compiled()
 
         variables = dict(variables or {})
         variables["value"] = value
@@ -583,9 +582,7 @@ class Template:
             variables["value_json"] = json_loads(value)
 
         try:
-            return _render_with_context(
-                self.template, self._compiled, **variables
-            ).strip()
+            return _render_with_context(self.template, compiled, **variables).strip()
         except jinja2.TemplateError as ex:
             if error_value is _SENTINEL:
                 _LOGGER.error(

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -561,7 +561,7 @@ class Template:
     def async_render_with_possible_json_value(
         self,
         value: Any,
-        error_value: object | None = _SENTINEL,
+        error_value: Any = _SENTINEL,
         variables: dict[str, Any] | None = None,
     ) -> Any:
         """Render template with value exposed.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I spotted this one whilst working on REST type hints

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
