### PR TITLE
Remove (2021) backwards supporting functionality from UniFi

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -1,6 +1,4 @@
 """Integration to UniFi Network and its various features."""
-from collections.abc import Mapping
-from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -10,12 +8,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_CONTROLLER,
-    DOMAIN as UNIFI_DOMAIN,
-    PLATFORMS,
-    UNIFI_WIRELESS_CLIENTS,
-)
+from .const import DOMAIN as UNIFI_DOMAIN, PLATFORMS, UNIFI_WIRELESS_CLIENTS
 from .controller import UniFiController, get_unifi_controller
 from .errors import AuthenticationRequired, CannotConnect
 from .services import async_setup_services, async_unload_services
@@ -40,9 +33,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # Removal of legacy PoE control was introduced with 2022.12
     async_remove_poe_client_entities(hass, config_entry)
 
-    # Flat configuration was introduced with 2021.3
-    await async_flatten_entry_data(hass, config_entry)
-
     try:
         api = await get_unifi_controller(hass, config_entry.data)
         controller = UniFiController(hass, config_entry, api)
@@ -53,12 +43,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     except AuthenticationRequired as err:
         raise ConfigEntryAuthFailed from err
-
-    # Unique ID was introduced with 2021.3
-    if config_entry.unique_id is None:
-        hass.config_entries.async_update_entry(
-            config_entry, unique_id=controller.site_id
-        )
 
     hass.data[UNIFI_DOMAIN][config_entry.entry_id] = controller
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
@@ -104,52 +88,36 @@ def async_remove_poe_client_entities(
         ent_reg.async_remove(entity_id)
 
 
-async def async_flatten_entry_data(
-    hass: HomeAssistant, config_entry: ConfigEntry
-) -> None:
-    """Simpler configuration structure for entry data.
-
-    Keep controller key layer in case user rollbacks.
-    """
-
-    data: Mapping[str, Any] = {
-        **config_entry.data,
-        **config_entry.data[CONF_CONTROLLER],
-    }
-    if config_entry.data != data:
-        hass.config_entries.async_update_entry(config_entry, data=data)
-
-
 class UnifiWirelessClients:
     """Class to store clients known to be wireless.
 
     This is needed since wireless devices going offline might get marked as wired by UniFi.
     """
 
-    def __init__(self, hass):
+    def __init__(self, hass: HomeAssistant) -> None:
         """Set up client storage."""
         self.hass = hass
-        self.data = {}
-        self._store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self.data: dict[str, dict[str, list[str]]] = {}
+        self._store: Store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
 
-    async def async_load(self):
+    async def async_load(self) -> None:
         """Load data from file."""
         if (data := await self._store.async_load()) is not None:
             self.data = data
 
     @callback
-    def get_data(self, config_entry):
+    def get_data(self, config_entry: ConfigEntry) -> set[str]:
         """Get data related to a specific controller."""
         data = self.data.get(config_entry.entry_id, {"wireless_devices": []})
         return set(data["wireless_devices"])
 
     @callback
-    def update_data(self, data, config_entry):
+    def update_data(self, data: set[str], config_entry: ConfigEntry) -> None:
         """Update data and schedule to save to file."""
         self.data[config_entry.entry_id] = {"wireless_devices": list(data)}
         self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
-    def _data_to_save(self):
+    def _data_to_save(self) -> dict[str, dict[str, list[str]]]:
         """Return data of UniFi wireless clients to store in a file."""
         return self.data

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -2,19 +2,13 @@
 from unittest.mock import patch
 
 from homeassistant.components import unifi
-from homeassistant.components.unifi import async_flatten_entry_data
-from homeassistant.components.unifi.const import CONF_CONTROLLER, DOMAIN as UNIFI_DOMAIN
+from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
 from homeassistant.components.unifi.errors import AuthenticationRequired, CannotConnect
 from homeassistant.setup import async_setup_component
 
-from .test_controller import (
-    CONTROLLER_DATA,
-    DEFAULT_CONFIG_ENTRY_ID,
-    ENTRY_CONFIG,
-    setup_unifi_integration,
-)
+from .test_controller import DEFAULT_CONFIG_ENTRY_ID, setup_unifi_integration
 
-from tests.common import MockConfigEntry, flush_store
+from tests.common import flush_store
 
 
 async def test_setup_with_no_config(hass):
@@ -50,17 +44,6 @@ async def test_setup_entry_fails_trigger_reauth_flow(hass):
         mock_flow_init.assert_called_once()
 
     assert hass.data[UNIFI_DOMAIN] == {}
-
-
-async def test_flatten_entry_data(hass):
-    """Verify entry data can be flattened."""
-    entry = MockConfigEntry(
-        domain=UNIFI_DOMAIN,
-        data={CONF_CONTROLLER: CONTROLLER_DATA},
-    )
-    await async_flatten_entry_data(hass, entry)
-
-    assert entry.data == ENTRY_CONFIG
 
 
 async def test_unload_entry(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove functionality related to
- adding unique ID to existing config entries
- flattening but keeping old configuration

Also complete typing of __init__

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
