### PR TITLE
Fix invalid min and max color temp in bad ZHA light devices

### DIFF
--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -98,12 +98,26 @@ class ColorChannel(ZigbeeChannel):
     @property
     def min_mireds(self) -> int:
         """Return the coldest color_temp that this channel supports."""
-        return self.cluster.get("color_temp_physical_min", self.MIN_MIREDS)
+        min_mireds = self.cluster.get("color_temp_physical_min", self.MIN_MIREDS)
+        if min_mireds == 0:
+            self.warning(
+                "[Min mireds is 0, setting to %s] Please open an issue on the quirks repo to have this device corrected",
+                self.MIN_MIREDS,
+            )
+            min_mireds = self.MIN_MIREDS
+        return min_mireds
 
     @property
     def max_mireds(self) -> int:
         """Return the warmest color_temp that this channel supports."""
-        return self.cluster.get("color_temp_physical_max", self.MAX_MIREDS)
+        max_mireds = self.cluster.get("color_temp_physical_max", self.MAX_MIREDS)
+        if max_mireds == 0:
+            self.warning(
+                "[Max mireds is 0, setting to %s] Please open an issue on the quirks repo to have this device corrected",
+                self.MAX_MIREDS,
+            )
+            max_mireds = self.MAX_MIREDS
+        return max_mireds
 
     @property
     def hs_supported(self) -> bool:

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -242,7 +242,9 @@ async def eWeLink_light(hass, zigpy_device_mock, zha_device_joined):
     color_cluster = zigpy_device.endpoints[1].light_color
     color_cluster.PLUGGED_ATTR_READS = {
         "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature
-        | lighting.Color.ColorCapabilities.XY_attributes
+        | lighting.Color.ColorCapabilities.XY_attributes,
+        "color_temp_physical_min": 0,
+        "color_temp_physical_max": 0,
     }
     zha_device = await zha_device_joined(zigpy_device)
     zha_device.available = True
@@ -1192,6 +1194,8 @@ async def test_transitions(
     assert eWeLink_state.state == STATE_ON
     assert eWeLink_state.attributes["color_temp"] == 235
     assert eWeLink_state.attributes["color_mode"] == ColorMode.COLOR_TEMP
+    assert eWeLink_state.attributes["min_mireds"] == 153
+    assert eWeLink_state.attributes["max_mireds"] == 500
 
 
 async def async_test_on_off_from_light(hass, cluster, entity_id):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR patches around some faulty devices reporting 0 for min and max color temp. 

Fixes: #81446
Fixes: #81529

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81529, #81446
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
