### PR TITLE
Use `_attr_` for MQTT vacuum

### DIFF
--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -173,14 +173,13 @@ class MqttVacuum(MqttEntity, VacuumEntity):
 
     def __init__(self, hass, config, config_entry, discovery_data):
         """Initialize the vacuum."""
-        self._attr_is_on = False
         self._attr_battery_level = 0
+        self._attr_is_on = False
         self._attr_fan_speed = "unknown"
 
         self._charging = False
         self._docked = False
         self._error = None
-        self._attr_status = "Unknown"
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
@@ -314,7 +313,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
                     self._attr_status = "Docked & Charging"
                 else:
                     self._attr_status = "Docked"
-            elif self._attr_is_on:
+            elif self.is_on:
                 self._attr_status = "Cleaning"
             elif self._error:
                 self._attr_status = f"Error: {self._error}"
@@ -473,7 +472,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
         """Set fan speed."""
         if (
             self.supported_features & VacuumEntityFeature.FAN_SPEED == 0
-        ) or fan_speed not in self._attr_fan_speed_list:
+        ) or fan_speed not in self.fan_speed_list:
             return None
 
         await self.async_publish(

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -180,7 +180,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
         self._charging = False
         self._docked = False
         self._error = None
-        self._status = "Unknown"
+        self._attr_status = "Unknown"
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
@@ -311,15 +311,15 @@ class MqttVacuum(MqttEntity, VacuumEntity):
 
             if self._docked:
                 if self._charging:
-                    self._status = "Docked & Charging"
+                    self._attr_status = "Docked & Charging"
                 else:
-                    self._status = "Docked"
+                    self._attr_status = "Docked"
             elif self._attr_is_on:
-                self._status = "Cleaning"
+                self._attr_status = "Cleaning"
             elif self._error:
-                self._status = f"Error: {self._error}"
+                self._attr_status = f"Error: {self._error}"
             else:
-                self._status = "Stopped"
+                self._attr_status = "Stopped"
 
             if (
                 msg.topic == self._state_topics[CONF_FAN_SPEED_TOPIC]
@@ -355,18 +355,6 @@ class MqttVacuum(MqttEntity, VacuumEntity):
         await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
-    def is_on(self):
-        """Return true if vacuum is on."""
-        # Super method dos not return self._attr_is_on
-        return self._attr_is_on
-
-    @property
-    def status(self):
-        """Return a status string for the vacuum."""
-        # Super method returns None
-        return self._status
-
-    @property
     def battery_icon(self):
         """Return the battery icon for the vacuum cleaner.
 
@@ -375,11 +363,6 @@ class MqttVacuum(MqttEntity, VacuumEntity):
         return icon_for_battery_level(
             battery_level=self.battery_level, charging=self._charging
         )
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return self._attr_supported_features
 
     async def async_turn_on(self, **kwargs):
         """Turn the vacuum on."""
@@ -393,7 +376,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self._retain,
             self._encoding,
         )
-        self._status = "Cleaning"
+        self._attr_status = "Cleaning"
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
@@ -408,7 +391,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self._retain,
             self._encoding,
         )
-        self._status = "Turning Off"
+        self._attr_status = "Turning Off"
         self.async_write_ha_state()
 
     async def async_stop(self, **kwargs):
@@ -423,7 +406,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self._retain,
             self._encoding,
         )
-        self._status = "Stopping the current task"
+        self._attr_status = "Stopping the current task"
         self.async_write_ha_state()
 
     async def async_clean_spot(self, **kwargs):
@@ -438,7 +421,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self._retain,
             self._encoding,
         )
-        self._status = "Cleaning spot"
+        self._attr_status = "Cleaning spot"
         self.async_write_ha_state()
 
     async def async_locate(self, **kwargs):
@@ -453,7 +436,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self._retain,
             self._encoding,
         )
-        self._status = "Hi, I'm over here!"
+        self._attr_status = "Hi, I'm over here!"
         self.async_write_ha_state()
 
     async def async_start_pause(self, **kwargs):
@@ -468,7 +451,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self._retain,
             self._encoding,
         )
-        self._status = "Pausing/Resuming cleaning..."
+        self._attr_status = "Pausing/Resuming cleaning..."
         self.async_write_ha_state()
 
     async def async_return_to_base(self, **kwargs):
@@ -483,7 +466,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self._retain,
             self._encoding,
         )
-        self._status = "Returning home..."
+        self._attr_status = "Returning home..."
         self.async_write_ha_state()
 
     async def async_set_fan_speed(self, fan_speed, **kwargs):
@@ -500,7 +483,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self._retain,
             self._encoding,
         )
-        self._status = f"Setting fan to {fan_speed}..."
+        self._attr_status = f"Setting fan to {fan_speed}..."
         self.async_write_ha_state()
 
     async def async_send_command(self, command, params=None, **kwargs):
@@ -520,5 +503,5 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self._retain,
             self._encoding,
         )
-        self._status = f"Sending command {message}..."
+        self._attr_status = f"Sending command {message}..."
         self.async_write_ha_state()

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -161,7 +161,6 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
 
     def __init__(self, hass, config, config_entry, discovery_data):
         """Initialize the vacuum."""
-        self._attr_state = None
         self._state_attrs = {}
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -161,7 +161,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
 
     def __init__(self, hass, config, config_entry, discovery_data):
         """Initialize the vacuum."""
-        self._state = None
+        self._attr_state = None
         self._state_attrs = {}
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
@@ -212,7 +212,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
             if STATE in payload and (
                 payload[STATE] in POSSIBLE_STATES or payload[STATE] is None
             ):
-                self._state = (
+                self._attr_state = (
                     POSSIBLE_STATES[payload[STATE]] if payload[STATE] else None
                 )
                 del payload[STATE]
@@ -233,12 +233,6 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
         await subscription.async_subscribe_topics(self.hass, self._sub_state)
-
-    @property
-    def state(self):
-        """Return state of vacuum."""
-        # Super method returns None
-        return self._state
 
     async def async_start(self):
         """Start the vacuum."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `_attr_` for MQTT vacuum

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
