### PR TITLE
Include config entry id in response to WS API hardware/info

### DIFF
--- a/homeassistant/components/hardkernel/hardware.py
+++ b/homeassistant/components/hardkernel/hardware.py
@@ -27,6 +27,10 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     if not board.startswith("odroid"):
         raise HomeAssistantError
 
+    config_entries = [
+        entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)
+    ]
+
     return [
         HardwareInfo(
             board=BoardInfo(
@@ -35,6 +39,7 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
                 model=board,
                 revision=None,
             ),
+            config_entries=config_entries,
             dongle=None,
             name=BOARD_NAMES.get(board, f"Unknown hardkernel Odroid model '{board}'"),
             url=None,

--- a/homeassistant/components/hardware/models.py
+++ b/homeassistant/components/hardware/models.py
@@ -34,6 +34,7 @@ class HardwareInfo:
 
     name: str | None
     board: BoardInfo | None
+    config_entries: list[str] | None
     dongle: USBInfo | None
     url: str | None
 

--- a/homeassistant/components/homeassistant_sky_connect/hardware.py
+++ b/homeassistant/components/homeassistant_sky_connect/hardware.py
@@ -17,6 +17,7 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     return [
         HardwareInfo(
             board=None,
+            config_entries=[entry.entry_id],
             dongle=USBInfo(
                 vid=entry.data["vid"],
                 pid=entry.data["pid"],

--- a/homeassistant/components/homeassistant_yellow/hardware.py
+++ b/homeassistant/components/homeassistant_yellow/hardware.py
@@ -6,6 +6,8 @@ from homeassistant.components.hassio import get_os_info
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
+from .const import DOMAIN
+
 BOARD_NAME = "Home Assistant Yellow"
 MANUFACTURER = "homeassistant"
 MODEL = "yellow"
@@ -22,6 +24,10 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     if not board == "yellow":
         raise HomeAssistantError
 
+    config_entries = [
+        entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)
+    ]
+
     return [
         HardwareInfo(
             board=BoardInfo(
@@ -30,6 +36,7 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
                 model=MODEL,
                 revision=None,
             ),
+            config_entries=config_entries,
             dongle=None,
             name=BOARD_NAME,
             url=None,

--- a/homeassistant/components/raspberry_pi/hardware.py
+++ b/homeassistant/components/raspberry_pi/hardware.py
@@ -42,6 +42,10 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     if not board.startswith("rpi"):
         raise HomeAssistantError
 
+    config_entries = [
+        entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)
+    ]
+
     return [
         HardwareInfo(
             board=BoardInfo(
@@ -50,6 +54,7 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
                 model=MODELS.get(board),
                 revision=None,
             ),
+            config_entries=config_entries,
             dongle=None,
             name=BOARD_NAMES.get(board, f"Unknown Raspberry Pi model '{board}'"),
             url=None,

--- a/tests/components/hardkernel/test_hardware.py
+++ b/tests/components/hardkernel/test_hardware.py
@@ -48,6 +48,7 @@ async def test_hardware_info(hass: HomeAssistant, hass_ws_client) -> None:
                     "model": "odroid-n2",
                     "revision": None,
                 },
+                "config_entries": [config_entry.entry_id],
                 "dongle": None,
                 "name": "Home Assistant Blue / Hardkernel Odroid-N2",
                 "url": None,

--- a/tests/components/homeassistant_sky_connect/test_hardware.py
+++ b/tests/components/homeassistant_sky_connect/test_hardware.py
@@ -62,6 +62,7 @@ async def test_hardware_info(hass: HomeAssistant, hass_ws_client) -> None:
         "hardware": [
             {
                 "board": None,
+                "config_entries": [config_entry.entry_id],
                 "dongle": {
                     "vid": "bla_vid",
                     "pid": "bla_pid",
@@ -74,6 +75,7 @@ async def test_hardware_info(hass: HomeAssistant, hass_ws_client) -> None:
             },
             {
                 "board": None,
+                "config_entries": [config_entry_2.entry_id],
                 "dongle": {
                     "vid": "bla_vid_2",
                     "pid": "bla_pid_2",

--- a/tests/components/homeassistant_yellow/test_hardware.py
+++ b/tests/components/homeassistant_yellow/test_hardware.py
@@ -48,6 +48,7 @@ async def test_hardware_info(hass: HomeAssistant, hass_ws_client) -> None:
                     "model": "yellow",
                     "revision": None,
                 },
+                "config_entries": [config_entry.entry_id],
                 "dongle": None,
                 "name": "Home Assistant Yellow",
                 "url": None,

--- a/tests/components/raspberry_pi/test_hardware.py
+++ b/tests/components/raspberry_pi/test_hardware.py
@@ -48,6 +48,7 @@ async def test_hardware_info(hass: HomeAssistant, hass_ws_client) -> None:
                     "model": "1",
                     "revision": None,
                 },
+                "config_entries": [config_entry.entry_id],
                 "dongle": None,
                 "name": "Raspberry Pi",
                 "url": None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Include config entry id in response to WS API `hardware/info`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
