### PR TITLE
Enable SkyConnect config flow and use correct case in USB matching

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/manifest.json
+++ b/homeassistant/components/homeassistant_sky_connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "homeassistant_sky_connect",
   "name": "Home Assistant Sky Connect",
-  "config_flow": false,
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homeassistant_sky_connect",
   "dependencies": ["hardware", "usb"],
   "codeowners": ["@home-assistant/core"],

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -161,6 +161,7 @@ FLOWS = {
         "hlk_sw16",
         "home_connect",
         "home_plus_control",
+        "homeassistant_sky_connect",
         "homekit",
         "homekit_controller",
         "homematicip_cloud",

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -5,6 +5,12 @@ To update, run python3 -m script.hassfest
 
 USB = [
     {
+        "domain": "homeassistant_sky_connect",
+        "vid": "10C4",
+        "pid": "EA60",
+        "description": "*skyconnect v1.0*",
+    },
+    {
         "domain": "insteon",
         "vid": "10BF",
     },

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -13,12 +13,12 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 CONFIG_ENTRY_DATA = {
-    "device": "bla_device",
-    "vid": "bla_vid",
-    "pid": "bla_pid",
-    "serial_number": "bla_serial_number",
-    "manufacturer": "bla_manufacturer",
-    "description": "bla_description",
+    "device": "/dev/cu.SLAB_USBtoUART",
+    "vid": "10C4",
+    "pid": "EA60",
+    "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
+    "manufacturer": "Nabu Casa",
+    "description": "SkyConnect v1.0",
 }
 
 
@@ -66,6 +66,13 @@ async def test_setup_entry(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert len(mock_is_plugged_in.mock_calls) == 1
+
+    matcher = mock_is_plugged_in.mock_calls[0].args[1]
+    assert matcher["vid"].isupper()
+    assert matcher["pid"].isupper()
+    assert matcher["serial_number"].islower()
+    assert matcher["manufacturer"].islower()
+    assert matcher["description"].islower()
 
     # Finish setting up ZHA
     if num_entries > 0:

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 CONFIG_ENTRY_DATA = {
-    "device": "/dev/cu.SLAB_USBtoUART",
+    "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
     "vid": "10C4",
     "pid": "EA60",
     "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
@@ -126,12 +126,12 @@ async def test_setup_zha(mock_zha_config_flow_setup, hass: HomeAssistant) -> Non
         "device": {
             "baudrate": 115200,
             "flow_control": "software",
-            "path": "bla_device",
+            "path": CONFIG_ENTRY_DATA["device"],
         },
         "radio_type": "ezsp",
     }
     assert config_entry.options == {}
-    assert config_entry.title == "bla_description"
+    assert config_entry.title == CONFIG_ENTRY_DATA["description"]
 
 
 async def test_setup_entry_wait_usb(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR consists of two changes:

 1. Enable the config flow in the SkyConnect integration's `manifest.json`.
 2. Ensure the USB matching uses the correct case: see https://github.com/home-assistant/core/pull/81514

The SkyConnect is now correctly detected by a freshly-flashed Yellow running 2022.11.1:

<img width="298" alt="image" src="https://user-images.githubusercontent.com/32534428/199878864-b4530314-a980-4555-a058-94bb54eab56f.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
