### PR TITLE
Allow is_state to accept a list of values

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1361,10 +1361,12 @@ def distance(hass, *args):
     )
 
 
-def is_state(hass: HomeAssistant, entity_id: str, state: State) -> bool:
+def is_state(hass: HomeAssistant, entity_id: str, state: State | list[State]) -> bool:
     """Test if a state is a specific value."""
     state_obj = _get_state(hass, entity_id)
-    return state_obj is not None and state_obj.state == state
+    return state_obj is not None and (
+        isinstance(state, list) and state_obj.state in state or state_obj.state == state
+    )
 
 
 def is_state_attr(hass: HomeAssistant, entity_id: str, name: str, value: Any) -> bool:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1361,7 +1361,7 @@ def distance(hass, *args):
     )
 
 
-def is_state(hass: HomeAssistant, entity_id: str, state: State | list[State]) -> bool:
+def is_state(hass: HomeAssistant, entity_id: str, state: str | list[str]) -> bool:
     """Test if a state is a specific value."""
     state_obj = _get_state(hass, entity_id)
     return state_obj is not None and (

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1365,7 +1365,7 @@ def is_state(hass: HomeAssistant, entity_id: str, state: State | list[State]) ->
     """Test if a state is a specific value."""
     state_obj = _get_state(hass, entity_id)
     return state_obj is not None and (
-        isinstance(state, list) and state_obj.state in state or state_obj.state == state
+        state_obj.state == state or isinstance(state, list) and state_obj.state in state
     )
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1364,6 +1364,14 @@ def test_is_state(hass):
     )
     assert tpl.async_render() == "test.object"
 
+    tpl = template.Template(
+        """
+{{ is_state("test.object", ["on", "off", "available"]) }}
+        """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
 
 def test_is_state_attr(hass):
     """Test is_state_attr method."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

If `is_state` is passed a list of values it returns `true` if the state of the entity is in the list. Essentially this:
```
{{ states('binary_sensor.test') is in ['on', 'off'] }}
```
would become this after this PR:
```
{{ is_state('binary_sensor.test', ['on', 'off']) }}
```
Also this really helps with `expand` use cases as this:
```
{{ expand(my_list_of_entities) | selectattr('state', 'in', ['on', 'off'])
    | map(attribute='entity_id') | list }}
```
becomes this:
```
{{ my_list_of_entities | select('is_state', ['on', 'off']) | list }}
```

This is not a breaking change because a state cannot be a list. That's also why `is_state_attr` is not modified in the same way because an attribute can be a list.

Came up because I was auditing my templates after #79473 and realized now `expand` is really only needed in two cases:
1. When using `last_updated`, `last_changed` or `context`
2. When you want to `select` or `reject` based on the state or an attribute and the comparator is not equals (`in`, `gt`, `lt`, etc.)

This small change further whittled down the need for complex templates with `expand` as it means `in` comparisons based on state can be done without it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25031

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
