### PR TITLE
Validate matcher field case in `usb.async_is_plugged_in`

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -64,6 +64,24 @@ def async_register_scan_request_callback(
 @hass_callback
 def async_is_plugged_in(hass: HomeAssistant, matcher: USBCallbackMatcher) -> bool:
     """Return True is a USB device is present."""
+
+    vid = matcher.get("vid", "")
+    pid = matcher.get("pid", "")
+    serial_number = matcher.get("serial_number", "")
+    manufacturer = matcher.get("manufacturer", "")
+    description = matcher.get("description", "")
+
+    if (
+        vid != vid.upper()
+        or pid != pid.upper()
+        or serial_number != serial_number.lower()
+        or manufacturer != manufacturer.lower()
+        or description != description.lower()
+    ):
+        raise ValueError(
+            f"vid and pid must be uppercase, the rest lowercase in matcher {matcher!r}"
+        )
+
     usb_discovery: USBDiscovery = hass.data[DOMAIN]
     return any(
         _is_matching(USBDevice(*device_tuple), matcher)

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -6,7 +6,6 @@ import dataclasses
 import fnmatch
 import logging
 import os
-import re
 import sys
 from typing import TYPE_CHECKING, Any
 
@@ -126,11 +125,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-def _fnmatch_case_insensitive(name: str | None, pattern: str) -> bool:
-    """Match a name case-insensitively."""
+def _fnmatch_lower(name: str | None, pattern: str) -> bool:
+    """Match a lowercase version of the name."""
     if name is None:
         return False
-    return re.match(fnmatch.translate(pattern), name, re.IGNORECASE) is not None
+    return fnmatch.fnmatch(name.lower(), pattern)
 
 
 def _is_matching(device: USBDevice, matcher: USBMatcher | USBCallbackMatcher) -> bool:
@@ -139,15 +138,15 @@ def _is_matching(device: USBDevice, matcher: USBMatcher | USBCallbackMatcher) ->
         return False
     if "pid" in matcher and device.pid != matcher["pid"]:
         return False
-    if "serial_number" in matcher and not _fnmatch_case_insensitive(
+    if "serial_number" in matcher and not _fnmatch_lower(
         device.serial_number, matcher["serial_number"]
     ):
         return False
-    if "manufacturer" in matcher and not _fnmatch_case_insensitive(
+    if "manufacturer" in matcher and not _fnmatch_lower(
         device.manufacturer, matcher["manufacturer"]
     ):
         return False
-    if "description" in matcher and not _fnmatch_case_insensitive(
+    if "description" in matcher and not _fnmatch_lower(
         device.description, matcher["description"]
     ):
         return False

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -6,6 +6,7 @@ import dataclasses
 import fnmatch
 import logging
 import os
+import re
 import sys
 from typing import TYPE_CHECKING, Any
 
@@ -125,11 +126,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-def _fnmatch_lower(name: str | None, pattern: str) -> bool:
-    """Match a lowercase version of the name."""
+def _fnmatch_case_insensitive(name: str | None, pattern: str) -> bool:
+    """Match a name case-insensitively."""
     if name is None:
         return False
-    return fnmatch.fnmatch(name.lower(), pattern)
+    return re.match(fnmatch.translate(pattern), name, re.IGNORECASE) is not None
 
 
 def _is_matching(device: USBDevice, matcher: USBMatcher | USBCallbackMatcher) -> bool:
@@ -138,15 +139,15 @@ def _is_matching(device: USBDevice, matcher: USBMatcher | USBCallbackMatcher) ->
         return False
     if "pid" in matcher and device.pid != matcher["pid"]:
         return False
-    if "serial_number" in matcher and not _fnmatch_lower(
+    if "serial_number" in matcher and not _fnmatch_case_insensitive(
         device.serial_number, matcher["serial_number"]
     ):
         return False
-    if "manufacturer" in matcher and not _fnmatch_lower(
+    if "manufacturer" in matcher and not _fnmatch_case_insensitive(
         device.manufacturer, matcher["manufacturer"]
     ):
         return False
-    if "description" in matcher and not _fnmatch_lower(
+    if "description" in matcher and not _fnmatch_case_insensitive(
         device.description, matcher["description"]
     ):
         return False

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -403,7 +403,6 @@ async def test_discovered_by_websocket_scan_limited_by_manufacturer_matcher(
             "domain": "test1",
             "vid": "3039",
             "pid": "3039",
-            "description": "*ConBee*",
             "manufacturer": "dresden elektronik ingenieurtechnik*",
         }
     ]

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -403,6 +403,7 @@ async def test_discovered_by_websocket_scan_limited_by_manufacturer_matcher(
             "domain": "test1",
             "vid": "3039",
             "pid": "3039",
+            "description": "*ConBee*",
             "manufacturer": "dresden elektronik ingenieurtechnik*",
         }
     ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The matching logic does not properly deal with mixed case patterns and strings, resulting in the SkyConnect never being considered "plugged in".

I'm not entirely sure if this is a bug with the SkyConnect integration or with USB so I'll just include the gist of it here. The following matcher is passed into `usb.async_is_plugged_in`:

```python
{
    "device": "/dev/cu.SLAB_USBtoUART",
    "vid": "10C4",
    "pid": "EA60",
    "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
    "manufacturer": "Nabu Casa",
    "description": "SkyConnect v1.0",
}
```

And the corresponding device:

```Python
USBDevice(
	device="/dev/cu.SLAB_USBtoUART",
	vid="10C4",
	pid="EA60",
	serial_number="3c0ed67c628beb11b1cd64a0f320645d",
	manufacturer="Nabu Casa",
	description="SkyConnect v1.0",
)
```

`usb._is_matching` does not match the above device because `Nabu Casa` is lowercased but the corresponding "pattern" is not.

~~This change makes the descriptor matching case-insensitive.  Is case insensitivity (or lowercasing) necessary to begin with?~~

This change causes an error to be thrown instead of the matching implicitly failing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
