### PR TITLE
Add `async_get_active_reauth_flows` helper for config entries

### DIFF
--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 from pyopenuv.errors import InvalidApiKeyError, OpenUvError
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.debounce import Debouncer
@@ -56,7 +56,10 @@ class ReauthFlowManager:
     @callback
     def _get_active_reauth_flow(self) -> FlowResult | None:
         """Get an active reauth flow (if it exists)."""
-        return next(iter(self.entry.async_get_active_reauth_flows(self.hass)), None)
+        return next(
+            iter(self.entry.async_get_active_flows(self.hass, {SOURCE_REAUTH})),
+            None,
+        )
 
     @callback
     def cancel_reauth(self) -> None:

--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -56,9 +56,7 @@ class ReauthFlowManager:
     @callback
     def _get_active_reauth_flow(self) -> FlowResult | None:
         """Get an active reauth flow (if it exists)."""
-        for flow in self.entry.async_get_active_reauth_flows(self.hass):
-            return flow
-        return None
+        return next(iter(self.entry.async_get_active_reauth_flows(self.hass)), None)
 
     @callback
     def cancel_reauth(self) -> None:

--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -13,7 +13,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, LOGGER
+from .const import LOGGER
 
 DEFAULT_DEBOUNCER_COOLDOWN_SECONDS = 15 * 60
 
@@ -56,19 +56,9 @@ class ReauthFlowManager:
     @callback
     def _get_active_reauth_flow(self) -> FlowResult | None:
         """Get an active reauth flow (if it exists)."""
-        try:
-            [reauth_flow] = [
-                flow
-                for flow in self.hass.config_entries.flow.async_progress_by_handler(
-                    DOMAIN
-                )
-                if flow["context"]["source"] == "reauth"
-                and flow["context"]["entry_id"] == self.entry.entry_id
-            ]
-        except ValueError:
-            return None
-
-        return reauth_flow
+        for flow in self.entry.async_get_active_reauth_flows(self.hass):
+            return flow
+        return None
 
     @callback
     def cancel_reauth(self) -> None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -663,7 +663,7 @@ class ConfigEntry:
         data: dict[str, Any] | None = None,
     ) -> None:
         """Start a reauth flow."""
-        if any(self.async_get_active_reauth_flows(hass)):
+        if any(self.async_get_active_flows(hass, {SOURCE_REAUTH})):
             # Reauth flow already in progress for this entry
             return
 
@@ -682,14 +682,14 @@ class ConfigEntry:
         )
 
     @callback
-    def async_get_active_reauth_flows(
-        self, hass: HomeAssistant
+    def async_get_active_flows(
+        self, hass: HomeAssistant, sources: set[str]
     ) -> Generator[FlowResult, None, None]:
-        """Get any active reauth flows for this entry."""
+        """Get any active flows of certain sources for this entry."""
         return (
             flow
             for flow in hass.config_entries.flow.async_progress_by_handler(self.domain)
-            if flow["context"].get("source") == SOURCE_REAUTH
+            if flow["context"].get("source") in sources
             and flow["context"].get("entry_id") == self.entry_id
         )
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import ChainMap
-from collections.abc import Callable, Coroutine, Iterable, Mapping
+from collections.abc import Callable, Coroutine, Generator, Iterable, Mapping
 from contextvars import ContextVar
 from enum import Enum
 import functools
@@ -19,6 +19,7 @@ from .backports.enum import StrEnum
 from .components import persistent_notification
 from .const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP, Platform
 from .core import CALLBACK_TYPE, CoreState, Event, HomeAssistant, callback
+from .data_entry_flow import FlowResult
 from .exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady, HomeAssistantError
 from .helpers import device_registry, entity_registry, storage
 from .helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
@@ -662,12 +663,7 @@ class ConfigEntry:
         data: dict[str, Any] | None = None,
     ) -> None:
         """Start a reauth flow."""
-        if any(
-            flow
-            for flow in hass.config_entries.flow.async_progress_by_handler(self.domain)
-            if flow["context"].get("source") == SOURCE_REAUTH
-            and flow["context"].get("entry_id") == self.entry_id
-        ):
+        if any(self.async_get_active_reauth_flows(hass)):
             # Reauth flow already in progress for this entry
             return
 
@@ -683,6 +679,18 @@ class ConfigEntry:
                 | (context or {}),
                 data=self.data | (data or {}),
             )
+        )
+
+    @callback
+    def async_get_active_reauth_flows(
+        self, hass: HomeAssistant
+    ) -> Generator[FlowResult, None, None]:
+        """Get any active reauth flows for this entry."""
+        return (
+            flow
+            for flow in hass.config_entries.flow.async_progress_by_handler(self.domain)
+            if flow["context"].get("source") == SOURCE_REAUTH
+            and flow["context"].get("entry_id") == self.entry_id
         )
 
     @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
[Per recommendation from @bdraco](https://github.com/home-assistant/core/pull/79691/files#r1016109416), this PR adds a new helper to get all active reauth flows for a config entry. Per his suggestion, the PR includes two spots (including an integration of mine) in which this logic was being duplicated.

Existing tests should cover this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
