### PR TITLE
Improve error logging of WebSocket API

### DIFF
--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -1,8 +1,11 @@
 """Test WebSocket Connection class."""
 import asyncio
 import logging
-from unittest.mock import Mock
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
 
+from aiohttp.test_utils import make_mocked_request
+import pytest
 import voluptuous as vol
 
 from homeassistant import exceptions
@@ -11,37 +14,86 @@ from homeassistant.components import websocket_api
 from tests.common import MockUser
 
 
-async def test_exception_handling():
-    """Test handling of exceptions."""
-    send_messages = []
-    user = MockUser()
-    refresh_token = Mock()
-    conn = websocket_api.ActiveConnection(
-        logging.getLogger(__name__), None, send_messages.append, user, refresh_token
-    )
-
-    for (exc, code, err) in (
-        (exceptions.Unauthorized(), websocket_api.ERR_UNAUTHORIZED, "Unauthorized"),
+@pytest.mark.parametrize(
+    "exc,code,err,log",
+    [
+        (
+            exceptions.Unauthorized(),
+            websocket_api.ERR_UNAUTHORIZED,
+            "Unauthorized",
+            "Error handling message: Unauthorized (unauthorized) from 127.0.0.42 (Browser)",
+        ),
         (
             vol.Invalid("Invalid something"),
             websocket_api.ERR_INVALID_FORMAT,
             "Invalid something. Got {'id': 5}",
+            "Error handling message: Invalid something. Got {'id': 5} (invalid_format) from 127.0.0.42 (Browser)",
         ),
-        (asyncio.TimeoutError(), websocket_api.ERR_TIMEOUT, "Timeout"),
+        (
+            asyncio.TimeoutError(),
+            websocket_api.ERR_TIMEOUT,
+            "Timeout",
+            "Error handling message: Timeout (timeout) from 127.0.0.42 (Browser)",
+        ),
         (
             exceptions.HomeAssistantError("Failed to do X"),
             websocket_api.ERR_UNKNOWN_ERROR,
             "Failed to do X",
+            "Error handling message: Failed to do X (unknown_error) from 127.0.0.42 (Browser)",
         ),
-        (ValueError("Really bad"), websocket_api.ERR_UNKNOWN_ERROR, "Unknown error"),
         (
-            exceptions.HomeAssistantError(),
+            ValueError("Really bad"),
             websocket_api.ERR_UNKNOWN_ERROR,
             "Unknown error",
+            "Error handling message: Unknown error (unknown_error) from 127.0.0.42 (Browser)",
         ),
-    ):
-        send_messages.clear()
+        (
+            exceptions.HomeAssistantError,
+            websocket_api.ERR_UNKNOWN_ERROR,
+            "Unknown error",
+            "Error handling message: Unknown error (unknown_error) from 127.0.0.42 (Browser)",
+        ),
+    ],
+)
+async def test_exception_handling(
+    caplog: pytest.LogCaptureFixture,
+    exc: Exception,
+    code: str,
+    err: str,
+    log: str,
+):
+    """Test handling of exceptions."""
+    send_messages = []
+    user = MockUser()
+    refresh_token = Mock()
+    current_request = AsyncMock()
+
+    def get_extra_info(key: str) -> Any:
+        if key == "sslcontext":
+            return True
+
+        if key == "peername":
+            return ("127.0.0.42", 8123)
+
+    mocked_transport = Mock()
+    mocked_transport.get_extra_info = get_extra_info
+    mocked_request = make_mocked_request(
+        "GET",
+        "/api/websocket",
+        headers={"Host": "example.com", "User-Agent": "Browser"},
+        transport=mocked_transport,
+    )
+
+    with patch(
+        "homeassistant.components.websocket_api.connection.current_request",
+    ) as current_request:
+        current_request.get.return_value = mocked_request
+        conn = websocket_api.ActiveConnection(
+            logging.getLogger(__name__), None, send_messages.append, user, refresh_token
+        )
+
         conn.async_handle_exception({"id": 5}, exc)
-        assert len(send_messages) == 1
-        assert send_messages[0]["error"]["code"] == code
-        assert send_messages[0]["error"]["message"] == err
+    assert len(send_messages) == 1
+    assert send_messages[0]["error"]["code"] == code
+    assert send_messages[0]["error"]["message"] == err
+    assert log in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The WebSocket API is currently able to log messages like these:

```
Logger: homeassistant.components.websocket_api.http.connection
Source: components/websocket_api/connection.py:103
Integration: Home Assistant WebSocket API (documentation, issues)
First occurred: 12:48:23 (44 occurrences)
Last logged: 21:45:36
```

``` 
Error handling message: Unauthorized (unauthorized)
Error handling message: Unauthorized (unauthorized)
Error handling message: Unauthorized (unauthorized)
Error handling message: Unauthorized (unauthorized)
Error handling message: Unauthorized (unauthorized)
```

However, as a user, there is nothing you can do even to start debugging these issues, not even to think about fixing them as a developer.

This PR adds a little more information to the logged error messages: The remote peer and the user agent (if available). This should provide a little bit more of a hint on what is triggering these messages.

Lot of reference to be found on this:

- https://community.home-assistant.io/t/error-handling-message-unauthorized-unauthorized/449168
- https://community.home-assistant.io/t/unauthorized-unauthorized-in-logs/460152
- https://community.home-assistant.io/t/error-handling-message-unauthorized-what-is-it/187114
- https://github.com/home-assistant/core/issues/76125
- https://github.com/home-assistant/core/issues/69852

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
