### PR TITLE
Change ZHA StartUpColorTemperature to use Slider and Kelvin

### DIFF
--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -277,7 +277,12 @@ class NumberEntity(Entity):
         ):
             self._report_deprecated_number_entity()  # type: ignore[unreachable]
             return self.entity_description.min_value
-        return self._convert_to_state_value(self.native_min_value, floor_decimal)
+
+        # Some conversions may invert the scale, like color temperature mired to kelvin
+        return min(
+            self._convert_to_state_value(self.native_min_value, floor_decimal),
+            self._convert_to_state_value(self.native_max_value, ceil_decimal),
+        )
 
     @property
     def native_max_value(self) -> float:
@@ -304,7 +309,12 @@ class NumberEntity(Entity):
         ):
             self._report_deprecated_number_entity()  # type: ignore[unreachable]
             return self.entity_description.max_value
-        return self._convert_to_state_value(self.native_max_value, ceil_decimal)
+
+        # Some conversions may invert the scale, like color temperature mired to kelvin
+        return max(
+            self._convert_to_state_value(self.native_min_value, floor_decimal),
+            self._convert_to_state_value(self.native_max_value, ceil_decimal),
+        )
 
     @property
     def native_step(self) -> float | None:

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -1,6 +1,7 @@
 """Support for ZHA AnalogOutput cluster."""
 from __future__ import annotations
 
+from collections.abc import Callable
 import functools
 import logging
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -15,6 +16,10 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.color import (
+    color_temperature_kelvin_to_mired,
+    color_temperature_mired_to_kelvin,
+)
 
 from .core import discovery
 from .core.const import (
@@ -553,6 +558,16 @@ class StartUpColorTemperatureConfigurationEntity(
         if self._channel:
             self._attr_native_min_value: float = self._channel.min_mireds
             self._attr_native_max_value: float = self._channel.max_mireds
+
+    def _convert_to_state_value(
+        self, value: float, method: Callable[[float, int], float]
+    ) -> float:
+        """Convert a value in the number's native unit to the configured unit."""
+        return color_temperature_mired_to_kelvin(value)
+
+    def convert_to_native_value(self, value: float) -> float:
+        """Convert a value to the number's native unit."""
+        return color_temperature_kelvin_to_mired(value)
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import zigpy.exceptions
 from zigpy.zcl.foundation import Status
 
-from homeassistant.components.number import NumberEntity
+from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
@@ -535,6 +535,7 @@ class StartUpColorTemperatureConfigurationEntity(
 ):
     """Representation of a ZHA startup color temperature configuration entity."""
 
+    _attr_mode: NumberMode = NumberMode.SLIDER
     _attr_native_min_value: float = 153
     _attr_native_max_value: float = 500
     _zcl_attribute: str = "start_up_color_temperature"

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -563,10 +563,18 @@ class StartUpColorTemperatureConfigurationEntity(
         self, value: float, method: Callable[[float, int], float]
     ) -> float:
         """Convert a value in the number's native unit to the configured unit."""
+
+        This is overridden because NumberEntity does not know about converting between
+        K and mireds, and the user can't choose the preferred color temp unit of a number.
+        """
         return color_temperature_mired_to_kelvin(value)
 
     def convert_to_native_value(self, value: float) -> float:
-        """Convert a value to the number's native unit."""
+        """Convert a value to the number's native unit.
+
+        This is overridden because NumberEntity does not know about converting between
+        K and mireds, and the user can't choose the preferred color temp unit of a number..
+        """
         return color_temperature_kelvin_to_mired(value)
 
 

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -327,18 +327,25 @@ async def test_level_control_number(
 
 
 @pytest.mark.parametrize(
-    "attr, initial_value, new_value",
-    (("start_up_color_temperature", 500, 350),),
+    "attr, initial_native_value, initial_value, new_value, new_native_value",
+    (("start_up_color_temperature", 500, 2000, 4000, 250),),
 )
 async def test_color_number(
-    hass, light, zha_device_joined, attr, initial_value, new_value
+    hass,
+    light,
+    zha_device_joined,
+    attr,
+    initial_native_value,
+    initial_value,
+    new_value,
+    new_native_value,
 ):
     """Test zha color number entities - new join."""
 
     entity_registry = er.async_get(hass)
     color_cluster = light.endpoints[1].light_color
     color_cluster.PLUGGED_ATTR_READS = {
-        attr: initial_value,
+        attr: initial_native_value,
     }
     zha_device = await zha_device_joined(light)
 
@@ -387,7 +394,7 @@ async def test_color_number(
 
     assert color_cluster.write_attributes.call_count == 1
     assert color_cluster.write_attributes.call_args[0][0] == {
-        attr: new_value,
+        attr: new_native_value,
     }
 
     state = hass.states.get(entity_id)
@@ -431,6 +438,6 @@ async def test_color_number(
 
     assert color_cluster.write_attributes.call_count == 1
     assert color_cluster.write_attributes.call_args[0][0] == {
-        attr: new_value,
+        attr: new_native_value,
     }
     assert hass.states.get(entity_id).state == str(initial_value)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow up to #80853 to adhere with the November release announcement to use Kelvin for color temperature and the changes in #79591.

This PR changes the ZHA StartUpColorTemperature entity to use Kelvin values instead of Mireds, as well.
The change required some smaller fix in the baseclass `NumberEntity`, as Kelvin to Mired conversion and vice versa inverts the min/max values.

Additionally this PR also changes the Entity to use a slider for the color temperature instead of a number input.

![image](https://user-images.githubusercontent.com/4631548/200194607-d0fa251d-d52d-444e-8318-6fb50341ec79.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: _none_
- This PR is related to issue: _none_
- Link to documentation pull request: _none_

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
