### PR TITLE
Add TI router transmit power config entity to ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -161,6 +161,12 @@ class BasicChannel(ZigbeeChannel):
                 self.ZCL_INIT_ATTRS.copy()
             )
             self.ZCL_INIT_ATTRS["trigger_indicator"] = True
+        elif (
+            self.cluster.endpoint.manufacturer == "TexasInstruments"
+            and self.cluster.endpoint.model == "ti.router"
+        ):
+            self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
+            self.ZCL_INIT_ATTRS["transmit_power"] = True
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryInput.cluster_id)

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .core import discovery
 from .core.const import (
     CHANNEL_ANALOG_OUTPUT,
+    CHANNEL_BASIC,
     CHANNEL_COLOR,
     CHANNEL_INOVELLI,
     CHANNEL_LEVEL,
@@ -583,6 +584,20 @@ class FilterLifeTime(ZHANumberConfigurationEntity, id_suffix="filter_life_time")
     _attr_native_unit_of_measurement: str | None = UNITS[72]
     _zcl_attribute: str = "filter_life_time"
     _attr_name = "Filter life time"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names=CHANNEL_BASIC,
+    manufacturers={"TexasInstruments"},
+    models={"ti.router"},
+)
+class TiRouterTransmitPower(ZHANumberConfigurationEntity, id_suffix="transmit_power"):
+    """Representation of a ZHA TI transmit power configuration entity."""
+
+    _attr_native_min_value: float = -20
+    _attr_native_max_value: float = 20
+    _zcl_attribute: str = "transmit_power"
+    _attr_name = "Transmit power"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_INOVELLI)


### PR DESCRIPTION
## Proposed change
This adds a config entity to ZHA for TI routers with Koenkk's Z-Stack firmware running ``20221102`` and later (currently on ``dev`` branch).

The config entity goes from -20 to 20 (dBm). Some routers might only support 5 dBm. The slider will still go to 20 (dBm) but that's also what the firmware reports on the custom attribute.
The firmware itself (obviously) doesn't set the transmit power higher than possible.

Older Z-Stack router firmware versions (which don't support the attribute) only print a debug message like expected:
``DEBUG (MainThread) [homeassistant.components.zha.number] transmit_power is not supported - skipping TiRouterTransmitPower entity creation``

**REQUIRES**:
- ✅ https://github.com/zigpy/zha-device-handlers/pull/1886
- ✅ new ``zha-quirks`` release: https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.85
- PR to merge new ``zha-quirks`` release into Home Assistant Core:
- https://github.com/home-assistant/core/pull/81587

I'll convert this from a "draft" to "ready" when the ``zha-quirks`` update is merged into HA.

Example of the config entity:
![image](https://user-images.githubusercontent.com/6409465/199859651-89205da3-b98f-4de1-a9b6-55e9315f7aec.png)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/zigpy/zha-device-handlers/issues/1884
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
