### PR TITLE
Update lutron_caseta buttons to use keypad data

### DIFF
--- a/homeassistant/components/lutron_caseta/button.py
+++ b/homeassistant/components/lutron_caseta/button.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import LutronCasetaDevice
 from .const import DOMAIN as CASETA_DOMAIN
-from .models import LutronButton, LutronCasetaData, LutronKeypad
+from .models import LutronButton, LutronCasetaData
 
 
 async def async_setup_entry(
@@ -19,12 +19,8 @@ async def async_setup_entry(
     """Set up Lutron pico and keypad buttons."""
     data: LutronCasetaData = hass.data[CASETA_DOMAIN][config_entry.entry_id]
     buttons = data.keypad_data.buttons
-    keypads = data.keypad_data.keypads
 
-    async_add_entities(
-        LutronCasetaButton(button, keypads[button["parent_keypad"]], data)
-        for button in buttons.values()
-    )
+    async_add_entities(LutronCasetaButton(button, data) for button in buttons.values())
 
 
 class LutronCasetaButton(LutronCasetaDevice, ButtonEntity):
@@ -33,11 +29,12 @@ class LutronCasetaButton(LutronCasetaDevice, ButtonEntity):
     def __init__(
         self,
         button: LutronButton,
-        keypad: LutronKeypad,
         data: LutronCasetaData,
     ) -> None:
         """Init a button entity."""
         bridge_button = data.bridge.buttons[button["lutron_device_id"]]
+        keypad = data.keypad_data.keypads[button["parent_keypad"]]
+
         super().__init__(bridge_button, data)
 
         self._attr_entity_registry_enabled_default = button["enabled_default"]

--- a/homeassistant/components/lutron_caseta/button.py
+++ b/homeassistant/components/lutron_caseta/button.py
@@ -1,18 +1,14 @@
 """Support for pico and keypad buttons."""
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import LutronCasetaDevice
 from .const import DOMAIN as CASETA_DOMAIN
-from .device_trigger import LEAP_TO_DEVICE_TYPE_SUBTYPE_MAP
-from .models import LutronCasetaData
+from .models import LutronButton, LutronCasetaData, LutronKeypad
 
 
 async def async_setup_entry(
@@ -22,48 +18,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up Lutron pico and keypad buttons."""
     data: LutronCasetaData = hass.data[CASETA_DOMAIN][config_entry.entry_id]
-    bridge = data.bridge
-    button_devices = bridge.get_buttons()
-    all_devices = data.bridge.get_devices()
+    buttons = data.keypad_data.buttons
     keypads = data.keypad_data.keypads
-    entities: list[LutronCasetaButton] = []
 
-    for device in button_devices.values():
-
-        parent_keypad = keypads[device["parent_device"]]
-        parent_device_info = parent_keypad["device_info"]
-
-        enabled_default = True
-        if not (device_name := device.get("device_name")):
-            # device name (button name) is missing, probably a caseta pico
-            # try to get the name using the button number from the triggers
-            # disable the button by default
-            enabled_default = False
-            keypad_device = all_devices[device["parent_device"]]
-            button_numbers = LEAP_TO_DEVICE_TYPE_SUBTYPE_MAP.get(
-                keypad_device["type"],
-                {},
-            )
-            device_name = (
-                button_numbers.get(
-                    int(device["button_number"]),
-                    f"button {device['button_number']}",
-                )
-                .replace("_", " ")
-                .title()
-            )
-
-        # Append the child device name to the end of the parent keypad name to create the entity name
-        full_name = f'{parent_device_info.get("name")} {device_name}'
-        # Set the device_info to the same as the Parent Keypad
-        # The entities will be nested inside the keypad device
-        entities.append(
-            LutronCasetaButton(
-                device, data, full_name, enabled_default, parent_device_info
-            ),
-        )
-
-    async_add_entities(entities)
+    async_add_entities(
+        LutronCasetaButton(button, keypads[button["parent_keypad"]], data)
+        for button in buttons.values()
+    )
 
 
 class LutronCasetaButton(LutronCasetaDevice, ButtonEntity):
@@ -71,17 +32,19 @@ class LutronCasetaButton(LutronCasetaDevice, ButtonEntity):
 
     def __init__(
         self,
-        device: dict[str, Any],
+        button: LutronButton,
+        keypad: LutronKeypad,
         data: LutronCasetaData,
-        full_name: str,
-        enabled_default: bool,
-        device_info: DeviceInfo,
     ) -> None:
         """Init a button entity."""
-        super().__init__(device, data)
-        self._attr_entity_registry_enabled_default = enabled_default
-        self._attr_name = full_name
-        self._attr_device_info = device_info
+        bridge_button = data.bridge.buttons[button["lutron_device_id"]]
+        super().__init__(bridge_button, data)
+
+        self._attr_entity_registry_enabled_default = button["enabled_default"]
+        self._attr_name = (
+            f'{keypad["area_name"]} {keypad["name"]} {button["button_name"]}'
+        )
+        self._attr_device_info = keypad["device_info"]
 
     async def async_press(self) -> None:
         """Send a button press event."""

--- a/homeassistant/components/lutron_caseta/models.py
+++ b/homeassistant/components/lutron_caseta/models.py
@@ -53,3 +53,4 @@ class LutronButton(TypedDict):
     button_name: str
     led_device_id: int
     parent_keypad: int
+    enabled_default: bool

--- a/tests/components/lutron_caseta/test_diagnostics.py
+++ b/tests/components/lutron_caseta/test_diagnostics.py
@@ -198,6 +198,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "led_device_id": None,
                     "lutron_device_id": "111",
                     "parent_keypad": "9",
+                    "enabled_default": False,
                 },
                 "1372": {
                     "button_name": "Kitchen " "Pendants",
@@ -205,6 +206,7 @@ async def test_diagnostics(hass, hass_client) -> None:
                     "led_device_id": "1362",
                     "lutron_device_id": "1372",
                     "parent_keypad": "1355",
+                    "enabled_default": True,
                 },
             },
             "keypads": {


### PR DESCRIPTION
## Proposed change
Update the button entity code to use the data and naming defined in the keypad setup.

- removes naming logic from async_setup_entry in buttons.py, which is already completed during keypad setup
- simplifies and removes unnecessary code

Tested On:
- [X] Radio RA3
- [X] Lutron Caseta Pro
- [ ] Lutron Caseta
- [ ] Radio RA2 Select

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
