### PR TITLE
Use location info helper for IP in Cloudflare DNS

### DIFF
--- a/homeassistant/components/cloudflare/__init__.py
+++ b/homeassistant/components/cloudflare/__init__.py
@@ -90,17 +90,8 @@ async def _async_update_cloudflare(
     records = await cfupdate.get_record_info(zone_id)
     _LOGGER.debug("Records: %s", records)
 
-    if not (location_info := await async_detect_location_info(session)):
-        _LOGGER.error("Unable to detect IP address")
-        return
+    location_info = await async_detect_location_info(session)
 
-    if not is_ipv4_address(location_info.ip):
-        # Only IPv4 is currently supported
-        _LOGGER.error(
-            "Detected IP address (%s), which is currently not supported",
-            location_info.ip,
-        )
-        return
-
-    await cfupdate.update_records(zone_id, records, location_info.ip)
-    _LOGGER.debug("Update for zone %s is complete", cfupdate.zone)
+    if location_info and is_ipv4_address(location_info.ip):
+        await cfupdate.update_records(zone_id, records, location_info.ip)
+        _LOGGER.debug("Update for zone %s is complete", cfupdate.zone)

--- a/tests/components/cloudflare/test_init.py
+++ b/tests/components/cloudflare/test_init.py
@@ -1,4 +1,6 @@
 """Test the Cloudflare integration."""
+from unittest.mock import patch
+
 from pycfdns.exceptions import (
     CloudflareAuthenticationException,
     CloudflareConnectionException,
@@ -6,6 +8,7 @@ from pycfdns.exceptions import (
 
 from homeassistant.components.cloudflare.const import DOMAIN, SERVICE_UPDATE_RECORDS
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.util.location import LocationInfo
 
 from . import ENTRY_CONFIG, init_integration
 
@@ -70,12 +73,29 @@ async def test_integration_services(hass, cfupdate):
     entry = await init_integration(hass)
     assert entry.state is ConfigEntryState.LOADED
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_UPDATE_RECORDS,
-        {},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.cloudflare.async_detect_location_info",
+        return_value=LocationInfo(
+            "0.0.0.0",
+            "US",
+            "USD",
+            "CA",
+            "California",
+            "San Diego",
+            "92122",
+            "America/Los_Angeles",
+            32.8594,
+            -117.2073,
+            True,
+        ),
+    ):
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UPDATE_RECORDS,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
     instance.update_records.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The Cloudflare integration no longer relies on ipify.org to determine your IP, but instead is using the [whoami service](https://github.com/home-assistant/services.home-assistant.io).
This means that if you have configured your network to only allow traffic there, you would need to do some adjustments.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The library used by this integration removed the auto lookup of IP.
To make the version bump PR as small as possible, that change is handled here by getting the IP with the `location.async_detect_location_info` helper which uses our whoami service.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24854

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
