### PR TITLE
Refactor + strictly-type image component

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -151,6 +151,7 @@ homeassistant.components.http.*
 homeassistant.components.huawei_lte.*
 homeassistant.components.hyperion.*
 homeassistant.components.ibeacon.*
+homeassistant.components.image.*
 homeassistant.components.image_processing.*
 homeassistant.components.input_button.*
 homeassistant.components.input_select.*

--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -199,11 +199,16 @@ class ImageServeView(HomeAssistantView):
         )
 
 
-def _generate_thumbnail(original_path, content_type, target_path, target_size):
+def _generate_thumbnail(
+    original_path: pathlib.Path,
+    content_type: str,
+    target_path: pathlib.Path,
+    target_size: tuple[int, int],
+) -> None:
     """Generate a size."""
     image = ImageOps.exif_transpose(Image.open(original_path))
     image.thumbnail(target_size)
-    image.save(target_path, format=content_type.split("/", 1)[1])
+    image.save(target_path, format=content_type.partition("/")[-1])
 
 
 def _validate_size_from_filename(filename: str) -> tuple[int, int]:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1263,6 +1263,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.image.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.image_processing.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change

This PR adds better typing to the `image` component and switches a couple of places that were using the `.split(..., 1)[...]` idiom to use the better-suited `partition` function.

I also added some type annotations where they were missing, bringing the `image` component into the hallowed halls of `.strict-typing`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
  - No new tests, 99% pre-covered. 

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
