### PR TITLE
Deduplicate `sensor_device_info_to_device_info`

### DIFF
--- a/homeassistant/components/bluemaestro/device.py
+++ b/homeassistant/components/bluemaestro/device.py
@@ -1,13 +1,11 @@
 """Support for BlueMaestro devices."""
 from __future__ import annotations
 
-from bluemaestro_ble import DeviceKey, SensorDeviceInfo
+from bluemaestro_ble import DeviceKey
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothEntityKey,
 )
-from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
-from homeassistant.helpers.entity import DeviceInfo
 
 
 def device_key_to_bluetooth_entity_key(
@@ -15,17 +13,3 @@ def device_key_to_bluetooth_entity_key(
 ) -> PassiveBluetoothEntityKey:
     """Convert a device key to an entity key."""
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
-
-
-def sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a bluemaestro device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info

--- a/homeassistant/components/bluemaestro/sensor.py
+++ b/homeassistant/components/bluemaestro/sensor.py
@@ -31,9 +31,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 SENSOR_DESCRIPTIONS = {
     (BlueMaestroSensorDeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
@@ -96,7 +97,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -22,9 +22,10 @@ from homeassistant.components.bluetooth.passive_update_processor import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 BINARY_SENSOR_DESCRIPTIONS = {
     BTHomeBinarySensorDeviceClass.BATTERY: BinarySensorEntityDescription(
@@ -147,7 +148,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a binary sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/bthome/device.py
+++ b/homeassistant/components/bthome/device.py
@@ -1,13 +1,11 @@
 """Support for BTHome Bluetooth devices."""
 from __future__ import annotations
 
-from bthome_ble import DeviceKey, SensorDeviceInfo
+from bthome_ble import DeviceKey
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothEntityKey,
 )
-from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
-from homeassistant.helpers.entity import DeviceInfo
 
 
 def device_key_to_bluetooth_entity_key(
@@ -15,17 +13,3 @@ def device_key_to_bluetooth_entity_key(
 ) -> PassiveBluetoothEntityKey:
     """Convert a device key to an entity key."""
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
-
-
-def sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info

--- a/homeassistant/components/bthome/sensor.py
+++ b/homeassistant/components/bthome/sensor.py
@@ -39,9 +39,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 SENSOR_DESCRIPTIONS = {
     (BTHomeSensorDeviceClass.TEMPERATURE, Units.TEMP_CELSIUS): SensorEntityDescription(
@@ -243,7 +244,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/govee_ble/sensor.py
+++ b/homeassistant/components/govee_ble/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from govee_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
+from govee_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -20,16 +20,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NAME,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
 
@@ -72,27 +69,13 @@ def _device_key_to_bluetooth_entity_key(
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
 
 
-def _sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to hass device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info
-
-
 def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
 ) -> PassiveBluetoothDataUpdate:
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: _sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/inkbird/sensor.py
+++ b/homeassistant/components/inkbird/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from inkbird_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
+from inkbird_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -20,16 +20,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NAME,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
 
@@ -72,27 +69,13 @@ def _device_key_to_bluetooth_entity_key(
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
 
 
-def _sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info
-
-
 def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
 ) -> PassiveBluetoothDataUpdate:
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: _sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/kegtron/device.py
+++ b/homeassistant/components/kegtron/device.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 
 import logging
 
-from kegtron_ble import DeviceKey, SensorDeviceInfo
+from kegtron_ble import DeviceKey
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothEntityKey,
 )
-from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
-from homeassistant.helpers.entity import DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,17 +17,3 @@ def device_key_to_bluetooth_entity_key(
 ) -> PassiveBluetoothEntityKey:
     """Convert a device key to an entity key."""
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
-
-
-def sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info

--- a/homeassistant/components/kegtron/sensor.py
+++ b/homeassistant/components/kegtron/sensor.py
@@ -26,9 +26,10 @@ from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT, VOLUME_LITER
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 SENSOR_DESCRIPTIONS = {
     KegtronSensorDeviceClass.PORT_COUNT: SensorEntityDescription(
@@ -85,7 +86,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/moat/sensor.py
+++ b/homeassistant/components/moat/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from moat_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
+from moat_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -20,17 +20,14 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NAME,
     ELECTRIC_POTENTIAL_VOLT,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
 
@@ -79,27 +76,13 @@ def _device_key_to_bluetooth_entity_key(
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
 
 
-def _sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to hass device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info
-
-
 def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
 ) -> PassiveBluetoothDataUpdate:
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: _sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/oralb/device.py
+++ b/homeassistant/components/oralb/device.py
@@ -1,13 +1,11 @@
 """Support for OralB devices."""
 from __future__ import annotations
 
-from oralb_ble import DeviceKey, SensorDeviceInfo
+from oralb_ble import DeviceKey
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothEntityKey,
 )
-from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
-from homeassistant.helpers.entity import DeviceInfo
 
 
 def device_key_to_bluetooth_entity_key(
@@ -15,17 +13,3 @@ def device_key_to_bluetooth_entity_key(
 ) -> PassiveBluetoothEntityKey:
     """Convert a device key to an entity key."""
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
-
-
-def sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a oralb device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info

--- a/homeassistant/components/oralb/sensor.py
+++ b/homeassistant/components/oralb/sensor.py
@@ -22,9 +22,10 @@ from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT, TIME_SECONDS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     OralBSensor.TIME: SensorEntityDescription(
@@ -67,7 +68,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/qingping/binary_sensor.py
+++ b/homeassistant/components/qingping/binary_sensor.py
@@ -22,9 +22,10 @@ from homeassistant.components.bluetooth.passive_update_processor import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 BINARY_SENSOR_DESCRIPTIONS = {
     QingpingBinarySensorDeviceClass.MOTION: BinarySensorEntityDescription(
@@ -52,7 +53,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/qingping/device.py
+++ b/homeassistant/components/qingping/device.py
@@ -1,13 +1,11 @@
 """Support for Qingping devices."""
 from __future__ import annotations
 
-from qingping_ble import DeviceKey, SensorDeviceInfo
+from qingping_ble import DeviceKey
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothEntityKey,
 )
-from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
-from homeassistant.helpers.entity import DeviceInfo
 
 
 def device_key_to_bluetooth_entity_key(
@@ -15,17 +13,3 @@ def device_key_to_bluetooth_entity_key(
 ) -> PassiveBluetoothEntityKey:
     """Convert a device key to an entity key."""
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
-
-
-def sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a qingping device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info

--- a/homeassistant/components/qingping/sensor.py
+++ b/homeassistant/components/qingping/sensor.py
@@ -34,9 +34,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 SENSOR_DESCRIPTIONS = {
     (QingpingSensorDeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
@@ -120,7 +121,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/ruuvitag_ble/sensor.py
+++ b/homeassistant/components/ruuvitag_ble/sensor.py
@@ -7,7 +7,6 @@ from sensor_state_data import (
     DeviceKey,
     SensorDescription,
     SensorDeviceClass,
-    SensorDeviceInfo,
     SensorUpdate,
     Units,
 )
@@ -26,8 +25,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
 
@@ -85,20 +84,6 @@ def _device_key_to_bluetooth_entity_key(
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
 
 
-def _sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to a sensor device info."""
-    hass_device_info = DeviceInfo()
-    if sensor_device_info.name is not None:
-        hass_device_info[const.ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[const.ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[const.ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info
-
-
 def _to_sensor_key(
     description: SensorDescription,
 ) -> tuple[SensorDeviceClass, Units | None]:
@@ -112,7 +97,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: _sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/sensorpro/device.py
+++ b/homeassistant/components/sensorpro/device.py
@@ -1,13 +1,11 @@
 """Support for SensorPro devices."""
 from __future__ import annotations
 
-from sensorpro_ble import DeviceKey, SensorDeviceInfo
+from sensorpro_ble import DeviceKey
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothEntityKey,
 )
-from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
-from homeassistant.helpers.entity import DeviceInfo
 
 
 def device_key_to_bluetooth_entity_key(
@@ -15,17 +13,3 @@ def device_key_to_bluetooth_entity_key(
 ) -> PassiveBluetoothEntityKey:
     """Convert a device key to an entity key."""
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
-
-
-def sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensorpro device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info

--- a/homeassistant/components/sensorpro/sensor.py
+++ b/homeassistant/components/sensorpro/sensor.py
@@ -31,9 +31,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 SENSOR_DESCRIPTIONS = {
     (SensorProSensorDeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
@@ -87,7 +88,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/sensorpush/sensor.py
+++ b/homeassistant/components/sensorpush/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from sensorpush_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
+from sensorpush_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -20,17 +20,14 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NAME,
     PERCENTAGE,
     PRESSURE_MBAR,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
 
@@ -73,27 +70,13 @@ def _device_key_to_bluetooth_entity_key(
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
 
 
-def _sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info
-
-
 def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
 ) -> PassiveBluetoothDataUpdate:
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: _sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/thermobeacon/device.py
+++ b/homeassistant/components/thermobeacon/device.py
@@ -1,13 +1,11 @@
 """Support for ThermoBeacon devices."""
 from __future__ import annotations
 
-from thermobeacon_ble import DeviceKey, SensorDeviceInfo
+from thermobeacon_ble import DeviceKey
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothEntityKey,
 )
-from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
-from homeassistant.helpers.entity import DeviceInfo
 
 
 def device_key_to_bluetooth_entity_key(
@@ -15,17 +13,3 @@ def device_key_to_bluetooth_entity_key(
 ) -> PassiveBluetoothEntityKey:
     """Convert a device key to an entity key."""
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
-
-
-def sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a thermobeacon device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info

--- a/homeassistant/components/thermobeacon/sensor.py
+++ b/homeassistant/components/thermobeacon/sensor.py
@@ -31,9 +31,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 SENSOR_DESCRIPTIONS = {
     (ThermoBeaconSensorDeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
@@ -87,7 +88,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/thermopro/sensor.py
+++ b/homeassistant/components/thermopro/sensor.py
@@ -6,7 +6,6 @@ from typing import Optional, Union
 from thermopro_ble import (
     DeviceKey,
     SensorDeviceClass as ThermoProSensorDeviceClass,
-    SensorDeviceInfo,
     SensorUpdate,
     Units,
 )
@@ -26,16 +25,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NAME,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
 
@@ -75,27 +71,13 @@ def _device_key_to_bluetooth_entity_key(
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
 
 
-def _sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info
-
-
 def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
 ) -> PassiveBluetoothDataUpdate:
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: _sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/tilt_ble/sensor.py
+++ b/homeassistant/components/tilt_ble/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from tilt_ble import DeviceClass, DeviceKey, SensorDeviceInfo, SensorUpdate, Units
+from tilt_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -19,16 +19,10 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import (
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NAME,
-    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    TEMP_FAHRENHEIT,
-)
+from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
 
@@ -63,27 +57,13 @@ def _device_key_to_bluetooth_entity_key(
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
 
 
-def _sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info
-
-
 def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
 ) -> PassiveBluetoothDataUpdate:
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: _sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/xiaomi_ble/binary_sensor.py
+++ b/homeassistant/components/xiaomi_ble/binary_sensor.py
@@ -22,9 +22,10 @@ from homeassistant.components.bluetooth.passive_update_processor import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 BINARY_SENSOR_DESCRIPTIONS = {
     XiaomiBinarySensorDeviceClass.MOTION: BinarySensorEntityDescription(
@@ -51,7 +52,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/components/xiaomi_ble/device.py
+++ b/homeassistant/components/xiaomi_ble/device.py
@@ -1,13 +1,11 @@
 """Support for Xioami BLE devices."""
 from __future__ import annotations
 
-from xiaomi_ble import DeviceKey, SensorDeviceInfo
+from xiaomi_ble import DeviceKey
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothEntityKey,
 )
-from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
-from homeassistant.helpers.entity import DeviceInfo
 
 
 def device_key_to_bluetooth_entity_key(
@@ -15,17 +13,3 @@ def device_key_to_bluetooth_entity_key(
 ) -> PassiveBluetoothEntityKey:
     """Convert a device key to an entity key."""
     return PassiveBluetoothEntityKey(device_key.key, device_key.device_id)
-
-
-def sensor_device_info_to_hass(
-    sensor_device_info: SensorDeviceInfo,
-) -> DeviceInfo:
-    """Convert a sensor device info to a sensor device info."""
-    hass_device_info = DeviceInfo({})
-    if sensor_device_info.name is not None:
-        hass_device_info[ATTR_NAME] = sensor_device_info.name
-    if sensor_device_info.manufacturer is not None:
-        hass_device_info[ATTR_MANUFACTURER] = sensor_device_info.manufacturer
-    if sensor_device_info.model is not None:
-        hass_device_info[ATTR_MODEL] = sensor_device_info.model
-    return hass_device_info

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -31,9 +31,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
-from .device import device_key_to_bluetooth_entity_key, sensor_device_info_to_hass
+from .device import device_key_to_bluetooth_entity_key
 
 SENSOR_DESCRIPTIONS = {
     (DeviceClass.TEMPERATURE, Units.TEMP_CELSIUS): SensorEntityDescription(
@@ -114,7 +115,7 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
-            device_id: sensor_device_info_to_hass(device_info)
+            device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={

--- a/homeassistant/helpers/sensor.py
+++ b/homeassistant/helpers/sensor.py
@@ -1,0 +1,28 @@
+"""Common functions related to Bluetooth device management."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant import const
+
+from .entity import DeviceInfo
+
+if TYPE_CHECKING:
+    # `sensor_state_data` is a second-party library (i.e. maintained by Home Assistant
+    # core members) which is not strictly required by Home Assistant.
+    # Therefore, we import it as a type hint only.
+    from sensor_state_data import SensorDeviceInfo
+
+
+def sensor_device_info_to_hass_device_info(
+    sensor_device_info: SensorDeviceInfo,
+) -> DeviceInfo:
+    """Convert a sensor_state_data sensor device info to a Home Assistant device info."""
+    device_info = DeviceInfo()
+    if sensor_device_info.name is not None:
+        device_info[const.ATTR_NAME] = sensor_device_info.name
+    if sensor_device_info.manufacturer is not None:
+        device_info[const.ATTR_MANUFACTURER] = sensor_device_info.manufacturer
+    if sensor_device_info.model is not None:
+        device_info[const.ATTR_MODEL] = sensor_device_info.model
+    return device_info

--- a/homeassistant/helpers/sensor.py
+++ b/homeassistant/helpers/sensor.py
@@ -1,4 +1,4 @@
-"""Common functions related to Bluetooth device management."""
+"""Common functions related to sensor device management."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING


### PR DESCRIPTION
## Proposed change

This PR de-duplicates the `sensor_device_info_to_device_info` code that had been copy-pasted across various BLE integrations into a new `homeassistant.components.bluetooth.common_device` module.

(If this passes, I would do the same for `device_key_to_bluetooth_entity_key`.)

cc @bdraco 


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
  - No new tests, just refactoring of duplicate code.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
