### PR TITLE
Late-import some modules required via conftest

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -73,7 +73,6 @@ if TYPE_CHECKING:
     # Only import for paho-mqtt type checking here, imports are done locally
     # because integrations should be able to optionally rely on MQTT.
     import paho.mqtt.client as mqtt
-    from paho.mqtt.client import MQTTMessage
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -620,7 +619,7 @@ class MQTT:
             )
 
     def _mqtt_on_message(
-        self, _mqttc: mqtt.Client, _userdata: None, msg: MQTTMessage
+        self, _mqttc: mqtt.Client, _userdata: None, msg: mqtt.MQTTMessage
     ) -> None:
         """Message received callback."""
         self.hass.add_job(self._mqtt_handle_message, msg)
@@ -634,7 +633,7 @@ class MQTT:
         return subscriptions
 
     @callback
-    def _mqtt_handle_message(self, msg: MQTTMessage) -> None:
+    def _mqtt_handle_message(self, msg: mqtt.MQTTMessage) -> None:
         _LOGGER.debug(
             "Received%s message on %s: %s",
             " retained" if msg.retain else "",

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -15,7 +15,6 @@ import uuid
 
 import attr
 import certifi
-from paho.mqtt.client import MQTTMessage
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -74,6 +73,7 @@ if TYPE_CHECKING:
     # Only import for paho-mqtt type checking here, imports are done locally
     # because integrations should be able to optionally rely on MQTT.
     import paho.mqtt.client as mqtt
+    from paho.mqtt.client import MQTTMessage
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -387,7 +387,9 @@ class StreamView(HomeAssistantView):
 
 
 def _transform_image(image: np.ndarray, orientation: int) -> np.ndarray:
-    # Late import since tests require mqtt.camera -> stream.core
+    """Transform the image using numpy."""
+
+    # Keep import here so that we can import stream integration without installing reqs
     import numpy as np  # pylint: disable=import-outside-toplevel
 
     if orientation == 2:  # Mirror

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 from aiohttp import web
 import async_timeout
 import attr
-import numpy as np
 
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
@@ -27,6 +26,7 @@ from .const import (
 
 if TYPE_CHECKING:
     from av import CodecContext, Packet
+    import numpy as np
 
     from . import Stream
 
@@ -386,17 +386,25 @@ class StreamView(HomeAssistantView):
         raise NotImplementedError()
 
 
-TRANSFORM_IMAGE_FUNCTION = (
-    lambda image: image,  # Unused
-    lambda image: image,  # No transform
-    lambda image: np.fliplr(image).copy(),  # Mirror
-    lambda image: np.rot90(image, 2).copy(),  # Rotate 180
-    lambda image: np.flipud(image).copy(),  # Flip
-    lambda image: np.flipud(np.rot90(image)).copy(),  # Rotate left and flip
-    lambda image: np.rot90(image).copy(),  # Rotate left
-    lambda image: np.flipud(np.rot90(image, -1)).copy(),  # Rotate right and flip
-    lambda image: np.rot90(image, -1).copy(),  # Rotate right
-)
+def _transform_image(image: np.ndarray, orientation: int) -> np.ndarray:
+    # Late import since tests require mqtt.camera -> stream.core
+    import numpy as np  # pylint: disable=import-outside-toplevel
+
+    if orientation == 2:  # Mirror
+        return np.fliplr(image).copy()
+    if orientation == 3:  # Rotate 180
+        return np.rot90(image, 2).copy()
+    if orientation == 4:  # Flip
+        return np.flipud(image).copy()
+    if orientation == 5:  # Rotate left and flip
+        return np.flipud(np.rot90(image)).copy()
+    if orientation == 6:  # Rotate left
+        return np.rot90(image).copy()
+    if orientation == 7:  # Rotate right and flip
+        return np.flipud(np.rot90(image, -1)).copy()
+    if orientation == 8:  # Rotate right
+        return np.rot90(image, -1).copy()
+    return image  # Transforms 0 and 1 (and others not yet defined) are identity
 
 
 class KeyFrameConverter:
@@ -450,7 +458,7 @@ class KeyFrameConverter:
     @staticmethod
     def transform_image(image: np.ndarray, orientation: int) -> np.ndarray:
         """Transform image to a given orientation."""
-        return TRANSFORM_IMAGE_FUNCTION[orientation](image)
+        return _transform_image(image, orientation)
 
     def _generate_image(self, width: int | None, height: int | None) -> None:
         """


### PR DESCRIPTION
## Proposed change

This PR gently adjusts some imports to happen within late and/or within `TYPE_CHECKING` blocks to make it possible to run tests for a given component without requiring that many unnecessary dependencies.

This does **not** fully fix the situation; `sqlalchemy` and `fnvhash` are required by `recorder`, which was much harder to untangle than these, but those are still not automatically installed in e.g. a GitHub Codespace (they're e.g. not in `requirements_test.txt`).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
