### PR TITLE
Adjust REST schema validation

### DIFF
--- a/homeassistant/components/rest/schema.py
+++ b/homeassistant/components/rest/schema.py
@@ -75,7 +75,7 @@ BINARY_SENSOR_SCHEMA = {
 }
 
 
-COMBINED_SCHEMA = vol.Schema(
+COMBINED_SCHEMA = vol.All(
     {
         vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
         **RESOURCE_SCHEMA,
@@ -85,7 +85,8 @@ COMBINED_SCHEMA = vol.Schema(
         vol.Optional(BINARY_SENSOR_DOMAIN): vol.All(
             cv.ensure_list, [vol.Schema(BINARY_SENSOR_SCHEMA)]
         ),
-    }
+    },
+    cv.has_at_least_one_key(CONF_RESOURCE, CONF_RESOURCE_TEMPLATE),
 )
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/rest/schema.py
+++ b/homeassistant/components/rest/schema.py
@@ -75,7 +75,7 @@ BINARY_SENSOR_SCHEMA = {
 }
 
 
-COMBINED_SCHEMA = vol.All(
+COMBINED_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
         **RESOURCE_SCHEMA,
@@ -85,11 +85,17 @@ COMBINED_SCHEMA = vol.All(
         vol.Optional(BINARY_SENSOR_DOMAIN): vol.All(
             cv.ensure_list, [vol.Schema(BINARY_SENSOR_SCHEMA)]
         ),
-    },
-    cv.has_at_least_one_key(CONF_RESOURCE, CONF_RESOURCE_TEMPLATE),
+    }
 )
 
 CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: vol.All(cv.ensure_list, [COMBINED_SCHEMA])},
+    {
+        DOMAIN: vol.All(
+            # convert empty dict to empty list
+            lambda x: [] if x == {} else x,
+            cv.ensure_list,
+            [COMBINED_SCHEMA],
+        )
+    },
     extra=vol.ALLOW_EXTRA,
 )

--- a/tests/components/rest/test_init.py
+++ b/tests/components/rest/test_init.py
@@ -19,7 +19,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from tests.common import async_fire_time_changed, get_fixture_path
+from tests.common import (
+    assert_setup_component,
+    async_fire_time_changed,
+    get_fixture_path,
+)
 
 
 @respx.mock
@@ -408,8 +412,9 @@ async def test_empty_config(hass: HomeAssistant) -> None:
     For example (with rest.yaml an empty file):
         rest: !include rest.yaml
     """
-    assert not await async_setup_component(
+    assert await async_setup_component(
         hass,
         DOMAIN,
         {DOMAIN: {}},
     )
+    assert_setup_component(0, DOMAIN)

--- a/tests/components/rest/test_init.py
+++ b/tests/components/rest/test_init.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     SERVICE_RELOAD,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -399,3 +400,16 @@ async def test_multiple_rest_endpoints(hass):
     assert hass.states.get("sensor.json_date_time").state == "07:11:08 PM"
     assert hass.states.get("sensor.json_time").state == "07:11:39 PM"
     assert hass.states.get("binary_sensor.binary_sensor").state == "on"
+
+
+async def test_empty_config(hass: HomeAssistant) -> None:
+    """Test setup with empty configuration.
+
+    For example (with rest.yaml an empty file):
+        rest: !include rest.yaml
+    """
+    assert not await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {}},
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #81551

In 2022.10, passing an empty configuration to `rest` resulted in a successful setup, with a failing coordinator and no sensors.
```yaml
rest:
```

In 2022.11, code was adjusted on the coordinator to ensure we had a valid resource before creating the dataclass, which resulted in a `HomeAssistantError`:
```python
raise HomeAssistantError("Resource not set for RestData")
```

The side effect of this change is that it highlited invalid configurations in the real world (previously throwing errors in logs, but probably ignored, now failing).

This PR adjusts the schema validation to ensure an empty dict first gets converted to an empty list rather than get converted to a list with a single dict

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81551
- This PR is related to issue:
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
