### PR TITLE
Enable more customization of the LIFX pulse and color loop effects

### DIFF
--- a/homeassistant/components/lifx/services.yaml
+++ b/homeassistant/components/lifx/services.yaml
@@ -79,12 +79,20 @@ effect_pulse:
             - "strobe"
             - "solid"
     brightness:
-      name: Brightness
-      description: Number indicating brightness of the temporary color.
+      name: Brightness value
+      description: Number indicating brightness of the temporary color, where 1 is the minimum brightness and 255 is the maximum brightness supported by the light.
       selector:
         number:
-          min: 0
+          min: 1
           max: 255
+    brightness_pct:
+      name: Brightness
+      description: Number indicating percentage of full brightness of the temporary color, where 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
+      selector:
+        number:
+          min: 1
+          max: 100
+          unit_of_measurement: "%"
     color_name:
       name: Color name
       description: A human readable color name.
@@ -131,12 +139,38 @@ effect_colorloop:
       domain: light
   fields:
     brightness:
-      name: Brightness
-      description: Number indicating brightness of the effect. Leave this out to maintain the current brightness of each participating light.
+      name: Brightness value
+      description: Number indicating brightness of the color loop, where 1 is the minimum brightness and 255 is the maximum brightness supported by the light.
       selector:
         number:
           min: 0
           max: 255
+    brightness_pct:
+      name: Brightness
+      description: Number indicating percentage of full brightness of the color loop, where 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+    saturation_min:
+      name: Minimum saturation
+      description: Number indicating the minimum saturation of the colors in the loop. Leave this out to use the default value of 80%.
+      default: 80
+      selector:
+        number:
+          min: 1
+          max: 100
+          unit_of_measurement: "%"
+    saturation_max:
+      name: Maximum saturation
+      description: Number indicationg the maximum saturation of the colors in the loop. Leave this out to use the default value of 100%.
+      default: 100
+      selector:
+        number:
+          min: 1
+          max: 100
+          unit_of_measurement: "%"
     period:
       name: Period
       description: Duration between color changes.

--- a/homeassistant/components/lifx/services.yaml
+++ b/homeassistant/components/lifx/services.yaml
@@ -155,7 +155,7 @@ effect_colorloop:
           unit_of_measurement: "%"
     saturation_min:
       name: Minimum saturation
-      description: Percentage indicating the minimum saturation of the colors in the loop. Leave this out to use the default value of 80%.
+      description: Percentage indicating the minimum saturation of the colors in the loop.
       default: 80
       selector:
         number:
@@ -164,7 +164,7 @@ effect_colorloop:
           unit_of_measurement: "%"
     saturation_max:
       name: Maximum saturation
-      description: Percentage indicating the maximum saturation of the colors in the loop. Leave this out to use the default value of 100%.
+      description: Percentage indicating the maximum saturation of the colors in the loop.
       default: 100
       selector:
         number:

--- a/homeassistant/components/lifx/services.yaml
+++ b/homeassistant/components/lifx/services.yaml
@@ -87,7 +87,7 @@ effect_pulse:
           max: 255
     brightness_pct:
       name: Brightness
-      description: Number indicating percentage of full brightness of the temporary color, where 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
+      description: Percentage indicating the brightness of the temporary color, where 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
       selector:
         number:
           min: 1
@@ -147,7 +147,7 @@ effect_colorloop:
           max: 255
     brightness_pct:
       name: Brightness
-      description: Number indicating percentage of full brightness of the color loop, where 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
+      description: Percentage indicating the brightness of the color loop, where 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
       selector:
         number:
           min: 0
@@ -155,7 +155,7 @@ effect_colorloop:
           unit_of_measurement: "%"
     saturation_min:
       name: Minimum saturation
-      description: Number indicating the minimum saturation of the colors in the loop. Leave this out to use the default value of 80%.
+      description: Percentage indicating the minimum saturation of the colors in the loop. Leave this out to use the default value of 80%.
       default: 80
       selector:
         number:
@@ -164,7 +164,7 @@ effect_colorloop:
           unit_of_measurement: "%"
     saturation_max:
       name: Maximum saturation
-      description: Number indicationg the maximum saturation of the colors in the loop. Leave this out to use the default value of 100%.
+      description: Percentage indicating the maximum saturation of the colors in the loop. Leave this out to use the default value of 100%.
       default: 100
       selector:
         number:

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -13,6 +13,8 @@ from homeassistant.components.lifx.light import ATTR_INFRARED, ATTR_ZONES
 from homeassistant.components.lifx.manager import (
     ATTR_DIRECTION,
     ATTR_PALETTE,
+    ATTR_SATURATION_MAX,
+    ATTR_SATURATION_MIN,
     ATTR_SPEED,
     ATTR_THEME,
     SERVICE_EFFECT_COLORLOOP,
@@ -1009,7 +1011,20 @@ async def test_color_light_with_temp(
     await hass.services.async_call(
         DOMAIN,
         SERVICE_EFFECT_COLORLOOP,
-        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS_PCT: 50, ATTR_SATURATION_MAX: 90},
+        blocking=True,
+    )
+    start_call = mock_effect_conductor.start.mock_calls
+    first_call = start_call[0][1]
+    assert isinstance(first_call[0], aiolifx_effects.EffectColorloop)
+    assert first_call[1][0] == bulb
+    mock_effect_conductor.start.reset_mock()
+    mock_effect_conductor.stop.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_EFFECT_COLORLOOP,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128, ATTR_SATURATION_MIN: 90},
         blocking=True,
     )
     start_call = mock_effect_conductor.start.mock_calls


### PR DESCRIPTION

## Proposed change

Enable the use of either `brightness` or `brightness_pct` for both `lifx.effect_pulse` and `lifx.effect_colorloop` and enable user configurable min/max saturation values for `lifx.effect_colorloop`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24845

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
