### PR TITLE
Revert google calendar back to old API for free/busy readers

### DIFF
--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -198,7 +198,7 @@ async def async_setup_entry(
                         entity_entry.entity_id,
                     )
             coordinator: CalendarSyncUpdateCoordinator | CalendarQueryUpdateCoordinator
-            # Prefer calendar sync down of resources when possible. However, sync does not
+            # Prefer calendar sync down of resources when possible. However, sync does not work
             # for search. Also free-busy calendars denormalize recurring events as individual
             # events which is not efficient for sync
             if (

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -47,7 +47,6 @@ TEST_API_CALENDAR = {
     "id": CALENDAR_ID,
     "etag": '"3584134138943410"',
     "timeZone": "UTC",
-    "accessRole": "reader",
     "foregroundColor": "#000000",
     "selected": True,
     "kind": "calendar#calendarListEntry",
@@ -62,10 +61,19 @@ CLIENT_ID = "client-id"
 CLIENT_SECRET = "client-secret"
 
 
+@pytest.fixture(name="calendar_access_role")
+def test_calendar_access_role() -> str:
+    """Default access role to use for test_api_calendar in tests."""
+    return "reader"
+
+
 @pytest.fixture
-def test_api_calendar():
+def test_api_calendar(calendar_access_role: str):
     """Return a test calendar object used in API responses."""
-    return TEST_API_CALENDAR
+    return {
+        **TEST_API_CALENDAR,
+        "accessRole": calendar_access_role,
+    }
 
 
 @pytest.fixture

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -60,6 +60,14 @@ TEST_EVENT = {
 }
 
 
+@pytest.fixture(
+    autouse=True, scope="module", params=["reader", "owner", "freeBusyReader"]
+)
+def calendar_access_role(request) -> str:
+    """Fixture to exercise access roles in tests."""
+    return request.param
+
+
 @pytest.fixture(autouse=True)
 def mock_test_setup(
     test_api_calendar,
@@ -720,12 +728,15 @@ async def test_invalid_unique_id_cleanup(
 
 
 @pytest.mark.parametrize(
-    "time_zone,event_order",
+    "time_zone,event_order,calendar_access_role",
+    # This only tests the reader role to force testing against the local
+    # database filtering based on start/end time. (free busy reader would
+    # just use the API response which this test is not exercising)
     [
-        ("America/Los_Angeles", ["One", "Two", "All Day Event"]),
-        ("America/Regina", ["One", "Two", "All Day Event"]),
-        ("UTC", ["One", "All Day Event", "Two"]),
-        ("Asia/Tokyo", ["All Day Event", "One", "Two"]),
+        ("America/Los_Angeles", ["One", "Two", "All Day Event"], "reader"),
+        ("America/Regina", ["One", "Two", "All Day Event"], "reader"),
+        ("UTC", ["One", "All Day Event", "Two"], "reader"),
+        ("Asia/Tokyo", ["All Day Event", "One", "Two"], "reader"),
     ],
 )
 async def test_all_day_iter_order(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Revert google calendar back to old API when a calendar is only exposed free/busy readers. When using the new sync API, free/busy readers are exposed as denormalized single events rather than a single event with a recurrence rule. As a result, sync pulls down too much data in the future -- so we'll just go back to the old behavior and not get the performance wins for free/busy.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81721
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
