### PR TITLE
Support HitachiAirToAirHeatPump (hlrrwifi:HLinkMainController) in Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/climate_entities/__init__.py
+++ b/homeassistant/components/overkiz/climate_entities/__init__.py
@@ -9,6 +9,7 @@ from .atlantic_electrical_towel_dryer import AtlanticElectricalTowelDryer
 from .atlantic_heat_recovery_ventilation import AtlanticHeatRecoveryVentilation
 from .atlantic_pass_apc_heating_zone import AtlanticPassAPCHeatingZone
 from .atlantic_pass_apc_zone_control import AtlanticPassAPCZoneControl
+from .hitachi_air_to_air_heat_pump import HitachiAirToAirHeatPump
 from .somfy_thermostat import SomfyThermostat
 from .valve_heating_temperature_interface import ValveHeatingTemperatureInterface
 
@@ -21,6 +22,7 @@ WIDGET_TO_CLIMATE_ENTITY = {
     UIWidget.ATLANTIC_PASS_APC_HEATING_AND_COOLING_ZONE: AtlanticPassAPCHeatingZone,
     UIWidget.ATLANTIC_PASS_APC_HEATING_ZONE: AtlanticPassAPCHeatingZone,
     UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: AtlanticPassAPCZoneControl,
+    UIWidget.HITACHI_AIR_TO_AIR_HEAT_PUMP: HitachiAirToAirHeatPump,
     UIWidget.SOMFY_THERMOSTAT: SomfyThermostat,
     UIWidget.VALVE_HEATING_TEMPERATURE_INTERFACE: ValveHeatingTemperatureInterface,
 }

--- a/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump.py
+++ b/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump.py
@@ -19,7 +19,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 
 from ..coordinator import OverkizDataUpdateCoordinator
 from ..entity import OverkizEntity
@@ -125,7 +125,7 @@ class HitachiAirToAirHeatPump(OverkizEntity, ClimateEntity):
     _attr_preset_modes = [PRESET_NONE, PRESET_HOLIDAY_MODE]
     _attr_swing_modes = [*SWING_MODES_TO_OVERKIZ]
     _attr_target_temperature_step = 1.0
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
     def __init__(
         self, device_url: str, coordinator: OverkizDataUpdateCoordinator
@@ -139,7 +139,7 @@ class HitachiAirToAirHeatPump(OverkizEntity, ClimateEntity):
             | ClimateEntityFeature.PRESET_MODE
         )
 
-        if self.executor.has_state(*SWING_STATE):
+        if self.device.states.get(SWING_STATE[self.device.protocol]):
             self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
 
         if self._attr_device_info:

--- a/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump.py
+++ b/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump.py
@@ -1,0 +1,242 @@
+"""Support for HitachiAirToAirHeatPump."""
+from __future__ import annotations
+
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+from pyoverkiz.types import StateType as OverkizStateType
+
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
+    FAN_AUTO,
+    FAN_HIGH,
+    FAN_LOW,
+    FAN_MEDIUM,
+    PRESET_NONE,
+    SWING_BOTH,
+    SWING_HORIZONTAL,
+    SWING_OFF,
+    SWING_VERTICAL,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+
+from ..coordinator import OverkizDataUpdateCoordinator
+from ..entity import OverkizEntity
+
+PRESET_HOLIDAY_MODE = "holiday_mode"
+
+OVP_HLINK_MAIN_CONTROLLER = "ovp:HLinkMainController"
+
+FAN_SPEED_STATE = [OverkizState.OVP_FAN_SPEED, OverkizState.HLRRWIFI_FAN_SPEED]
+LEAVE_HOME_STATE = [OverkizState.OVP_LEAVE_HOME, OverkizState.HLRRWIFI_LEAVE_HOME]
+MAIN_OPERATION_STATE = [
+    OverkizState.OVP_MAIN_OPERATION,
+    OverkizState.HLRRWIFI_MAIN_OPERATION,
+]
+MODE_CHANGE_STATE = [OverkizState.OVP_MODE_CHANGE, OverkizState.HLRRWIFI_MODE_CHANGE]
+ROOM_TEMPERATURE_STATE = [
+    OverkizState.OVP_ROOM_TEMPERATURE,
+    OverkizState.HLRRWIFI_ROOM_TEMPERATURE,
+]
+SWING_STATE = [OverkizState.OVP_SWING, OverkizState.HLRRWIFI_SWING]
+
+OVERKIZ_TO_HVAC_MODES = {
+    "autocooling": HVACMode.AUTO,
+    "autoheating": HVACMode.AUTO,
+    "off": HVACMode.OFF,
+    "heating": HVACMode.HEAT,
+    "fan": HVACMode.FAN_ONLY,
+    "dehumidify": HVACMode.DRY,
+    "cooling": HVACMode.COOL,
+    "auto": HVACMode.AUTO,
+}
+
+HVAC_MODES_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODES.items()}
+
+OVERKIZ_TO_SWING_MODES = {
+    "both": SWING_BOTH,
+    "horizontal": SWING_HORIZONTAL,
+    "stop": SWING_OFF,
+    "vertical": SWING_VERTICAL,
+}
+
+SWING_MODES_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_SWING_MODES.items()}
+
+HLRRWIFI_OVERKIZ_TO_FAN_MODES = {
+    "auto": FAN_AUTO,
+    "high": FAN_HIGH,
+    "low": FAN_LOW,
+    "medium": FAN_MEDIUM,
+    "silent": "silent",
+}
+
+OVP_OVERKIZ_TO_FAN_MODES = {
+    "auto": FAN_AUTO,
+    "hi": FAN_HIGH,
+    "lo": FAN_LOW,
+    "med": FAN_MEDIUM,
+    "silent": "silent",
+}
+
+FAN_MODES_TO_HLRRWIFI_OVERKIZ = {v: k for k, v in HLRRWIFI_OVERKIZ_TO_FAN_MODES.items()}
+FAN_MODES_TO_OVP_OVERKIZ = {v: k for k, v in OVP_OVERKIZ_TO_FAN_MODES.items()}
+
+
+class HitachiAirToAirHeatPump(OverkizEntity, ClimateEntity):
+    """Representation of Hitachi Air To Air HeatPump."""
+
+    _attr_hvac_modes = [*HVAC_MODES_TO_OVERKIZ]
+    _attr_preset_modes = [PRESET_NONE, PRESET_HOLIDAY_MODE]
+    _attr_swing_modes = [*SWING_MODES_TO_OVERKIZ]
+    _attr_target_temperature_step = 1.0
+    _attr_temperature_unit = TEMP_CELSIUS
+
+    def __init__(
+        self, device_url: str, coordinator: OverkizDataUpdateCoordinator
+    ) -> None:
+        """Init method."""
+        super().__init__(device_url, coordinator)
+
+        self._attr_supported_features = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.PRESET_MODE
+        )
+
+        if self.executor.has_state(*SWING_STATE):
+            self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
+
+        self._attr_device_info["manufacturer"] = "Hitachi"
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return hvac operation ie. heat, cool mode."""
+        if self._select_state(*MAIN_OPERATION_STATE) == OverkizCommandParam.OFF:
+            return HVACMode.OFF
+
+        return OVERKIZ_TO_HVAC_MODES[self._select_state(*MODE_CHANGE_STATE)]
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        if hvac_mode == HVACMode.OFF:
+            await self._global_control(main_operation=OverkizCommandParam.OFF)
+        else:
+            await self._global_control(
+                main_operation=OverkizCommandParam.ON,
+                hvac_mode=HVAC_MODES_TO_OVERKIZ[hvac_mode],
+            )
+
+    @property
+    def fan_mode(self) -> str | None:
+        """Return the fan setting."""
+        if self.device.controllable_name == OVP_HLINK_MAIN_CONTROLLER:
+            return OVP_OVERKIZ_TO_FAN_MODES[self._select_state(*FAN_SPEED_STATE)]
+
+        return HLRRWIFI_OVERKIZ_TO_FAN_MODES[self._select_state(*FAN_SPEED_STATE)]
+
+    @property
+    def fan_modes(self) -> list[str] | None:
+        """Return the list of available fan modes."""
+        if self.device.controllable_name == OVP_HLINK_MAIN_CONTROLLER:
+            return [*FAN_MODES_TO_OVP_OVERKIZ]
+
+        return [*FAN_MODES_TO_HLRRWIFI_OVERKIZ]
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set new target fan mode."""
+        if self.device.controllable_name == OVP_HLINK_MAIN_CONTROLLER:
+            await self._global_control(fan_mode=FAN_MODES_TO_OVP_OVERKIZ[fan_mode])
+        else:
+            await self._global_control(fan_mode=FAN_MODES_TO_HLRRWIFI_OVERKIZ[fan_mode])
+
+    @property
+    def swing_mode(self) -> str | None:
+        """Return the swing setting."""
+        return OVERKIZ_TO_SWING_MODES[self._select_state(*SWING_STATE)]
+
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        """Set new target swing operation."""
+        await self._global_control(swing_mode=SWING_MODES_TO_OVERKIZ[swing_mode])
+
+    @property
+    def target_temperature(self) -> float:
+        """Return the temperature."""
+        return self._select_state(OverkizState.CORE_TARGET_TEMPERATURE)
+
+    @property
+    def current_temperature(self) -> float:
+        """Return current temperature."""
+        return self._select_state(*ROOM_TEMPERATURE_STATE)
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Set new temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        await self._global_control(target_temperature=int(temperature))
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode, e.g., home, away, temp."""
+        leave_home_state = self._select_state(*LEAVE_HOME_STATE)
+
+        if leave_home_state == OverkizCommandParam.ON:
+            return PRESET_HOLIDAY_MODE
+
+        if leave_home_state == OverkizCommandParam.OFF:
+            return PRESET_NONE
+
+        return None
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        if preset_mode == PRESET_HOLIDAY_MODE:
+            await self._global_control(leave_home=OverkizCommandParam.ON)
+
+        if preset_mode == PRESET_NONE:
+            await self._global_control(leave_home=OverkizCommandParam.OFF)
+
+    async def _global_control(
+        self,
+        main_operation=None,
+        target_temperature=None,
+        fan_mode=None,
+        hvac_mode=None,
+        swing_mode=None,
+        leave_home=None,
+    ):
+        """Execute globalControl command with all parameters."""
+        if self.device.controllable_name == OVP_HLINK_MAIN_CONTROLLER:
+            await self.executor.async_execute_command(
+                OverkizCommand.GLOBAL_CONTROL,
+                main_operation
+                or self._select_state(*MAIN_OPERATION_STATE),  # Main Operation
+                target_temperature
+                or self._select_state(
+                    OverkizState.CORE_TARGET_TEMPERATURE
+                ),  # Target Temperature
+                fan_mode or self._select_state(*FAN_SPEED_STATE),  # Fan Mode
+                hvac_mode or self._select_state(*MODE_CHANGE_STATE),  # Mode
+                swing_mode or self._select_state(*SWING_STATE),  # Swing Mode
+            )
+        else:
+            await self.executor.async_execute_command(
+                OverkizCommand.GLOBAL_CONTROL,
+                main_operation
+                or self._select_state(*MAIN_OPERATION_STATE),  # Main Operation
+                target_temperature
+                or self._select_state(
+                    OverkizState.CORE_TARGET_TEMPERATURE
+                ),  # Target Temperature
+                fan_mode or self._select_state(*FAN_SPEED_STATE),  # Fan Mode
+                hvac_mode or self._select_state(*MODE_CHANGE_STATE),  # Mode
+                swing_mode or self._select_state(*SWING_STATE),  # Swing Mode
+                leave_home or self._select_state(*LEAVE_HOME_STATE),  # Leave Home
+            )
+
+    def _select_state(self, *states) -> OverkizStateType:
+        """Make all strings lowercase, since Hi Kumo server returns capitalized strings for some devices."""
+        state = self.executor.select_state(*states)
+
+        if state and isinstance(state, str):
+            return state.lower()
+
+        return state

--- a/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump.py
+++ b/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump.py
@@ -25,6 +25,7 @@ from ..coordinator import OverkizDataUpdateCoordinator
 from ..entity import OverkizEntity
 
 PRESET_HOLIDAY_MODE = "holiday_mode"
+FAN_SILENT = "silent"
 
 FAN_SPEED_STATE = {
     Protocol.OVP: OverkizState.OVP_FAN_SPEED,
@@ -85,14 +86,14 @@ OVERKIZ_TO_FAN_MODES: dict[Protocol, dict[str, str]] = {
         OverkizCommandParam.HI: FAN_HIGH,
         OverkizCommandParam.LO: FAN_LOW,
         OverkizCommandParam.MED: FAN_MEDIUM,
-        OverkizCommandParam.SILENT: "silent",
+        OverkizCommandParam.SILENT: FAN_SILENT,
     },
     Protocol.HLRR_WIFI: {
         OverkizCommandParam.AUTO: FAN_AUTO,
         OverkizCommandParam.HIGH: FAN_HIGH,
         OverkizCommandParam.LOW: FAN_LOW,
         OverkizCommandParam.MEDIUM: FAN_MEDIUM,
-        OverkizCommandParam.SILENT: "silent",
+        OverkizCommandParam.SILENT: FAN_SILENT,
     },
 }
 
@@ -102,14 +103,14 @@ FAN_MODES_TO_OVERKIZ: dict[Protocol, dict[str, str]] = {
         FAN_HIGH: OverkizCommandParam.HI,
         FAN_LOW: OverkizCommandParam.LO,
         FAN_MEDIUM: OverkizCommandParam.MED,
-        "silent": OverkizCommandParam.SILENT,
+        FAN_SILENT: OverkizCommandParam.SILENT,
     },
     Protocol.HLRR_WIFI: {
         FAN_AUTO: OverkizCommandParam.AUTO,
         FAN_HIGH: OverkizCommandParam.HIGH,
         FAN_LOW: OverkizCommandParam.LOW,
         FAN_MEDIUM: OverkizCommandParam.MEDIUM,
-        "silent": OverkizCommandParam.SILENT,
+        FAN_SILENT: OverkizCommandParam.SILENT,
     },
 }
 

--- a/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump.py
+++ b/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump.py
@@ -25,8 +25,16 @@ from ..entity import OverkizEntity
 
 PRESET_HOLIDAY_MODE = "holiday_mode"
 
-FAN_SPEED_STATE = [OverkizState.OVP_FAN_SPEED, OverkizState.HLRRWIFI_FAN_SPEED]
-LEAVE_HOME_STATE = [OverkizState.OVP_LEAVE_HOME, OverkizState.HLRRWIFI_LEAVE_HOME]
+FAN_SPEED_STATE = {
+    Protocol.OVP: OverkizState.OVP_FAN_SPEED,
+    Protocol.HLRR_WIFI: OverkizState.HLRRWIFI_FAN_SPEED,
+}
+
+LEAVE_HOME_STATE = {
+    Protocol.OVP: OverkizState.OVP_LEAVE_HOME,
+    Protocol.HLRR_WIFI: OverkizState.HLRRWIFI_LEAVE_HOME,
+}
+
 MAIN_OPERATION_STATE = [
     OverkizState.OVP_MAIN_OPERATION,
     OverkizState.HLRRWIFI_MAIN_OPERATION,
@@ -60,25 +68,42 @@ OVERKIZ_TO_SWING_MODES: dict[str, str] = {
 
 SWING_MODES_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_SWING_MODES.items()}
 
-
-HLRRWIFI_OVERKIZ_TO_FAN_MODES: dict[str, str] = {
-    OverkizCommandParam.AUTO: FAN_AUTO,
-    OverkizCommandParam.HIGH: FAN_HIGH,
-    OverkizCommandParam.LOW: FAN_LOW,
-    OverkizCommandParam.MEDIUM: FAN_MEDIUM,
-    OverkizCommandParam.SILENT: "silent",
+OVERKIZ_TO_FAN_MODES: dict[Protocol, dict[str, str]] = {
+    Protocol.OVP: {
+        OverkizCommandParam.AUTO: FAN_AUTO,
+        OverkizCommandParam.HI: FAN_HIGH,
+        OverkizCommandParam.LO: FAN_LOW,
+        OverkizCommandParam.MED: FAN_MEDIUM,
+        OverkizCommandParam.SILENT: "silent",
+    },
+    Protocol.HLRR_WIFI: {
+        OverkizCommandParam.AUTO: FAN_AUTO,
+        OverkizCommandParam.HIGH: FAN_HIGH,
+        OverkizCommandParam.LOW: FAN_LOW,
+        OverkizCommandParam.MEDIUM: FAN_MEDIUM,
+        OverkizCommandParam.SILENT: "silent",
+    },
 }
 
-OVP_OVERKIZ_TO_FAN_MODES: dict[str, str] = {
-    OverkizCommandParam.AUTO: FAN_AUTO,
-    OverkizCommandParam.HI: FAN_HIGH,
-    OverkizCommandParam.LO: FAN_LOW,
-    OverkizCommandParam.MED: FAN_MEDIUM,
-    OverkizCommandParam.SILENT: "silent",
-}
+# TODO figure out if we can reverse the dictionary above
+# FAN_MODES_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_FAN_MODES.items()}
 
-FAN_MODES_TO_HLRRWIFI_OVERKIZ = {v: k for k, v in HLRRWIFI_OVERKIZ_TO_FAN_MODES.items()}
-FAN_MODES_TO_OVP_OVERKIZ = {v: k for k, v in OVP_OVERKIZ_TO_FAN_MODES.items()}
+FAN_MODES_TO_OVERKIZ: dict[Protocol, dict[str, str]] = {
+    Protocol.OVP: {
+        FAN_AUTO: OverkizCommandParam.AUTO,
+        FAN_HIGH: OverkizCommandParam.HI,
+        FAN_LOW: OverkizCommandParam.LO,
+        FAN_MEDIUM: OverkizCommandParam.MED,
+        "silent": OverkizCommandParam.SILENT,
+    },
+    Protocol.HLRR_WIFI: {
+        FAN_AUTO: OverkizCommandParam.AUTO,
+        FAN_HIGH: OverkizCommandParam.HIGH,
+        FAN_LOW: OverkizCommandParam.LOW,
+        FAN_MEDIUM: OverkizCommandParam.MEDIUM,
+        "silent": OverkizCommandParam.SILENT,
+    },
+}
 
 
 class HitachiAirToAirHeatPump(OverkizEntity, ClimateEntity):
@@ -129,25 +154,25 @@ class HitachiAirToAirHeatPump(OverkizEntity, ClimateEntity):
     @property
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
-        if self.device.protocol == Protocol.OVP:
-            return OVP_OVERKIZ_TO_FAN_MODES[self._select_state(*FAN_SPEED_STATE)]
 
-        return HLRRWIFI_OVERKIZ_TO_FAN_MODES[self._select_state(*FAN_SPEED_STATE)]
+        states = self.device.states
+        if (
+            state := states[FAN_SPEED_STATE[self.device.protocol]]
+        ) and state.value_as_str:
+            return OVERKIZ_TO_FAN_MODES[self.device.protocol][state.value_as_str]
+
+        return None
 
     @property
     def fan_modes(self) -> list[str] | None:
         """Return the list of available fan modes."""
-        if self.device.protocol == Protocol.OVP:
-            return [*FAN_MODES_TO_OVP_OVERKIZ]
-
-        return [*FAN_MODES_TO_HLRRWIFI_OVERKIZ]
+        return [*FAN_MODES_TO_OVERKIZ[self.device.protocol]]
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        if self.device.protocol == Protocol.OVP:
-            await self._global_control(fan_mode=FAN_MODES_TO_OVP_OVERKIZ[fan_mode])
-        else:
-            await self._global_control(fan_mode=FAN_MODES_TO_HLRRWIFI_OVERKIZ[fan_mode])
+        await self._global_control(
+            fan_mode=FAN_MODES_TO_OVERKIZ[self.device.protocol][fan_mode]
+        )
 
     @property
     def swing_mode(self) -> str | None:

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -90,6 +90,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform | None] = {
     UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.DOMESTIC_HOT_WATER_PRODUCTION: Platform.WATER_HEATER,  # widgetName, uiClass is WaterHeatingSystem (not supported)
     UIWidget.DOMESTIC_HOT_WATER_TANK: Platform.SWITCH,  # widgetName, uiClass is WaterHeatingSystem (not supported)
+    UIWidget.HITACHI_AIR_TO_AIR_HEAT_PUMP: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.HITACHI_DHW: Platform.WATER_HEATER,  # widgetName, uiClass is HitachiHeatingSystem (not supported)
     UIWidget.MY_FOX_ALARM_CONTROLLER: Platform.ALARM_CONTROL_PANEL,  # widgetName, uiClass is Alarm (not supported)
     UIWidget.MY_FOX_SECURITY_CAMERA: Platform.SWITCH,  # widgetName, uiClass is Camera (not supported)

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -40,6 +40,7 @@
               "external": "External",
               "freeze": "Freeze",
               "frost_protection": "Frost protection",
+              "holiday_mode": "Holiday mode",
               "manual": "Manual",
               "night": "Night",
               "prog": "Prog"
@@ -50,7 +51,8 @@
               "away": "Away",
               "bypass_boost": "Bypass boost",
               "home_boost": "Home boost",
-              "kitchen_boost": "Kitchen boost"
+              "kitchen_boost": "Kitchen boost",
+              "silent": "Silent"
             }
           }
         }


### PR DESCRIPTION
## Proposed change
Add support for the HitachiAirToAirHeatPump (hlrrwifi:HLinkMainController) climate entity, ported from
https://github.com/iMicknl/ha-tahoma/blob/master/custom_components/tahoma/climate_devices/hitachi_air_to_air_heat_pump.py. 

Fixes #85781

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81596
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
