### PR TITLE
Add unit conversion for energy costs

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -38,7 +38,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import unit_conversion
 import homeassistant.util.dt as dt_util
-from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import DOMAIN
 from .data import EnergyManager, async_get_manager
@@ -273,7 +273,7 @@ class EnergyCostSensor(SensorEntity):
 
         elif self._adapter.source_type == "water":
             valid_units = VALID_VOLUME_UNITS_WATER
-            if self.hass.config.units is US_CUSTOMARY_SYSTEM:
+            if self.hass.config.units is METRIC_SYSTEM:
                 default_price_unit = UnitOfVolume.CUBIC_METERS
             else:
                 default_price_unit = UnitOfVolume.GALLONS

--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -38,6 +38,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import unit_conversion
 import homeassistant.util.dt as dt_util
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .const import DOMAIN
 from .data import EnergyManager, async_get_manager
@@ -272,7 +273,7 @@ class EnergyCostSensor(SensorEntity):
 
         elif self._adapter.source_type == "water":
             valid_units = VALID_VOLUME_UNITS_WATER
-            if self.hass.config.units.is_metric:
+            if self.hass.config.units is US_CUSTOMARY_SYSTEM:
                 default_price_unit = UnitOfVolume.CUBIC_METERS
             else:
                 default_price_unit = UnitOfVolume.GALLONS

--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -275,7 +275,7 @@ class EnergyCostSensor(SensorEntity):
             if self.hass.config.units.is_metric:
                 default_price_unit = UnitOfVolume.CUBIC_METERS
             else:
-                default_price_unit = UnitOfVolume.CUBIC_FEET
+                default_price_unit = UnitOfVolume.GALLONS
 
         energy_state = self.hass.states.get(
             cast(str, self._config[self._adapter.stat_energy_key])

--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import copy
 from dataclasses import dataclass
 import logging
@@ -22,6 +23,7 @@ from homeassistant.const import (
     VOLUME_GALLONS,
     VOLUME_LITERS,
     UnitOfEnergy,
+    UnitOfVolume,
 )
 from homeassistant.core import (
     HomeAssistant,
@@ -34,29 +36,34 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import unit_conversion
 import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
 from .data import EnergyManager, async_get_manager
 
-SUPPORTED_STATE_CLASSES = [
+SUPPORTED_STATE_CLASSES = {
     SensorStateClass.MEASUREMENT,
     SensorStateClass.TOTAL,
     SensorStateClass.TOTAL_INCREASING,
-]
-VALID_ENERGY_UNITS = [
+}
+VALID_ENERGY_UNITS: set[str] = {
     UnitOfEnergy.WATT_HOUR,
     UnitOfEnergy.KILO_WATT_HOUR,
     UnitOfEnergy.MEGA_WATT_HOUR,
     UnitOfEnergy.GIGA_JOULE,
-]
-VALID_ENERGY_UNITS_GAS = [VOLUME_CUBIC_FEET, VOLUME_CUBIC_METERS] + VALID_ENERGY_UNITS
-VALID_VOLUME_UNITS_WATER = [
+}
+VALID_ENERGY_UNITS_GAS = {
+    VOLUME_CUBIC_FEET,
+    VOLUME_CUBIC_METERS,
+    *VALID_ENERGY_UNITS,
+}
+VALID_VOLUME_UNITS_WATER = {
     VOLUME_CUBIC_FEET,
     VOLUME_CUBIC_METERS,
     VOLUME_GALLONS,
     VOLUME_LITERS,
-]
+}
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -252,8 +259,24 @@ class EnergyCostSensor(SensorEntity):
         self.async_write_ha_state()
 
     @callback
-    def _update_cost(self) -> None:  # noqa: C901
+    def _update_cost(self) -> None:
         """Update incurred costs."""
+        if self._adapter.source_type == "grid":
+            valid_units = VALID_ENERGY_UNITS
+            default_price_unit: str | None = UnitOfEnergy.KILO_WATT_HOUR
+
+        elif self._adapter.source_type == "gas":
+            valid_units = VALID_ENERGY_UNITS_GAS
+            # No conversion for gas.
+            default_price_unit = None
+
+        elif self._adapter.source_type == "water":
+            valid_units = VALID_VOLUME_UNITS_WATER
+            if self.hass.config.units.is_metric:
+                default_price_unit = UnitOfVolume.CUBIC_METERS
+            else:
+                default_price_unit = UnitOfVolume.CUBIC_FEET
+
         energy_state = self.hass.states.get(
             cast(str, self._config[self._adapter.stat_energy_key])
         )
@@ -298,52 +321,27 @@ class EnergyCostSensor(SensorEntity):
             except ValueError:
                 return
 
-            if energy_price_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, "").endswith(
-                f"/{UnitOfEnergy.WATT_HOUR}"
-            ):
-                energy_price *= 1000.0
+            energy_price_unit: str | None = energy_price_state.attributes.get(
+                ATTR_UNIT_OF_MEASUREMENT, ""
+            ).partition("/")[2]
 
-            if energy_price_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, "").endswith(
-                f"/{UnitOfEnergy.MEGA_WATT_HOUR}"
-            ):
-                energy_price /= 1000.0
-
-            if energy_price_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, "").endswith(
-                f"/{UnitOfEnergy.GIGA_JOULE}"
-            ):
-                energy_price /= 1000 / 3.6
+            # For backwards compatibility we don't validate the unit of the price
+            # If it is not valid, we assume it's our default price unit.
+            if energy_price_unit not in valid_units:
+                energy_price_unit = default_price_unit
 
         else:
-            energy_price_state = None
             energy_price = cast(float, self._config["number_energy_price"])
+            energy_price_unit = default_price_unit
 
         if self._last_energy_sensor_state is None:
             # Initialize as it's the first time all required entities are in place.
             self._reset(energy_state)
             return
 
-        energy_unit = energy_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        energy_unit: str | None = energy_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
 
-        if self._adapter.source_type == "grid":
-            if energy_unit not in VALID_ENERGY_UNITS:
-                energy_unit = None
-
-        elif self._adapter.source_type == "gas":
-            if energy_unit not in VALID_ENERGY_UNITS_GAS:
-                energy_unit = None
-
-        elif self._adapter.source_type == "water":
-            if energy_unit not in VALID_VOLUME_UNITS_WATER:
-                energy_unit = None
-
-        if energy_unit == UnitOfEnergy.WATT_HOUR:
-            energy_price /= 1000
-        elif energy_unit == UnitOfEnergy.MEGA_WATT_HOUR:
-            energy_price *= 1000
-        elif energy_unit == UnitOfEnergy.GIGA_JOULE:
-            energy_price *= 1000 / 3.6
-
-        if energy_unit is None:
+        if energy_unit is None or energy_unit not in valid_units:
             if not self._wrong_unit_reported:
                 self._wrong_unit_reported = True
                 _LOGGER.warning(
@@ -373,10 +371,30 @@ class EnergyCostSensor(SensorEntity):
             energy_state_copy = copy.copy(energy_state)
             energy_state_copy.state = "0.0"
             self._reset(energy_state_copy)
+
         # Update with newly incurred cost
         old_energy_value = float(self._last_energy_sensor_state.state)
         cur_value = cast(float, self._attr_native_value)
-        self._attr_native_value = cur_value + (energy - old_energy_value) * energy_price
+
+        if energy_price_unit is None:
+            converted_energy_price = energy_price
+        else:
+            if self._adapter.source_type == "grid":
+                converter: Callable[
+                    [float, str, str], float
+                ] = unit_conversion.EnergyConverter.convert
+            elif self._adapter.source_type in ("gas", "water"):
+                converter = unit_conversion.VolumeConverter.convert
+
+            converted_energy_price = converter(
+                energy_price,
+                energy_unit,
+                energy_price_unit,
+            )
+
+        self._attr_native_value = (
+            cur_value + (energy - old_energy_value) * converted_energy_price
+        )
 
         self._last_energy_sensor_state = energy_state
 

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -941,9 +941,9 @@ async def test_cost_sensor_handle_gas_kwh(
 @pytest.mark.parametrize(
     "unit_system,usage_unit,growth",
     (
-        (US_CUSTOMARY_SYSTEM, VOLUME_CUBIC_FEET, "50.0"),
-        # 1 Gallon = 0.13 cubic foot, 100 gl growth @ 0.5/ft3:
-        (US_CUSTOMARY_SYSTEM, VOLUME_GALLONS, "6.68402777777778"),
+        # 1 cubic foot = 7.47 gl, 100 ft3 growth @ 0.5/ft3:
+        (US_CUSTOMARY_SYSTEM, VOLUME_CUBIC_FEET, "374.025974025974"),
+        (US_CUSTOMARY_SYSTEM, VOLUME_GALLONS, "50.0"),
         (METRIC_SYSTEM, VOLUME_CUBIC_METERS, "50.0"),
     ),
 )

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -942,9 +942,9 @@ async def test_cost_sensor_handle_gas_kwh(
     "unit_system,usage_unit,growth",
     (
         # 1 cubic foot = 7.47 gl, 100 ft3 growth @ 0.5/ft3:
-        (US_CUSTOMARY_SYSTEM, VOLUME_CUBIC_FEET, "374.025974025974"),
-        (US_CUSTOMARY_SYSTEM, VOLUME_GALLONS, "50.0"),
-        (METRIC_SYSTEM, VOLUME_CUBIC_METERS, "50.0"),
+        (US_CUSTOMARY_SYSTEM, VOLUME_CUBIC_FEET, 374.025974025974),
+        (US_CUSTOMARY_SYSTEM, VOLUME_GALLONS, 50.0),
+        (METRIC_SYSTEM, VOLUME_CUBIC_METERS, 50.0),
     ),
 )
 async def test_cost_sensor_handle_water(
@@ -995,7 +995,7 @@ async def test_cost_sensor_handle_water(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.water_consumption_cost")
-    assert state.state == growth
+    assert float(state.state) == pytest.approx(growth)
 
 
 @pytest.mark.parametrize("state_class", [None])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds unit conversion to water cost calculation and also accept more units for electricity calculation. It does not change gas calculation.

- It now always uses unit of cost entity if possible (ie `EUR/gl`)
- Water is assumed in m3/gl based on metric/US unit system. (prior beta releases this was ft3 for US)

Existing tests work + added test case that matches #81297

Fixes #81297

Note: people having calculated water costs during beta will have to set the water costs again.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
