### PR TITLE
Add signal_messenger_jsonrpc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1128,6 +1128,7 @@ omit =
     homeassistant/components/sia/sia_entity_base.py
     homeassistant/components/sia/utils.py
     homeassistant/components/sigfox/sensor.py
+    homeassistant/components/signal_messenger_jsonrpc/notify.py
     homeassistant/components/simplepush/__init__.py
     homeassistant/components/simplepush/notify.py
     homeassistant/components/simplisafe/__init__.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1022,6 +1022,7 @@ build.json @home-assistant/supervisor
 /tests/components/sighthound/ @robmarkcole
 /homeassistant/components/signal_messenger/ @bbernhard
 /tests/components/signal_messenger/ @bbernhard
+/homeassistant/components/signal_messenger_jsonrpc/ @morph027
 /homeassistant/components/simplepush/ @engrbm87
 /tests/components/simplepush/ @engrbm87
 /homeassistant/components/simplisafe/ @bachya

--- a/homeassistant/components/signal_messenger_jsonrpc/__init__.py
+++ b/homeassistant/components/signal_messenger_jsonrpc/__init__.py
@@ -1,0 +1,1 @@
+"""The signal messenger (JSONRPC) component."""

--- a/homeassistant/components/signal_messenger_jsonrpc/manifest.json
+++ b/homeassistant/components/signal_messenger_jsonrpc/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "signal_messenger_jsonrpc",
+  "name": "Signal Messenger (JSONRPC)",
+  "documentation": "https://www.home-assistant.io/integrations/signal_messenger_jsonrpc",
+  "codeowners": ["@morph027"],
+  "requirements": ["pysignalclijsonrpc==22.11.9"],
+  "iot_class": "cloud_push",
+  "loggers": ["pysignalclijsonrpc"]
+}

--- a/homeassistant/components/signal_messenger_jsonrpc/notify.py
+++ b/homeassistant/components/signal_messenger_jsonrpc/notify.py
@@ -1,0 +1,199 @@
+"""Signal Messenger (JSONRPC) for notify component."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pysignalclijsonrpc.api import SignalCliJSONRPCApi, SignalCliJSONRPCError
+from requests import Session
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    ATTR_DATA,
+    PLATFORM_SCHEMA,
+    BaseNotificationService,
+)
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ACCOUNT = "account"
+CONF_RECICPIENTS = "recipients"
+CONF_SIGNAL_CLI_REST_API_URL = "url"
+CONF_SIGNAL_CLI_REST_API_USERNAME = "username"
+CONF_SIGNAL_CLI_REST_API_PASSWORD = "password"
+CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES = 52428800
+ATTR_FILENAMES = "attachments"
+ATTR_URLS = "urls"
+ATTR_VERIFY_SSL = "verify_ssl"
+
+DATA_FILENAMES_SCHEMA = vol.Schema({vol.Required(ATTR_FILENAMES): [cv.string]})
+
+DATA_URLS_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_URLS): [cv.url],
+        vol.Optional(ATTR_VERIFY_SSL, default=True): cv.boolean,
+    }
+)
+
+DATA_SCHEMA = vol.Any(
+    None,
+    DATA_FILENAMES_SCHEMA,
+    DATA_URLS_SCHEMA,
+)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_ACCOUNT): cv.string,
+        vol.Required(CONF_SIGNAL_CLI_REST_API_URL): cv.string,
+        vol.Optional(CONF_SIGNAL_CLI_REST_API_USERNAME, default=""): cv.string,
+        vol.Optional(CONF_SIGNAL_CLI_REST_API_PASSWORD, default=""): cv.string,
+        vol.Required(CONF_RECICPIENTS): vol.All(cv.ensure_list, [cv.string]),
+    }
+)
+
+
+def get_service(
+    hass: HomeAssistant,
+    config: ConfigType,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> SignalNotificationService:
+    """Get the SignalMessenger notification service."""
+
+    account = config[CONF_ACCOUNT]
+    recipients = config[CONF_RECICPIENTS]
+    signal_cli_rest_api_url = config[CONF_SIGNAL_CLI_REST_API_URL]
+    signal_cli_rest_api_username = config[CONF_SIGNAL_CLI_REST_API_USERNAME]
+    signal_cli_rest_api_password = config[CONF_SIGNAL_CLI_REST_API_PASSWORD]
+    opts = {
+        "endpoint": signal_cli_rest_api_url,
+        "account": account,
+    }
+    if signal_cli_rest_api_username and signal_cli_rest_api_password:
+        opts.update(
+            {"auth": (signal_cli_rest_api_username, signal_cli_rest_api_password)}
+        )
+    signal_cli_rest_api = SignalCliJSONRPCApi(**opts)
+    return SignalNotificationService(hass, recipients, signal_cli_rest_api)
+
+
+class SignalNotificationService(BaseNotificationService):
+    """Implement the notification service for SignalMessenger."""
+
+    _session = Session()
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        recipients: list[str],
+        signal_cli_rest_api: SignalCliJSONRPCApi,
+    ) -> None:
+        """Initialize the service."""
+
+        self._hass = hass
+        self._recipients = recipients
+        self._signal_cli_rest_api = signal_cli_rest_api
+
+    def send_message(self, message: str = "", **kwargs: Any) -> None:
+        """Send a message to a one or more recipients. Additionally a file can be attached."""
+
+        _LOGGER.debug("Sending signal message")
+
+        data = kwargs.get(ATTR_DATA)
+
+        try:
+            data = DATA_SCHEMA(data)
+        except vol.Invalid as ex:
+            _LOGGER.error("Invalid message data: %s", ex)
+            raise ex
+
+        attachments_as_files = self.get_filenames(data)
+        attachments_as_bytes = self.get_attachments_as_bytes(
+            data, CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES, self._hass
+        )
+
+        try:
+            self._signal_cli_rest_api.send_message(
+                message=message,
+                recipients=self._recipients,
+                attachments_as_files=attachments_as_files,
+                attachments_as_bytes=attachments_as_bytes,
+            )
+        except SignalCliJSONRPCError as ex:
+            _LOGGER.error("%s", ex)
+            raise ex
+
+    @staticmethod
+    def get_filenames(data: Any) -> list[str] | None:
+        """Extract attachment filenames from data."""
+        try:
+            data = DATA_FILENAMES_SCHEMA(data)
+        except vol.Invalid:
+            return None
+
+        return data[ATTR_FILENAMES]
+
+    @classmethod
+    def get_attachments_as_bytes(
+        cls,
+        data: Any,
+        attachment_size_limit: int,
+        hass: HomeAssistant,
+    ) -> list[bytearray] | None:
+        """Retrieve attachments from URLs defined in data."""
+        try:
+            data = DATA_URLS_SCHEMA(data)
+        except vol.Invalid:
+            return None
+
+        urls = data[ATTR_URLS]
+
+        attachments_as_bytes: list[bytearray] = []
+
+        for url in urls:
+            try:
+                if not hass.config.is_allowed_external_url(url):
+                    _LOGGER.error("URL '%s' not in allow list", url)
+                    continue
+
+                resp = cls._session.get(
+                    url, verify=data[ATTR_VERIFY_SSL], timeout=10, stream=True
+                )
+                resp.raise_for_status()
+
+                if (
+                    resp.headers.get("Content-Length") is not None
+                    and int(str(resp.headers.get("Content-Length")))
+                    > attachment_size_limit
+                ):
+                    raise ValueError(
+                        "Attachment too large (Content-Length reports {}). Max size: {} bytes".format(
+                            int(str(resp.headers.get("Content-Length"))),
+                            CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES,
+                        )
+                    )
+
+                size = 0
+                chunks = bytearray()
+                for chunk in resp.iter_content(1024):
+                    size += len(chunk)
+                    if size > attachment_size_limit:
+                        raise ValueError(
+                            "Attachment too large (Stream reports {}). Max size: {} bytes".format(
+                                size, CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES
+                            )
+                        )
+
+                    chunks.extend(chunk)
+
+                attachments_as_bytes.append(chunks)
+            except Exception as ex:
+                _LOGGER.error("%s", ex)
+                raise ex
+
+        if not attachments_as_bytes:
+            return None
+
+        return attachments_as_bytes

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4698,6 +4698,12 @@
       "config_flow": false,
       "iot_class": "cloud_push"
     },
+    "signal_messenger_jsonrpc": {
+      "name": "Signal Messenger (JSONRPC)",
+      "integration_type": "hub",
+      "config_flow": false,
+      "iot_class": "cloud_push"
+    },
     "simplepush": {
       "name": "Simplepush",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1900,6 +1900,9 @@ pysher==1.0.7
 # homeassistant.components.sia
 pysiaalarm==3.0.2
 
+# homeassistant.components.signal_messenger_jsonrpc
+pysignalclijsonrpc==22.11.6
+
 # homeassistant.components.signal_messenger
 pysignalclirestapi==0.3.18
 


### PR DESCRIPTION
Signed-off-by: morph027 <stefan.heitmueller@gmx.com>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

[signal-cli 0.11.5](https://github.com/AsamK/signal-cli/blob/master/CHANGELOG.md#0115---2022-11-07) introduced a native http endpoint for JSON-RPC. Therefore, there's no longer the need to use any of the wrappers like https://github.com/bbernhard/signal-cli-rest-api/ or https://gitlab.com/morph027/python-signal-cli-rest-api/.

I've already created a drop-in replacement lib in https://gitlab.com/morph027/pysignalclijsonrpc.

This PR adds a new additional component `signal_messenger_jsonrpc` for this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: **WIP**

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (https://github.com/home-assistant/home-assistant.io/pull/24869)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
