### PR TITLE
Fix legacy scrape scan interval

### DIFF
--- a/homeassistant/components/scrape/__init__.py
+++ b/homeassistant/components/scrape/__init__.py
@@ -60,13 +60,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     load_coroutines: list[Coroutine[Any, Any, None]] = []
     for resource_config in scrape_config:
         rest = create_rest_data_from_config(hass, resource_config)
-        coordinator = ScrapeCoordinator(
-            hass,
-            rest,
-            timedelta(
-                seconds=resource_config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-            ),
-        )
+        scan_interval: timedelta = config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        coordinator = ScrapeCoordinator(hass, rest, scan_interval)
 
         sensors: list[ConfigType] = resource_config.get(SENSOR_DOMAIN, [])
         if sensors:

--- a/homeassistant/components/scrape/const.py
+++ b/homeassistant/components/scrape/const.py
@@ -1,12 +1,14 @@
 """Constants for Scrape integration."""
 from __future__ import annotations
 
+from datetime import timedelta
+
 from homeassistant.const import Platform
 
 DOMAIN = "scrape"
 DEFAULT_NAME = "Web scrape"
 DEFAULT_VERIFY_SSL = True
-DEFAULT_SCAN_INTERVAL = 60 * 10
+DEFAULT_SCAN_INTERVAL = timedelta(60 * 10)
 
 PLATFORMS = [Platform.SENSOR]
 

--- a/homeassistant/components/scrape/const.py
+++ b/homeassistant/components/scrape/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import Platform
 DOMAIN = "scrape"
 DEFAULT_NAME = "Web scrape"
 DEFAULT_VERIFY_SSL = True
-DEFAULT_SCAN_INTERVAL = timedelta(60 * 10)
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=10)
 
 PLATFORMS = [Platform.SENSOR]
 

--- a/homeassistant/components/scrape/sensor.py
+++ b/homeassistant/components/scrape/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_RESOURCE,
+    CONF_SCAN_INTERVAL,
     CONF_UNIQUE_ID,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_USERNAME,
@@ -43,12 +44,17 @@ from homeassistant.helpers.template_entity import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_INDEX, CONF_SELECT, DEFAULT_NAME, DEFAULT_VERIFY_SSL, DOMAIN
+from .const import (
+    CONF_INDEX,
+    CONF_SELECT,
+    DEFAULT_NAME,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+)
 from .coordinator import ScrapeCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-
-SCAN_INTERVAL = timedelta(minutes=10)
 
 PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
     {
@@ -98,7 +104,8 @@ async def async_setup_platform(
         resource_config = vol.Schema(RESOURCE_SCHEMA, extra=vol.REMOVE_EXTRA)(config)
         rest = create_rest_data_from_config(hass, resource_config)
 
-        coordinator = ScrapeCoordinator(hass, rest, SCAN_INTERVAL)
+        scan_interval: timedelta = config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        coordinator = ScrapeCoordinator(hass, rest, scan_interval)
 
         sensors_config = [
             vol.Schema(TEMPLATE_SENSOR_BASE_SCHEMA.schema, extra=vol.ALLOW_EXTRA)(

--- a/tests/components/scrape/test_init.py
+++ b/tests/components/scrape/test_init.py
@@ -6,8 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.scrape.const import DOMAIN
-from homeassistant.components.scrape.sensor import SCAN_INTERVAL
+from homeassistant.components.scrape.const import DEFAULT_SCAN_INTERVAL, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -67,7 +66,7 @@ async def test_setup_no_data_fails_with_recovery(
         assert "Platform scrape not ready yet" in caplog.text
 
         mocker.payload = "test_scrape_sensor"
-        async_fire_time_changed(hass, datetime.utcnow() + SCAN_INTERVAL)
+        async_fire_time_changed(hass, datetime.utcnow() + DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.ha_version")

--- a/tests/components/scrape/test_sensor.py
+++ b/tests/components/scrape/test_sensor.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.scrape.sensor import SCAN_INTERVAL
+from homeassistant.components.scrape.const import DEFAULT_SCAN_INTERVAL
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
     DOMAIN as SENSOR_DOMAIN,
@@ -298,7 +298,7 @@ async def test_scrape_sensor_no_data_refresh(hass: HomeAssistant) -> None:
         assert state.state == "Current Version: 2021.12.10"
 
         mocker.payload = "test_scrape_sensor_no_data"
-        async_fire_time_changed(hass, datetime.utcnow() + SCAN_INTERVAL)
+        async_fire_time_changed(hass, datetime.utcnow() + DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.ha_version")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #80593, the data retrieval was moved to a DataUpdateCoordinator, but the scan interval was missed.

This is a clone of #81763, targeted at the current/dev branch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #81558
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
