### PR TITLE
Add the ability to register for shelly event callbacks

### DIFF
--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -461,8 +461,9 @@ class ShellyRpcCoordinator(DataUpdateCoordinator):
         return self.device.firmware_version if self.device.initialized else ""
 
     @callback
-    def _async_handle_update(self, device: RpcDevice) -> None:
+    def _async_handle_update(self, device_: RpcDevice) -> None:
         """Handle device update."""
+        device = self.device
         if not device.initialized:
             return
         event = device.event

--- a/tests/components/shelly/__init__.py
+++ b/tests/components/shelly/__init__.py
@@ -1,4 +1,10 @@
 """Tests for the Shelly integration."""
+from copy import deepcopy
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
 from homeassistant.components.shelly.const import CONF_SLEEP_PERIOD, DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -26,3 +32,16 @@ async def init_integration(
     await hass.async_block_till_done()
 
     return entry
+
+
+def mutate_rpc_device_status(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_rpc_device: Mock,
+    top_level_key: str,
+    key: str,
+    value: Any,
+) -> None:
+    """Mutate status for rpc device."""
+    new_status = deepcopy(mock_rpc_device.status)
+    new_status[top_level_key][key] = value
+    monkeypatch.setattr(mock_rpc_device, "status", new_status)

--- a/tests/components/shelly/test_light.py
+++ b/tests/components/shelly/test_light.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 
-from . import init_integration
+from . import init_integration, mutate_rpc_device_status
 
 RELAY_BLOCK_ID = 0
 LIGHT_BLOCK_ID = 2
@@ -374,7 +374,7 @@ async def test_rpc_device_switch_type_lights_mode(hass, mock_rpc_device, monkeyp
     )
     assert hass.states.get("light.test_switch_0").state == STATE_ON
 
-    monkeypatch.setitem(mock_rpc_device.status["switch:0"], "output", False)
+    mutate_rpc_device_status(monkeypatch, mock_rpc_device, "switch:0", "output", False)
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is an internal change only to support #82007

We now avoid writing shelly state unless status changes
    
We always wrote the state via async_set_updated_data when
there was an event. With many BLE events this results
in hundreds of state writes per minute




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
