### PR TITLE
Fix Bravia TV options flow when device is off

### DIFF
--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import suppress
 from typing import Any
 from urllib.parse import urlparse
 
@@ -262,7 +263,8 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
             self.config_entry.entry_id
         ]
 
-        await coordinator.async_update_sources()
+        with suppress(BraviaTVError):
+            await coordinator.async_update_sources()
         sources = coordinator.source_map.values()
         self.source_list = [item["title"] for item in sources]
         return await self.async_step_user()

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from contextlib import suppress
 from typing import Any
 from urllib.parse import urlparse
 
@@ -263,8 +262,11 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
             self.config_entry.entry_id
         ]
 
-        with suppress(BraviaTVError):
+        try:
             await coordinator.async_update_sources()
+        except BraviaTVError:
+            return self.async_abort(reason="failed_update")
+
         sources = coordinator.source_map.values()
         self.source_list = [item["title"] for item in sources]
         return await self.async_step_user()

--- a/homeassistant/components/braviatv/strings.json
+++ b/homeassistant/components/braviatv/strings.json
@@ -44,11 +44,13 @@
     "step": {
       "user": {
         "title": "Options for Sony Bravia TV",
-        "description": "Ensure that your TV is turned on before trying to set it up.",
         "data": {
           "ignored_sources": "List of ignored sources"
         }
       }
+    },
+    "abort": {
+      "failed_update": "An error occurred while updating the list of sources.\n\n Ensure that your TV is turned on before trying to set it up."
     }
   }
 }

--- a/homeassistant/components/braviatv/strings.json
+++ b/homeassistant/components/braviatv/strings.json
@@ -44,6 +44,7 @@
     "step": {
       "user": {
         "title": "Options for Sony Bravia TV",
+        "description": "Ensure that your TV is turned on before trying to set it up.",
         "data": {
           "ignored_sources": "List of ignored sources"
         }

--- a/homeassistant/components/braviatv/translations/en.json
+++ b/homeassistant/components/braviatv/translations/en.json
@@ -41,12 +41,14 @@
         }
     },
     "options": {
+        "abort": {
+            "failed_update": "An error occurred while updating the list of sources.\n\n Ensure that your TV is turned on before trying to set it up."
+        },
         "step": {
             "user": {
                 "data": {
                     "ignored_sources": "List of ignored sources"
                 },
-                "description": "Ensure that your TV is turned on before trying to set it up.",
                 "title": "Options for Sony Bravia TV"
             }
         }

--- a/homeassistant/components/braviatv/translations/en.json
+++ b/homeassistant/components/braviatv/translations/en.json
@@ -46,6 +46,7 @@
                 "data": {
                     "ignored_sources": "List of ignored sources"
                 },
+                "description": "Ensure that your TV is turned on before trying to set it up.",
                 "title": "Options for Sony Bravia TV"
             }
         }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Bravia TV options flow when the device is off.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80662, #78919
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
