### PR TITLE
Make hassfest.dependencies faster with multiprocessing

### DIFF
--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import ast
 from collections import deque
+import multiprocessing
 from pathlib import Path
 
 from homeassistant.const import Platform
@@ -227,29 +228,49 @@ def find_non_referenced_integrations(
     return referenced
 
 
-def _validate_dependency_imports(
-    integrations: dict[str, Integration],
+def _compute_integration_dependencies(
     integration: Integration,
-) -> None:
-    """Validate all dependencies."""
+) -> tuple[str, dict[Path, set[str]] | None]:
+    """Compute integration dependencies."""
     # Some integrations are allowed to have violations.
     if integration.domain in IGNORE_VIOLATIONS:
-        return
+        return (integration.domain, None)
 
     # Find usage of hass.components
     collector = ImportCollector(integration)
     collector.collect()
+    return (integration.domain, collector.referenced)
 
-    for domain in sorted(
-        find_non_referenced_integrations(
-            integrations, integration, collector.referenced
+
+def _validate_dependency_imports(
+    integrations: dict[str, Integration],
+) -> None:
+    """Validate all dependencies."""
+
+    # Find integration dependencies with multiprocessing
+    # (because it takes some time to parse thousands of files)
+    with multiprocessing.Pool() as pool:
+        integration_imports = dict(
+            pool.imap_unordered(
+                _compute_integration_dependencies,
+                integrations.values(),
+                chunksize=10,
+            )
         )
-    ):
-        integration.add_error(
-            "dependencies",
-            f"Using component {domain} but it's not in 'dependencies' "
-            "or 'after_dependencies'",
-        )
+
+    for integration in integrations.values():
+        referenced = integration_imports[integration.domain]
+        if not referenced:  # Either ignored or has no references
+            continue
+
+        for domain in sorted(
+            find_non_referenced_integrations(integrations, integration, referenced)
+        ):
+            integration.add_error(
+                "dependencies",
+                f"Using component {domain} but it's not in 'dependencies' "
+                "or 'after_dependencies'",
+            )
 
 
 def _check_circular_deps(
@@ -329,9 +350,7 @@ def validate(
     config: Config,
 ) -> None:
     """Handle dependencies for integrations."""
-    for integration in integrations.values():
-        # check for non-existing dependencies
-        _validate_dependency_imports(integrations, integration)
+    _validate_dependency_imports(integrations)
 
     if not config.specific_integrations:
         _validate_dependencies_exist(integrations)


### PR DESCRIPTION
## Proposed change

This PR makes `hassfest.dependencies` faster by using `multiprocessing` for the slow part (which is parsing all integration source code).

The speedup is about 60% on my macOS machine, but will depend on the number of cores available, of course:

```
(dev) $ hyperfine 'python -m script.hassfest -p dependencies'
Benchmark 1: python -m script.hassfest -p dependencies
  Time (mean ± σ):     10.798 s ±  1.204 s    [User: 9.569 s, System: 0.582 s]
  Range (min … max):    9.564 s … 13.960 s    10 runs
(faster-hassfest-deps) $ hyperfine 'python -m script.hassfest -p dependencies'
Benchmark 1: python -m script.hassfest -p dependencies
  Time (mean ± σ):      4.449 s ±  0.107 s    [User: 38.233 s, System: 4.630 s]
  Range (min … max):    4.299 s …  4.645 s    10 runs
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
  - No new tests, `hassfest` is validated by... everything really.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
