### PR TITLE
Implement ConfigEntry async_wait_for_states

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -12,6 +12,8 @@ from types import MappingProxyType, MethodType
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 import weakref
 
+import async_timeout
+
 from . import data_entry_flow, loader
 from .backports.enum import StrEnum
 from .components import persistent_notification
@@ -19,7 +21,7 @@ from .const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP, Platfo
 from .core import CALLBACK_TYPE, CoreState, Event, HomeAssistant, callback
 from .exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady, HomeAssistantError
 from .helpers import device_registry, entity_registry, storage
-from .helpers.dispatcher import async_dispatcher_send
+from .helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
 from .helpers.event import async_call_later
 from .helpers.frame import report
 from .helpers.typing import UNDEFINED, ConfigType, DiscoveryInfoType, UndefinedType
@@ -1238,6 +1240,36 @@ class ConfigEntries:
 
         await entry.async_setup(self.hass, integration=integration)
         return True
+
+    async def async_wait_for_states(
+        self, entry: ConfigEntry, states: set[ConfigEntryState], timeout: float = 60.0
+    ) -> ConfigEntryState:
+        """Wait for the setup of an entry to reach one of the supplied states state.
+
+        Returns the state the entry reached or raises asyncio.TimeoutError if the
+        entry did not reach one of the supplied states within the timeout.
+        """
+        state_reached_future: asyncio.Future[ConfigEntryState] = asyncio.Future()
+
+        @callback
+        def _async_entry_changed(
+            change: ConfigEntryChange, event_entry: ConfigEntry
+        ) -> None:
+            if (
+                event_entry is entry
+                and change is ConfigEntryChange.UPDATED
+                and entry.state in states
+            ):
+                state_reached_future.set_result(entry.state)
+
+        unsub = async_dispatcher_connect(
+            self.hass, SIGNAL_CONFIG_ENTRY_CHANGED, _async_entry_changed
+        )
+        try:
+            async with async_timeout.timeout(timeout):
+                return await state_reached_future
+        finally:
+            unsub()
 
     async def async_unload_platforms(
         self, entry: ConfigEntry, platforms: Iterable[Platform | str]

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3330,3 +3330,108 @@ async def test_reauth(hass):
     entry2.async_start_reauth(hass, {"extra_context": "some_extra_context"})
     await hass.async_block_till_done()
     assert len(hass.config_entries.flow.async_progress()) == 2
+
+
+async def test_wait_for_loading_entry(hass: HomeAssistant):
+    """Test waiting for entry to be set up."""
+
+    entry = MockConfigEntry(title="test_title", domain="test")
+
+    mock_setup_entry = AsyncMock(return_value=True)
+    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
+    mock_entity_platform(hass, "config_flow.test", None)
+
+    await entry.async_setup(hass)
+    await hass.async_block_till_done()
+
+    flow = hass.config_entries.flow
+
+    async def _load_entry():
+        # Mock config entry
+        assert await async_setup_component(hass, "test", {})
+
+    entry = MockConfigEntry(title="test_title", domain="test")
+    entry.add_to_hass(hass)
+    flow = hass.config_entries.flow
+    with patch.object(flow, "async_init", wraps=flow.async_init):
+        hass.async_add_job(_load_entry)
+        await hass.config_entries.async_wait_for_states(
+            entry,
+            {
+                config_entries.ConfigEntryState.LOADED,
+                config_entries.ConfigEntryState.SETUP_ERROR,
+            },
+            timeout=1.0,
+        )
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+
+
+async def test_wait_for_loading_failed_entry(hass: HomeAssistant):
+    """Test waiting for entry to be set up that fails loading."""
+
+    entry = MockConfigEntry(title="test_title", domain="test")
+
+    mock_setup_entry = AsyncMock(side_effect=HomeAssistantError)
+    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
+    mock_entity_platform(hass, "config_flow.test", None)
+
+    await entry.async_setup(hass)
+    await hass.async_block_till_done()
+
+    flow = hass.config_entries.flow
+
+    async def _load_entry():
+        # Mock config entry
+        assert await async_setup_component(hass, "test", {})
+
+    entry = MockConfigEntry(title="test_title", domain="test")
+    entry.add_to_hass(hass)
+    flow = hass.config_entries.flow
+    with patch.object(flow, "async_init", wraps=flow.async_init):
+        hass.async_add_job(_load_entry)
+        await hass.config_entries.async_wait_for_states(
+            entry,
+            {
+                config_entries.ConfigEntryState.LOADED,
+                config_entries.ConfigEntryState.SETUP_ERROR,
+            },
+            timeout=1.0,
+        )
+    assert entry.state is config_entries.ConfigEntryState.SETUP_ERROR
+
+
+async def test_wait_for_loading_timeout(hass: HomeAssistant):
+    """Test waiting for entry to be set up that fails loading."""
+
+    async def _async_setup_entry(hass, entry):
+        await asyncio.sleep(1)
+        return True
+
+    entry = MockConfigEntry(title="test_title", domain="test")
+
+    mock_integration(hass, MockModule("test", async_setup_entry=_async_setup_entry))
+    mock_entity_platform(hass, "config_flow.test", None)
+
+    await entry.async_setup(hass)
+    await hass.async_block_till_done()
+
+    flow = hass.config_entries.flow
+
+    async def _load_entry():
+        # Mock config entry
+        assert await async_setup_component(hass, "test", {})
+
+    entry = MockConfigEntry(title="test_title", domain="test")
+    entry.add_to_hass(hass)
+    flow = hass.config_entries.flow
+    with patch.object(flow, "async_init", wraps=flow.async_init):
+        hass.async_add_job(_load_entry)
+        with pytest.raises(asyncio.exceptions.TimeoutError):
+            await hass.config_entries.async_wait_for_states(
+                entry,
+                {
+                    config_entries.ConfigEntryState.LOADED,
+                    config_entries.ConfigEntryState.SETUP_ERROR,
+                },
+                timeout=0.1,
+            )

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3355,7 +3355,7 @@ async def test_wait_for_loading_entry(hass):
     flow = hass.config_entries.flow
     with patch.object(flow, "async_init", wraps=flow.async_init):
         hass.async_add_job(_load_entry)
-        await hass.config_entries.async_wait_for_states(
+        new_state = await hass.config_entries.async_wait_for_states(
             entry,
             {
                 config_entries.ConfigEntryState.LOADED,
@@ -3363,6 +3363,7 @@ async def test_wait_for_loading_entry(hass):
             },
             timeout=1.0,
         )
+        assert new_state is config_entries.ConfigEntryState.LOADED
     assert entry.state is config_entries.ConfigEntryState.LOADED
 
 
@@ -3389,7 +3390,7 @@ async def test_wait_for_loading_failed_entry(hass):
     flow = hass.config_entries.flow
     with patch.object(flow, "async_init", wraps=flow.async_init):
         hass.async_add_job(_load_entry)
-        await hass.config_entries.async_wait_for_states(
+        new_state = await hass.config_entries.async_wait_for_states(
             entry,
             {
                 config_entries.ConfigEntryState.LOADED,
@@ -3397,6 +3398,7 @@ async def test_wait_for_loading_failed_entry(hass):
             },
             timeout=1.0,
         )
+        assert new_state is config_entries.ConfigEntryState.SETUP_ERROR
     assert entry.state is config_entries.ConfigEntryState.SETUP_ERROR
 
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3332,7 +3332,7 @@ async def test_reauth(hass):
     assert len(hass.config_entries.flow.async_progress()) == 2
 
 
-async def test_wait_for_loading_entry(hass: HomeAssistant):
+async def test_wait_for_loading_entry(hass):
     """Test waiting for entry to be set up."""
 
     entry = MockConfigEntry(title="test_title", domain="test")
@@ -3366,7 +3366,7 @@ async def test_wait_for_loading_entry(hass: HomeAssistant):
     assert entry.state is config_entries.ConfigEntryState.LOADED
 
 
-async def test_wait_for_loading_failed_entry(hass: HomeAssistant):
+async def test_wait_for_loading_failed_entry(hass):
     """Test waiting for entry to be set up that fails loading."""
 
     entry = MockConfigEntry(title="test_title", domain="test")
@@ -3400,8 +3400,8 @@ async def test_wait_for_loading_failed_entry(hass: HomeAssistant):
     assert entry.state is config_entries.ConfigEntryState.SETUP_ERROR
 
 
-async def test_wait_for_loading_timeout(hass: HomeAssistant):
-    """Test waiting for entry to be set up that fails loading."""
+async def test_wait_for_loading_timeout(hass):
+    """Test waiting for entry to be set up that fails with a timeout."""
 
     async def _async_setup_entry(hass, entry):
         await asyncio.sleep(1)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an integration has a dependency, then `async_setup` is awaited, this does not assure the config entry is loaded. This PR adds a function to support awaiting a state change of the entry while loading.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/81431
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
