### PR TITLE
Immediately prefer advertisements from alternate sources when a scanner goes away

### DIFF
--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -379,6 +379,7 @@ class BluetoothManager:
         if (
             (old_service_info := all_history.get(address))
             and source != old_service_info.source
+            and old_service_info.source in self._adapters
             and self._prefer_previous_adv_from_different_source(
                 old_service_info, service_info
             )
@@ -398,6 +399,7 @@ class BluetoothManager:
                     # the old connectable advertisement
                     or (
                         source != old_connectable_service_info.source
+                        and old_connectable_service_info.source in self._adapters
                         and self._prefer_previous_adv_from_different_source(
                             old_connectable_service_info, service_info
                         )

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -127,6 +127,7 @@ class BluetoothManager:
         self._non_connectable_scanners: list[BaseHaScanner] = []
         self._connectable_scanners: list[BaseHaScanner] = []
         self._adapters: dict[str, AdapterDetails] = {}
+        self._sources: set[str] = set()
 
     @property
     def supports_passive_scan(self) -> bool:
@@ -379,7 +380,7 @@ class BluetoothManager:
         if (
             (old_service_info := all_history.get(address))
             and source != old_service_info.source
-            and old_service_info.source in self._adapters
+            and old_service_info.source in self._sources
             and self._prefer_previous_adv_from_different_source(
                 old_service_info, service_info
             )
@@ -399,7 +400,7 @@ class BluetoothManager:
                     # the old connectable advertisement
                     or (
                         source != old_connectable_service_info.source
-                        and old_connectable_service_info.source in self._adapters
+                        and old_connectable_service_info.source in self._sources
                         and self._prefer_previous_adv_from_different_source(
                             old_connectable_service_info, service_info
                         )
@@ -599,8 +600,10 @@ class BluetoothManager:
         def _unregister_scanner() -> None:
             self._advertisement_tracker.async_remove_source(scanner.source)
             scanners.remove(scanner)
+            self._sources.remove(scanner.source)
 
         scanners.append(scanner)
+        self._sources.add(scanner.source)
         return _unregister_scanner
 
     @hass_callback

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -5,11 +5,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from bleak.backends.scanner import BLEDevice
 from bluetooth_adapters import AdvertisementHistory
+import pytest
 
 from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import models
 from homeassistant.components.bluetooth.manager import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import (
@@ -20,8 +23,28 @@ from . import (
 )
 
 
+@pytest.fixture
+def register_hci0_scanner(hass: HomeAssistant) -> None:
+    """Register an hci0 scanner."""
+    cancel = bluetooth.async_register_scanner(
+        hass, models.BaseHaScanner(hass, "hci0"), True
+    )
+    yield
+    cancel()
+
+
+@pytest.fixture
+def register_hci1_scanner(hass: HomeAssistant) -> None:
+    """Register an hci1 scanner."""
+    cancel = bluetooth.async_register_scanner(
+        hass, models.BaseHaScanner(hass, "hci1"), True
+    )
+    yield
+    cancel()
+
+
 async def test_advertisements_do_not_switch_adapters_for_no_reason(
-    hass, enable_bluetooth
+    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
 ):
     """Test we only switch adapters when needed."""
 
@@ -68,7 +91,9 @@ async def test_advertisements_do_not_switch_adapters_for_no_reason(
     )
 
 
-async def test_switching_adapters_based_on_rssi(hass, enable_bluetooth):
+async def test_switching_adapters_based_on_rssi(
+    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
+):
     """Test switching adapters based on rssi."""
 
     address = "44:44:33:11:23:45"
@@ -122,7 +147,9 @@ async def test_switching_adapters_based_on_rssi(hass, enable_bluetooth):
     )
 
 
-async def test_switching_adapters_based_on_zero_rssi(hass, enable_bluetooth):
+async def test_switching_adapters_based_on_zero_rssi(
+    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
+):
     """Test switching adapters based on zero rssi."""
 
     address = "44:44:33:11:23:45"
@@ -176,7 +203,9 @@ async def test_switching_adapters_based_on_zero_rssi(hass, enable_bluetooth):
     )
 
 
-async def test_switching_adapters_based_on_stale(hass, enable_bluetooth):
+async def test_switching_adapters_based_on_stale(
+    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
+):
     """Test switching adapters based on the previous advertisement being stale."""
 
     address = "44:44:33:11:23:41"
@@ -256,7 +285,7 @@ async def test_restore_history_from_dbus(hass, one_adapter):
 
 
 async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
-    hass, enable_bluetooth
+    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
 ):
     """Test switching adapters based on rssi from connectable to non connectable."""
 
@@ -339,7 +368,7 @@ async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
 
 
 async def test_connectable_advertisement_can_be_retrieved_with_best_path_is_non_connectable(
-    hass, enable_bluetooth
+    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
 ):
     """Test we can still get a connectable BLEDevice when the best path is non-connectable.
 
@@ -382,5 +411,56 @@ async def test_connectable_advertisement_can_be_retrieved_with_best_path_is_non_
     )
     assert (
         bluetooth.async_ble_device_from_address(hass, address, True)
+        is switchbot_device_poor_signal
+    )
+
+
+async def test_switching_adapters_when_one_goes_away(
+    hass, enable_bluetooth, register_hci0_scanner
+):
+    """Test switching adapters when one goes away."""
+    cancel_hci2 = bluetooth.async_register_scanner(
+        hass, models.BaseHaScanner(hass, "hci2"), True
+    )
+
+    address = "44:44:33:11:23:45"
+
+    switchbot_device_good_signal = BLEDevice(address, "wohand_good_signal")
+    switchbot_adv_good_signal = generate_advertisement_data(
+        local_name="wohand_good_signal", service_uuids=[], rssi=-60
+    )
+    inject_advertisement_with_source(
+        hass, switchbot_device_good_signal, switchbot_adv_good_signal, "hci2"
+    )
+
+    assert (
+        bluetooth.async_ble_device_from_address(hass, address)
+        is switchbot_device_good_signal
+    )
+
+    switchbot_device_poor_signal = BLEDevice(address, "wohand_poor_signal")
+    switchbot_adv_poor_signal = generate_advertisement_data(
+        local_name="wohand_poor_signal", service_uuids=[], rssi=-100
+    )
+    inject_advertisement_with_source(
+        hass, switchbot_device_poor_signal, switchbot_adv_poor_signal, "hci0"
+    )
+
+    # We want to prefer the good signal when we have options
+    assert (
+        bluetooth.async_ble_device_from_address(hass, address)
+        is switchbot_device_good_signal
+    )
+
+    cancel_hci2()
+
+    inject_advertisement_with_source(
+        hass, switchbot_device_poor_signal, switchbot_adv_poor_signal, "hci0"
+    )
+
+    # Now that hci2 is gone, we should prefer the poor signal
+    # since no poor signal is better than no signal
+    assert (
+        bluetooth.async_ble_device_from_address(hass, address)
         is switchbot_device_poor_signal
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If an esp32 is disconnected or a bluetooth adapter is unplugged we should immediately prefer any new advertisements from other sources instead of waiting for the timeout as it means we can drop notifications and miss events if we do not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
