### PR TITLE
Ensure HomeKit temperature controls appear before fan controls on thermostat accessories

### DIFF
--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -306,7 +306,7 @@ class Thermostat(HomeAccessory):
             if attributes.get(ATTR_HVAC_ACTION) is not None:
                 self.fan_chars.append(CHAR_CURRENT_FAN_STATE)
             serv_fan = self.add_preload_service(SERV_FANV2, self.fan_chars)
-            serv_fan.add_linked_service(serv_thermostat)
+            serv_thermostat.add_linked_service(serv_fan)
             self.char_active = serv_fan.configure_char(
                 CHAR_ACTIVE, value=1, setter_callback=self._set_fan_active
             )


### PR DESCRIPTION
Reverts home-assistant/core#81473. While the previous PR fixed the issue for the user, the real problem was previously unstable iid allocation. By changing the linkage the config number was incrementing which reset the cache and forced the iOS device to "reinterview" the accessory.

The correct solution would have been to delete the config entry and recreate it because it was created when the IIDs were unstable and they were out of sync with iCloud.  Any HomeKit bridge created before 2022.11.x is at risk being out of sync with iCloud Home data because of the unstable IIDs since they were never saved between restarts since day one of the HomeKit integration.