### PR TITLE
Add type hints for MQTT tag

### DIFF
--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -135,6 +135,8 @@ class MQTTTagScanner(MqttDiscoveryDeviceUpdate):
             if not tag_id:  # No output from template, ignore
                 return
 
+            # Importing tag via hass.components in case it is overridden
+            # in a custom_components (custom_components.tag)
             tag = self.hass.components.tag
             await tag.async_scan_tag(tag_id, self.device_id)
 

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -107,11 +107,11 @@ class MQTTTagScanner(MqttDiscoveryDeviceUpdate):
         config_entry: ConfigEntry,
     ) -> None:
         """Initialize."""
-        self._config: ConfigType = config
-        self._config_entry: ConfigEntry = config_entry
-        self.device_id: str | None = device_id
-        self.discovery_data: DiscoveryInfoType = discovery_data
-        self.hass: HomeAssistant = hass
+        self._config = config
+        self._config_entry = config_entry
+        self.device_id = device_id
+        self.discovery_data = discovery_data
+        self.hass = hass
         self._sub_state: dict[str, EntitySubscription] | None = None
         self._value_template: Callable[..., ReceivePayloadType] = MqttValueTemplate(
             config.get(CONF_VALUE_TEMPLATE),

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -107,11 +107,11 @@ class MQTTTagScanner(MqttDiscoveryDeviceUpdate):
         config_entry: ConfigEntry,
     ) -> None:
         """Initialize."""
-        self._config = config
-        self._config_entry = config_entry
-        self.device_id = device_id
-        self.discovery_data = discovery_data
-        self.hass = hass
+        self._config: ConfigType = config
+        self._config_entry: ConfigEntry = config_entry
+        self.device_id: str | None = device_id
+        self.discovery_data: DiscoveryInfoType = discovery_data
+        self.hass: HomeAssistant = hass
         self._sub_state: dict[str, EntitySubscription] | None = None
         self._value_template: Callable[..., ReceivePayloadType] = MqttValueTemplate(
             config.get(CONF_VALUE_TEMPLATE),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints for MQTT tag

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
