### PR TITLE
Unifi use entity description with sensors

### DIFF
--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -3,23 +3,128 @@
 Support for bandwidth sensors of network clients.
 Support for uptime sensors of network clients.
 """
-from datetime import datetime, timedelta
+from __future__ import annotations
 
-from homeassistant.components.sensor import DOMAIN, SensorDeviceClass, SensorEntity
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Generic, TypeVar
+
+import aiounifi
+from aiounifi.interfaces.api_handlers import CallbackType, ItemEvent, UnsubscribeType
+from aiounifi.interfaces.clients import Clients
+from aiounifi.models.client import Client
+
+from homeassistant.components.sensor import (
+    DOMAIN,
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfInformation
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN as UNIFI_DOMAIN
+from .controller import UniFiController
 from .unifi_client import UniFiClient
 
 RX_SENSOR = "rx"
 TX_SENSOR = "tx"
 UPTIME_SENSOR = "uptime"
+
+_DataT = TypeVar("_DataT")
+_HandlerT = TypeVar("_HandlerT")
+_SubscriptionT = Callable[[CallbackType, ItemEvent], UnsubscribeType]
+
+
+@callback
+def async_client_rx_value_fn(controller: UniFiController, client: Client) -> float:
+    """Calculate if all apps are enabled."""
+    if client.mac not in controller.wireless_clients:
+        return client.wired_rx_bytes_r / 1000000
+    return client.rx_bytes_r / 1000000
+
+
+@callback
+def async_client_tx_value_fn(controller: UniFiController, client: Client) -> float:
+    """Calculate if all apps are enabled."""
+    if client.mac not in controller.wireless_clients:
+        return client.wired_tx_bytes_r / 1000000
+    return client.tx_bytes_r / 1000000
+
+
+@callback
+def async_client_device_info_fn(api: aiounifi.Controller, obj_id: str) -> DeviceInfo:
+    """Create device registry entry for client."""
+    client = api.clients[obj_id]
+    return DeviceInfo(
+        connections={(CONNECTION_NETWORK_MAC, obj_id)},
+        default_manufacturer=client.oui,
+        default_name=client.name or client.hostname,
+    )
+
+
+@dataclass
+class UnifiEntityLoader(Generic[_HandlerT, _DataT]):
+    """Validate and load entities from different UniFi handlers."""
+
+    allowed_fn: Callable[[UniFiController, str], bool]
+    api_handler_fn: Callable[[aiounifi.Controller], _HandlerT]
+    available_fn: Callable[[UniFiController, str], bool]
+    device_info_fn: Callable[[aiounifi.Controller, str], DeviceInfo]
+    name_fn: Callable[[_DataT], str | None]
+    object_fn: Callable[[aiounifi.Controller, str], _DataT]
+    supported_fn: Callable[[UniFiController, str], bool | None]
+    unique_id_fn: Callable[[str], str]
+    value_fn: Callable[[UniFiController, _DataT], float]
+
+
+@dataclass
+class UnifiEntityDescription(
+    SensorEntityDescription, UnifiEntityLoader[_HandlerT, _DataT]
+):
+    """Class describing UniFi sensor entity."""
+
+
+ENTITY_DESCRIPTIONS: tuple[UnifiEntityDescription, ...] = (
+    UnifiEntityDescription[Clients, Client](
+        key="Bandwidth sensor RX",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfInformation.MEGABYTES,
+        has_entity_name=True,
+        allowed_fn=lambda controller, _: controller.option_allow_bandwidth_sensors,
+        api_handler_fn=lambda api: api.clients,
+        available_fn=lambda controller, _: controller.available,
+        device_info_fn=async_client_device_info_fn,
+        name_fn=lambda _: "RX",
+        object_fn=lambda api, obj_id: api.clients[obj_id],
+        supported_fn=lambda controller, _: controller.option_allow_bandwidth_sensors,
+        unique_id_fn=lambda obj_id: f"rx-{obj_id}",
+        value_fn=async_client_rx_value_fn,
+    ),
+    UnifiEntityDescription[Clients, Client](
+        key="Bandwidth sensor TX",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfInformation.MEGABYTES,
+        has_entity_name=True,
+        allowed_fn=lambda controller, _: controller.option_allow_bandwidth_sensors,
+        api_handler_fn=lambda api: api.clients,
+        available_fn=lambda controller, _: controller.available,
+        device_info_fn=async_client_device_info_fn,
+        name_fn=lambda _: "TX",
+        object_fn=lambda api, obj_id: api.clients[obj_id],
+        supported_fn=lambda controller, _: controller.option_allow_bandwidth_sensors,
+        unique_id_fn=lambda obj_id: f"tx-{obj_id}",
+        value_fn=async_client_tx_value_fn,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -40,9 +145,6 @@ async def async_setup_entry(
         clients: set = controller.api.clients, devices: set = controller.api.devices
     ) -> None:
         """Update the values of the controller."""
-        if controller.option_allow_bandwidth_sensors:
-            add_bandwidth_entities(controller, async_add_entities, clients)
-
         if controller.option_allow_uptime_sensors:
             add_uptime_entities(controller, async_add_entities, clients)
 
@@ -53,21 +155,34 @@ async def async_setup_entry(
 
     items_added()
 
+    @callback
+    def async_load_entities(description: UnifiEntityDescription) -> None:
+        """Load and subscribe to UniFi devices."""
+        entities: list[SensorEntity] = []
+        api_handler = description.api_handler_fn(controller.api)
 
-@callback
-def add_bandwidth_entities(controller, async_add_entities, clients):
-    """Add new sensor entities from the controller."""
-    sensors = []
+        @callback
+        def async_create_entity(event: ItemEvent, obj_id: str) -> None:
+            """Create UniFi entity."""
+            if not description.allowed_fn(
+                controller, obj_id
+            ) or not description.supported_fn(controller, obj_id):
+                return
 
-    for mac in clients:
-        for sensor_class in (UniFiRxBandwidthSensor, UniFiTxBandwidthSensor):
-            if mac in controller.entities[DOMAIN][sensor_class.TYPE]:
-                continue
+            entity = UnifiSensorEntity(obj_id, controller, description)
+            if event == ItemEvent.ADDED:
+                async_add_entities([entity])
+                return
+            entities.append(entity)
 
-            client = controller.api.clients[mac]
-            sensors.append(sensor_class(client, controller))
+        for obj_id in api_handler:
+            async_create_entity(ItemEvent.CHANGED, obj_id)
+        async_add_entities(entities)
 
-    async_add_entities(sensors)
+        api_handler.subscribe(async_create_entity, ItemEvent.ADDED)
+
+    for description in ENTITY_DESCRIPTIONS:
+        async_load_entities(description)
 
 
 @callback
@@ -83,52 +198,6 @@ def add_uptime_entities(controller, async_add_entities, clients):
         sensors.append(UniFiUpTimeSensor(client, controller))
 
     async_add_entities(sensors)
-
-
-class UniFiBandwidthSensor(UniFiClient, SensorEntity):
-    """UniFi Network bandwidth sensor base class."""
-
-    DOMAIN = DOMAIN
-
-    _attr_device_class = SensorDeviceClass.DATA_SIZE
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_native_unit_of_measurement = UnitOfInformation.MEGABYTES
-
-    @property
-    def name(self) -> str:
-        """Return the name of the client."""
-        return f"{super().name} {self.TYPE.upper()}"
-
-    async def options_updated(self) -> None:
-        """Config entry options are updated, remove entity if option is disabled."""
-        if not self.controller.option_allow_bandwidth_sensors:
-            await self.remove_item({self.client.mac})
-
-
-class UniFiRxBandwidthSensor(UniFiBandwidthSensor):
-    """Receiving bandwidth sensor."""
-
-    TYPE = RX_SENSOR
-
-    @property
-    def native_value(self) -> int:
-        """Return the state of the sensor."""
-        if self._is_wired:
-            return self.client.wired_rx_bytes_r / 1000000
-        return self.client.rx_bytes_r / 1000000
-
-
-class UniFiTxBandwidthSensor(UniFiBandwidthSensor):
-    """Transmitting bandwidth sensor."""
-
-    TYPE = TX_SENSOR
-
-    @property
-    def native_value(self) -> int:
-        """Return the state of the sensor."""
-        if self._is_wired:
-            return self.client.wired_tx_bytes_r / 1000000
-        return self.client.tx_bytes_r / 1000000
 
 
 class UniFiUpTimeSensor(UniFiClient, SensorEntity):
@@ -184,3 +253,99 @@ class UniFiUpTimeSensor(UniFiClient, SensorEntity):
         """Config entry options are updated, remove entity if option is disabled."""
         if not self.controller.option_allow_uptime_sensors:
             await self.remove_item({self.client.mac})
+
+
+class UnifiSensorEntity(SensorEntity):
+    """Base representation of a UniFi switch."""
+
+    entity_description: UnifiEntityDescription
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        obj_id: str,
+        controller: UniFiController,
+        description: UnifiEntityDescription,
+    ) -> None:
+        """Set up UniFi switch entity."""
+        self._obj_id = obj_id
+        self.controller = controller
+        self.entity_description = description
+
+        self._removed = False
+
+        self._attr_available = description.available_fn(controller, obj_id)
+        self._attr_device_info = description.device_info_fn(controller.api, obj_id)
+        self._attr_unique_id = description.unique_id_fn(obj_id)
+
+        obj = description.object_fn(controller.api, obj_id)
+        self._attr_native_value = description.value_fn(controller, obj)
+        self._attr_name = description.name_fn(obj)
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        description = self.entity_description
+        handler = description.api_handler_fn(self.controller.api)
+        self.async_on_remove(
+            handler.subscribe(
+                self.async_signalling_callback,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_reachable,
+                self.async_signal_reachable_callback,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_options_update,
+                self.options_updated,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_remove,
+                self.remove_item,
+            )
+        )
+
+    @callback
+    def async_signalling_callback(self, event: ItemEvent, obj_id: str) -> None:
+        """Update the switch state."""
+        if event == ItemEvent.DELETED and obj_id == self._obj_id:
+            self.hass.async_create_task(self.remove_item({self._obj_id}))
+            return
+
+        description = self.entity_description
+        if not description.supported_fn(self.controller, self._obj_id):
+            self.hass.async_create_task(self.remove_item({self._obj_id}))
+            return
+
+        obj = description.object_fn(self.controller.api, self._obj_id)
+        self._attr_native_value = description.value_fn(self.controller, obj)
+        self._attr_available = description.available_fn(self.controller, self._obj_id)
+        self.async_write_ha_state()
+
+    @callback
+    def async_signal_reachable_callback(self) -> None:
+        """Call when controller connection state change."""
+        self.async_signalling_callback(ItemEvent.ADDED, self._obj_id)
+
+    async def options_updated(self) -> None:
+        """Config entry options are updated, remove entity if option is disabled."""
+        if not self.entity_description.allowed_fn(self.controller, self._obj_id):
+            await self.remove_item({self._obj_id})
+
+    async def remove_item(self, keys: set) -> None:
+        """Remove entity if object ID is part of set."""
+        if self._obj_id not in keys or self._removed:
+            return
+        self._removed = True
+        if self.registry_entry:
+            er.async_get(self.hass).async_remove(self.entity_id)
+        else:
+            await self.async_remove(force_remove=True)

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -11,9 +11,8 @@ from datetime import datetime, timedelta
 from typing import Generic, TypeVar
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
+from aiounifi.interfaces.api_handlers import ItemEvent
 from aiounifi.interfaces.clients import Clients
-from aiounifi.models.api import APIItem
 from aiounifi.models.client import Client
 
 from homeassistant.components.sensor import (
@@ -34,8 +33,8 @@ import homeassistant.util.dt as dt_util
 from .const import DOMAIN as UNIFI_DOMAIN
 from .controller import UniFiController
 
-_DataT = TypeVar("_DataT", bound=APIItem)
-_HandlerT = TypeVar("_HandlerT", bound=APIHandler)
+_DataT = TypeVar("_DataT", bound=Client)
+_HandlerT = TypeVar("_HandlerT", bound=Clients)
 
 
 @callback
@@ -152,7 +151,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors for UniFi Network integration."""
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+    controller: UniFiController = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     @callback
     def async_load_entities(description: UnifiEntityDescription) -> None:
@@ -184,17 +183,17 @@ async def async_setup_entry(
         async_load_entities(description)
 
 
-class UnifiSensorEntity(SensorEntity):
+class UnifiSensorEntity(SensorEntity, Generic[_HandlerT, _DataT]):
     """Base representation of a UniFi switch."""
 
-    entity_description: UnifiEntityDescription
+    entity_description: UnifiEntityDescription[_HandlerT, _DataT]
     _attr_should_poll = False
 
     def __init__(
         self,
         obj_id: str,
         controller: UniFiController,
-        description: UnifiEntityDescription,
+        description: UnifiEntityDescription[_HandlerT, _DataT],
     ) -> None:
         """Set up UniFi switch entity."""
         self._obj_id = obj_id

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -11,8 +11,9 @@ from datetime import datetime, timedelta
 from typing import Generic, TypeVar
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import CallbackType, ItemEvent, UnsubscribeType
+from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
 from aiounifi.interfaces.clients import Clients
+from aiounifi.models.api import APIItem
 from aiounifi.models.client import Client
 
 from homeassistant.components.sensor import (
@@ -33,9 +34,8 @@ import homeassistant.util.dt as dt_util
 from .const import DOMAIN as UNIFI_DOMAIN
 from .controller import UniFiController
 
-_DataT = TypeVar("_DataT")
-_HandlerT = TypeVar("_HandlerT")
-_SubscriptionT = Callable[[CallbackType, ItemEvent], UnsubscribeType]
+_DataT = TypeVar("_DataT", bound=APIItem)
+_HandlerT = TypeVar("_HandlerT", bound=APIHandler)
 
 
 @callback

--- a/homeassistant/components/unifi/unifi_client.py
+++ b/homeassistant/components/unifi/unifi_client.py
@@ -54,5 +54,5 @@ class UniFiClient(UniFiClientBase):
         return DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, self.client.mac)},
             default_manufacturer=self.client.oui,
-            default_name=self.name,
+            default_name=self.client.name or self.client.hostname,
         )

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -13,10 +13,8 @@ from homeassistant.components.unifi.const import (
     CONF_ALLOW_UPTIME_SENSORS,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
-    DOMAIN as UNIFI_DOMAIN,
 )
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import EntityCategory
 import homeassistant.util.dt as dt_util
 
@@ -188,35 +186,6 @@ async def test_uptime_sensors(
     assert len(hass.states.async_all()) == 1
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
     assert hass.states.get("sensor.client1_uptime") is None
-
-    # Enable option
-
-    options[CONF_ALLOW_UPTIME_SENSORS] = True
-    with patch("homeassistant.util.dt.now", return_value=now):
-        hass.config_entries.async_update_entry(config_entry, options=options.copy())
-        await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 2
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
-    assert hass.states.get("sensor.client1_uptime")
-
-    # Try to add the sensors again, using a signal
-
-    clients_connected = {uptime_client["mac"]}
-    devices_connected = set()
-
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
-
-    async_dispatcher_send(
-        hass,
-        controller.signal_update,
-        clients_connected,
-        devices_connected,
-    )
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 2
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
 
 
 async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -106,37 +106,6 @@ async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
     assert hass.states.get("sensor.wired_client_rx") is None
     assert hass.states.get("sensor.wired_client_tx") is None
 
-    # Enable option
-
-    options[CONF_ALLOW_BANDWIDTH_SENSORS] = True
-    hass.config_entries.async_update_entry(config_entry, options=options.copy())
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 5
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
-    assert hass.states.get("sensor.wireless_client_rx")
-    assert hass.states.get("sensor.wireless_client_tx")
-    assert hass.states.get("sensor.wired_client_rx")
-    assert hass.states.get("sensor.wired_client_tx")
-
-    # Try to add the sensors again, using a signal
-
-    clients_connected = {wired_client["mac"], wireless_client["mac"]}
-    devices_connected = set()
-
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
-
-    async_dispatcher_send(
-        hass,
-        controller.signal_update,
-        clients_connected,
-        devices_connected,
-    )
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 5
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
-
 
 @pytest.mark.parametrize(
     "initial_uptime,event_uptime,new_uptime",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate sensor platform to utilize entity description much as switch and [update](https://github.com/home-assistant/core/pull/81821) platforms
This currently breaks signalling for when config entry options are enabled thus removing those tests, will be readded later on
Once device trackers are migrated and strict typing is achieved I will start merging entity descriptions to one common.

Related PRs
- #81680
- #81821
- #81930
- #81979

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
