### PR TITLE
Address late review of config entry wait for states tests

### DIFF
--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3349,7 +3349,6 @@ async def test_wait_for_loading_entry(hass: HomeAssistant) -> None:
     async def _load_entry() -> None:
         assert await async_setup_component(hass, "test", {})
 
-    entry = MockConfigEntry(title="test_title", domain="test")
     entry.add_to_hass(hass)
     flow = hass.config_entries.flow
     with patch.object(flow, "async_init", wraps=flow.async_init):
@@ -3382,7 +3381,6 @@ async def test_wait_for_loading_failed_entry(hass: HomeAssistant) -> None:
     async def _load_entry() -> None:
         assert await async_setup_component(hass, "test", {})
 
-    entry = MockConfigEntry(title="test_title", domain="test")
     entry.add_to_hass(hass)
     flow = hass.config_entries.flow
     with patch.object(flow, "async_init", wraps=flow.async_init):
@@ -3418,7 +3416,6 @@ async def test_wait_for_loading_timeout(hass: HomeAssistant) -> None:
     async def _load_entry() -> None:
         assert await async_setup_component(hass, "test", {})
 
-    entry = MockConfigEntry(title="test_title", domain="test")
     entry.add_to_hass(hass)
     flow = hass.config_entries.flow
     with patch.object(flow, "async_init", wraps=flow.async_init):

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3332,7 +3332,7 @@ async def test_reauth(hass):
     assert len(hass.config_entries.flow.async_progress()) == 2
 
 
-async def test_wait_for_loading_entry(hass):
+async def test_wait_for_loading_entry(hass: HomeAssistant) -> None:
     """Test waiting for entry to be set up."""
 
     entry = MockConfigEntry(title="test_title", domain="test")
@@ -3346,15 +3346,14 @@ async def test_wait_for_loading_entry(hass):
 
     flow = hass.config_entries.flow
 
-    async def _load_entry():
-        # Mock config entry
+    async def _load_entry() -> None:
         assert await async_setup_component(hass, "test", {})
 
     entry = MockConfigEntry(title="test_title", domain="test")
     entry.add_to_hass(hass)
     flow = hass.config_entries.flow
     with patch.object(flow, "async_init", wraps=flow.async_init):
-        hass.async_add_job(_load_entry)
+        hass.async_create_task(_load_entry())
         new_state = await hass.config_entries.async_wait_for_states(
             entry,
             {
@@ -3367,7 +3366,7 @@ async def test_wait_for_loading_entry(hass):
     assert entry.state is config_entries.ConfigEntryState.LOADED
 
 
-async def test_wait_for_loading_failed_entry(hass):
+async def test_wait_for_loading_failed_entry(hass: HomeAssistant) -> None:
     """Test waiting for entry to be set up that fails loading."""
 
     entry = MockConfigEntry(title="test_title", domain="test")
@@ -3376,20 +3375,18 @@ async def test_wait_for_loading_failed_entry(hass):
     mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
     mock_entity_platform(hass, "config_flow.test", None)
 
-    await entry.async_setup(hass)
     await hass.async_block_till_done()
 
     flow = hass.config_entries.flow
 
-    async def _load_entry():
-        # Mock config entry
+    async def _load_entry() -> None:
         assert await async_setup_component(hass, "test", {})
 
     entry = MockConfigEntry(title="test_title", domain="test")
     entry.add_to_hass(hass)
     flow = hass.config_entries.flow
     with patch.object(flow, "async_init", wraps=flow.async_init):
-        hass.async_add_job(_load_entry)
+        hass.async_create_task(_load_entry())
         new_state = await hass.config_entries.async_wait_for_states(
             entry,
             {
@@ -3402,7 +3399,7 @@ async def test_wait_for_loading_failed_entry(hass):
     assert entry.state is config_entries.ConfigEntryState.SETUP_ERROR
 
 
-async def test_wait_for_loading_timeout(hass):
+async def test_wait_for_loading_timeout(hass: HomeAssistant) -> None:
     """Test waiting for entry to be set up that fails with a timeout."""
 
     async def _async_setup_entry(hass, entry):
@@ -3414,20 +3411,18 @@ async def test_wait_for_loading_timeout(hass):
     mock_integration(hass, MockModule("test", async_setup_entry=_async_setup_entry))
     mock_entity_platform(hass, "config_flow.test", None)
 
-    await entry.async_setup(hass)
     await hass.async_block_till_done()
 
     flow = hass.config_entries.flow
 
-    async def _load_entry():
-        # Mock config entry
+    async def _load_entry() -> None:
         assert await async_setup_component(hass, "test", {})
 
     entry = MockConfigEntry(title="test_title", domain="test")
     entry.add_to_hass(hass)
     flow = hass.config_entries.flow
     with patch.object(flow, "async_init", wraps=flow.async_init):
-        hass.async_add_job(_load_entry)
+        hass.async_create_task(_load_entry())
         with pytest.raises(asyncio.exceptions.TimeoutError):
             await hass.config_entries.async_wait_for_states(
                 entry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Late review on tests #81771

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
