### PR TITLE
Partially revert google local sync for search cases

### DIFF
--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 import logging
 from typing import Any
 
-from gcal_sync.api import SyncEventsRequest
+from gcal_sync.api import GoogleCalendarService, ListEventsRequest, SyncEventsRequest
 from gcal_sync.exceptions import ApiException
 from gcal_sync.model import DateOrDatetime, Event
 from gcal_sync.store import ScopedCalendarStore
@@ -196,21 +197,30 @@ async def async_setup_entry(
                     entity_registry.async_remove(
                         entity_entry.entity_id,
                     )
-            request_template = SyncEventsRequest(
-                calendar_id=calendar_id,
-                search=data.get(CONF_SEARCH),
-                start_time=dt_util.now() + SYNC_EVENT_MIN_TIME,
-            )
-            sync = CalendarEventSyncManager(
-                calendar_service,
-                store=ScopedCalendarStore(store, unique_id or entity_name),
-                request_template=request_template,
-            )
-            coordinator = CalendarUpdateCoordinator(
-                hass,
-                sync,
-                data[CONF_NAME],
-            )
+            coordinator: CalendarSyncUpdateCoordinator | CalendarQueryUpdateCoordinator
+            if search := data.get(CONF_SEARCH):
+                coordinator = CalendarQueryUpdateCoordinator(
+                    hass,
+                    calendar_service,
+                    data[CONF_NAME],
+                    calendar_id,
+                    search,
+                )
+            else:
+                request_template = SyncEventsRequest(
+                    calendar_id=calendar_id,
+                    start_time=dt_util.now() + SYNC_EVENT_MIN_TIME,
+                )
+                sync = CalendarEventSyncManager(
+                    calendar_service,
+                    store=ScopedCalendarStore(store, unique_id or entity_name),
+                    request_template=request_template,
+                )
+                coordinator = CalendarSyncUpdateCoordinator(
+                    hass,
+                    sync,
+                    data[CONF_NAME],
+                )
             entities.append(
                 GoogleCalendarEntity(
                     coordinator,
@@ -242,8 +252,8 @@ async def async_setup_entry(
         )
 
 
-class CalendarUpdateCoordinator(DataUpdateCoordinator[Timeline]):
-    """Coordinator for calendar RPC calls."""
+class CalendarSyncUpdateCoordinator(DataUpdateCoordinator[Timeline]):
+    """Coordinator for calendar RPC calls that use an efficient sync."""
 
     def __init__(
         self,
@@ -251,7 +261,7 @@ class CalendarUpdateCoordinator(DataUpdateCoordinator[Timeline]):
         sync: CalendarEventSyncManager,
         name: str,
     ) -> None:
-        """Create the Calendar event device."""
+        """Create the CalendarSyncUpdateCoordinator."""
         super().__init__(
             hass,
             _LOGGER,
@@ -271,6 +281,87 @@ class CalendarUpdateCoordinator(DataUpdateCoordinator[Timeline]):
             dt_util.DEFAULT_TIME_ZONE
         )
 
+    async def async_get_events(
+        self, start_date: datetime, end_date: datetime
+    ) -> Iterable[Event]:
+        """Get all events in a specific time frame."""
+        if not self.data:
+            raise HomeAssistantError(
+                "Unable to get events: Sync from server has not completed"
+            )
+        return self.data.overlapping(
+            dt_util.as_local(start_date),
+            dt_util.as_local(end_date),
+        )
+
+    @property
+    def upcoming(self) -> Iterable[Event] | None:
+        """Return upcoming events if any."""
+        if self.data:
+            return self.data.active_after(dt_util.now())
+        return None
+
+
+class CalendarQueryUpdateCoordinator(DataUpdateCoordinator[list[Event]]):
+    """Coordinator for calendar RPC calls.
+
+    This sends a polling RPC, not using sync, as a workaround
+    for limitations in the calendar API for supporting search.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        calendar_service: GoogleCalendarService,
+        name: str,
+        calendar_id: str,
+        search: str | None,
+    ) -> None:
+        """Create the CalendarQueryUpdateCoordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=name,
+            update_interval=MIN_TIME_BETWEEN_UPDATES,
+        )
+        self.calendar_service = calendar_service
+        self.calendar_id = calendar_id
+        self._search = search
+
+    async def async_get_events(
+        self, start_date: datetime, end_date: datetime
+    ) -> Iterable[Event]:
+        """Get all events in a specific time frame."""
+        request = ListEventsRequest(
+            calendar_id=self.calendar_id,
+            start_time=start_date,
+            end_time=end_date,
+            search=self._search,
+        )
+        result_items = []
+        try:
+            result = await self.calendar_service.async_list_events(request)
+            async for result_page in result:
+                result_items.extend(result_page.items)
+        except ApiException as err:
+            self.async_set_update_error(err)
+            raise HomeAssistantError(str(err)) from err
+        return result_items
+
+    async def _async_update_data(self) -> list[Event]:
+        """Fetch data from API endpoint."""
+        request = ListEventsRequest(calendar_id=self.calendar_id, search=self._search)
+        try:
+            result = await self.calendar_service.async_list_events(request)
+        except ApiException as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+        return result.items
+
+    @property
+    def upcoming(self) -> Iterable[Event] | None:
+        """Return the next upcoming event if any."""
+        return self.data
+
 
 class GoogleCalendarEntity(CoordinatorEntity, CalendarEntity):
     """A calendar event entity."""
@@ -279,7 +370,7 @@ class GoogleCalendarEntity(CoordinatorEntity, CalendarEntity):
 
     def __init__(
         self,
-        coordinator: CalendarUpdateCoordinator,
+        coordinator: CalendarSyncUpdateCoordinator | CalendarQueryUpdateCoordinator,
         calendar_id: str,
         data: dict[str, Any],
         entity_id: str,
@@ -352,14 +443,7 @@ class GoogleCalendarEntity(CoordinatorEntity, CalendarEntity):
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
-        if not (timeline := self.coordinator.data):
-            raise HomeAssistantError(
-                "Unable to get events: Sync from server has not completed"
-            )
-        result_items = timeline.overlapping(
-            dt_util.as_local(start_date),
-            dt_util.as_local(end_date),
-        )
+        result_items = await self.coordinator.async_get_events(start_date, end_date)
         return [
             _get_calendar_event(event)
             for event in filter(self._event_filter, result_items)
@@ -367,14 +451,12 @@ class GoogleCalendarEntity(CoordinatorEntity, CalendarEntity):
 
     def _apply_coordinator_update(self) -> None:
         """Copy state from the coordinator to this entity."""
-        if (timeline := self.coordinator.data) and (
-            api_event := next(
-                filter(
-                    self._event_filter,
-                    timeline.active_after(dt_util.now()),
-                ),
-                None,
-            )
+        if api_event := next(
+            filter(
+                self._event_filter,
+                self.coordinator.upcoming or [],
+            ),
+            None,
         ):
             self._event = _get_calendar_event(api_event)
             (self._event.summary, self._offset_value) = extract_offset(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Partially revert #80925 to fix bugs in google local sync for search cases. The problem is the API returns invalid sync tokens when used with search, breaking the API contract, and as a result acts as if no search filter is present, mixing events across virtual calendars. The simplest temporary workaround is to go back to the old behavior for entities that use search.

The search case has behavior that matches the original code before PR #80925 though some of the logic moved to the update coordinator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81532
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
