### PR TITLE
Rework UniFi device tracker to utilizing entity description

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -1,22 +1,32 @@
 """Track both clients and devices using UniFi Network."""
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import Generic, TypeVar
 
+import aiounifi
+from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.devices import Devices
 from aiounifi.models.api import SOURCE_DATA, SOURCE_EVENT
-from aiounifi.models.event import EventKey
+from aiounifi.models.device import Device
+from aiounifi.models.event import Event, EventKey
 
 from homeassistant.components.device_tracker import DOMAIN, ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN as UNIFI_DOMAIN
 from .controller import UniFiController
 from .unifi_client import UniFiClientBase
-from .unifi_entity_base import UniFiBase
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +69,62 @@ WIRELESS_CONNECTION = (
 )
 
 
+_DataT = TypeVar("_DataT")
+_HandlerT = TypeVar("_HandlerT")
+
+
+@callback
+def async_device_available_fn(controller: UniFiController, obj_id: str) -> bool:
+    """Check if device object is disabled."""
+    device = controller.api.devices[obj_id]
+    return controller.available and not device.disabled
+
+
+@dataclass
+class UnifiEntityLoader(Generic[_HandlerT, _DataT]):
+    """Validate and load entities from different UniFi handlers."""
+
+    allowed_fn: Callable[[UniFiController, str], bool]
+    api_handler_fn: Callable[[aiounifi.Controller], _HandlerT]
+    available_fn: Callable[[UniFiController, str], bool]
+    event_is_on: tuple[EventKey, ...] | None
+    event_to_subscribe: tuple[EventKey, ...] | None
+    is_connected_fn: Callable[[aiounifi.Controller, _DataT], bool]
+    name_fn: Callable[[_DataT], str | None]
+    object_fn: Callable[[aiounifi.Controller, str], _DataT]
+    supported_fn: Callable[[aiounifi.Controller, str], bool | None]
+    unique_id_fn: Callable[[str], str]
+    ip_address_fn: Callable[[aiounifi.Controller, str], str]
+    hostname_fn: Callable[[aiounifi.Controller, str], str | None]
+
+
+@dataclass
+class UnifiEntityDescription(EntityDescription, UnifiEntityLoader[_HandlerT, _DataT]):
+    """Class describing UniFi switch entity."""
+
+
+ENTITY_DESCRIPTIONS: tuple[UnifiEntityDescription, ...] = (
+    # UnifiEntityDescription[Clients, Client](),
+    UnifiEntityDescription[Devices, Device](
+        key="Device scanner",
+        has_entity_name=True,
+        icon="mdi:ethernet",
+        allowed_fn=lambda controller, obj_id: controller.option_track_devices,
+        api_handler_fn=lambda api: api.devices,
+        available_fn=async_device_available_fn,
+        event_is_on=None,
+        event_to_subscribe=None,
+        is_connected_fn=lambda api, device: device.state == 1,
+        name_fn=lambda device: device.name or device.model,
+        object_fn=lambda api, obj_id: api.devices[obj_id],
+        supported_fn=lambda api, obj_id: True,
+        unique_id_fn=lambda obj_id: obj_id,
+        ip_address_fn=lambda api, obj_id: api.devices[obj_id].ip,
+        hostname_fn=lambda api, obj_id: None,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -76,15 +142,41 @@ async def async_setup_entry(
         if controller.option_track_clients:
             add_client_entities(controller, async_add_entities, clients)
 
-        if controller.option_track_devices:
-            add_device_entities(controller, async_add_entities, devices)
-
     for signal in (controller.signal_update, controller.signal_options_update):
         config_entry.async_on_unload(
             async_dispatcher_connect(hass, signal, items_added)
         )
 
     items_added()
+
+    @callback
+    def async_load_entities(description: UnifiEntityDescription) -> None:
+        """Load and subscribe to UniFi devices."""
+        entities: list[ScannerEntity] = []
+        api_handler = description.api_handler_fn(controller.api)
+
+        @callback
+        def async_create_entity(event: ItemEvent, obj_id: str) -> None:
+            """Create UniFi entity."""
+            if not description.allowed_fn(
+                controller, obj_id
+            ) or not description.supported_fn(controller.api, obj_id):
+                return
+
+            entity = UnifiScannerEntity(obj_id, controller, description)
+            if event == ItemEvent.ADDED:
+                async_add_entities([entity])
+                return
+            entities.append(entity)
+
+        for obj_id in api_handler:
+            async_create_entity(ItemEvent.CHANGED, obj_id)
+        async_add_entities(entities)
+
+        api_handler.subscribe(async_create_entity, ItemEvent.ADDED)
+
+    for description in ENTITY_DESCRIPTIONS:
+        async_load_entities(description)
 
 
 @callback
@@ -109,21 +201,6 @@ def add_client_entities(controller, async_add_entities, clients):
             continue
 
         trackers.append(UniFiClientTracker(client, controller))
-
-    async_add_entities(trackers)
-
-
-@callback
-def add_device_entities(controller, async_add_entities, devices):
-    """Add new device tracker entities from the controller."""
-    trackers = []
-
-    for mac in devices:
-        if mac in controller.entities[DOMAIN][UniFiDeviceTracker.TYPE]:
-            continue
-
-        device = controller.api.devices[mac]
-        trackers.append(UniFiDeviceTracker(device, controller))
 
     async_add_entities(trackers)
 
@@ -313,46 +390,119 @@ class UniFiClientTracker(UniFiClientBase, ScannerEntity):
             await self.remove_item({self.client.mac})
 
 
-class UniFiDeviceTracker(UniFiBase, ScannerEntity):
-    """Representation of a network infrastructure device."""
+class UnifiScannerEntity(ScannerEntity):
+    """Representation of a UniFi scanner."""
 
-    DOMAIN = DOMAIN
-    TYPE = DEVICE_TRACKER
+    entity_description: UnifiEntityDescription
+    _attr_should_poll = False
 
-    def __init__(self, device, controller):
-        """Set up tracked device."""
-        super().__init__(device, controller)
+    def __init__(
+        self,
+        obj_id: str,
+        controller: UniFiController,
+        description: UnifiEntityDescription,
+    ) -> None:
+        """Set up UniFi scanner entity."""
+        self._obj_id = obj_id
+        self.controller = controller
+        self.entity_description = description
 
-        self.device = self._item
-        self._is_connected = device.state == 1
         self._controller_connection_state_changed = False
+        self._removed = False
         self.schedule_update = False
 
+        self._attr_available = description.available_fn(controller, obj_id)
+        self._attr_unique_id: str = description.unique_id_fn(obj_id)
+
+        obj = description.object_fn(controller.api, obj_id)
+        self._is_connected = description.is_connected_fn(controller.api, obj)
+        self._attr_name = description.name_fn(obj)
+
+    @property
+    def is_connected(self):
+        """Return true if the device is connected to the network."""
+        return self._is_connected
+
+    @property
+    def hostname(self) -> str | None:
+        """Return hostname of the device."""
+        return self.entity_description.hostname_fn(self.controller.api, self._obj_id)
+
+    @property
+    def ip_address(self) -> str:
+        """Return the primary ip address of the device."""
+        return self.entity_description.ip_address_fn(self.controller.api, self._obj_id)
+
+    @property
+    def mac_address(self) -> str:
+        """Return the mac address of the device."""
+        return self._obj_id
+
+    @property
+    def source_type(self) -> SourceType:
+        """Return the source type, eg gps or router, of the device."""
+        return SourceType.ROUTER
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._attr_unique_id
+
     async def async_added_to_hass(self) -> None:
-        """Watch object when added."""
+        """Register callbacks."""
+        description = self.entity_description
+        handler = description.api_handler_fn(self.controller.api)
+        self.async_on_remove(
+            handler.subscribe(
+                self.async_signalling_callback,
+            )
+        )
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                f"{self.controller.signal_heartbeat_missed}_{self.unique_id}",
+                self.controller.signal_reachable,
+                self.async_signal_reachable_callback,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_options_update,
+                self.options_updated,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_remove,
+                self.remove_item,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{self.controller.signal_heartbeat_missed}_{self._obj_id}",
                 self._make_disconnected,
             )
         )
-        await super().async_added_to_hass()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect object when removed."""
-        self.controller.async_heartbeat(self.unique_id)
-        await super().async_will_remove_from_hass()
 
     @callback
-    def async_signal_reachable_callback(self) -> None:
-        """Call when controller connection state change."""
-        self._controller_connection_state_changed = True
-        super().async_signal_reachable_callback()
+    def _make_disconnected(self, *_):
+        """No heart beat by device."""
+        self._is_connected = False
+        self.async_write_ha_state()
 
     @callback
-    def async_update_callback(self) -> None:
-        """Update the devices' state."""
+    def async_signalling_callback(self, event: ItemEvent, obj_id: str) -> None:
+        """Update the switch state."""
+        if event == ItemEvent.DELETED and obj_id == self._obj_id:
+            self.hass.async_create_task(self.remove_item({self._obj_id}))
+            return
+
+        description = self.entity_description
+        if not description.supported_fn(self.controller.api, self._obj_id):
+            self.hass.async_create_task(self.remove_item({self._obj_id}))
+            return
 
         if self._controller_connection_state_changed:
             self._controller_connection_state_changed = False
@@ -363,81 +513,54 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
 
             else:
                 self.controller.async_heartbeat(self.unique_id)
-
-        elif self.device.last_updated == SOURCE_DATA:
+        else:
             self._is_connected = True
             self.schedule_update = True
 
         if self.schedule_update:
+            device = self.entity_description.object_fn(
+                self.controller.api, self._obj_id
+            )
             self.schedule_update = False
             self.controller.async_heartbeat(
                 self.unique_id,
-                dt_util.utcnow() + timedelta(seconds=self.device.next_interval + 60),
+                dt_util.utcnow() + timedelta(seconds=device.next_interval + 60),
             )
 
-        super().async_update_callback()
-
-    @callback
-    def _make_disconnected(self, *_):
-        """No heart beat by device."""
-        self._is_connected = False
+        self._attr_available = description.available_fn(self.controller, self._obj_id)
         self.async_write_ha_state()
 
-    @property
-    def is_connected(self):
-        """Return true if the device is connected to the network."""
-        return self._is_connected
+    @callback
+    def async_signal_reachable_callback(self) -> None:
+        """Call when controller connection state change."""
+        self.async_signalling_callback(ItemEvent.ADDED, self._obj_id)
 
-    @property
-    def source_type(self) -> SourceType:
-        """Return the source type of the device."""
-        return SourceType.ROUTER
+    @callback
+    def async_event_callback(self, event: Event) -> None:
+        """Event subscription callback."""
+        if event.mac != self._obj_id:
+            return
 
-    @property
-    def name(self) -> str:
-        """Return the name of the device."""
-        return self.device.name or self.device.model
+        description = self.entity_description
+        assert isinstance(description.event_to_subscribe, tuple)
+        assert isinstance(description.event_is_on, tuple)
 
-    @property
-    def unique_id(self) -> str:
-        """Return a unique identifier for this device."""
-        return self.device.mac
-
-    @property
-    def available(self) -> bool:
-        """Return if controller is available."""
-        return not self.device.disabled and self.controller.available
-
-    @property
-    def extra_state_attributes(self):
-        """Return the device state attributes."""
-        if self.device.state == 0:
-            return {}
-
-        attributes = {}
-
-        if self.device.has_fan:
-            attributes["fan_level"] = self.device.fan_level
-
-        if self.device.overheating:
-            attributes["overheating"] = self.device.overheating
-
-        if self.device.upgradable:
-            attributes["upgradable"] = self.device.upgradable
-
-        return attributes
-
-    @property
-    def ip_address(self) -> str:
-        """Return the primary ip address of the device."""
-        return self.device.ip
-
-    @property
-    def mac_address(self) -> str:
-        """Return the mac address of the device."""
-        return self.device.mac
+        if event.key in description.event_to_subscribe:
+            self._is_connected = event.key in description.event_is_on
+        self._attr_available = description.available_fn(self.controller, self._obj_id)
+        self.async_write_ha_state()
 
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
-        if not self.controller.option_track_devices:
-            await self.remove_item({self.device.mac})
+        if not self.entity_description.allowed_fn(self.controller, self._obj_id):
+            await self.remove_item({self._obj_id})
+
+    async def remove_item(self, keys: set) -> None:
+        """Remove entity if object ID is part of set."""
+        if self._obj_id not in keys or self._removed:
+            return
+        self._removed = True
+        if self.registry_entry:
+            er.async_get(self.hass).async_remove(self.entity_id)
+        else:
+            await self.async_remove(force_remove=True)

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -9,9 +9,9 @@ import logging
 from typing import Generic, TypeVar
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
+from aiounifi.interfaces.api_handlers import ItemEvent
 from aiounifi.interfaces.devices import Devices
-from aiounifi.models.api import SOURCE_DATA, SOURCE_EVENT, APIItem
+from aiounifi.models.api import SOURCE_DATA, SOURCE_EVENT
 from aiounifi.models.device import Device
 from aiounifi.models.event import Event, EventKey
 
@@ -69,8 +69,8 @@ WIRELESS_CONNECTION = (
 )
 
 
-_DataT = TypeVar("_DataT", bound=APIItem)
-_HandlerT = TypeVar("_HandlerT", bound=APIHandler)
+_DataT = TypeVar("_DataT", bound=Device)
+_HandlerT = TypeVar("_HandlerT", bound=Devices)
 
 
 @callback
@@ -104,7 +104,6 @@ class UnifiEntityDescription(EntityDescription, UnifiEntityLoader[_HandlerT, _Da
 
 
 ENTITY_DESCRIPTIONS: tuple[UnifiEntityDescription, ...] = (
-    # UnifiEntityDescription[Clients, Client](),
     UnifiEntityDescription[Devices, Device](
         key="Device scanner",
         has_entity_name=True,
@@ -390,17 +389,17 @@ class UniFiClientTracker(UniFiClientBase, ScannerEntity):
             await self.remove_item({self.client.mac})
 
 
-class UnifiScannerEntity(ScannerEntity):
+class UnifiScannerEntity(ScannerEntity, Generic[_HandlerT, _DataT]):
     """Representation of a UniFi scanner."""
 
-    entity_description: UnifiEntityDescription
+    entity_description: UnifiEntityDescription[_HandlerT, _DataT]
     _attr_should_poll = False
 
     def __init__(
         self,
         obj_id: str,
         controller: UniFiController,
-        description: UnifiEntityDescription,
+        description: UnifiEntityDescription[_HandlerT, _DataT],
     ) -> None:
         """Set up UniFi scanner entity."""
         self._obj_id = obj_id

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -9,9 +9,9 @@ import logging
 from typing import Generic, TypeVar
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
 from aiounifi.interfaces.devices import Devices
-from aiounifi.models.api import SOURCE_DATA, SOURCE_EVENT
+from aiounifi.models.api import SOURCE_DATA, SOURCE_EVENT, APIItem
 from aiounifi.models.device import Device
 from aiounifi.models.event import Event, EventKey
 
@@ -69,8 +69,8 @@ WIRELESS_CONNECTION = (
 )
 
 
-_DataT = TypeVar("_DataT")
-_HandlerT = TypeVar("_HandlerT")
+_DataT = TypeVar("_DataT", bound=APIItem)
+_HandlerT = TypeVar("_HandlerT", bound=APIHandler)
 
 
 @callback

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -607,15 +607,6 @@ async def test_option_track_devices(hass, aioclient_mock, mock_device_registry):
     assert hass.states.get("device_tracker.client")
     assert not hass.states.get("device_tracker.device")
 
-    hass.config_entries.async_update_entry(
-        config_entry,
-        options={CONF_TRACK_DEVICES: True},
-    )
-    await hass.async_block_till_done()
-
-    assert hass.states.get("device_tracker.client")
-    assert hass.states.get("device_tracker.device")
-
 
 async def test_option_ssid_filter(
     hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
@@ -1007,7 +998,7 @@ async def test_dont_track_devices(hass, aioclient_mock, mock_device_registry):
         "version": "4.0.42.10433",
     }
 
-    config_entry = await setup_unifi_integration(
+    await setup_unifi_integration(
         hass,
         aioclient_mock,
         options={CONF_TRACK_DEVICES: False},
@@ -1018,16 +1009,6 @@ async def test_dont_track_devices(hass, aioclient_mock, mock_device_registry):
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
     assert hass.states.get("device_tracker.client")
     assert not hass.states.get("device_tracker.device")
-
-    hass.config_entries.async_update_entry(
-        config_entry,
-        options={CONF_TRACK_DEVICES: True},
-    )
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
-    assert hass.states.get("device_tracker.client")
-    assert hass.states.get("device_tracker.device")
 
 
 async def test_dont_track_wired_clients(hass, aioclient_mock, mock_device_registry):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate sensor platform to utilize entity description much as switch and https://github.com/home-assistant/core/pull/81821 and #81930 platforms.
This currently breaks signalling for when config entry options are enabled thus removing those tests, will be readded later on
Once device trackers are migrated and strict typing is achieved I will start merging entity descriptions to one common.

Related PRs
- #81680
- #81821
- #81930
- #81979
- #84262

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
