### PR TITLE
deconz: Use partition instead of split where possible

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -33,6 +33,7 @@ import homeassistant.helpers.entity_registry as er
 from .const import ATTR_DARK, ATTR_ON, DOMAIN as DECONZ_DOMAIN
 from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
+from .util import serial_from_unique_id
 
 _SensorDeviceT = TypeVar("_SensorDeviceT", bound=PydeconzSensorBase)
 
@@ -187,7 +188,9 @@ def async_update_unique_id(
         return
 
     if description.old_unique_id_suffix:
-        unique_id = f'{unique_id.split("-", 1)[0]}-{description.old_unique_id_suffix}'
+        unique_id = (
+            f"{serial_from_unique_id(unique_id)}-{description.old_unique_id_suffix}"
+        )
 
     if entity_id := ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, unique_id):
         ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import DOMAIN as DECONZ_DOMAIN
 from .gateway import DeconzGateway
+from .util import serial_from_unique_id
 
 _DeviceT = TypeVar(
     "_DeviceT",
@@ -55,9 +56,7 @@ class DeconzBase(Generic[_DeviceT]):
     def serial(self) -> str | None:
         """Return a serial number for this device."""
         assert isinstance(self._device, PydeconzDevice)
-        if not self._device.unique_id or self._device.unique_id.count(":") != 7:
-            return None
-        return self._device.unique_id.split("-", 1)[0]
+        return serial_from_unique_id(self._device.unique_id)
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -26,6 +26,7 @@ import homeassistant.helpers.entity_registry as er
 from .const import DOMAIN as DECONZ_DOMAIN
 from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
+from .util import serial_from_unique_id
 
 T = TypeVar("T", Presence, PydeconzSensorBase)
 
@@ -88,7 +89,7 @@ def async_update_unique_id(
     if ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, new_unique_id):
         return
 
-    unique_id = f'{unique_id.split("-", 1)[0]}-{description.key}'
+    unique_id = f"{serial_from_unique_id(unique_id)}-{description.key}"
     if entity_id := ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, unique_id):
         ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
 

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -50,6 +50,7 @@ import homeassistant.util.dt as dt_util
 from .const import ATTR_DARK, ATTR_ON, DOMAIN as DECONZ_DOMAIN
 from .deconz_device import DeconzDevice
 from .gateway import DeconzGateway, get_gateway_from_config_entry
+from .util import serial_from_unique_id
 
 PROVIDES_EXTRA_ATTRIBUTES = (
     "battery",
@@ -248,7 +249,9 @@ def async_update_unique_id(
         return
 
     if description.old_unique_id_suffix:
-        unique_id = f'{unique_id.split("-", 1)[0]}-{description.old_unique_id_suffix}'
+        unique_id = (
+            f"{serial_from_unique_id(unique_id)}-{description.old_unique_id_suffix}"
+        )
 
     if entity_id := ent_reg.async_get_entity_id(DOMAIN, DECONZ_DOMAIN, unique_id):
         ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
@@ -290,7 +293,7 @@ async def async_setup_entry(
                     sensor.type.startswith("CLIP")
                     or (no_sensor_data and description.key != "battery")
                     or (
-                        (unique_id := sensor.unique_id.rsplit("-", 1)[0])
+                        (unique_id := sensor.unique_id.rpartition("-")[0])
                         in known_device_entities[description.key]
                     )
                 ):

--- a/homeassistant/components/deconz/util.py
+++ b/homeassistant/components/deconz/util.py
@@ -1,0 +1,9 @@
+"""Utilities for deCONZ component."""
+from __future__ import annotations
+
+
+def serial_from_unique_id(unique_id: str | None) -> str | None:
+    """Get a device serial number from a unique ID, if possible."""
+    if not unique_id or unique_id.count(":") != 7:
+        return None
+    return unique_id.partition("-")[0]

--- a/homeassistant/components/deconz/util.py
+++ b/homeassistant/components/deconz/util.py
@@ -1,4 +1,4 @@
-"""Utilities for deCONZ component."""
+"""Utilities for deCONZ integration."""
 from __future__ import annotations
 
 

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -7,6 +7,7 @@ from homeassistant.components.deconz.deconz_event import (
     CONF_DECONZ_ALARM_EVENT,
     CONF_DECONZ_EVENT,
 )
+from homeassistant.components.deconz.util import serial_from_unique_id
 from homeassistant.const import (
     CONF_CODE,
     CONF_DEVICE_ID,
@@ -60,7 +61,7 @@ async def test_humanifying_deconz_alarm_event(hass, aioclient_mock):
     device_registry = dr.async_get(hass)
 
     keypad_event_id = slugify(data["sensors"]["1"]["name"])
-    keypad_serial = data["sensors"]["1"]["uniqueid"].split("-", 1)[0]
+    keypad_serial = serial_from_unique_id(data["sensors"]["1"]["uniqueid"])
     keypad_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, keypad_serial)}
     )
@@ -131,25 +132,25 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
     device_registry = dr.async_get(hass)
 
     switch_event_id = slugify(data["sensors"]["1"]["name"])
-    switch_serial = data["sensors"]["1"]["uniqueid"].split("-", 1)[0]
+    switch_serial = serial_from_unique_id(data["sensors"]["1"]["uniqueid"])
     switch_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, switch_serial)}
     )
 
     hue_remote_event_id = slugify(data["sensors"]["2"]["name"])
-    hue_remote_serial = data["sensors"]["2"]["uniqueid"].split("-", 1)[0]
+    hue_remote_serial = serial_from_unique_id(data["sensors"]["2"]["uniqueid"])
     hue_remote_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, hue_remote_serial)}
     )
 
     xiaomi_cube_event_id = slugify(data["sensors"]["3"]["name"])
-    xiaomi_cube_serial = data["sensors"]["3"]["uniqueid"].split("-", 1)[0]
+    xiaomi_cube_serial = serial_from_unique_id(data["sensors"]["3"]["uniqueid"])
     xiaomi_cube_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, xiaomi_cube_serial)}
     )
 
     faulty_event_id = slugify(data["sensors"]["4"]["name"])
-    faulty_serial = data["sensors"]["4"]["uniqueid"].split("-", 1)[0]
+    faulty_serial = serial_from_unique_id(data["sensors"]["4"]["uniqueid"])
     faulty_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, faulty_serial)}
     )


### PR DESCRIPTION
## Proposed change

Use `.partition` instead of `.split(..., 1)` in the deCONZ component, and deduplicate code that did use it.
(`.partition` is faster and the returned 3-tuple uses less memory than a 2-item list.)

Split out/refactored of #81493.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
  - No new tests, everything is covered earlier. 

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
