### PR TITLE
Fix watermeter issue for old P1 Monitor versions

### DIFF
--- a/homeassistant/components/p1_monitor/__init__.py
+++ b/homeassistant/components/p1_monitor/__init__.py
@@ -5,6 +5,7 @@ from typing import TypedDict
 
 from p1monitor import (
     P1Monitor,
+    P1MonitorConnectionError,
     P1MonitorNoDataError,
     Phases,
     Settings,
@@ -101,8 +102,8 @@ class P1MonitorDataUpdateCoordinator(DataUpdateCoordinator[P1MonitorData]):
             try:
                 data[SERVICE_WATERMETER] = await self.p1monitor.watermeter()
                 self.has_water_meter = True
-            except P1MonitorNoDataError:
-                LOGGER.debug("No watermeter data received from P1 Monitor")
+            except (P1MonitorNoDataError, P1MonitorConnectionError):
+                LOGGER.debug("No water meter data received from P1 Monitor")
                 if self.has_water_meter is None:
                     self.has_water_meter = False
 

--- a/homeassistant/components/p1_monitor/manifest.json
+++ b/homeassistant/components/p1_monitor/manifest.json
@@ -3,7 +3,7 @@
   "name": "P1 Monitor",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/p1_monitor",
-  "requirements": ["p1monitor==2.1.0"],
+  "requirements": ["p1monitor==2.1.1"],
   "codeowners": ["@klaasnicolaas"],
   "quality_scale": "platinum",
   "iot_class": "local_polling",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1256,7 +1256,7 @@ orvibo==1.1.1
 ovoenergy==1.2.0
 
 # homeassistant.components.p1_monitor
-p1monitor==2.1.0
+p1monitor==2.1.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -895,7 +895,7 @@ oralb-ble==0.10.2
 ovoenergy==1.2.0
 
 # homeassistant.components.p1_monitor
-p1monitor==2.1.0
+p1monitor==2.1.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request fixes a bug for those using an old version (< 1.1.0) of P1 Monitor and not using a water meter.

Changelog new package version:
https://github.com/klaasnicolaas/python-p1monitor/releases/tag/v2.1.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #78775
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
