### PR TITLE
Add more sensors to SensorEntityDescription for RFLink

### DIFF
--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -182,7 +182,7 @@ SENSOR_TYPES = (
         key="total_rain",
         name="Total rain",
         device_class=SensorDeviceClass.PRECIPITATION,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=PRECIPITATION_MILLIMETERS,
     ),
     SensorEntityDescription(

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_SENSOR_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
+    DEGREE,
     ELECTRIC_CURRENT_AMPERE,
     ELECTRIC_POTENTIAL_VOLT,
     LIGHT_LUX,
@@ -27,6 +28,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfSpeed,
     UnitOfTemperature,
+    UnitOfVolumetricFlux,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -71,7 +73,8 @@ SENSOR_TYPES = (
     SensorEntityDescription(
         key="co2_air_quality",
         name="CO2 air quality",
-        icon="mdi:molecule-co2",
+        device_class=SensorDeviceClass.CO2,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="command",
@@ -159,9 +162,9 @@ SENSOR_TYPES = (
     SensorEntityDescription(
         key="rain_rate",
         name="Rain rate",
-        icon="mdi:cup-water",
+        device_class=SensorDeviceClass.PRECIPITATION_INTENSITY,
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=PRECIPITATION_MILLIMETERS,
+        native_unit_of_measurement=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
     ),
     SensorEntityDescription(
         key="revision",
@@ -224,6 +227,8 @@ SENSOR_TYPES = (
         key="winddirection",
         name="Wind direction",
         icon="mdi:compass",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=DEGREE,
     ),
     SensorEntityDescription(
         key="windgusts",

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -181,7 +181,7 @@ SENSOR_TYPES = (
     SensorEntityDescription(
         key="total_rain",
         name="Total rain",
-        icon="mdi:cup-water",
+        device_class=SensorDeviceClass.PRECIPITATION,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PRECIPITATION_MILLIMETERS,
     ),

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -18,6 +18,13 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_SENSOR_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
+    ELECTRIC_CURRENT_AMPERE,
+    ELECTRIC_POTENTIAL_VOLT,
+    LIGHT_LUX,
+    PERCENTAGE,
+    PRECIPITATION_MILLIMETERS,
+    UV_INDEX,
+    UnitOfPower,
     UnitOfSpeed,
     UnitOfTemperature,
 )
@@ -41,18 +48,14 @@ from . import (
     RflinkDevice,
 )
 
-SENSOR_ICONS = {
-    "humidity": "mdi:water-percent",
-    "battery": "mdi:battery",
-}
-
 SENSOR_TYPES = (
     # check new descriptors against PACKET_FIELDS & UNITS from rflink.parser
     SensorEntityDescription(
-        key="distance",
-        name="Distance",
-        device_class=SensorDeviceClass.DISTANCE,
+        key="average_windspeed",
+        name="Average windspeed",
+        device_class=SensorDeviceClass.WIND_SPEED,
         state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
     ),
     SensorEntityDescription(
         key="barometric_pressure",
@@ -61,11 +64,166 @@ SENSOR_TYPES = (
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
-        key="average_windspeed",
-        name="Average windspeed",
-        device_class=SensorDeviceClass.WIND_SPEED,
+        key="battery",
+        name="Battery",
+        icon="mdi:battery",
+    ),
+    SensorEntityDescription(
+        key="co2_air_quality",
+        name="CO2 air quality",
+        icon="mdi:molecule-co2",
+    ),
+    SensorEntityDescription(
+        key="command",
+        name="Command",
+        icon="mdi:text",
+    ),
+    SensorEntityDescription(
+        key="current_phase_1",
+        name="Current phase 1",
+        device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+    ),
+    SensorEntityDescription(
+        key="current_phase_2",
+        name="Current phase 2",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+    ),
+    SensorEntityDescription(
+        key="current_phase_3",
+        name="Current phase 3",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+    ),
+    SensorEntityDescription(
+        key="distance",
+        name="Distance",
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="doorbell_melody",
+        name="Doorbell melody",
+        icon="mdi:bell",
+    ),
+    SensorEntityDescription(
+        key="firmware",
+        name="Firmware",
+        icon="mdi:information-outline",
+    ),
+    SensorEntityDescription(
+        key="hardware",
+        name="Hardware",
+        icon="mdi:chip",
+    ),
+    SensorEntityDescription(
+        key="humidity",
+        name="Humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+    ),
+    SensorEntityDescription(
+        key="humidity_status",
+        name="Humidity status",
+        icon="mdi:water-percent",
+    ),
+    SensorEntityDescription(
+        key="kilowatt",
+        name="Kilowatt",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+    ),
+    SensorEntityDescription(
+        key="light_intensity",
+        name="Light intensity",
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=LIGHT_LUX,
+    ),
+    SensorEntityDescription(
+        key="meter_value",
+        name="Meter value",
+        icon="mdi:counter",
+    ),
+    SensorEntityDescription(
+        key="noise_level",
+        name="Noise level",
+        icon="mdi:bell-alert",
+    ),
+    SensorEntityDescription(
+        key="rain_rate",
+        name="Rain rate",
+        icon="mdi:cup-water",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PRECIPITATION_MILLIMETERS,
+    ),
+    SensorEntityDescription(
+        key="revision",
+        name="Revision",
+        icon="mdi:information",
+    ),
+    SensorEntityDescription(
+        key="temperature",
+        name="Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    SensorEntityDescription(
+        key="total_rain",
+        name="Total rain",
+        icon="mdi:cup-water",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PRECIPITATION_MILLIMETERS,
+    ),
+    SensorEntityDescription(
+        key="uv_intensity",
+        name="UV intensity",
+        icon="mdi:sunglasses",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UV_INDEX,
+    ),
+    SensorEntityDescription(
+        key="version",
+        name="Version",
+        icon="mdi:information",
+    ),
+    SensorEntityDescription(
+        key="voltage",
+        name="Voltage",
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
+    ),
+    SensorEntityDescription(
+        key="watt",
+        name="Watt",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+    ),
+    SensorEntityDescription(
+        key="weather_forecast",
+        name="Weather forecast",
+        icon="mdi:weather-cloudy-clock",
+    ),
+    SensorEntityDescription(
+        key="windchill",
+        name="Wind chill",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    SensorEntityDescription(
+        key="winddirection",
+        name="Wind direction",
+        icon="mdi:compass",
     ),
     SensorEntityDescription(
         key="windgusts",
@@ -82,22 +240,8 @@ SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
     ),
     SensorEntityDescription(
-        key="temperature",
-        name="Temperature",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-    ),
-    SensorEntityDescription(
         key="windtemp",
         name="Wind temperature",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-    ),
-    SensorEntityDescription(
-        key="windchill",
-        name="Wind chill",
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -248,9 +392,3 @@ class RflinkSensor(RflinkDevice, SensorEntity):
     def native_value(self):
         """Return value."""
         return self._state
-
-    @property
-    def icon(self):
-        """Return possible sensor specific icon."""
-        if self._sensor_type in SENSOR_ICONS:
-            return SENSOR_ICONS[self._sensor_type]

--- a/tests/components/rflink/test_sensor.py
+++ b/tests/components/rflink/test_sensor.py
@@ -285,7 +285,7 @@ async def test_sensor_attributes(hass, monkeypatch):
 
     rain_state = hass.states.get("sensor.rain_device")
     assert rain_state
-    assert "device_class" not in rain_state.attributes
+    assert rain_state.attributes["device_class"] == SensorDeviceClass.PRECIPITATION
     assert rain_state.attributes["state_class"] == SensorStateClass.MEASUREMENT
     assert rain_state.attributes["unit_of_measurement"] == PRECIPITATION_MILLIMETERS
 

--- a/tests/components/rflink/test_sensor.py
+++ b/tests/components/rflink/test_sensor.py
@@ -286,7 +286,7 @@ async def test_sensor_attributes(hass, monkeypatch):
     rain_state = hass.states.get("sensor.rain_device")
     assert rain_state
     assert rain_state.attributes["device_class"] == SensorDeviceClass.PRECIPITATION
-    assert rain_state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+    assert rain_state.attributes["state_class"] == SensorStateClass.TOTAL_INCREASING
     assert rain_state.attributes["unit_of_measurement"] == PRECIPITATION_MILLIMETERS
 
     humidity_state = hass.states.get("sensor.humidity_device")

--- a/tests/components/rflink/test_sensor.py
+++ b/tests/components/rflink/test_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
     PERCENTAGE,
+    PRECIPITATION_MILLIMETERS,
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
@@ -87,17 +88,15 @@ async def test_default_setup(hass, monkeypatch):
     )  # temperature uses SensorEntityDescription
 
     # test event for new unconfigured sensor
-    event_callback(
-        {"id": "test3", "sensor": "humidity", "value": 43, "unit": PERCENTAGE}
-    )
+    event_callback({"id": "test3", "sensor": "battery", "value": "ok", "unit": None})
     await hass.async_block_till_done()
 
-    # test state of hum sensor
-    hum_sensor = hass.states.get("sensor.test3")
-    assert hum_sensor
-    assert hum_sensor.state == "43"
-    assert hum_sensor.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
-    assert hum_sensor.attributes[ATTR_ICON] == "mdi:water-percent"
+    # test state of battery sensor
+    bat_sensor = hass.states.get("sensor.test3")
+    assert bat_sensor
+    assert bat_sensor.state == "ok"
+    assert ATTR_UNIT_OF_MEASUREMENT not in bat_sensor.attributes
+    assert bat_sensor.attributes[ATTR_ICON] == "mdi:battery"
 
 
 async def test_disable_automatic_add(hass, monkeypatch):
@@ -195,7 +194,7 @@ async def test_aliases(hass, monkeypatch):
     )
     await hass.async_block_till_done()
 
-    # test  state of new sensor
+    # test state of new sensor
     updated_sensor = hass.states.get("sensor.test_02")
     assert updated_sensor
     assert updated_sensor.state == "65"
@@ -221,11 +220,11 @@ async def test_race_condition(hass, monkeypatch):
 
     await hass.async_block_till_done()
 
-    # test  state of new sensor
+    # test state of new sensor
     updated_sensor = hass.states.get("sensor.test3")
     assert updated_sensor
 
-    # test  state of new sensor
+    # test state of new sensor
     new_sensor = hass.states.get(f"{DOMAIN}.test3")
     assert new_sensor
     assert new_sensor.state == "ok"
@@ -235,7 +234,7 @@ async def test_race_condition(hass, monkeypatch):
     # tmp_entity must be deleted from EVENT_KEY_COMMAND
     assert tmp_entity not in hass.data[DATA_ENTITY_LOOKUP][EVENT_KEY_SENSOR]["test3"]
 
-    # test  state of new sensor
+    # test state of new sensor
     new_sensor = hass.states.get(f"{DOMAIN}.test3")
     assert new_sensor
     assert new_sensor.state == "ko"
@@ -249,6 +248,14 @@ async def test_sensor_attributes(hass, monkeypatch):
         DOMAIN: {
             "platform": "rflink",
             "devices": {
+                "my_meter_device_unique_id": {
+                    "name": "meter_device",
+                    "sensor_type": "meter_value",
+                },
+                "my_rain_device_unique_id": {
+                    "name": "rain_device",
+                    "sensor_type": "total_rain",
+                },
                 "my_humidity_device_unique_id": {
                     "name": "humidity_device",
                     "sensor_type": "humidity",
@@ -270,10 +277,22 @@ async def test_sensor_attributes(hass, monkeypatch):
     event_callback, _, _, _ = await mock_rflink(hass, config, DOMAIN, monkeypatch)
 
     # test sensor loaded from config
+    meter_state = hass.states.get("sensor.meter_device")
+    assert meter_state
+    assert "device_class" not in meter_state.attributes
+    assert "state_class" not in meter_state.attributes
+    assert "unit_of_measurement" not in meter_state.attributes
+
+    rain_state = hass.states.get("sensor.rain_device")
+    assert rain_state
+    assert "device_class" not in rain_state.attributes
+    assert rain_state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+    assert rain_state.attributes["unit_of_measurement"] == PRECIPITATION_MILLIMETERS
+
     humidity_state = hass.states.get("sensor.humidity_device")
     assert humidity_state
-    assert "device_class" not in humidity_state.attributes
-    assert "state_class" not in humidity_state.attributes
+    assert humidity_state.attributes["device_class"] == SensorDeviceClass.HUMIDITY
+    assert humidity_state.attributes["state_class"] == SensorStateClass.MEASUREMENT
     assert humidity_state.attributes["unit_of_measurement"] == PERCENTAGE
 
     temperature_state = hass.states.get("sensor.temperature_device")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following https://github.com/home-assistant/core/pull/79436, I've added all the missing sensors as `SensorEntityDescription` adding `device_class` or `icon`, `state_class` and `unit_of_measurement` were needed.

RFLink sensors and units are defined here https://github.com/aequitas/python-rflink/blob/master/rflink/parser.py

Please note that I have reordered sensors alphabetically by `key`. I have also added tests to test the changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
