### PR TITLE
Align implementation of the unifi update platform with the unifi switch platform

### DIFF
--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -315,17 +315,17 @@ async def async_setup_entry(
         async_load_entities(description)
 
 
-class UnifiSwitchEntity(SwitchEntity):
+class UnifiSwitchEntity(SwitchEntity, Generic[_HandlerT, _DataT]):
     """Base representation of a UniFi switch."""
 
-    entity_description: UnifiEntityDescription
+    entity_description: UnifiEntityDescription[_HandlerT, _DataT]
     _attr_should_poll = False
 
     def __init__(
         self,
         obj_id: str,
         controller: UniFiController,
-        description: UnifiEntityDescription,
+        description: UnifiEntityDescription[_HandlerT, _DataT],
     ) -> None:
         """Set up UniFi switch entity."""
         self._obj_id = obj_id

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -51,8 +51,8 @@ from .controller import UniFiController
 CLIENT_BLOCKED = (EventKey.WIRED_CLIENT_BLOCKED, EventKey.WIRELESS_CLIENT_BLOCKED)
 CLIENT_UNBLOCKED = (EventKey.WIRED_CLIENT_UNBLOCKED, EventKey.WIRELESS_CLIENT_UNBLOCKED)
 
-Data = TypeVar("Data")
-Handler = TypeVar("Handler")
+_DataT = TypeVar("_DataT")
+_HandlerT = TypeVar("_HandlerT")
 
 Subscription = Callable[[CallbackType, ItemEvent], UnsubscribeType]
 
@@ -157,25 +157,27 @@ async def async_poe_port_control_fn(
 
 
 @dataclass
-class UnifiEntityLoader(Generic[Handler, Data]):
+class UnifiEntityLoader(Generic[_HandlerT, _DataT]):
     """Validate and load entities from different UniFi handlers."""
 
     allowed_fn: Callable[[UniFiController, str], bool]
-    api_handler_fn: Callable[[aiounifi.Controller], Handler]
+    api_handler_fn: Callable[[aiounifi.Controller], _HandlerT]
     available_fn: Callable[[UniFiController, str], bool]
     control_fn: Callable[[aiounifi.Controller, str, bool], Coroutine[Any, Any, None]]
     device_info_fn: Callable[[aiounifi.Controller, str], DeviceInfo]
     event_is_on: tuple[EventKey, ...] | None
     event_to_subscribe: tuple[EventKey, ...] | None
-    is_on_fn: Callable[[aiounifi.Controller, Data], bool]
-    name_fn: Callable[[Data], str | None]
-    object_fn: Callable[[aiounifi.Controller, str], Data]
+    is_on_fn: Callable[[aiounifi.Controller, _DataT], bool]
+    name_fn: Callable[[_DataT], str | None]
+    object_fn: Callable[[aiounifi.Controller, str], _DataT]
     supported_fn: Callable[[aiounifi.Controller, str], bool | None]
     unique_id_fn: Callable[[str], str]
 
 
 @dataclass
-class UnifiEntityDescription(SwitchEntityDescription, UnifiEntityLoader[Handler, Data]):
+class UnifiEntityDescription(
+    SwitchEntityDescription, UnifiEntityLoader[_HandlerT, _DataT]
+):
     """Class describing UniFi switch entity."""
 
     custom_subscribe: Callable[[aiounifi.Controller], Subscription] | None = None

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -9,14 +9,20 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, Union
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import CallbackType, ItemEvent, UnsubscribeType
+from aiounifi.interfaces.api_handlers import (
+    APIHandler,
+    CallbackType,
+    ItemEvent,
+    UnsubscribeType,
+)
 from aiounifi.interfaces.clients import Clients
 from aiounifi.interfaces.dpi_restriction_groups import DPIRestrictionGroups
 from aiounifi.interfaces.outlets import Outlets
 from aiounifi.interfaces.ports import Ports
+from aiounifi.models.api import APIItem
 from aiounifi.models.client import Client, ClientBlockRequest
 from aiounifi.models.device import (
     DeviceSetOutletRelayRequest,
@@ -51,8 +57,8 @@ from .controller import UniFiController
 CLIENT_BLOCKED = (EventKey.WIRED_CLIENT_BLOCKED, EventKey.WIRELESS_CLIENT_BLOCKED)
 CLIENT_UNBLOCKED = (EventKey.WIRED_CLIENT_UNBLOCKED, EventKey.WIRELESS_CLIENT_UNBLOCKED)
 
-_DataT = TypeVar("_DataT")
-_HandlerT = TypeVar("_HandlerT")
+_DataT = TypeVar("_DataT", bound=Union[APIItem, Outlet, Port])
+_HandlerT = TypeVar("_HandlerT", bound=Union[APIHandler, Outlets, Ports])
 
 Subscription = Callable[[CallbackType, ItemEvent], UnsubscribeType]
 

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -1,20 +1,25 @@
 """Update entities for Ubiquiti network devices."""
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from aiounifi.interfaces.api_handlers import ItemEvent
-from aiounifi.models.device import DeviceUpgradeRequest
+import aiounifi
+from aiounifi.interfaces.api_handlers import CallbackType, ItemEvent, UnsubscribeType
+from aiounifi.interfaces.devices import Devices
+from aiounifi.models.device import Device, DeviceUpgradeRequest
 
 from homeassistant.components.update import (
-    DOMAIN,
     UpdateDeviceClass,
     UpdateEntity,
+    UpdateEntityDescription,
     UpdateEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
@@ -23,11 +28,88 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import ATTR_MANUFACTURER, DOMAIN as UNIFI_DOMAIN
 
 if TYPE_CHECKING:
+    from aiounifi.models.event import EventKey
+
     from .controller import UniFiController
+
+Data = TypeVar("Data")
+Handler = TypeVar("Handler")
+
+Subscription = Callable[[CallbackType, ItemEvent], UnsubscribeType]
 
 LOGGER = logging.getLogger(__name__)
 
-DEVICE_UPDATE = "device_update"
+
+@callback
+def async_device_available_fn(controller: UniFiController, obj_id: str) -> bool:
+    """Check if device is available."""
+    device = controller.api.devices[obj_id]
+    return controller.available and not device.disabled
+
+
+async def async_device_control_fn(api: aiounifi.Controller, obj_id: str) -> None:
+    """Control upgrade of device."""
+    await api.request(DeviceUpgradeRequest.create(obj_id))
+
+
+@callback
+def async_device_device_info_fn(api: aiounifi.Controller, obj_id: str) -> DeviceInfo:
+    """Create device registry entry for device."""
+    device = api.devices[obj_id]
+    return DeviceInfo(
+        connections={(CONNECTION_NETWORK_MAC, device.mac)},
+        manufacturer=ATTR_MANUFACTURER,
+        model=device.model,
+        name=device.name or None,
+        sw_version=device.version,
+        hw_version=str(device.board_revision),
+    )
+
+
+@dataclass
+class UnifiEntityLoader(Generic[Handler, Data]):
+    """Validate and load entities from different UniFi handlers."""
+
+    allowed_fn: Callable[[UniFiController, str], bool]
+    api_handler_fn: Callable[[aiounifi.Controller], Handler]
+    available_fn: Callable[[UniFiController, str], bool]
+    control_fn: Callable[[aiounifi.Controller, str], Coroutine[Any, Any, None]]
+    device_info_fn: Callable[[aiounifi.Controller, str], DeviceInfo]
+    event_is_on: tuple[EventKey, ...] | None
+    event_to_subscribe: tuple[EventKey, ...] | None
+    name_fn: Callable[[Data], str | None]
+    object_fn: Callable[[aiounifi.Controller, str], Data]
+    state_fn: Callable[[aiounifi.Controller, Data], bool]
+    supported_fn: Callable[[aiounifi.Controller, str], bool | None]
+    unique_id_fn: Callable[[str], str]
+
+
+@dataclass
+class UnifiEntityDescription(UpdateEntityDescription, UnifiEntityLoader[Handler, Data]):
+    """Class describing UniFi update entity."""
+
+    custom_subscribe: Callable[[aiounifi.Controller], Subscription] | None = None
+
+
+ENTITY_DESCRIPTIONS: tuple[UnifiEntityDescription, ...] = (
+    UnifiEntityDescription[Devices, Device](
+        key="Upgrade device",
+        device_class=UpdateDeviceClass.FIRMWARE,
+        has_entity_name=True,
+        allowed_fn=lambda controller, obj_id: True,
+        api_handler_fn=lambda api: api.devices,
+        available_fn=async_device_available_fn,
+        control_fn=async_device_control_fn,
+        device_info_fn=async_device_device_info_fn,
+        event_is_on=None,
+        event_to_subscribe=None,
+        name_fn=lambda device: None,
+        object_fn=lambda api, obj_id: api.devices[obj_id],
+        state_fn=lambda api, device: device.state == 4,
+        supported_fn=lambda api, obj_id: True,
+        unique_id_fn=lambda obj_id: f"device_update-{obj_id}",
+    ),
+)
 
 
 async def async_setup_entry(
@@ -37,57 +119,84 @@ async def async_setup_entry(
 ) -> None:
     """Set up update entities for UniFi Network integration."""
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
-    controller.entities[DOMAIN] = {DEVICE_UPDATE: set()}
 
     @callback
-    def async_add_update_entity(_: ItemEvent, obj_id: str) -> None:
-        """Add new device update entities from the controller."""
-        async_add_entities([UnifiDeviceUpdateEntity(obj_id, controller)])
+    def async_load_entities(description: UnifiEntityDescription) -> None:
+        """Load and subscribe to UniFi devices."""
+        entities: list[UpdateEntity] = []
+        api_handler = description.api_handler_fn(controller.api)
 
-    controller.api.devices.subscribe(async_add_update_entity, ItemEvent.ADDED)
+        @callback
+        def async_create_entity(event: ItemEvent, obj_id: str) -> None:
+            """Create UniFi entity."""
+            if not description.allowed_fn(
+                controller, obj_id
+            ) or not description.supported_fn(controller.api, obj_id):
+                return
 
-    for device_id in controller.api.devices:
-        async_add_update_entity(ItemEvent.ADDED, device_id)
+            entity = UnifiDeviceUpdateEntity(obj_id, controller, description)
+            if event == ItemEvent.ADDED:
+                async_add_entities([entity])
+                return
+            entities.append(entity)
+
+        for obj_id in api_handler:
+            async_create_entity(ItemEvent.CHANGED, obj_id)
+        async_add_entities(entities)
+
+        api_handler.subscribe(async_create_entity, ItemEvent.ADDED)
+
+    for description in ENTITY_DESCRIPTIONS:
+        async_load_entities(description)
 
 
 class UnifiDeviceUpdateEntity(UpdateEntity):
-    """Update entity for a UniFi network infrastructure device."""
+    """Representation of a UniFi device update entity."""
 
-    DOMAIN = DOMAIN
-    TYPE = DEVICE_UPDATE
-    _attr_device_class = UpdateDeviceClass.FIRMWARE
-    _attr_has_entity_name = True
+    entity_description: UnifiEntityDescription
+    _attr_should_poll = False
 
-    def __init__(self, obj_id: str, controller: UniFiController) -> None:
-        """Set up device update entity."""
-        controller.entities[DOMAIN][DEVICE_UPDATE].add(obj_id)
-        self.controller = controller
+    def __init__(
+        self,
+        obj_id: str,
+        controller: UniFiController,
+        description: UnifiEntityDescription,
+    ) -> None:
+        """Set up UniFi switch entity."""
         self._obj_id = obj_id
-        self._attr_unique_id = f"{self.TYPE}-{obj_id}"
+        self.controller = controller
+        self.entity_description = description
+
+        self._removed = False
 
         self._attr_supported_features = UpdateEntityFeature.PROGRESS
         if controller.site_role == "admin":
             self._attr_supported_features |= UpdateEntityFeature.INSTALL
 
-        device = controller.api.devices[obj_id]
-        self._attr_available = controller.available and not device.disabled
-        self._attr_in_progress = device.state == 4
-        self._attr_installed_version = device.version
-        self._attr_latest_version = device.upgrade_to_firmware or device.version
+        self._attr_available = description.available_fn(controller, obj_id)
+        self._attr_device_info = description.device_info_fn(controller.api, obj_id)
+        self._attr_unique_id = description.unique_id_fn(obj_id)
 
-        self._attr_device_info = DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, obj_id)},
-            manufacturer=ATTR_MANUFACTURER,
-            model=device.model,
-            name=device.name or None,
-            sw_version=device.version,
-            hw_version=device.board_revision,
-        )
+        obj = description.object_fn(self.controller.api, obj_id)
+        self._attr_in_progress = description.state_fn(controller.api, obj)
+        self._attr_name = description.name_fn(obj)
+        self._attr_installed_version = obj.version
+        self._attr_latest_version = obj.upgrade_to_firmware or obj.version
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install an update."""
+        await self.entity_description.control_fn(self.controller.api, self._obj_id)
 
     async def async_added_to_hass(self) -> None:
-        """Entity created."""
+        """Register callbacks."""
+        description = self.entity_description
+        handler = description.api_handler_fn(self.controller.api)
         self.async_on_remove(
-            self.controller.api.devices.subscribe(self.async_signalling_callback)
+            handler.subscribe(
+                self.async_signalling_callback,
+            )
         )
         self.async_on_remove(
             async_dispatcher_connect(
@@ -96,19 +205,27 @@ class UnifiDeviceUpdateEntity(UpdateEntity):
                 self.async_signal_reachable_callback,
             )
         )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect object when removed."""
-        self.controller.entities[DOMAIN][DEVICE_UPDATE].remove(self._obj_id)
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_remove,
+                self.remove_item,
+            )
+        )
 
     @callback
     def async_signalling_callback(self, event: ItemEvent, obj_id: str) -> None:
-        """Object has new event."""
-        device = self.controller.api.devices[self._obj_id]
-        self._attr_available = self.controller.available and not device.disabled
-        self._attr_in_progress = device.state == 4
-        self._attr_installed_version = device.version
-        self._attr_latest_version = device.upgrade_to_firmware or device.version
+        """Update the switch state."""
+        if event == ItemEvent.DELETED and obj_id == self._obj_id:
+            self.hass.async_create_task(self.remove_item({self._obj_id}))
+            return
+
+        description = self.entity_description
+        obj = description.object_fn(self.controller.api, self._obj_id)
+        self._attr_available = description.available_fn(self.controller, self._obj_id)
+        self._attr_in_progress = description.state_fn(self.controller.api, obj)
+        self._attr_installed_version = obj.version
+        self._attr_latest_version = obj.upgrade_to_firmware or obj.version
         self.async_write_ha_state()
 
     @callback
@@ -116,8 +233,12 @@ class UnifiDeviceUpdateEntity(UpdateEntity):
         """Call when controller connection state change."""
         self.async_signalling_callback(ItemEvent.ADDED, self._obj_id)
 
-    async def async_install(
-        self, version: str | None, backup: bool, **kwargs: Any
-    ) -> None:
-        """Install an update."""
-        await self.controller.api.request(DeviceUpgradeRequest.create(self._obj_id))
+    async def remove_item(self, keys: set) -> None:
+        """Remove entity if object ID is part of set."""
+        if self._obj_id not in keys or self._removed:
+            return
+        self._removed = True
+        if self.registry_entry:
+            er.async_get(self.hass).async_remove(self.entity_id)
+        else:
+            await self.async_remove(force_remove=True)

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -7,8 +7,14 @@ import logging
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import CallbackType, ItemEvent, UnsubscribeType
+from aiounifi.interfaces.api_handlers import (
+    APIHandler,
+    CallbackType,
+    ItemEvent,
+    UnsubscribeType,
+)
 from aiounifi.interfaces.devices import Devices
+from aiounifi.models.api import APIItem
 from aiounifi.models.device import Device, DeviceUpgradeRequest
 
 from homeassistant.components.update import (
@@ -32,8 +38,8 @@ if TYPE_CHECKING:
 
     from .controller import UniFiController
 
-_DataT = TypeVar("_DataT")
-_HandlerT = TypeVar("_HandlerT")
+_DataT = TypeVar("_DataT", bound=APIItem)
+_HandlerT = TypeVar("_HandlerT", bound=APIHandler)
 
 Subscription = Callable[[CallbackType, ItemEvent], UnsubscribeType]
 

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -32,8 +32,8 @@ if TYPE_CHECKING:
 
     from .controller import UniFiController
 
-Data = TypeVar("Data")
-Handler = TypeVar("Handler")
+_DataT = TypeVar("_DataT")
+_HandlerT = TypeVar("_HandlerT")
 
 Subscription = Callable[[CallbackType, ItemEvent], UnsubscribeType]
 
@@ -67,25 +67,27 @@ def async_device_device_info_fn(api: aiounifi.Controller, obj_id: str) -> Device
 
 
 @dataclass
-class UnifiEntityLoader(Generic[Handler, Data]):
+class UnifiEntityLoader(Generic[_HandlerT, _DataT]):
     """Validate and load entities from different UniFi handlers."""
 
     allowed_fn: Callable[[UniFiController, str], bool]
-    api_handler_fn: Callable[[aiounifi.Controller], Handler]
+    api_handler_fn: Callable[[aiounifi.Controller], _HandlerT]
     available_fn: Callable[[UniFiController, str], bool]
     control_fn: Callable[[aiounifi.Controller, str], Coroutine[Any, Any, None]]
     device_info_fn: Callable[[aiounifi.Controller, str], DeviceInfo]
     event_is_on: tuple[EventKey, ...] | None
     event_to_subscribe: tuple[EventKey, ...] | None
-    name_fn: Callable[[Data], str | None]
-    object_fn: Callable[[aiounifi.Controller, str], Data]
-    state_fn: Callable[[aiounifi.Controller, Data], bool]
+    name_fn: Callable[[_DataT], str | None]
+    object_fn: Callable[[aiounifi.Controller, str], _DataT]
+    state_fn: Callable[[aiounifi.Controller, _DataT], bool]
     supported_fn: Callable[[aiounifi.Controller, str], bool | None]
     unique_id_fn: Callable[[str], str]
 
 
 @dataclass
-class UnifiEntityDescription(UpdateEntityDescription, UnifiEntityLoader[Handler, Data]):
+class UnifiEntityDescription(
+    UpdateEntityDescription, UnifiEntityLoader[_HandlerT, _DataT]
+):
     """Class describing UniFi update entity."""
 
     custom_subscribe: Callable[[aiounifi.Controller], Subscription] | None = None


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rework the UniFi update platform to use the same boilerplate as the switch platform but separately
Once all platforms are migrated I will consolidate them into one entity class

Related PRs
- #81680
- #81821
- #81930
- #81979

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
