### PR TITLE
Fix ZHA configuration APIs

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1090,11 +1090,17 @@ async def websocket_update_zha_configuration(
             ):
                 data_to_save[CUSTOM_CONFIGURATION][section].pop(entry)
             # remove entire section block if empty
-            if not data_to_save[CUSTOM_CONFIGURATION][section]:
+            if (
+                not data_to_save[CUSTOM_CONFIGURATION].get(section)
+                and section in data_to_save[CUSTOM_CONFIGURATION]
+            ):
                 data_to_save[CUSTOM_CONFIGURATION].pop(section)
 
     # remove entire custom_configuration block if empty
-    if not data_to_save[CUSTOM_CONFIGURATION]:
+    if (
+        not data_to_save.get(CUSTOM_CONFIGURATION)
+        and CUSTOM_CONFIGURATION in data_to_save
+    ):
         data_to_save.pop(CUSTOM_CONFIGURATION)
 
     _LOGGER.info(

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -221,11 +221,13 @@ def async_get_zha_config_value(
     )
 
 
-def async_cluster_exists(hass, cluster_id):
+def async_cluster_exists(hass, cluster_id, skip_coordinator=True):
     """Determine if a device containing the specified in cluster is paired."""
     zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     zha_devices = zha_gateway.devices.values()
     for zha_device in zha_devices:
+        if skip_coordinator and zha_device.is_coordinator:
+            continue
         clusters_by_endpoint = zha_device.async_get_clusters()
         for clusters in clusters_by_endpoint.values():
             if (

--- a/tests/components/zha/data.py
+++ b/tests/components/zha/data.py
@@ -1,0 +1,153 @@
+"""Test data for ZHA API tests."""
+
+BASE_CUSTOM_CONFIGURATION = {
+    "schemas": {
+        "zha_options": [
+            {
+                "type": "integer",
+                "valueMin": 0,
+                "name": "default_light_transition",
+                "optional": True,
+                "default": 0,
+            },
+            {
+                "type": "boolean",
+                "name": "enhanced_light_transition",
+                "required": True,
+                "default": False,
+            },
+            {
+                "type": "boolean",
+                "name": "light_transitioning_flag",
+                "required": True,
+                "default": True,
+            },
+            {
+                "type": "boolean",
+                "name": "always_prefer_xy_color_mode",
+                "required": True,
+                "default": True,
+            },
+            {
+                "type": "boolean",
+                "name": "enable_identify_on_join",
+                "required": True,
+                "default": True,
+            },
+            {
+                "type": "integer",
+                "valueMin": 0,
+                "name": "consider_unavailable_mains",
+                "optional": True,
+                "default": 7200,
+            },
+            {
+                "type": "integer",
+                "valueMin": 0,
+                "name": "consider_unavailable_battery",
+                "optional": True,
+                "default": 21600,
+            },
+        ]
+    },
+    "data": {
+        "zha_options": {
+            "enhanced_light_transition": True,
+            "default_light_transition": 0,
+            "light_transitioning_flag": True,
+            "always_prefer_xy_color_mode": True,
+            "enable_identify_on_join": True,
+            "consider_unavailable_mains": 7200,
+            "consider_unavailable_battery": 21600,
+        }
+    },
+}
+
+CONFIG_WITH_ALARM_OPTIONS = {
+    "schemas": {
+        "zha_options": [
+            {
+                "type": "integer",
+                "valueMin": 0,
+                "name": "default_light_transition",
+                "optional": True,
+                "default": 0,
+            },
+            {
+                "type": "boolean",
+                "name": "enhanced_light_transition",
+                "required": True,
+                "default": False,
+            },
+            {
+                "type": "boolean",
+                "name": "light_transitioning_flag",
+                "required": True,
+                "default": True,
+            },
+            {
+                "type": "boolean",
+                "name": "always_prefer_xy_color_mode",
+                "required": True,
+                "default": True,
+            },
+            {
+                "type": "boolean",
+                "name": "enable_identify_on_join",
+                "required": True,
+                "default": True,
+            },
+            {
+                "type": "integer",
+                "valueMin": 0,
+                "name": "consider_unavailable_mains",
+                "optional": True,
+                "default": 7200,
+            },
+            {
+                "type": "integer",
+                "valueMin": 0,
+                "name": "consider_unavailable_battery",
+                "optional": True,
+                "default": 21600,
+            },
+        ],
+        "zha_alarm_options": [
+            {
+                "type": "string",
+                "name": "alarm_master_code",
+                "required": True,
+                "default": "1234",
+            },
+            {
+                "type": "integer",
+                "valueMin": 0,
+                "name": "alarm_failed_tries",
+                "required": True,
+                "default": 3,
+            },
+            {
+                "type": "boolean",
+                "name": "alarm_arm_requires_code",
+                "required": True,
+                "default": False,
+            },
+        ],
+    },
+    "data": {
+        "zha_options": {
+            "enhanced_light_transition": True,
+            "default_light_transition": 0,
+            "light_transitioning_flag": True,
+            "always_prefer_xy_color_mode": True,
+            "enable_identify_on_join": True,
+            "consider_unavailable_mains": 7200,
+            "consider_unavailable_battery": 21600,
+        },
+        "zha_alarm_options": {
+            "alarm_arm_requires_code": False,
+            "alarm_master_code": "4321",
+            "alarm_failed_tries": 2,
+        },
+    },
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR corrects 2 issues in the ZHA configuration APIs. 1 returned alarm control panel options when it shouldn't have and the other prevented saving the configuration. The PR also adds tests for each API.

Fixes: #81862

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81862
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
