### PR TITLE
Use partition/rpartition instead of split/rsplit

### DIFF
--- a/homeassistant/auth/permissions/entities.py
+++ b/homeassistant/auth/permissions/entities.py
@@ -47,7 +47,7 @@ def _lookup_domain(
     perm_lookup: PermissionLookup, domains_dict: SubCategoryDict, entity_id: str
 ) -> ValueType | None:
     """Look up entity permissions by domain."""
-    return domains_dict.get(entity_id.split(".", 1)[0])
+    return domains_dict.get(entity_id.partition(".")[0])
 
 
 def _lookup_area(

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -90,7 +90,7 @@ class CommandLineAuthProvider(AuthProvider):
                     line = _line.decode().lstrip()
                     if line.startswith("#"):
                         continue
-                    key, value = line.split("=", 1)
+                    key, _, value = line.partition("=")
                 except ValueError:
                     # malformed line
                     continue

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -404,7 +404,7 @@ async def async_mount_local_lib_path(config_dir: str) -> str:
 def _get_domains(hass: core.HomeAssistant, config: dict[str, Any]) -> set[str]:
     """Get domains of components to set up."""
     # Filter out the repeating and common config section [homeassistant]
-    domains = {key.split(" ")[0] for key in config if key != core.DOMAIN}
+    domains = {key.partition(" ")[0] for key in config if key != core.DOMAIN}
 
     # Add config entry domains
     if not hass.config.safe_mode:

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -197,7 +197,7 @@ async def async_send_add_or_update_message(hass, config, entity_ids):
     endpoints = []
 
     for entity_id in entity_ids:
-        if (domain := entity_id.split(".", 1)[0]) not in ENTITY_ADAPTERS:
+        if (domain := entity_id.partition(".")[0]) not in ENTITY_ADAPTERS:
             continue
 
         if (state := hass.states.get(entity_id)) is None:
@@ -232,7 +232,7 @@ async def async_send_delete_message(hass, config, entity_ids):
     endpoints = []
 
     for entity_id in entity_ids:
-        domain = entity_id.split(".", 1)[0]
+        domain = entity_id.partition(".")[0]
 
         if domain not in ENTITY_ADAPTERS:
             continue

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -181,7 +181,7 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=AXIS_DOMAIN):
             {
                 CONF_HOST: discovery_info.host,
                 CONF_MAC: format_mac(discovery_info.properties["macaddress"]),
-                CONF_NAME: discovery_info.name.split(".", 1)[0],
+                CONF_NAME: discovery_info.name.partition(".")[0],
                 CONF_PORT: discovery_info.port,
             }
         )

--- a/homeassistant/components/bosch_shc/config_flow.py
+++ b/homeassistant/components/bosch_shc/config_flow.py
@@ -154,7 +154,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_SSL_KEY: self.hass.config.path(DOMAIN, CONF_SHC_KEY),
                     CONF_HOST: self.host,
                     CONF_TOKEN: result["token"],
-                    CONF_HOSTNAME: result["token"].split(":", 1)[1],
+                    CONF_HOSTNAME: result["token"].partition(":", 1)[-1],
                 }
                 existing_entry = await self.async_set_unique_id(self.info["unique_id"])
                 if existing_entry:

--- a/homeassistant/components/coinbase/__init__.py
+++ b/homeassistant/components/coinbase/__init__.py
@@ -78,7 +78,7 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
 
     # Remove orphaned entities
     for entity in entities:
-        currency = entity.unique_id.split("-")[-1]
+        currency = entity.unique_id.rpartition("-")[-1]
         if "xe" in entity.unique_id and currency not in config_entry.options.get(
             CONF_EXCHANGE_RATES, []
         ):

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -152,7 +152,7 @@ class CommandSensorData:
             args = None
             args_compiled = None
         else:
-            prog, args = command.split(" ", 1)
+            prog, _, args = command.partition(" ")
             args_compiled = Template(args, self.hass)
 
         if args_compiled:

--- a/homeassistant/components/coronavirus/__init__.py
+++ b/homeassistant/components/coronavirus/__init__.py
@@ -33,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         @callback
         def _async_migrator(entity_entry: entity_registry.RegistryEntry):
             """Migrate away from unstable ID."""
-            country, info_type = entity_entry.unique_id.rsplit("-", 1)
+            country, _, info_type = entity_entry.unique_id.rpartition("-")
             if not country.isnumeric():
                 return None
             return {"new_unique_id": f"{entry.title}-{info_type}"}

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -187,7 +187,7 @@ def async_update_unique_id(
         return
 
     if description.old_unique_id_suffix:
-        unique_id = f'{unique_id.split("-", 1)[0]}-{description.old_unique_id_suffix}'
+        unique_id = f'{unique_id.partition("-")[0]}-{description.old_unique_id_suffix}'
 
     if entity_id := ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, unique_id):
         ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -57,7 +57,7 @@ class DeconzBase(Generic[_DeviceT]):
         assert isinstance(self._device, PydeconzDevice)
         if not self._device.unique_id or self._device.unique_id.count(":") != 7:
             return None
-        return self._device.unique_id.split("-", 1)[0]
+        return self._device.unique_id.partition("-")[0]
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -88,7 +88,7 @@ def async_update_unique_id(
     if ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, new_unique_id):
         return
 
-    unique_id = f'{unique_id.split("-", 1)[0]}-{description.key}'
+    unique_id = f'{unique_id.partition("-")[0]}-{description.key}'
     if entity_id := ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, unique_id):
         ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
 

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -248,7 +248,7 @@ def async_update_unique_id(
         return
 
     if description.old_unique_id_suffix:
-        unique_id = f'{unique_id.split("-", 1)[0]}-{description.old_unique_id_suffix}'
+        unique_id = f'{unique_id.partition("-")[0]}-{description.old_unique_id_suffix}'
 
     if entity_id := ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, unique_id):
         ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
@@ -290,7 +290,7 @@ async def async_setup_entry(
                     sensor.type.startswith("CLIP")
                     or (no_sensor_data and description.key != "battery")
                     or (
-                        (unique_id := sensor.unique_id.rsplit("-", 1)[0])
+                        (unique_id := sensor.unique_id.rpartition("-")[0])
                         in known_device_entities[description.key]
                     )
                 ):

--- a/homeassistant/components/devolo_home_network/config_flow.py
+++ b/homeassistant/components/devolo_home_network/config_flow.py
@@ -40,7 +40,7 @@ async def validate_input(
 
     return {
         SERIAL_NUMBER: str(device.serial_number),
-        TITLE: device.hostname.split(".")[0],
+        TITLE: device.hostname.partition(".")[0],
     }
 
 
@@ -90,7 +90,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.context[CONF_HOST] = discovery_info.host
         self.context["title_placeholders"] = {
             PRODUCT: discovery_info.properties["Product"],
-            CONF_NAME: discovery_info.hostname.split(".")[0],
+            CONF_NAME: discovery_info.hostname.partition(".")[0],
         }
 
         return await self.async_step_zeroconf_confirm()

--- a/homeassistant/components/dlna_dms/dms.py
+++ b/homeassistant/components/dlna_dms/dms.py
@@ -666,7 +666,7 @@ def _resource_is_streaming(resource: didl_lite.Resource) -> bool:
     # Err on the side of "True" if the protocol info is not available
     if not resource.protocol_info:
         return True
-    protocol = resource.protocol_info.split(":")[0].lower()
+    protocol = resource.protocol_info.partition(":")[0].lower()
     return protocol.lower() in STREAMABLE_PROTOCOLS
 
 

--- a/homeassistant/components/filesize/config_flow.py
+++ b/homeassistant/components/filesize/config_flow.py
@@ -58,7 +58,7 @@ class FilesizeConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(full_path)
                 self._abort_if_unique_id_configured()
 
-                name = str(user_input[CONF_FILE_PATH]).rsplit("/", maxsplit=1)[-1]
+                name = str(user_input[CONF_FILE_PATH]).rpartition("/")[-1]
                 return self.async_create_entry(
                     title=name,
                     data={CONF_FILE_PATH: user_input[CONF_FILE_PATH]},

--- a/homeassistant/components/forked_daapd/config_flow.py
+++ b/homeassistant/components/forked_daapd/config_flow.py
@@ -166,7 +166,7 @@ class ForkedDaapdFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if zeroconf_properties.get("Machine Name"):
             with suppress(ValueError):
                 version_num = int(
-                    zeroconf_properties.get("mtd-version", "0").split(".")[0]
+                    zeroconf_properties.get("mtd-version", "0").partition(".")[0]
                 )
         if version_num < 27:
             return self.async_abort(reason="not_forked_daapd")

--- a/homeassistant/components/forked_daapd/media_player.py
+++ b/homeassistant/components/forked_daapd/media_player.py
@@ -883,7 +883,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         }:
             return None, None
         owntone_uri = convert_to_owntone_uri(media_content_id)
-        item_id_str = owntone_uri.rsplit(":", maxsplit=1)[-1]
+        item_id_str = owntone_uri.rpartition(":")[-1]
         if media_content_type == MediaType.TRACK:
             result = await self.api.get_track(int(item_id_str))
         elif media_content_type == MediaType.ALBUM:

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -700,7 +700,7 @@ async def websocket_get_version(
 
     for req in integration.requirements:
         if req.startswith("home-assistant-frontend=="):
-            frontend = req.split("==", 1)[1]
+            frontend = req.partition("==")[-1]
 
     if frontend is None:
         connection.send_error(msg["id"], "unknown_version", "Version not found")

--- a/homeassistant/components/guardian/config_flow.py
+++ b/homeassistant/components/guardian/config_flow.py
@@ -30,7 +30,7 @@ UNIQUE_ID = "guardian_{0}"
 @callback
 def async_get_pin_from_discovery_hostname(hostname: str) -> str:
     """Get the device's 4-digit PIN from its zeroconf-discovered hostname."""
-    return hostname.split(".")[0].split("-")[1]
+    return hostname.partition(".")[0].split("-")[1]
 
 
 @callback

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -63,9 +63,8 @@ async def _migrate_old_unique_ids(
     def _async_migrator(entity_entry: entity_registry.RegistryEntry):
         # Old format for switches was {remote_unique_id}-{activity_name}
         # New format is activity_{activity_id}
-        parts = entity_entry.unique_id.split("-", 1)
-        if len(parts) > 1:  # old format
-            activity_name = parts[1]
+        remote_unique_id, _, activity_name = entity_entry.unique_id.partition("-")
+        if activity_name:  # old format
             activity_id = names_to_ids.get(activity_name)
 
             if activity_id is not None:

--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -41,7 +41,7 @@ class HassIOBaseAuth(HomeAssistantView):
     def _check_access(self, request: web.Request):
         """Check if this call is from Supervisor."""
         # Check caller IP
-        hassio_ip = os.environ["SUPERVISOR"].split(":")[0]
+        hassio_ip = os.environ["SUPERVISOR"].partition(":")[0]
         assert request.transport
         if ip_address(request.transport.get_extra_info("peername")[0]) != ip_address(
             hassio_ip

--- a/homeassistant/components/hddtemp/sensor.py
+++ b/homeassistant/components/hddtemp/sensor.py
@@ -64,7 +64,7 @@ def setup_platform(
     hddtemp.update()
 
     if not disks:
-        disks = [next(iter(hddtemp.data)).split("|")[0]]
+        disks = [next(iter(hddtemp.data)).partition("|")[0]]
 
     dev = []
     for disk in disks:
@@ -126,7 +126,9 @@ class HddTempData:
                 .rstrip("|")
                 .split("||")
             )
-            self.data = {data[i].split("|")[0]: data[i] for i in range(0, len(data), 1)}
+            self.data = {
+                data[i].partition("|")[0]: data[i] for i in range(0, len(data), 1)
+            }
         except ConnectionRefusedError:
             _LOGGER.error("HDDTemp is not available at %s:%s", self.host, self.port)
             self.data = None

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -160,9 +160,10 @@ class OriginSensor(HERETravelTimeSensor):
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """GPS coordinates."""
         if self.coordinator.data is not None:
+            lat, _, lon = self.coordinator.data[ATTR_ORIGIN].partition(",")
             return {
-                ATTR_LATITUDE: self.coordinator.data[ATTR_ORIGIN].split(",")[0],
-                ATTR_LONGITUDE: self.coordinator.data[ATTR_ORIGIN].split(",")[1],
+                ATTR_LATITUDE: lat,
+                ATTR_LONGITUDE: lon,
             }
         return None
 

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -430,7 +430,7 @@ def _system_callback_handler(hass, config, src, *args):
 
         addresses = []
         for dev in dev_descriptions:
-            address = dev["ADDRESS"].partition(":")[0]
+            address = dev["ADDRESS"].split(":")[0]
             if address not in hass.data[DATA_STORE]:
                 hass.data[DATA_STORE].add(address)
                 addresses.append(address)
@@ -578,8 +578,8 @@ def _create_ha_id(name, channel, param, count):
 def _hm_event_handler(hass, interface, device, caller, attribute, value):
     """Handle all pyhomematic device events."""
     try:
-        address, _, channel_str = device.partition(":")
-        channel = int(channel_str)
+        channel = int(device.split(":")[1])
+        address = device.split(":")[0]
         hmdevice = hass.data[DATA_HOMEMATIC].devices[interface].get(address)
     except (TypeError, ValueError):
         _LOGGER.error("Event handling channel convert error!")

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -430,7 +430,7 @@ def _system_callback_handler(hass, config, src, *args):
 
         addresses = []
         for dev in dev_descriptions:
-            address = dev["ADDRESS"].split(":")[0]
+            address = dev["ADDRESS"].partition(":")[0]
             if address not in hass.data[DATA_STORE]:
                 hass.data[DATA_STORE].add(address)
                 addresses.append(address)
@@ -578,8 +578,8 @@ def _create_ha_id(name, channel, param, count):
 def _hm_event_handler(hass, interface, device, caller, attribute, value):
     """Handle all pyhomematic device events."""
     try:
-        channel = int(device.split(":")[1])
-        address = device.split(":")[0]
+        address, _, channel_str = device.partition(":")
+        channel = int(channel_str)
         hmdevice = hass.data[DATA_HOMEMATIC].devices[interface].get(address)
     except (TypeError, ValueError):
         _LOGGER.error("Event handling channel convert error!")

--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -87,7 +87,7 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
         for domain, mac in hass_dev.identifiers:
             if domain != DOMAIN:
                 continue
-            normalized_mac = mac.split("-")[0]
+            normalized_mac = mac.partition("-")[0]
             dev_ids[normalized_mac] = hass_dev.id
 
     # initialize bridge connection just for the migration

--- a/homeassistant/components/ibeacon/coordinator.py
+++ b/homeassistant/components/ibeacon/coordinator.py
@@ -375,7 +375,7 @@ class IBeaconCoordinator:
             unique_id,
             ibeacon_advertisement,
         ) in self._last_ibeacon_advertisement_by_unique_id.items():
-            address = unique_id.split("_")[-1]
+            address = unique_id.rpartition("_")[-1]
             service_info = bluetooth.async_last_service_info(
                 self.hass, address, connectable=False
             )

--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -168,11 +168,11 @@ class ImageServeView(HomeAssistantView):
 
     async def get(self, request: web.Request, image_id: str, filename: str):
         """Serve image."""
-        image_size = filename.split("-", 1)[0]
+        image_size = filename.partition("-")[0]
         try:
-            parts = image_size.split("x", 1)
-            width = int(parts[0])
-            height = int(parts[1])
+            width, _, height = image_size.partition("x")
+            width = int(width)
+            height = int(height)
         except (ValueError, IndexError) as err:
             raise web.HTTPBadRequest from err
 
@@ -205,8 +205,13 @@ class ImageServeView(HomeAssistantView):
         )
 
 
-def _generate_thumbnail(original_path, content_type, target_path, target_size):
+def _generate_thumbnail(
+    original_path: pathlib.Path | str,
+    content_type: str,
+    target_path: pathlib.Path | str,
+    target_size: tuple[int, int],
+) -> None:
     """Generate a size."""
     image = ImageOps.exif_transpose(Image.open(original_path))
     image.thumbnail(target_size)
-    image.save(target_path, format=content_type.split("/", 1)[1])
+    image.save(target_path, format=content_type.partition("/")[-1])

--- a/homeassistant/components/lovelace/cast.py
+++ b/homeassistant/components/lovelace/cast.py
@@ -126,7 +126,7 @@ async def async_play_media(
         return False
 
     if "/" in media_id:
-        url_path, view_path = media_id.split("/", 1)
+        url_path, _, view_path = media_id.partition("/")
     else:
         url_path = media_id
         try:

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1264,7 +1264,7 @@ async def async_fetch_image(
         if response.status == HTTPStatus.OK:
             content = await response.read()
             if content_type := response.headers.get(CONTENT_TYPE):
-                content_type = content_type.split(";")[0]
+                content_type = content_type.partition(";")[0]
 
     if content is None:
         url_parts = URL(url)

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -152,7 +152,7 @@ class LocalSource(MediaSource):
 
         # Check that it's a media file
         if is_file and (
-            not mime_type or mime_type.split("/")[0] not in MEDIA_MIME_TYPES
+            not mime_type or mime_type.partition("/")[0] not in MEDIA_MIME_TYPES
         ):
             return None
 
@@ -161,7 +161,7 @@ class LocalSource(MediaSource):
         media_class = MediaClass.DIRECTORY
         if mime_type:
             media_class = MEDIA_CLASS_MAP.get(
-                mime_type.split("/")[0], MediaClass.DIRECTORY
+                mime_type.partition("/")[0], MediaClass.DIRECTORY
             )
 
         media = BrowseMediaSource(
@@ -226,7 +226,7 @@ class LocalMediaView(http.HomeAssistantView):
 
         # Check that it's a media file
         mime_type, _ = mimetypes.guess_type(str(media_path))
-        if not mime_type or mime_type.split("/")[0] not in MEDIA_MIME_TYPES:
+        if not mime_type or mime_type.partition("/")[0] not in MEDIA_MIME_TYPES:
             raise web.HTTPNotFound()
 
         return web.FileResponse(media_path)

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -77,7 +77,7 @@ def log_rate_limits(hass, device_name, resp, level=logging.INFO):
         rate_limits[ATTR_PUSH_RATE_LIMITS_SUCCESSFUL],
         rate_limits[ATTR_PUSH_RATE_LIMITS_MAXIMUM],
         rate_limits[ATTR_PUSH_RATE_LIMITS_ERRORS],
-        str(resetsAtTime).split(".", maxsplit=1)[0],
+        str(resetsAtTime).partition(".")[0],
     )
 
 

--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -115,7 +115,7 @@ def split_motioneye_device_identifier(
     """Get the identifiers for a motionEye device."""
     if len(identifier) != 2 or identifier[0] != DOMAIN or "_" not in identifier[1]:
         return None
-    config_id, camera_id_str = identifier[1].split("_", 1)
+    config_id, _, camera_id_str = identifier[1].partition("_")
     try:
         camera_id = int(camera_id_str)
     except ValueError:

--- a/homeassistant/components/netatmo/media_source.py
+++ b/homeassistant/components/netatmo/media_source.py
@@ -146,13 +146,13 @@ def async_parse_identifier(
     if not item.identifier or "/" not in item.identifier:
         return "events", "", None
 
-    source, path = item.identifier.lstrip("/").split("/", 1)
+    source, _, path = item.identifier.lstrip("/").partition("/")
 
     if source != "events":
         raise Unresolvable("Unknown source directory.")
 
     if "/" in path:
-        camera_id, event_id = path.split("/", 1)
+        camera_id, _, event_id = path.partition("/")
         return source, camera_id, int(event_id)
 
     return source, path, None

--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -63,7 +63,7 @@ def prepare_user_input(
     tmp: dict[str, Any] = {}
 
     for reg in user_input[CONF_REGIONS]:
-        tmp[_all_region_codes_sorted[reg]] = reg.split("_", 1)[0]
+        tmp[_all_region_codes_sorted[reg]] = reg.partition("_")[0]
 
     compact: dict[str, Any] = {}
 

--- a/homeassistant/components/nmap_tracker/config_flow.py
+++ b/homeassistant/components/nmap_tracker/config_flow.py
@@ -55,7 +55,7 @@ def _normalize_ips_and_network(hosts_str: str) -> list[str] | None:
 
     for host in sorted(hosts):
         try:
-            start, end = host.split("-", 1)
+            start, _, end = host.partition("-")
             if "." not in end:
                 ip_1, ip_2, ip_3, _ = start.split(".", 3)
                 end = ".".join([ip_1, ip_2, ip_3, end])

--- a/homeassistant/components/nuki/helpers.py
+++ b/homeassistant/components/nuki/helpers.py
@@ -4,7 +4,7 @@ from homeassistant import exceptions
 
 def parse_id(hardware_id):
     """Parse Nuki ID."""
-    return hex(hardware_id).split("x")[-1].upper()
+    return hex(hardware_id).rpartition("x")[-1].upper()
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -61,10 +61,11 @@ async def async_discovery(hass) -> list[dict[str, Any]]:
         }
         for scope in service.getScopes():
             scope_str = scope.getValue()
+            value_suffix = scope_str.rpartition("/")[-1]
             if scope_str.lower().startswith("onvif://www.onvif.org/name"):
-                device[CONF_NAME] = scope_str.split("/")[-1]
+                device[CONF_NAME] = value_suffix
             if scope_str.lower().startswith("onvif://www.onvif.org/mac"):
-                device[CONF_DEVICE_ID] = scope_str.split("/")[-1]
+                device[CONF_DEVICE_ID] = value_suffix
         devices.append(device)
 
     return devices

--- a/homeassistant/components/openhardwaremonitor/sensor.py
+++ b/homeassistant/components/openhardwaremonitor/sensor.py
@@ -102,16 +102,15 @@ class OpenHardwareMonitorDevice(SensorEntity):
             values = array[path_number]
 
             if path_index == len(self.path) - 1:
-                self.value = self.parse_number(values[OHM_VALUE].split(" ")[0])
+                value_str = values[OHM_VALUE].partition(" ")[0]
+                min_str = values[OHM_MIN].partition(" ")[0]
+                max_str = values[OHM_MAX].partition(" ")[0]
+                self.value = self.parse_number(value_str)
                 _attributes.update(
                     {
                         "name": values[OHM_NAME],
-                        STATE_MIN_VALUE: self.parse_number(
-                            values[OHM_MIN].split(" ")[0]
-                        ),
-                        STATE_MAX_VALUE: self.parse_number(
-                            values[OHM_MAX].split(" ")[0]
-                        ),
+                        STATE_MIN_VALUE: self.parse_number(min_str),
+                        STATE_MAX_VALUE: self.parse_number(max_str),
                     }
                 )
 

--- a/homeassistant/components/plex/media_browser.py
+++ b/homeassistant/components/plex/media_browser.py
@@ -199,7 +199,7 @@ def browse_media(  # noqa: C901
                 payload["children"].append(station_payload(item))
             else:
                 extra_params = None
-                hub_context = hub.context.split(".")[-1]
+                hub_context = hub.context.rpartition(".")[-1]
                 if hub_context in ("continue", "inprogress", "ondeck"):
                     extra_params = {"resume": 1}
                 payload["children"].append(

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -187,7 +187,7 @@ class PlexServer:
                 while error and not isinstance(error, ssl.SSLCertVerificationError):
                     error = error.__context__
                 if isinstance(error, ssl.SSLCertVerificationError):
-                    domain = urlparse(self._url).netloc.split(":")[0]
+                    domain = urlparse(self._url).netloc.partition(":")[0]
                     if domain.endswith("plex.direct") and error.args[0].startswith(
                         f"hostname '{domain}' doesn't match"
                     ):

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -93,7 +93,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         self.discovery_info = discovery_info
         _properties = discovery_info.properties
 
-        unique_id = discovery_info.hostname.split(".")[0].split("-")[0]
+        unique_id = discovery_info.hostname.partition(".")[0].partition("-")[0]
         if config_entry := await self.async_set_unique_id(unique_id):
             try:
                 await validate_gw_input(

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -264,7 +264,7 @@ def _add_columns(
         "Adding columns %s to table %s. Note: this can take several "
         "minutes on large databases and slow computers. Please "
         "be patient!",
-        ", ".join(column.split(" ")[0] for column in columns_def),
+        ", ".join(column.partition(" ")[0] for column in columns_def),
         table_name,
     )
 
@@ -318,7 +318,7 @@ def _modify_columns(
             "Skipping to modify columns %s in table %s; "
             "Modifying column length in SQLite is unnecessary, "
             "it does not impose any length restrictions",
-            ", ".join(column.split(" ")[0] for column in columns_def),
+            ", ".join(column.partition(" ")[0] for column in columns_def),
             table_name,
         )
         return
@@ -327,7 +327,7 @@ def _modify_columns(
         "Modifying columns %s in table %s. Note: this can take several "
         "minutes on large databases and slow computers. Please "
         "be patient!",
-        ", ".join(column.split(" ")[0] for column in columns_def),
+        ", ".join(column.partition(" ")[0] for column in columns_def),
         table_name,
     )
 

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -247,11 +247,6 @@ class PlatformCompiledStatistics:
     current_metadata: dict[str, tuple[int, StatisticMetaData]]
 
 
-def split_statistic_id(entity_id: str) -> list[str]:
-    """Split a state entity ID into domain and object ID."""
-    return entity_id.split(":", 1)
-
-
 VALID_STATISTIC_ID = re.compile(r"^(?!.+__)(?!_)[\da-z_]+(?<!_):(?!_)[\da-z_]+(?<!_)$")
 
 
@@ -1902,7 +1897,7 @@ def async_add_external_statistics(
         raise HomeAssistantError("Invalid statistic_id")
 
     # The source must not be empty and must be aligned with the statistic_id
-    domain, _object_id = split_statistic_id(metadata["statistic_id"])
+    domain, _, _object_id = metadata["statistic_id"].partition(":")
     if not metadata["source"] or metadata["source"] != domain:
         raise HomeAssistantError("Invalid source")
 

--- a/homeassistant/components/rflink/cover.py
+++ b/homeassistant/components/rflink/cover.py
@@ -71,7 +71,7 @@ def entity_type_for_device_id(device_id):
         # KlikAanKlikUit cover have the controls inverted
         "newkaku": TYPE_INVERTED
     }
-    protocol = device_id.split("_")[0]
+    protocol = device_id.partition("_")[0]
     return entity_type_mapping.get(protocol, TYPE_STANDARD)
 
 

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -88,7 +88,7 @@ def entity_type_for_device_id(device_id):
         # protocol
         "newkaku": TYPE_HYBRID
     }
-    protocol = device_id.split("_")[0]
+    protocol = device_id.partition("_")[0]
     return entity_type_mapping.get(protocol)
 
 

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -311,7 +311,7 @@ def _async_get_roomba_discovery():
 @callback
 def _async_blid_from_hostname(hostname):
     """Extract the blid from the hostname."""
-    return hostname.split("-")[1].split(".")[0].upper()
+    return hostname.split("-")[1].partition(".")[0].upper()
 
 
 async def _async_discover_roombas(hass, host):

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -42,7 +42,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             args_compiled = None
             cache[cmd] = prog, args, args_compiled
         else:
-            prog, args = cmd.split(" ", 1)
+            prog, _, args = cmd.partition(" ")
             args_compiled = template.Template(args, hass)
             cache[cmd] = prog, args, args_compiled
 

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -212,7 +212,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self.context.update(
             {
-                "title_placeholders": {"name": discovery_info.name.split(".")[0]},
+                "title_placeholders": {"name": discovery_info.name.partition(".")[0]},
                 "configuration_url": f"http://{discovery_info.host}",
             }
         )

--- a/homeassistant/components/snips/__init__.py
+++ b/homeassistant/components/snips/__init__.py
@@ -127,10 +127,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             _LOGGER.error("Intent has invalid schema: %s. %s", err, request)
             return
 
-        if request["intent"]["intentName"].startswith("user_"):
-            intent_type = request["intent"]["intentName"].split("__")[-1]
+        intent_name = request["intent"]["intentName"]
+        if intent_name.startswith("user_"):
+            intent_type = intent_name.rpartition("__")[-1]
         else:
-            intent_type = request["intent"]["intentName"].split(":")[-1]
+            intent_type = intent_name.rpartition(":")[-1]
         slots = {}
         for slot in request.get("slots", []):
             slots[slot["slotName"]] = {"value": resolve_slot_values(slot)}
@@ -153,9 +154,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 hass, "hermes/dialogueManager/endSession", json.dumps(notification)
             )
         except intent.UnknownIntent:
-            _LOGGER.warning(
-                "Received unknown intent %s", request["intent"]["intentName"]
-            )
+            _LOGGER.warning("Received unknown intent %s", intent_name)
         except intent.IntentError:
             _LOGGER.exception("Error while handling intent: %s", intent_type)
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -598,7 +598,7 @@ def _udn_from_usn(usn: str | None) -> str | None:
     if usn is None:
         return None
     if usn.startswith("uuid:"):
-        return usn.split("::")[0]
+        return usn.partition("::")[0]
     return None
 
 

--- a/homeassistant/components/steamist/config_flow.py
+++ b/homeassistant/components/steamist/config_flow.py
@@ -113,7 +113,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: device.ipaddress})
         data = {CONF_HOST: device.ipaddress, CONF_NAME: device.name}
         if device.hostname:
-            data[CONF_MODEL] = device.hostname.split("-", maxsplit=1)[0]
+            data[CONF_MODEL] = device.hostname.partition("-")[0]
         return self.async_create_entry(
             title=device.name,
             data=data,

--- a/homeassistant/components/steamist/discovery.py
+++ b/homeassistant/components/steamist/discovery.py
@@ -45,7 +45,7 @@ def async_update_entry_from_discovery(
     if not entry.data.get(CONF_NAME) or is_ip_address(entry.data[CONF_NAME]):
         updates["title"] = data_updates[CONF_NAME] = device.name
     if not entry.data.get(CONF_MODEL) and "-" in device.hostname:
-        data_updates[CONF_MODEL] = device.hostname.split("-", maxsplit=1)[0]
+        data_updates[CONF_MODEL] = device.hostname.partition("-")[0]
     if data_updates:
         updates["data"] = {**entry.data, **data_updates}
     if updates:

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -244,7 +244,7 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle a discovered synology_dsm."""
         parsed_url = urlparse(discovery_info.ssdp_location)
         friendly_name = (
-            discovery_info.upnp[ssdp.ATTR_UPNP_FRIENDLY_NAME].split("(", 1)[0].strip()
+            discovery_info.upnp[ssdp.ATTR_UPNP_FRIENDLY_NAME].partition("(")[0].strip()
         )
 
         discovered_mac = discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL].upper()

--- a/homeassistant/components/tailscale/__init__.py
+++ b/homeassistant/components/tailscale/__init__.py
@@ -71,6 +71,6 @@ class TailscaleEntity(CoordinatorEntity):
             identifiers={(DOMAIN, device.device_id)},
             manufacturer="Tailscale Inc.",
             model=device.os,
-            name=device.name.split(".")[0],
+            name=device.name.partition(".")[0],
             sw_version=device.client_version,
         )

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -571,6 +571,7 @@ class LightTemplate(TemplateEntity, LightEntity):
             if render in ("None", ""):
                 self._color = None
                 return
+            # TODO: use partition or maybe ast.literal_eval
             h_str, s_str = map(
                 float, render.replace("(", "").replace(")", "").split(",", 1)
             )

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -177,7 +177,8 @@ class TriggerEntity(CoordinatorEntity[TriggerUpdateCoordinator]):
 
             self._rendered = rendered
         except TemplateError as err:
-            logging.getLogger(f"{__package__}.{self.entity_id.split('.')[0]}").error(
+            platform = self.entity_id.partition(".")[0]
+            logging.getLogger(f"{__package__}.{platform}").error(
                 "Error rendering %s template for %s: %s", key, self.entity_id, err
             )
             self._rendered = self._static_rendered

--- a/homeassistant/components/trace/__init__.py
+++ b/homeassistant/components/trace/__init__.py
@@ -95,7 +95,7 @@ async def async_list_contexts(
 
     def _trace_id(run_id: str, key: str) -> dict[str, str]:
         """Make trace_id for the response."""
-        domain, item_id = key.split(".", 1)
+        domain, _, item_id = key.partition(".")
         return {"run_id": run_id, "domain": domain, "item_id": item_id}
 
     return {
@@ -127,7 +127,7 @@ async def async_list_traces(
     if not wanted_key:
         traces: list[dict[str, Any]] = []
         for key in _get_data(hass):
-            domain = key.split(".", 1)[0]
+            domain = key.partition(".")[0]
             if domain == wanted_domain:
                 traces.extend(_get_debug_traces(hass, key))
     else:

--- a/homeassistant/components/trace/models.py
+++ b/homeassistant/components/trace/models.py
@@ -120,7 +120,7 @@ class ActionTrace(BaseTrace):
 
         if self._trace:
             last_step = list(self._trace)[-1]
-        domain, item_id = self.key.split(".", 1)
+        domain, _, item_id = self.key.partition(".")
 
         result = {
             "last_step": last_step,

--- a/homeassistant/components/trace/websocket_api.py
+++ b/homeassistant/components/trace/websocket_api.py
@@ -193,7 +193,7 @@ def websocket_breakpoint_list(
     breakpoints = breakpoint_list(hass)
     for _breakpoint in breakpoints:
         key = _breakpoint.pop("key")
-        _breakpoint["domain"], _breakpoint["item_id"] = key.split(".", 1)
+        _breakpoint["domain"], _, _breakpoint["item_id"] = key.partition(".")
 
     connection.send_result(msg["id"], breakpoints)
 
@@ -213,7 +213,7 @@ def websocket_subscribe_breakpoint_events(
     @callback
     def breakpoint_hit(key, run_id, node):
         """Forward events to websocket."""
-        domain, item_id = key.split(".", 1)
+        domain, _, item_id = key.partition(".")
         connection.send_message(
             websocket_api.event_message(
                 msg["id"],

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -298,12 +298,14 @@ class UniFiController:
         for entry in async_entries_for_config_entry(
             entity_registry, self.config_entry.entry_id
         ):
+            mac_prefix, _, mac_suffix = entry.unique_id.partition("_")
             if entry.domain == Platform.DEVICE_TRACKER:
-                mac = entry.unique_id.split("-", 1)[0]
-            elif entry.domain == Platform.SWITCH and entry.unique_id.startswith(
-                BLOCK_SWITCH
+                mac = mac_prefix
+            elif entry.domain == Platform.SWITCH and (
+                entry.unique_id.startswith(BLOCK_SWITCH)
+                or entry.unique_id.startswith(POE_SWITCH)
             ):
-                mac = entry.unique_id.split("-", 1)[1]
+                mac = mac_suffix
             else:
                 continue
 

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -178,7 +178,7 @@ async def _set_paired_camera(obj: Light | Sensor | Doorlock, camera_id: str) -> 
 
 async def _set_doorbell_message(obj: Camera, message: str) -> None:
     if message.startswith(DoorbellMessageType.CUSTOM_MESSAGE.value):
-        message = message.split(":")[-1]
+        message = message.rpartition(":")[-1]
         await obj.set_lcd_text(DoorbellMessageType.CUSTOM_MESSAGE, text=message)
     elif message == TYPE_EMPTY_VALUE:
         await obj.set_lcd_text(None)

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -125,7 +125,7 @@ async def set_default_doorbell_text(hass: HomeAssistant, call: ServiceCall) -> N
 @callback
 def _async_unique_id_to_mac(unique_id: str) -> str:
     """Extract the MAC address from the registry entry unique id."""
-    return unique_id.split("_")[0]
+    return unique_id.partition("_")[0]
 
 
 async def set_chime_paired_doorbells(hass: HomeAssistant, call: ServiceCall) -> None:

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -98,9 +98,9 @@ def _get_pairing_schema(input_dict: dict[str, Any] | None = None) -> vol.Schema:
 
 def _host_is_same(host1: str, host2: str) -> bool:
     """Check if host1 and host2 are the same."""
-    host1 = host1.split(":")[0]
+    host1 = host1.partition(":")[0]
     host1 = host1 if is_ip_address(host1) else socket.gethostbyname(host1)
-    host2 = host2.split(":")[0]
+    host2 = host2.partition(":")[0]
     host2 = host2 if is_ip_address(host2) else socket.gethostbyname(host2)
     return host1 == host2
 

--- a/homeassistant/components/webostv/trigger.py
+++ b/homeassistant/components/webostv/trigger.py
@@ -17,12 +17,12 @@ TRIGGERS = {
 
 def _get_trigger_platform(config: ConfigType) -> TriggersPlatformModule:
     """Return trigger platform."""
-    platform_split = config[CONF_PLATFORM].split(".", maxsplit=1)
-    if len(platform_split) < 2 or platform_split[1] not in TRIGGERS:
+    trigger = config[CONF_PLATFORM].partition(".")[-1]
+    if trigger not in TRIGGERS:
         raise ValueError(
             f"Unknown webOS Smart TV trigger platform {config[CONF_PLATFORM]}"
         )
-    return cast(TriggersPlatformModule, TRIGGERS[platform_split[1]])
+    return cast(TriggersPlatformModule, TRIGGERS[trigger])
 
 
 async def async_validate_trigger_config(

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -17,7 +17,7 @@ from ..helpers import (
 )
 
 # Platform type should be <DOMAIN>.<SUBMODULE_NAME>
-PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
+PLATFORM_TYPE = f"{DOMAIN}.{__name__.rpartition('.')[-1]}"
 
 TRIGGER_TYPE_TURN_ON = "turn_on"
 

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -434,7 +434,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
             pid,
         )
         self.context["title_placeholders"] = {
-            CONF_NAME: self._title.split(" - ")[0].strip()
+            CONF_NAME: self._title.partition(" - ")[0].strip()
         }
         return await self.async_step_usb_confirm()
 

--- a/homeassistant/components/zwave_js/discovery_data_template.py
+++ b/homeassistant/components/zwave_js/discovery_data_template.py
@@ -301,7 +301,7 @@ class DynamicCurrentTempClimateDataTemplate(BaseDiscoverySchemaDataTemplate):
         if dependent_value and dependent_value.value is not None:
             lookup_key = dependent_value.metadata.states[
                 str(dependent_value.value)
-            ].split("-")[0]
+            ].partition("-")[0]
             return lookup_table.get(lookup_key)
 
         return None

--- a/homeassistant/components/zwave_js/trigger.py
+++ b/homeassistant/components/zwave_js/trigger.py
@@ -19,10 +19,10 @@ TRIGGERS = {
 
 def _get_trigger_platform(config: ConfigType) -> ModuleType:
     """Return trigger platform."""
-    platform_split = config[CONF_PLATFORM].split(".", maxsplit=1)
-    if len(platform_split) < 2 or platform_split[1] not in TRIGGERS:
+    trigger = config[CONF_PLATFORM].partition(".")[-1]
+    if trigger not in TRIGGERS:
         raise ValueError(f"Unknown Z-Wave JS trigger platform {config[CONF_PLATFORM]}")
-    return TRIGGERS[platform_split[1]]
+    return TRIGGERS[trigger]
 
 
 async def async_validate_trigger_config(

--- a/homeassistant/components/zwave_js/triggers/event.py
+++ b/homeassistant/components/zwave_js/triggers/event.py
@@ -34,7 +34,7 @@ from ..helpers import (
 from .trigger_helpers import async_bypass_dynamic_config_validation
 
 # Platform type should be <DOMAIN>.<SUBMODULE_NAME>
-PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
+PLATFORM_TYPE = f"{DOMAIN}.{__name__.rpartition('.')[-1]}"
 
 
 def validate_non_node_event_source(obj: dict) -> dict:

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -33,7 +33,7 @@ from ..helpers import async_get_nodes_from_targets, get_device_id
 from .trigger_helpers import async_bypass_dynamic_config_validation
 
 # Platform type should be <DOMAIN>.<SUBMODULE_NAME>
-PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
+PLATFORM_TYPE = f"{DOMAIN}.{__name__.rpartition('.')[-1]}"
 
 ATTR_FROM = "from"
 ATTR_TO = "to"

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -734,7 +734,7 @@ async def merge_packages_config(
                 continue
             # If component name is given with a trailing description, remove it
             # when looking for component
-            domain = comp_name.split(" ")[0]
+            domain = comp_name.partition(" ")[0]
 
             try:
                 integration = await async_get_integration_with_requirements(

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -122,7 +122,7 @@ async def async_check_ha_config_file(  # noqa: C901
     core_config.pop(CONF_PACKAGES, None)
 
     # Filter out repeating config sections
-    components = {key.split(" ")[0] for key in config.keys()}
+    components = {key.partition(" ")[0] for key in config.keys()}
 
     # Process and validate config
     for domain in components:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -36,7 +36,7 @@ _EntityT = TypeVar("_EntityT", bound=entity.Entity)
 @bind_hass
 async def async_update_entity(hass: HomeAssistant, entity_id: str) -> None:
     """Trigger an update for an entity."""
-    domain = entity_id.split(".", 1)[0]
+    domain = entity_id.partition(".")[0]
     entity_comp: EntityComponent[entity.Entity] | None
     entity_comp = hass.data.get(DATA_INSTANCES, {}).get(domain)
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -202,7 +202,7 @@ def async_prepare_call_from_config(
                 f"Template rendered invalid service: {domain_service}"
             ) from ex
 
-    domain, service = domain_service.split(".", 1)
+    domain, _, service = domain_service.partition(".")
 
     target = {}
     if CONF_TARGET in config:

--- a/homeassistant/helpers/trace.py
+++ b/homeassistant/helpers/trace.py
@@ -63,7 +63,7 @@ class TraceElement:
         """Return dictionary version of this TraceElement."""
         result: dict[str, Any] = {"path": self.path, "timestamp": self._timestamp}
         if self._child_key is not None:
-            domain, item_id = self._child_key.split(".", 1)
+            domain, _, item_id = self._child_key.partition(".")
             result["child_id"] = {
                 "domain": domain,
                 "item_id": item_id,

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -97,10 +97,7 @@ def _merge_resources(
     # Build response
     resources: dict[str, dict[str, Any]] = {}
     for component in components:
-        if "." not in component:
-            domain = component
-        else:
-            domain = component.split(".", 1)[0]
+        domain = component.partition(".")[0]
 
         domain_resources = resources.setdefault(domain, {})
 

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -145,7 +145,7 @@ async def async_get_component_strings(
     hass: HomeAssistant, language: str, components: set[str]
 ) -> dict[str, Any]:
     """Load translations."""
-    domains = list({loaded.split(".")[-1] for loaded in components})
+    domains = list({loaded.rpartition(".")[-1] for loaded in components})
 
     integrations: dict[str, Integration] = {}
     ints_or_excs = await async_get_integrations(hass, domains)

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -433,7 +433,7 @@ def async_get_loaded_integrations(hass: core.HomeAssistant) -> set[str]:
         if "." not in component:
             integrations.add(component)
             continue
-        domain, platform = component.split(".", 1)
+        domain, _, platform = component.partition(".")
         if domain in BASE_PLATFORMS:
             integrations.add(platform)
     return integrations
@@ -458,10 +458,7 @@ def async_start_setup(
     time_taken = dt_util.utcnow() - started
     for unique, domain in unique_components.items():
         del setup_started[unique]
-        if "." in domain:
-            _, integration = domain.split(".", 1)
-        else:
-            integration = domain
+        integration = domain.rpartition(".")[-1]
         if integration in setup_time:
             setup_time[integration] += time_taken
         else:

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -156,7 +156,7 @@ class Throttle:
         # be prefixed by '.<locals>.' so we strip that out.
         is_func = (
             not hasattr(method, "__self__")
-            and "." not in method.__qualname__.split(".<locals>.")[-1]
+            and "." not in method.__qualname__.rpartition(".<locals>.")[-1]
         )
 
         @wraps(method)

--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -50,7 +50,7 @@ HASS_PLUGINS = [
 ]
 
 ALL_PLUGIN_NAMES = [
-    plugin.__name__.rsplit(".", maxsplit=1)[-1]
+    plugin.__name__.rpartition(".")[-1]
     for plugin in (*INTEGRATION_PLUGINS, *HASS_PLUGINS)
 ]
 
@@ -147,7 +147,7 @@ def main():
         plugins += HASS_PLUGINS
 
     for plugin in plugins:
-        plugin_name = plugin.__name__.rsplit(".", maxsplit=1)[-1]
+        plugin_name = plugin.__name__.rpartition(".")[-1]
         if plugin_name not in config.plugins:
             continue
         try:
@@ -194,7 +194,7 @@ def main():
 
         if config.action == "generate":
             for plugin in plugins:
-                plugin_name = plugin.__name__.rsplit(".", maxsplit=1)[-1]
+                plugin_name = plugin.__name__.rpartition(".")[-1]
                 if plugin_name not in config.plugins:
                     continue
                 if hasattr(plugin, "generate"):

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -260,7 +260,7 @@ def install_requirements(integration: Integration, requirements: set[str]) -> bo
         normalized = normalize_package_name(requirement_arg)
 
         if normalized and "==" in requirement_arg:
-            ver = requirement_arg.split("==")[-1]
+            ver = requirement_arg.rpartition("==")[-1]
             item = PIPDEPTREE_CACHE.get(normalized)
             is_installed = item and item["installed_version"] == ver
 

--- a/script/translations/migrate.py
+++ b/script/translations/migrate.py
@@ -340,7 +340,7 @@ def apply_data_references(to_migrate):
             for key, value in step_data.items():
 
                 if key in to_migrate and value != to_migrate[key]:
-                    if key.split("_")[0].lower() in value.lower():
+                    if key.partition("_")[0].lower() in value.lower():
                         step_data[key] = to_migrate[key]
                         changed = True
                     elif value.startswith("[%key"):

--- a/tests/common.py
+++ b/tests/common.py
@@ -417,7 +417,7 @@ fire_time_changed = threadsafe_callback_factory(async_fire_time_changed)
 def get_fixture_path(filename: str, integration: str | None = None) -> pathlib.Path:
     """Get path of fixture."""
     if integration is None and "/" in filename and not filename.startswith("helpers/"):
-        integration, filename = filename.split("/", 1)
+        integration, _, filename = filename.partition("/")
 
     if integration is None:
         return pathlib.Path(__file__).parent.joinpath("fixtures", filename)

--- a/tests/components/coinbase/test_init.py
+++ b/tests/components/coinbase/test_init.py
@@ -81,13 +81,13 @@ async def test_option_updates(hass: HomeAssistant):
         )
         assert len(entities) == 4
         currencies = [
-            entity.unique_id.split("-")[-1]
+            entity.unique_id.rpartition("-")[-1]
             for entity in entities
             if "wallet" in entity.unique_id
         ]
 
         rates = [
-            entity.unique_id.split("-")[-1]
+            entity.unique_id.rpartition("-")[-1]
             for entity in entities
             if "xe" in entity.unique_id
         ]
@@ -112,13 +112,13 @@ async def test_option_updates(hass: HomeAssistant):
         )
         assert len(entities) == 2
         currencies = [
-            entity.unique_id.split("-")[-1]
+            entity.unique_id.rpartition("-")[-1]
             for entity in entities
             if "wallet" in entity.unique_id
         ]
 
         rates = [
-            entity.unique_id.split("-")[-1]
+            entity.unique_id.rpartition("-")[-1]
             for entity in entities
             if "xe" in entity.unique_id
         ]

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -60,7 +60,7 @@ async def test_humanifying_deconz_alarm_event(hass, aioclient_mock):
     device_registry = dr.async_get(hass)
 
     keypad_event_id = slugify(data["sensors"]["1"]["name"])
-    keypad_serial = data["sensors"]["1"]["uniqueid"].split("-", 1)[0]
+    keypad_serial = data["sensors"]["1"]["uniqueid"].partition("-")[0]
     keypad_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, keypad_serial)}
     )
@@ -131,25 +131,25 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
     device_registry = dr.async_get(hass)
 
     switch_event_id = slugify(data["sensors"]["1"]["name"])
-    switch_serial = data["sensors"]["1"]["uniqueid"].split("-", 1)[0]
+    switch_serial = data["sensors"]["1"]["uniqueid"].partition("-")[0]
     switch_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, switch_serial)}
     )
 
     hue_remote_event_id = slugify(data["sensors"]["2"]["name"])
-    hue_remote_serial = data["sensors"]["2"]["uniqueid"].split("-", 1)[0]
+    hue_remote_serial = data["sensors"]["2"]["uniqueid"].partition("-")[0]
     hue_remote_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, hue_remote_serial)}
     )
 
     xiaomi_cube_event_id = slugify(data["sensors"]["3"]["name"])
-    xiaomi_cube_serial = data["sensors"]["3"]["uniqueid"].split("-", 1)[0]
+    xiaomi_cube_serial = data["sensors"]["3"]["uniqueid"].partition("-")[0]
     xiaomi_cube_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, xiaomi_cube_serial)}
     )
 
     faulty_event_id = slugify(data["sensors"]["4"]["name"])
-    faulty_serial = data["sensors"]["4"]["uniqueid"].split("-", 1)[0]
+    faulty_serial = data["sensors"]["4"]["uniqueid"].partition("-")[0]
     faulty_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, faulty_serial)}
     )

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -178,13 +178,14 @@ async def test_form_reauth(hass: HomeAssistant):
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    conf_name = DISCOVERY_INFO.hostname.partition(".")[0]
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={
             "source": config_entries.SOURCE_REAUTH,
             "entry_id": entry.entry_id,
             "title_placeholders": {
-                CONF_NAME: DISCOVERY_INFO.hostname.split(".")[0],
+                CONF_NAME: conf_name,
             },
         },
         data=entry.data,

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -98,7 +98,7 @@ async def test_zeroconf(hass: HomeAssistant):
 
     assert (
         context["title_placeholders"][CONF_NAME]
-        == DISCOVERY_INFO.hostname.split(".", maxsplit=1)[0]
+        == DISCOVERY_INFO.hostname.partition(".")[0]
     )
 
     with patch(

--- a/tests/components/ecowitt/test_config_flow.py
+++ b/tests/components/ecowitt/test_config_flow.py
@@ -31,6 +31,6 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Ecowitt"
     assert result2["data"] == {
-        "webhook_id": result2["description_placeholders"]["path"].split("/")[-1],
+        "webhook_id": result2["description_placeholders"]["path"].rpartition("/")[-1],
     }
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -51,7 +51,7 @@ class FritzConnectionMock:  # pylint: disable=too-few-public-methods
             {**kwargs},
         )
         if ":" in service:
-            service, number = service.split(":", 1)
+            service, _, number = service.partition(":")
             service = service + number
         elif not service[-1].isnumeric():
             service = service + "1"

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -535,7 +535,7 @@ async def test_get_version(hass, ws_client):
     """Test get_version command."""
     frontend = await async_get_integration(hass, "frontend")
     cur_version = next(
-        req.split("==", 1)[1]
+        req.partition("==")[-1]
         for req in frontend.requirements
         if req.startswith("home-assistant-frontend==")
     )

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -75,7 +75,7 @@ async def test_setup_in_bridge_mode(hass, mock_get_source_ip):
         await hass.async_block_till_done()
 
     assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    bridge_name = (result3["title"].split(":"))[0]
+    bridge_name = result3["title"].partition(":")[0]
     assert bridge_name == SHORT_BRIDGE_NAME
     assert result3["data"] == {
         "filter": {
@@ -133,7 +133,7 @@ async def test_setup_in_bridge_mode_name_taken(hass, mock_get_source_ip):
     assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"] != SHORT_BRIDGE_NAME
     assert result3["title"].startswith(SHORT_BRIDGE_NAME)
-    bridge_name = (result3["title"].split(":"))[0]
+    bridge_name = result3["title"].partition(":")[0]
     assert result3["data"] == {
         "filter": {
             "exclude_domains": [],
@@ -214,7 +214,7 @@ async def test_setup_creates_entries_for_accessory_mode_devices(
 
     assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"][:11] == "HASS Bridge"
-    bridge_name = (result3["title"].split(":"))[0]
+    bridge_name = result3["title"].partition(":")[0]
     assert result3["data"] == {
         "filter": {
             "exclude_domains": [],
@@ -1267,7 +1267,7 @@ async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_sou
 
     assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result3["title"][:11] == "HASS Bridge"
-    bridge_name = (result3["title"].split(":"))[0]
+    bridge_name = result3["title"].partition(":")[0]
     assert result3["data"] == {
         "filter": {
             "exclude_domains": [],

--- a/tests/components/netatmo/common.py
+++ b/tests/components/netatmo/common.py
@@ -33,7 +33,7 @@ async def fake_post_request(*args, **kwargs):
     if "endpoint" not in kwargs:
         return "{}"
 
-    endpoint = kwargs["endpoint"].split("/")[-1]
+    endpoint = kwargs["endpoint"].rpartition("/")[-1]
 
     if endpoint in "snapshot_720.jpg":
         return b"test stream image bytes"
@@ -67,7 +67,7 @@ async def fake_get_image(*args, **kwargs):
     if "endpoint" not in kwargs:
         return "{}"
 
-    endpoint = kwargs["endpoint"].split("/")[-1]
+    endpoint = kwargs["endpoint"].rpartition("/")[-1]
 
     if endpoint in "snapshot_720.jpg":
         return b"test stream image bytes"

--- a/tests/components/netatmo/test_camera.py
+++ b/tests/components/netatmo/test_camera.py
@@ -486,7 +486,7 @@ async def test_camera_image_raises_exception(hass, config_entry, requests_mock):
         if "endpoint" not in kwargs:
             return "{}"
 
-        endpoint = kwargs["endpoint"].split("/")[-1]
+        endpoint = kwargs["endpoint"].rpartition("/")[-1]
 
         if "snapshot_720.jpg" in endpoint:
             raise pyatmo.ApiError()

--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 def plex_server_url(entry):
     """Return a protocol-less URL from a config entry."""
-    return entry.data[PLEX_SERVER_CONFIG][CONF_URL].split(":", 1)[-1]
+    return entry.data[PLEX_SERVER_CONFIG][CONF_URL].partition(":")[-1]
 
 
 @pytest.fixture(name="album", scope="session")

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -193,15 +193,14 @@ MOCK_INCLUDE_NO_APPS = {
 
 VIZIO_ZEROCONF_SERVICE_TYPE = "_viziocast._tcp.local."
 ZEROCONF_NAME = f"{NAME}.{VIZIO_ZEROCONF_SERVICE_TYPE}"
-ZEROCONF_HOST = HOST.split(":")[0]
-ZEROCONF_PORT = HOST.split(":")[1]
+ZEROCONF_HOST, _, ZEROCONF_PORT = HOST.partition(":")
 
 MOCK_ZEROCONF_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
     host=ZEROCONF_HOST,
     addresses=[ZEROCONF_HOST],
     hostname="mock_hostname",
     name=ZEROCONF_NAME,
-    port=ZEROCONF_PORT,
+    port=int(ZEROCONF_PORT),
     properties={"name": "SB4031-D5"},
     type=VIZIO_ZEROCONF_SERVICE_TYPE,
 )

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -200,7 +200,8 @@ async def test_devices(
     zha_entity_ids = {
         ent
         for ent in entity_ids
-        if not contains_ignored_suffix(ent) and ent.split(".")[0] in zha_const.PLATFORMS
+        if not contains_ignored_suffix(ent)
+        and ent.partition(".")[0] in zha_const.PLATFORMS
     }
     assert zha_entity_ids == {
         e[DEV_SIG_ENT_MAP_ID] for e in device[DEV_SIG_ENT_MAP].values()


### PR DESCRIPTION
## Proposed change

I spotted a couple of places (and then a couple more . . .) where uses of `.split` and `.partition` could be replaced with the more efficient but [not particularly well-known `partition`](https://docs.python.org/3.10/library/stdtypes.html#str.partition) function (and same for `rsplit`/`rpartition`).

* partition/rpartition always returns a 3-tuple so checks for how many pieces are returned aren't necessary anymore. This simplifies a bunch of code (a bit).
* It's also approximately 20% faster than split in a simple case (and yes, it's a microbenchmark but every little counts in my books); see timeit comparison below
* constructing tuples is, to my best knowledge, more memory-efficient than lists, so a modest memory usage improvement could also be in the cards.

I understand that this is a bit on the big side as far as the number of touched files/components goes, but it should nevertheless be easy to review:

* The changes are, in most cases, a single line per file. (Looks like opening this triggered quite some codeowners for review...)
  * In some places, I've pulled a value that's being `.split()` twice (or similar) into a local variable, for performance and readability.
* The changes are split into three commits based on the changed idioms.

If you like, I have no problem splitting this into smaller PRs either (though I'd like some guidance on what the scope of each PR should then be).

## Benchmarking getting the first or last bit of a delimited string

```
$ python timeit-compare.py -n 10000000 -s 's = "a.b"' 's.partition(".")[0]' 's.partition(".")[-1]' 's.split(".", 1)[0]' 's.split(".", 1)[-1]' 's.rpartition(".r")[0]' 's.rpartition(".")[-1]' 's.rsplit(".", 1)[0]' 's.rsplit(".", 1)[-1]'
s.partition(".")[0]   : 10000000 loop(s), best of 5: 0.079 usec per loop
s.partition(".")[-1]  : 10000000 loop(s), best of 5: 0.081 usec per loop
s.split(".", 1)[0]    : 10000000 loop(s), best of 5: 0.094 usec per loop
s.split(".", 1)[-1]   : 10000000 loop(s), best of 5: 0.092 usec per loop
s.rpartition(".r")[0] : 10000000 loop(s), best of 5: 0.071 usec per loop
s.rpartition(".")[-1] : 10000000 loop(s), best of 5: 0.084 usec per loop
s.rsplit(".", 1)[0]   : 10000000 loop(s), best of 5: 0.091 usec per loop
s.rsplit(".", 1)[-1]  : 10000000 loop(s), best of 5: 0.095 usec per loop
```


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
  - No new tests; behavior should not have changed, and current tests should cover all of this (hopefully...) 

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
