### PR TITLE
Add all_entities option to config flow of light and switch group

### DIFF
--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -87,6 +87,20 @@ def light_switch_options_schema(
     )
 
 
+LIGHT_CONFIG_SCHEMA = basic_group_config_schema("light").extend(
+    {
+        vol.Required(CONF_ALL, default=False): selector.BooleanSelector(),
+    }
+)
+
+
+SWITCH_CONFIG_SCHEMA = basic_group_config_schema("switch").extend(
+    {
+        vol.Required(CONF_ALL, default=False): selector.BooleanSelector(),
+    }
+)
+
+
 GROUP_TYPES = [
     "binary_sensor",
     "cover",
@@ -124,18 +138,14 @@ CONFIG_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
         basic_group_config_schema("cover"), set_group_type("cover")
     ),
     "fan": SchemaFlowFormStep(basic_group_config_schema("fan"), set_group_type("fan")),
-    "light": SchemaFlowFormStep(
-        basic_group_config_schema("light"), set_group_type("light")
-    ),
+    "light": SchemaFlowFormStep(LIGHT_CONFIG_SCHEMA, set_group_type("light")),
     "lock": SchemaFlowFormStep(
         basic_group_config_schema("lock"), set_group_type("lock")
     ),
     "media_player": SchemaFlowFormStep(
         basic_group_config_schema("media_player"), set_group_type("media_player")
     ),
-    "switch": SchemaFlowFormStep(
-        basic_group_config_schema("switch"), set_group_type("switch")
-    ),
+    "switch": SchemaFlowFormStep(SWITCH_CONFIG_SCHEMA, set_group_type("switch")),
 }
 
 

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -43,7 +43,9 @@
       },
       "light": {
         "title": "[%key:component::group::config::step::user::title%]",
+        "description": "[%key:component::group::config::step::binary_sensor::description%]",
         "data": {
+          "all": "[%key:component::group::config::step::binary_sensor::data::all%]",
           "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
           "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]",
           "name": "[%key:component::group::config::step::binary_sensor::data::name%]"
@@ -67,7 +69,9 @@
       },
       "switch": {
         "title": "[%key:component::group::config::step::user::title%]",
+        "description": "[%key:component::group::config::step::binary_sensor::description%]",
         "data": {
+          "all": "[%key:component::group::config::step::binary_sensor::data::all%]",
           "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
           "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]",
           "name": "[%key:component::group::config::step::binary_sensor::data::name%]"

--- a/homeassistant/components/group/translations/en.json
+++ b/homeassistant/components/group/translations/en.json
@@ -29,10 +29,12 @@
             },
             "light": {
                 "data": {
+                    "all": "All entities",
                     "entities": "Members",
                     "hide_members": "Hide members",
                     "name": "Name"
                 },
+                "description": "If \"all entities\" is enabled, the group's state is on only if all members are on. If \"all entities\" is disabled, the group's state is on if any member is on.",
                 "title": "Add Group"
             },
             "lock": {
@@ -53,10 +55,12 @@
             },
             "switch": {
                 "data": {
+                    "all": "All entities",
                     "entities": "Members",
                     "hide_members": "Hide members",
                     "name": "Name"
                 },
+                "description": "If \"all entities\" is enabled, the group's state is on only if all members are on. If \"all entities\" is disabled, the group's state is on if any member is on.",
                 "title": "Add Group"
             },
             "user": {

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -19,10 +19,12 @@ from tests.common import MockConfigEntry
         ("binary_sensor", "on", "on", {}, {"all": True}, {"all": True}, {}),
         ("cover", "open", "open", {}, {}, {}, {}),
         ("fan", "on", "on", {}, {}, {}, {}),
-        ("light", "on", "on", {}, {}, {}, {}),
+        ("light", "on", "on", {}, {}, {"all": False}, {}),
+        ("light", "on", "on", {}, {"all": True}, {"all": True}, {}),
         ("lock", "locked", "locked", {}, {}, {}, {}),
         ("media_player", "on", "on", {}, {}, {}, {}),
-        ("switch", "on", "on", {}, {}, {}, {}),
+        ("switch", "on", "on", {}, {}, {"all": False}, {}),
+        ("switch", "on", "on", {}, {"all": True}, {"all": True}, {}),
     ),
 )
 async def test_config_flow(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This PR adds the all_entities open for light and switch groups to the config_flow shown during setup. The option was already present in the binary sensor group but not in those. Furthermore, the option to set all_entities is already part of the options flow of a light and switch group


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
