### PR TITLE
Always use Celsius in Shelly integration, part 2

### DIFF
--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -9,6 +9,7 @@ from aioshelly.block_device import Block
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry, entity, entity_registry
@@ -615,6 +616,7 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity, RestoreEnti
         """Initialize the sleeping sensor."""
         self.sensors = sensors
         self.last_state: StateType = None
+        self.last_unit: str | None = None
         self.coordinator = coordinator
         self.attribute = attribute
         self.block: Block | None = block  # type: ignore[assignment]
@@ -644,6 +646,7 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity, RestoreEnti
 
         if last_state is not None:
             self.last_state = last_state.state
+            self.last_unit = last_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
 
     @callback
     def _update_callback(self) -> None:
@@ -696,6 +699,7 @@ class ShellySleepingRpcAttributeEntity(ShellyRpcAttributeEntity, RestoreEntity):
     ) -> None:
         """Initialize the sleeping sensor."""
         self.last_state: StateType = None
+        self.last_unit: str | None = None
         self.coordinator = coordinator
         self.key = key
         self.attribute = attribute
@@ -725,3 +729,4 @@ class ShellySleepingRpcAttributeEntity(ShellyRpcAttributeEntity, RestoreEntity):
 
         if last_state is not None:
             self.last_state = last_state.state
+            self.last_unit = last_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -431,8 +431,9 @@ RPC_SENSORS: Final = {
 def _build_block_description(entry: RegistryEntry) -> BlockSensorDescription:
     """Build description when restoring block attribute entities."""
     native_unit_of_measurement: str | None
-    # For the temperature entity native unit is Celsius but unit_of_measurement in entry
-    # will be Farenheit if user is using that unit.
+    # For the temperature entity, the native unit is Celsius,
+    # but the entry's unit_of_measurement will be Fahrenheit
+    # if the user is using that unit.
     if entry.original_device_class == SensorDeviceClass.TEMPERATURE:
         native_unit_of_measurement = TEMP_CELSIUS
     else:

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -430,19 +430,11 @@ RPC_SENSORS: Final = {
 
 def _build_block_description(entry: RegistryEntry) -> BlockSensorDescription:
     """Build description when restoring block attribute entities."""
-    native_unit_of_measurement: str | None
-    # For the temperature entity, the native unit is Celsius,
-    # but the entry's unit_of_measurement will be Fahrenheit
-    # if the user is using that unit.
-    if entry.original_device_class == SensorDeviceClass.TEMPERATURE:
-        native_unit_of_measurement = TEMP_CELSIUS
-    else:
-        native_unit_of_measurement = entry.unit_of_measurement
     return BlockSensorDescription(
         key="",
         name="",
         icon=entry.original_icon,
-        native_unit_of_measurement=native_unit_of_measurement,
+        native_unit_of_measurement=entry.unit_of_measurement,
         device_class=entry.original_device_class,
     )
 
@@ -553,8 +545,6 @@ class BlockSleepingSensor(ShellySleepingBlockAttributeEntity, SensorEntity):
         """Initialize the sleeping sensor."""
         super().__init__(coordinator, block, attribute, description, entry, sensors)
 
-        self._attr_native_unit_of_measurement = description.native_unit_of_measurement
-
     @property
     def native_value(self) -> StateType:
         """Return value of sensor."""
@@ -562,6 +552,14 @@ class BlockSleepingSensor(ShellySleepingBlockAttributeEntity, SensorEntity):
             return self.attribute_value
 
         return self.last_state
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement of the sensor, if any."""
+        if self.block is not None:
+            return self.entity_description.native_unit_of_measurement
+
+        return self.last_unit
 
 
 class RpcSleepingSensor(ShellySleepingRpcAttributeEntity, SensorEntity):
@@ -576,3 +574,11 @@ class RpcSleepingSensor(ShellySleepingRpcAttributeEntity, SensorEntity):
             return self.attribute_value
 
         return self.last_state
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement of the sensor, if any."""
+        if self.coordinator.device.initialized:
+            return self.entity_description.native_unit_of_measurement
+
+        return self.last_unit

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -5,13 +5,13 @@ from datetime import datetime, timedelta
 from typing import Any, cast
 
 from aiohttp.web import Request, WebSocketResponse
-from aioshelly.block_device import BLOCK_VALUE_UNIT, COAP, Block, BlockDevice
+from aioshelly.block_device import COAP, Block, BlockDevice
 from aioshelly.const import MODEL_NAMES
 from aioshelly.rpc_device import RpcDevice, WsServer
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry, entity_registry, singleton
 from homeassistant.helpers.typing import EventType
@@ -41,13 +41,6 @@ def async_remove_shelly_entity(
     if entity_id:
         LOGGER.debug("Removing entity: %s", entity_id)
         entity_reg.async_remove(entity_id)
-
-
-def temperature_unit(block_info: dict[str, Any]) -> str:
-    """Detect temperature unit."""
-    if block_info[BLOCK_VALUE_UNIT] == "F":
-        return TEMP_FAHRENHEIT
-    return TEMP_CELSIUS
 
 
 def get_block_device_name(device: BlockDevice) -> str:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We want integration internally to always use Celsius, also for sleeping devices like H&T. This is a continuation of #80842.

EDIT:
After the discussion with @thecode I changed the code, now the unit of measurement is also restored from registry, as is the value. When the device sends a new state, the unit is set based on `entity_description`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81494
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
