### PR TITLE
Create repairs issue if an outdated currency code is configured in core store

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -48,14 +48,9 @@ from .const import (
     LEGACY_CONF_WHITELIST_EXTERNAL_DIRS,
     __version__,
 )
-from .core import (
-    DOMAIN as CONF_CORE,
-    ConfigSource,
-    HomeAssistant,
-    async_get_hass,
-    callback,
-)
+from .core import DOMAIN as CONF_CORE, ConfigSource, HomeAssistant, callback
 from .exceptions import HomeAssistantError
+from .generated.currencies import HISTORIC_CURRENCIES
 from .helpers import (
     config_per_platform,
     config_validation as cv,
@@ -208,22 +203,25 @@ CUSTOMIZE_CONFIG_SCHEMA = vol.Schema(
 )
 
 
+def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> Any:
+    if currency in HISTORIC_CURRENCIES:
+        ir.async_create_issue(
+            hass,
+            "homeassistant",
+            "historic_currency",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="historic_currency",
+            translation_placeholders={"currency": currency},
+        )
+
+
 def _validate_currency(data: Any) -> Any:
-    hass = async_get_hass()
     try:
         return cv.currency(data)
     except vol.InInvalid:
         with suppress(vol.InInvalid):
             currency = cv.historic_currency(data)
-            ir.async_create_issue(
-                hass,
-                "homeassistant",
-                "historic_currency",
-                is_fixable=False,
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="historic_currency",
-                translation_placeholders={"currency": currency},
-            )
             return currency
         raise
 
@@ -579,6 +577,8 @@ async def async_process_ha_core_config(hass: HomeAssistant, config: dict) -> Non
     ):
         if key in config:
             setattr(hac, attr, config[key])
+
+    _raise_issue_if_historic_currency(hass, hass.config.currency)
 
     if CONF_TIME_ZONE in config:
         hac.set_time_zone(config[CONF_TIME_ZONE])

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -203,7 +203,7 @@ CUSTOMIZE_CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> Any:
+def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> None:
     if currency in HISTORIC_CURRENCIES:
         ir.async_create_issue(
             hass,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1207,13 +1207,28 @@ def test_identify_config_schema(domain, schema, expected):
     )
 
 
-def test_core_config_schema_historic_currency(hass):
+async def test_core_config_schema_historic_currency(hass):
     """Test core config schema."""
-    config_util.CORE_CONFIG_SCHEMA(
-        {
+    await config_util.async_process_ha_core_config(hass, {"currency": "LTT"})
+
+    issue_registry = ir.async_get(hass)
+    issue = issue_registry.async_get_issue("homeassistant", "historic_currency")
+    assert issue
+    assert issue.translation_placeholders == {"currency": "LTT"}
+
+
+async def test_core_store_historic_currency(hass, hass_storage):
+    """Test core config store."""
+    core_data = {
+        "data": {
             "currency": "LTT",
-        }
-    )
+        },
+        "key": "core.config",
+        "version": 1,
+        "minor_version": 1,
+    }
+    hass_storage["core.config"] = dict(core_data)
+    await config_util.async_process_ha_core_config(hass, {})
 
     issue_registry = ir.async_get(hass)
     issue = issue_registry.async_get_issue("homeassistant", "historic_currency")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Create repairs issue if an outdated currency code is configured in core store

this is a follow up to #81717 which only raises issue if an outdated currency code is configured in YAML

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
