### PR TITLE
Fix situation where deCONZ sensor platform setup would fail

### DIFF
--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -89,6 +89,7 @@ T = TypeVar(
 class DeconzSensorDescriptionMixin(Generic[T]):
     """Required values when describing secondary sensor attributes."""
 
+    supported_fn: Callable[[T], bool]
     update_key: str
     value_fn: Callable[[T], datetime | StateType]
 
@@ -105,6 +106,7 @@ class DeconzSensorDescription(SensorEntityDescription, DeconzSensorDescriptionMi
 ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     DeconzSensorDescription[AirQuality](
         key="air_quality",
+        supported_fn=lambda device: device.air_quality is not None,
         update_key="airquality",
         value_fn=lambda device: device.air_quality,
         instance_check=AirQuality,
@@ -112,6 +114,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[AirQuality](
         key="air_quality_ppb",
+        supported_fn=lambda device: device.air_quality_ppb is not None,
         update_key="airqualityppb",
         value_fn=lambda device: device.air_quality_ppb,
         instance_check=AirQuality,
@@ -122,6 +125,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[Consumption](
         key="consumption",
+        supported_fn=lambda device: device.consumption is not None,
         update_key="consumption",
         value_fn=lambda device: device.scaled_consumption,
         instance_check=Consumption,
@@ -131,6 +135,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[Daylight](
         key="daylight_status",
+        supported_fn=lambda device: True,
         update_key="status",
         value_fn=lambda device: DAYLIGHT_STATUS[device.daylight_status],
         instance_check=Daylight,
@@ -139,12 +144,14 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[GenericStatus](
         key="status",
+        supported_fn=lambda device: device.status is not None,
         update_key="status",
         value_fn=lambda device: device.status,
         instance_check=GenericStatus,
     ),
     DeconzSensorDescription[Humidity](
         key="humidity",
+        supported_fn=lambda device: device.humidity is not None,
         update_key="humidity",
         value_fn=lambda device: device.scaled_humidity,
         instance_check=Humidity,
@@ -154,6 +161,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[LightLevel](
         key="light_level",
+        supported_fn=lambda device: device.light_level is not None,
         update_key="lightlevel",
         value_fn=lambda device: device.scaled_light_level,
         instance_check=LightLevel,
@@ -163,6 +171,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[Power](
         key="power",
+        supported_fn=lambda device: device.power is not None,
         update_key="power",
         value_fn=lambda device: device.power,
         instance_check=Power,
@@ -172,6 +181,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[Pressure](
         key="pressure",
+        supported_fn=lambda device: device.pressure is not None,
         update_key="pressure",
         value_fn=lambda device: device.pressure,
         instance_check=Pressure,
@@ -181,6 +191,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[Temperature](
         key="temperature",
+        supported_fn=lambda device: device.temperature is not None,
         update_key="temperature",
         value_fn=lambda device: device.scaled_temperature,
         instance_check=Temperature,
@@ -190,6 +201,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[Time](
         key="last_set",
+        supported_fn=lambda device: device.last_set is not None,
         update_key="lastset",
         value_fn=lambda device: dt_util.parse_datetime(device.last_set),
         instance_check=Time,
@@ -197,6 +209,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[SensorResources](
         key="battery",
+        supported_fn=lambda device: device.battery is not None,
         update_key="battery",
         value_fn=lambda device: device.battery,
         name_suffix="Battery",
@@ -208,6 +221,7 @@ ENTITY_DESCRIPTIONS: tuple[DeconzSensorDescription, ...] = (
     ),
     DeconzSensorDescription[SensorResources](
         key="internal_temperature",
+        supported_fn=lambda device: device.internal_temperature is not None,
         update_key="temperature",
         value_fn=lambda device: device.internal_temperature,
         name_suffix="Temperature",
@@ -268,10 +282,7 @@ async def async_setup_entry(
                 continue
 
             no_sensor_data = False
-            try:
-                if description.value_fn(sensor) is None:
-                    no_sensor_data = True
-            except TypeError:
+            if not description.supported_fn(sensor):
                 no_sensor_data = True
 
             if description.instance_check is None:

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -268,7 +268,10 @@ async def async_setup_entry(
                 continue
 
             no_sensor_data = False
-            if description.value_fn(sensor) is None:
+            try:
+                if description.value_fn(sensor) is None:
+                    no_sensor_data = True
+            except TypeError:
                 no_sensor_data = True
 
             if description.instance_check is None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If state property of a scaled sensor value where None a TypeError would be raise blocking the sensor platform from completing setup.

Apparently I had a test (test_dont_add_sensor_if_state_is_none) but it only validated that the sensors weren't created (as expected) but it didn't show that the sensor platform setup failed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #81469 (partially)
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
