### PR TITLE
KNX Config/OptionsFlow: minimize wait time for interface discovery

### DIFF
--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator
 from typing import Any, Final
 
 import voluptuous as vol
@@ -95,6 +96,9 @@ class KNXCommonFlow(ABC, FlowHandler):
         self._found_tunnels: list[GatewayDescriptor] = []
         self._selected_tunnel: GatewayDescriptor | None = None
 
+        self._gatewayscanner: GatewayScanner | None = None
+        self._async_scan_gen: AsyncGenerator[GatewayDescriptor, None] | None = None
+
     @abstractmethod
     def finish_flow(self, title: str) -> FlowResult:
         """Finish the flow."""
@@ -104,6 +108,11 @@ class KNXCommonFlow(ABC, FlowHandler):
     ) -> FlowResult:
         """Handle connection type configuration."""
         if user_input is not None:
+            self._async_scan_gen = None  # stop the scan
+            if self._gatewayscanner:
+                self._found_gateways = list(
+                    self._gatewayscanner.found_gateways.values()
+                )
             connection_type = user_input[CONF_KNX_CONNECTION_TYPE]
             if connection_type == CONF_KNX_ROUTING:
                 return await self.async_step_routing()
@@ -129,8 +138,19 @@ class KNXCommonFlow(ABC, FlowHandler):
             CONF_KNX_TUNNELING: CONF_KNX_TUNNELING.capitalize(),
             CONF_KNX_ROUTING: CONF_KNX_ROUTING.capitalize(),
         }
-        self._found_gateways = await scan_for_gateways()
-        if self._found_gateways:
+
+        xknx = self.hass.data[DOMAIN].xknx if isinstance(self, OptionsFlow) else XKNX()
+        self._gatewayscanner = GatewayScanner(
+            xknx, stop_on_found=0, timeout_in_seconds=2
+        )
+        # keep a reference to the generator to avoid it being garbage collected before timeout
+        self._async_scan_gen = self._gatewayscanner.async_scan()
+        try:
+            assert self._async_scan_gen is not None
+            await self._async_scan_gen.__anext__()  # pylint: disable=unnecessary-dunder-call
+        except StopAsyncIteration:
+            pass  # scan finished, no interfaces discovered
+        else:
             # add automatic at first position only if a gateway responded
             supported_connection_types = {
                 CONF_KNX_AUTOMATIC: CONF_KNX_AUTOMATIC.capitalize()
@@ -614,12 +634,3 @@ class KNXOptionsFlow(KNXCommonFlow, OptionsFlow):
             data_schema=vol.Schema(data_schema),
             last_step=True,
         )
-
-
-async def scan_for_gateways(stop_on_found: int = 0) -> list[GatewayDescriptor]:
-    """Scan for gateways within the network."""
-    xknx = XKNX()
-    gatewayscanner = GatewayScanner(
-        xknx, stop_on_found=stop_on_found, timeout_in_seconds=2
-    )
-    return await gatewayscanner.scan()

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -139,7 +139,10 @@ class KNXCommonFlow(ABC, FlowHandler):
             CONF_KNX_ROUTING: CONF_KNX_ROUTING.capitalize(),
         }
 
-        xknx = self.hass.data[DOMAIN].xknx if isinstance(self, OptionsFlow) else XKNX()
+        if isinstance(self, OptionsFlow) and (knx_module := self.hass.data.get(DOMAIN)):
+            xknx = knx_module.xknx
+        else:
+            xknx = XKNX()
         self._gatewayscanner = GatewayScanner(
             xknx, stop_on_found=0, timeout_in_seconds=2
         )

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -224,15 +224,19 @@ async def test_routing_setup_advanced(
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_routing_secure_manual_setup(hass: HomeAssistant) -> None:
+@patch(
+    "homeassistant.components.knx.config_flow.GatewayScanner",
+    return_value=GatewayScannerMock(),
+)
+async def test_routing_secure_manual_setup(
+    gateway_scanner_mock, hass: HomeAssistant
+) -> None:
     """Test routing secure setup with manual key config."""
-    with patch("xknx.io.gateway_scanner.GatewayScanner.scan") as gateways:
-        gateways.return_value = []
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
-        assert result["type"] == FlowResultType.FORM
-        assert not result["errors"]
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert not result["errors"]
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -311,15 +315,19 @@ async def test_routing_secure_manual_setup(hass: HomeAssistant) -> None:
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_routing_secure_keyfile(hass: HomeAssistant) -> None:
+@patch(
+    "homeassistant.components.knx.config_flow.GatewayScanner",
+    return_value=GatewayScannerMock(),
+)
+async def test_routing_secure_keyfile(
+    gateway_scanner_mock, hass: HomeAssistant
+) -> None:
     """Test routing secure setup with keyfile."""
-    with patch("xknx.io.gateway_scanner.GatewayScanner.scan") as gateways:
-        gateways.return_value = []
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
-        assert result["type"] == FlowResultType.FORM
-        assert not result["errors"]
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert not result["errors"]
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
KNX Config/OptionsFlow: minimize wait time for interface discovery

Show options when first interface is found (to decide if we show "Automatic" too), keep scanning until timeout or the user chooses an item and proceeds to the following step. That way we can get rid of the 2 second async sleep in our flow while still having enough time to discover all interfaces.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
