### PR TITLE
Fix Renault charging power sensor

### DIFF
--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -191,7 +191,7 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
         # For vehicles that DO NOT report charging power in watts, this seems to
         # correspond to the maximum power that would be admissible by the car based
         # on the battery state, regardless of the type of charger.
-        key="charging_power",
+        key="admissible_charging_power",
         condition_lambda=lambda a: not a.details.reports_charging_power_in_watts(),
         coordinator="battery",
         data_key="chargingInstantaneousPower",

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -191,7 +191,7 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
         # For vehicles that DO NOT report charging power in watts, this seems to
         # correspond to the maximum power that would be admissible by the car based
         # on the battery state, regardless of the type of charger.
-        key="admissible_charging_power",
+        key="charging_power",
         condition_lambda=lambda a: not a.details.reports_charging_power_in_watts(),
         coordinator="battery",
         data_key="chargingInstantaneousPower",

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -197,7 +197,7 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
         data_key="chargingInstantaneousPower",
         device_class=SensorDeviceClass.POWER,
         entity_class=RenaultSensor[KamereonVehicleBatteryStatusData],
-        name="Charging power",
+        name="Admissible charging power",
         native_unit_of_measurement=POWER_KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -23,7 +23,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ELECTRIC_CURRENT_AMPERE,
     ENERGY_KILO_WATT_HOUR,
     LENGTH_KILOMETERS,
     PERCENTAGE,
@@ -189,17 +188,22 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
         state_class=SensorStateClass.MEASUREMENT,
     ),
     RenaultSensorEntityDescription(
+        # For vehicles that DO NOT report charging power in watts, this seems to
+        # correspond to the maximum power that would be admissible by the car based
+        # on the battery state, regardless of the type of charger.
         key="charging_power",
         condition_lambda=lambda a: not a.details.reports_charging_power_in_watts(),
         coordinator="battery",
         data_key="chargingInstantaneousPower",
-        device_class=SensorDeviceClass.CURRENT,
+        device_class=SensorDeviceClass.POWER,
         entity_class=RenaultSensor[KamereonVehicleBatteryStatusData],
         name="Charging power",
-        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+        native_unit_of_measurement=POWER_KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     RenaultSensorEntityDescription(
+        # For vehicles that DO report charging power in watts, this is the power
+        # effectively being transferred to the car.
         key="charging_power",
         condition_lambda=lambda a: a.details.reports_charging_power_in_watts(),
         coordinator="battery",

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -27,7 +27,6 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_PASSWORD,
     CONF_USERNAME,
-    ELECTRIC_CURRENT_AMPERE,
     ENERGY_KILO_WATT_HOUR,
     LENGTH_KILOMETERS,
     PERCENTAGE,
@@ -398,12 +397,12 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_charge_state",
             },
             {
-                ATTR_DEVICE_CLASS: SensorDeviceClass.CURRENT,
+                ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
                 ATTR_ENTITY_ID: "sensor.reg_number_charging_power",
                 ATTR_STATE: STATE_UNKNOWN,
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_charging_power",
-                ATTR_UNIT_OF_MEASUREMENT: ELECTRIC_CURRENT_AMPERE,
+                ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
             },
             {
                 ATTR_ENTITY_ID: "sensor.reg_number_charging_remaining_time",
@@ -617,12 +616,12 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_charge_state",
             },
             {
-                ATTR_DEVICE_CLASS: SensorDeviceClass.CURRENT,
+                ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
                 ATTR_ENTITY_ID: "sensor.reg_number_charging_power",
                 ATTR_STATE: "27.0",
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_charging_power",
-                ATTR_UNIT_OF_MEASUREMENT: ELECTRIC_CURRENT_AMPERE,
+                ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
             },
             {
                 ATTR_ENTITY_ID: "sensor.reg_number_charging_remaining_time",

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -398,7 +398,7 @@ MOCK_VEHICLES = {
             },
             {
                 ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
-                ATTR_ENTITY_ID: "sensor.reg_number_charging_power",
+                ATTR_ENTITY_ID: "sensor.reg_number_admissible_charging_power",
                 ATTR_STATE: STATE_UNKNOWN,
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_charging_power",
@@ -617,7 +617,7 @@ MOCK_VEHICLES = {
             },
             {
                 ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
-                ATTR_ENTITY_ID: "sensor.reg_number_charging_power",
+                ATTR_ENTITY_ID: "sensor.reg_number_admissible_charging_power",
                 ATTR_STATE: "27.0",
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_charging_power",

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -401,7 +401,7 @@ MOCK_VEHICLES = {
                 ATTR_ENTITY_ID: "sensor.reg_number_admissible_charging_power",
                 ATTR_STATE: STATE_UNKNOWN,
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
-                ATTR_UNIQUE_ID: "vf1aaaaa555777999_admissible_charging_power",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_charging_power",
                 ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
             },
             {
@@ -620,7 +620,7 @@ MOCK_VEHICLES = {
                 ATTR_ENTITY_ID: "sensor.reg_number_admissible_charging_power",
                 ATTR_STATE: "27.0",
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
-                ATTR_UNIQUE_ID: "vf1aaaaa555777123_admissible_charging_power",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777123_charging_power",
                 ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
             },
             {

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -401,7 +401,7 @@ MOCK_VEHICLES = {
                 ATTR_ENTITY_ID: "sensor.reg_number_admissible_charging_power",
                 ATTR_STATE: STATE_UNKNOWN,
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
-                ATTR_UNIQUE_ID: "vf1aaaaa555777999_charging_power",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_admissible_charging_power",
                 ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
             },
             {
@@ -620,7 +620,7 @@ MOCK_VEHICLES = {
                 ATTR_ENTITY_ID: "sensor.reg_number_admissible_charging_power",
                 ATTR_STATE: "27.0",
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
-                ATTR_UNIQUE_ID: "vf1aaaaa555777123_charging_power",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777123_admissible_charging_power",
                 ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
             },
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The unit of measurement for the charging power sensor has been corrected.
You will need to resolve the analytics warning by adjusting the previous unit.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Renault charging power sensor
cc @tbouron


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
