### PR TITLE
Omit native_unit_of_measurement=None

### DIFF
--- a/homeassistant/components/bthome/sensor.py
+++ b/homeassistant/components/bthome/sensor.py
@@ -174,7 +174,6 @@ SENSOR_DESCRIPTIONS = {
     (BTHomeSensorDeviceClass.COUNT, None): SensorEntityDescription(
         key=f"{BTHomeSensorDeviceClass.COUNT}",
         device_class=None,
-        native_unit_of_measurement=None,
         state_class=SensorStateClass.MEASUREMENT,
     ),
 }

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -76,7 +76,6 @@ SENSOR_TYPES: tuple[EcobeeSensorEntityDescription, ...] = (
         key="airQuality",
         name="Air Quality Index",
         device_class=SensorDeviceClass.AQI,
-        native_unit_of_measurement=None,
         state_class=SensorStateClass.MEASUREMENT,
         runtime_key="actualAQScore",
     ),

--- a/homeassistant/components/growatt_server/sensor_types/mix.py
+++ b/homeassistant/components/growatt_server/sensor_types/mix.py
@@ -230,7 +230,6 @@ MIX_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
         key="mix_last_update",
         name="Last Data Update",
         api_key="lastdataupdate",
-        native_unit_of_measurement=None,
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
     # Values from 'dashboard_data' API call

--- a/homeassistant/components/metoffice/sensor.py
+++ b/homeassistant/components/metoffice/sensor.py
@@ -51,7 +51,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="name",
         name="Station name",
         device_class=None,
-        native_unit_of_measurement=None,
         icon="mdi:label-outline",
         entity_registry_enabled_default=False,
     ),
@@ -59,7 +58,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="weather",
         name="Weather",
         device_class=None,
-        native_unit_of_measurement=None,
         icon="mdi:weather-sunny",  # but will adapt to current conditions
         entity_registry_enabled_default=True,
     ),
@@ -91,7 +89,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="wind_direction",
         name="Wind direction",
-        native_unit_of_measurement=None,
         icon="mdi:compass-outline",
         entity_registry_enabled_default=False,
     ),
@@ -108,7 +105,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="visibility",
         name="Visibility",
         device_class=None,
-        native_unit_of_measurement=None,
         icon="mdi:eye",
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/components/ondilo_ico/sensor.py
+++ b/homeassistant/components/ondilo_ico/sensor.py
@@ -50,7 +50,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="ph",
         name="pH",
-        native_unit_of_measurement=None,
         icon="mdi:pool",
         device_class=None,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
## Proposed change

According to @bdraco, [the standard](https://github.com/home-assistant/core/pull/81327#discussion_r1017017039) is to omit `native_unit_of_measurement=None` when a sensor describes an unitless quantity.

This fixes occurrences of that nonstandard clause.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
  - No new code.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
