### PR TITLE
Fix Todoist integration timezone issues, swap client library

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1159,8 +1159,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/time_date/ @fabaff
 /tests/components/time_date/ @fabaff
 /homeassistant/components/tmb/ @alemuro
-/homeassistant/components/todoist/ @boralyl
-/tests/components/todoist/ @boralyl
+/homeassistant/components/todoist/ @boralyl @nwithan8
+/tests/components/todoist/ @boralyl @nwithan8
 /homeassistant/components/tolo/ @MatthiasLohr
 /tests/components/tolo/ @MatthiasLohr
 /homeassistant/components/tomorrowio/ @raman325 @lymanepp

--- a/homeassistant/components/todoist/const.py
+++ b/homeassistant/components/todoist/const.py
@@ -73,8 +73,6 @@ PRIORITY = "priority"
 PROJECT_ID = "project_id"
 # Service Call: What Project do you want a Task added to?
 PROJECT_NAME = "project"
-# Todoist API: Fetch all Projects
-PROJECTS = "projects"
 # Calendar Platform: When does a calendar event start?
 START = "start"
 # Calendar Platform: What is the next calendar event about?

--- a/homeassistant/components/todoist/manifest.json
+++ b/homeassistant/components/todoist/manifest.json
@@ -2,8 +2,8 @@
   "domain": "todoist",
   "name": "Todoist",
   "documentation": "https://www.home-assistant.io/integrations/todoist",
-  "requirements": ["todoist-python==8.0.0"],
-  "codeowners": ["@boralyl"],
+  "requirements": ["todoist_api_python==2.0.1", "pytz==2022.6"],
+  "codeowners": ["@boralyl", "@nwithan8"],
   "iot_class": "cloud_polling",
   "loggers": ["todoist"]
 }

--- a/homeassistant/components/todoist/types.py
+++ b/homeassistant/components/todoist/types.py
@@ -1,14 +1,2 @@
 """Types for the Todoist component."""
 from __future__ import annotations
-
-from typing import TypedDict
-
-
-class DueDate(TypedDict):
-    """Dict representing a due date in a todoist api response."""
-
-    date: str
-    is_recurring: bool
-    lang: str
-    string: str
-    timezone: str | None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2074,6 +2074,9 @@ pytradfri[async]==9.0.0
 # homeassistant.components.trafikverket_weatherstation
 pytrafikverket==0.2.1
 
+# homeassistant.components.todoist
+pytz==2022.6
+
 # homeassistant.components.usb
 pyudev==0.23.2
 
@@ -2422,7 +2425,7 @@ tilt-ble==0.2.3
 tmb==0.0.4
 
 # homeassistant.components.todoist
-todoist-python==8.0.0
+todoist_api_python==2.0.1
 
 # homeassistant.components.tolo
 tololib==0.1.0b3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1437,6 +1437,9 @@ pytradfri[async]==9.0.0
 # homeassistant.components.trafikverket_weatherstation
 pytrafikverket==0.2.1
 
+# homeassistant.components.todoist
+pytz==2022.6
+
 # homeassistant.components.usb
 pyudev==0.23.2
 
@@ -1662,7 +1665,7 @@ thermopro-ble==0.4.3
 tilt-ble==0.2.3
 
 # homeassistant.components.todoist
-todoist-python==8.0.0
+todoist_api_python==2.0.1
 
 # homeassistant.components.tolo
 tololib==0.1.0b3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the Todoist integration to use [Todoist's new REST library](https://pypi.org/project/todoist-api-python/) (the old Sync API library [is deprecated](https://github.com/Doist/todoist-python))

This PR also fixes longstanding issues with timezone parsing that was affected by Todoist's API change.

As a result of the API change, reminders can no longer be set for tasks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
