### PR TITLE
Fix late-import numpy in stream.core

### DIFF
--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -387,7 +387,7 @@ class StreamView(HomeAssistantView):
 
 
 def _transform_image(image: np.ndarray, orientation: int) -> np.ndarray:
-    """Transform the image using numpy."""
+    """Transform the image to a given orientation using numpy."""
 
     if orientation in (0, 1):  # Unused/identity orientations
         return image

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -389,7 +389,7 @@ class StreamView(HomeAssistantView):
 def _transform_image(image: np.ndarray, orientation: int) -> np.ndarray:
     """Transform the image to a given orientation using numpy."""
 
-    if orientation in (0, 1):  # Unused/identity orientations
+    if orientation < 2 or orientation > 8:  # Unused/identity orientations
         return image
 
     # Keep import here so that we can import stream integration without installing reqs
@@ -407,9 +407,7 @@ def _transform_image(image: np.ndarray, orientation: int) -> np.ndarray:
         return np.rot90(image).copy()
     if orientation == 7:  # Rotate right and flip
         return np.flipud(np.rot90(image, -1)).copy()
-    if orientation == 8:  # Rotate right
-        return np.rot90(image, -1).copy()
-    return image  # Don't crash when using an unknown orientation
+    return np.rot90(image, -1).copy()  # Rotate right (orientation 8)
 
 
 class KeyFrameConverter:

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -389,6 +389,9 @@ class StreamView(HomeAssistantView):
 def _transform_image(image: np.ndarray, orientation: int) -> np.ndarray:
     """Transform the image using numpy."""
 
+    if orientation in (0, 1):  # Unused/identity orientations
+        return image
+
     # Keep import here so that we can import stream integration without installing reqs
     import numpy as np  # pylint: disable=import-outside-toplevel
 
@@ -406,7 +409,7 @@ def _transform_image(image: np.ndarray, orientation: int) -> np.ndarray:
         return np.flipud(np.rot90(image, -1)).copy()
     if orientation == 8:  # Rotate right
         return np.rot90(image, -1).copy()
-    return image  # Transforms 0 and 1 (and others not yet defined) are identity
+    return image  # Don't crash when using an unknown orientation
 
 
 class KeyFrameConverter:


### PR DESCRIPTION
## Proposed change

`numpy` is not listed in main requirements and is imported early by `conftest`.

Import it late to avoid an ImportError.

Split out from #81678.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
  - Nothing new. 

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
