### PR TITLE
Use attr in mqtt humidifier

### DIFF
--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -211,10 +211,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
 
     def __init__(self, hass, config, config_entry, discovery_data):
         """Initialize the MQTT humidifier."""
-        self._state = None
-        self._target_humidity = None
-        self._mode = None
-        self._supported_features = 0
+        self._attr_mode = None
 
         self._topic = None
         self._payload = None
@@ -265,10 +262,10 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
             "MODE_RESET": config[CONF_PAYLOAD_RESET_MODE],
         }
         if CONF_MODE_COMMAND_TOPIC in config and CONF_AVAILABLE_MODES_LIST in config:
-            self._available_modes = config[CONF_AVAILABLE_MODES_LIST]
+            self._attr_available_modes = config[CONF_AVAILABLE_MODES_LIST]
         else:
-            self._available_modes = []
-        if self._available_modes:
+            self._attr_available_modes = []
+        if self._attr_available_modes:
             self._attr_supported_features = HumidifierEntityFeature.MODES
         else:
             self._attr_supported_features = 0
@@ -304,11 +301,11 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                 _LOGGER.debug("Ignoring empty state from '%s'", msg.topic)
                 return
             if payload == self._payload["STATE_ON"]:
-                self._state = True
+                self._attr_is_on = True
             elif payload == self._payload["STATE_OFF"]:
-                self._state = False
+                self._attr_is_on = False
             elif payload == PAYLOAD_NONE:
-                self._state = None
+                self._attr_is_on = None
             get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         if self._topic[CONF_STATE_TOPIC] is not None:
@@ -330,7 +327,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                 _LOGGER.debug("Ignoring empty target humidity from '%s'", msg.topic)
                 return
             if rendered_target_humidity_payload == self._payload["HUMIDITY_RESET"]:
-                self._target_humidity = None
+                self._attr_target_humidity = None
                 get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
                 return
             try:
@@ -354,7 +351,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                     rendered_target_humidity_payload,
                 )
                 return
-            self._target_humidity = target_humidity
+            self._attr_target_humidity = target_humidity
             get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         if self._topic[CONF_TARGET_HUMIDITY_STATE_TOPIC] is not None:
@@ -364,7 +361,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                 "qos": self._config[CONF_QOS],
                 "encoding": self._config[CONF_ENCODING] or None,
             }
-            self._target_humidity = None
+            self._attr_target_humidity = None
 
         @callback
         @log_messages(self.hass, self.entity_id)
@@ -372,7 +369,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
             """Handle new received MQTT message for mode."""
             mode = self._value_templates[ATTR_MODE](msg.payload)
             if mode == self._payload["MODE_RESET"]:
-                self._mode = None
+                self._attr_mode = None
                 get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
                 return
             if not mode:
@@ -387,7 +384,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                 )
                 return
 
-            self._mode = mode
+            self._attr_mode = mode
             get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
 
         if self._topic[CONF_MODE_STATE_TOPIC] is not None:
@@ -397,7 +394,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                 "qos": self._config[CONF_QOS],
                 "encoding": self._config[CONF_ENCODING] or None,
             }
-            self._mode = None
+            self._attr_mode = None
 
         self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass, self._sub_state, topics
@@ -411,26 +408,6 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
     def assumed_state(self) -> bool:
         """Return true if we do optimistic updates."""
         return self._optimistic
-
-    @property
-    def available_modes(self) -> list:
-        """Get the list of available modes."""
-        return self._available_modes
-
-    @property
-    def is_on(self) -> bool | None:
-        """Return true if device is on."""
-        return self._state
-
-    @property
-    def target_humidity(self):
-        """Return the current target humidity."""
-        return self._target_humidity
-
-    @property
-    def mode(self):
-        """Return the current mode."""
-        return self._mode
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the entity.
@@ -446,7 +423,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
             self._config[CONF_ENCODING],
         )
         if self._optimistic:
-            self._state = True
+            self._attr_is_on = True
             self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -463,7 +440,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
             self._config[CONF_ENCODING],
         )
         if self._optimistic:
-            self._state = False
+            self._attr_is_on = False
             self.async_write_ha_state()
 
     async def async_set_humidity(self, humidity: int) -> None:
@@ -481,7 +458,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         )
 
         if self._optimistic_target_humidity:
-            self._target_humidity = humidity
+            self._attr_target_humidity = humidity
             self.async_write_ha_state()
 
     async def async_set_mode(self, mode: str) -> None:
@@ -489,7 +466,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
 
         This method is a coroutine.
         """
-        if mode not in self.available_modes:
+        if not self.available_modes or mode not in self.available_modes:
             _LOGGER.warning("'%s'is not a valid mode", mode)
             return
 
@@ -504,5 +481,5 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         )
 
         if self._optimistic_mode:
-            self._mode = mode
+            self._attr_mode = mode
             self.async_write_ha_state()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use attr in mqtt humidifier

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
