### PR TITLE
Fix bluetooth adapters with missing firmware patch files not being discovered

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from asyncio import Future
 from collections.abc import Callable, Iterable
+import datetime
 import logging
 import platform
 from typing import TYPE_CHECKING, cast
@@ -21,6 +22,7 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback as hass_ca
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, discovery_flow
 from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_create_issue,
@@ -33,6 +35,7 @@ from .const import (
     ADAPTER_ADDRESS,
     ADAPTER_HW_VERSION,
     ADAPTER_SW_VERSION,
+    BLUETOOTH_DISCOVERY_COOLDOWN_SECONDS,
     CONF_ADAPTER,
     CONF_DETAILS,
     CONF_PASSIVE,
@@ -40,6 +43,7 @@ from .const import (
     DEFAULT_ADDRESS,
     DOMAIN,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
+    LINUX_FIRMWARE_LOAD_FALLBACK_SECONDS,
     SOURCE_LOCAL,
     AdapterDetails,
 )
@@ -298,8 +302,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await async_discover_adapters(hass, discovered_adapters)
 
     discovery_debouncer = Debouncer(
-        hass, _LOGGER, cooldown=5, immediate=False, function=_async_rediscover_adapters
+        hass,
+        _LOGGER,
+        cooldown=BLUETOOTH_DISCOVERY_COOLDOWN_SECONDS,
+        immediate=False,
+        function=_async_rediscover_adapters,
     )
+
+    async def _async_call_debouncer(now: datetime.datetime) -> None:
+        """Call the debouncer at a later time."""
+        await discovery_debouncer.async_call()
 
     def _async_trigger_discovery() -> None:
         # There are so many bluetooth adapter models that
@@ -310,6 +322,17 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         # present.
         _LOGGER.debug("Triggering bluetooth usb discovery")
         hass.async_create_task(discovery_debouncer.async_call())
+        # Because it can take 120s for the firmware loader
+        # fallback to timeout we need to wait that plus
+        # the debounce time to ensure we do not miss the
+        # adapter becoming available to DBus since otherwise
+        # we will never see the new adapter until
+        # Home Assistant is restarted
+        async_call_later(
+            hass,
+            BLUETOOTH_DISCOVERY_COOLDOWN_SECONDS + LINUX_FIRMWARE_LOAD_FALLBACK_SECONDS,
+            _async_call_debouncer,
+        )
 
     cancel = usb.async_register_scan_request_callback(hass, _async_trigger_discovery)
     hass.bus.async_listen_once(

--- a/homeassistant/components/bluetooth/const.py
+++ b/homeassistant/components/bluetooth/const.py
@@ -59,6 +59,15 @@ SCANNER_WATCHDOG_TIMEOUT: Final = 90
 SCANNER_WATCHDOG_INTERVAL: Final = timedelta(seconds=30)
 
 
+# When the linux kernel is configured with
+# CONFIG_FW_LOADER_USER_HELPER_FALLBACK it
+# can take up to 120s before the USB device
+# is available if the firmware files
+# are not present
+LINUX_FIRMWARE_LOAD_FALLBACK_SECONDS = 120
+BLUETOOTH_DISCOVERY_COOLDOWN_SECONDS = 5
+
+
 class AdapterDetails(TypedDict, total=False):
     """Adapter details."""
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


If the linux kernel is configured with CONFIG_FW_LOADER_USER_HELPER_FALLBACK (which is currently set to y for the Odroid n2+ with HAOS) there is a 120s delay registered the USB bluetooth adapter on the bus which prevented discovery of the adapter because it was not there in time between when we get the signal for a new USB device to the time we ask Dbus about which adapters are available

This makes all it possible to discover the broadcom adapters without a restart of core

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24865

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
