### PR TITLE
Allow `device_attr` and `is_device_attr` to be used as a filter and a test (respectively)

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2093,6 +2093,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 
         self.globals["is_device_attr"] = hassfunction(is_device_attr)
         self.filters["is_device_attr"] = pass_context(self.globals["is_device_attr"])
+        self.tests["is_device_attr"] = pass_eval_context(self.globals["is_device_attr"])
 
         self.globals["config_entry_id"] = hassfunction(config_entry_id)
         self.filters["config_entry_id"] = pass_context(self.globals["config_entry_id"])

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -202,6 +202,7 @@ class TupleWrapper(tuple, ResultWrapper):
 
     def __init__(self, value: tuple, *, render_result: str | None = None) -> None:
         """Initialize a new tuple class."""
+        super().__init__()
         self.render_result = render_result
 
     def __str__(self) -> str:
@@ -2088,7 +2089,10 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["device_entities"] = pass_context(self.globals["device_entities"])
 
         self.globals["device_attr"] = hassfunction(device_attr)
+        self.filters["device_attr"] = pass_context(self.globals["device_attr"])
+
         self.globals["is_device_attr"] = hassfunction(is_device_attr)
+        self.filters["is_device_attr"] = pass_context(self.globals["is_device_attr"])
 
         self.globals["config_entry_id"] = hassfunction(config_entry_id)
         self.filters["config_entry_id"] = pass_context(self.globals["config_entry_id"])

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2092,7 +2092,6 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["device_attr"] = pass_context(self.globals["device_attr"])
 
         self.globals["is_device_attr"] = hassfunction(is_device_attr)
-        self.filters["is_device_attr"] = pass_context(self.globals["is_device_attr"])
         self.tests["is_device_attr"] = pass_eval_context(self.globals["is_device_attr"])
 
         self.globals["config_entry_id"] = hassfunction(config_entry_id)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -202,7 +202,6 @@ class TupleWrapper(tuple, ResultWrapper):
 
     def __init__(self, value: tuple, *, render_result: str | None = None) -> None:
         """Initialize a new tuple class."""
-        super().__init__()
         self.render_result = render_result
 
     def __str__(self) -> str:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -2713,6 +2713,20 @@ async def test_device_attr(hass):
     assert_result_info(info, True)
     assert info.rate_limit is None
 
+    # Test filter syntax (device_attr)
+    info = render_to_info(
+        hass, f"{{{{ '{entity_entry.entity_id}' | device_attr('model') }}}}"
+    )
+    assert_result_info(info, "test")
+    assert info.rate_limit is None
+
+    # Test filter syntax (is_device_attr)
+    info = render_to_info(
+        hass, f"{{{{ '{device_entry.id}' | is_device_attr('model', 'test') }}}}"
+    )
+    assert_result_info(info, True)
+    assert info.rate_limit is None
+
 
 async def test_area_id(hass):
     """Test area_id function."""

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -2727,6 +2727,14 @@ async def test_device_attr(hass):
     assert_result_info(info, True)
     assert info.rate_limit is None
 
+    # Test test syntax (is_device_attr)
+    info = render_to_info(
+        hass,
+        f"{{{{ ['{device_entry.id}'] | select('is_device_attr', 'model', 'test') | list }}}}",
+    )
+    assert_result_info(info, [device_entry.id])
+    assert info.rate_limit is None
+
 
 async def test_area_id(hass):
     """Test area_id function."""

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -2720,13 +2720,6 @@ async def test_device_attr(hass):
     assert_result_info(info, "test")
     assert info.rate_limit is None
 
-    # Test filter syntax (is_device_attr)
-    info = render_to_info(
-        hass, f"{{{{ '{device_entry.id}' | is_device_attr('model', 'test') }}}}"
-    )
-    assert_result_info(info, True)
-    assert info.rate_limit is None
-
     # Test test syntax (is_device_attr)
     info = render_to_info(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`device_attr` and `is_device_attr` are currently not available as filter/test templates. This PR allows `device_attr` to be used as a filter and `is_device_attr` as a test, e.g.

```
{{ list_of_device_ids | map("device_attr", "name_by_user") }}
```

```
{{ list_of_device_ids | select("is_device_attr", "manufacturer", "Acme") }}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25036

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
