### PR TITLE
Poll HomeKit Controller locks for state after lock operation

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -42,7 +42,7 @@ from .device_trigger import async_fire_triggers, async_setup_triggers_for_entry
 
 RETRY_INTERVAL = 60  # seconds
 MAX_POLL_FAILURES_TO_DECLARE_UNAVAILABLE = 3
-DEBOUNCE_COOLDOWN = 3  # seconds
+DEBOUNCE_COOLDOWN = 5  # seconds
 BLE_AVAILABILITY_CHECK_INTERVAL = 1800  # seconds
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -42,7 +42,7 @@ from .device_trigger import async_fire_triggers, async_setup_triggers_for_entry
 
 RETRY_INTERVAL = 60  # seconds
 MAX_POLL_FAILURES_TO_DECLARE_UNAVAILABLE = 3
-DEBOUNCE_COOLDOWN = 5  # seconds
+DEBOUNCE_COOLDOWN = 8  # seconds
 BLE_AVAILABILITY_CHECK_INTERVAL = 1800  # seconds
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -43,10 +43,12 @@ from .device_trigger import async_fire_triggers, async_setup_triggers_for_entry
 RETRY_INTERVAL = 60  # seconds
 MAX_POLL_FAILURES_TO_DECLARE_UNAVAILABLE = 3
 
-# 8 seconds was chosen because its soon enough
+# 10 seconds was chosen because its soon enough
 # for most state changes to happen but not too
-# long that the BLE connection is dropped.
-DEBOUNCE_COOLDOWN = 8  # seconds
+# long that the BLE connection is dropped. It
+# also happens to be the same value used by
+# the update coordinator.
+DEBOUNCE_COOLDOWN = 10  # seconds
 BLE_AVAILABILITY_CHECK_INTERVAL = 1800  # seconds
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -42,6 +42,10 @@ from .device_trigger import async_fire_triggers, async_setup_triggers_for_entry
 
 RETRY_INTERVAL = 60  # seconds
 MAX_POLL_FAILURES_TO_DECLARE_UNAVAILABLE = 3
+
+# 8 seconds was chosen because its soon enough
+# for most state changes to happen but not too
+# long that the BLE connection is dropped.
 DEBOUNCE_COOLDOWN = 8  # seconds
 BLE_AVAILABILITY_CHECK_INTERVAL = 1800  # seconds
 

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -107,3 +107,10 @@ STARTUP_EXCEPTIONS = (
     EncryptionError,
     AccessoryDisconnectedError,
 )
+
+# 10 seconds was chosen because its soon enough
+# for most state changes to happen but not too
+# long that the BLE connection is dropped. It
+# also happens to be the same value used by
+# the update coordinator.
+DEBOUNCE_COOLDOWN = 10  # seconds

--- a/homeassistant/components/homekit_controller/entity.py
+++ b/homeassistant/components/homekit_controller/entity.py
@@ -175,6 +175,10 @@ class HomeKitEntity(Entity):
         """Define the homekit characteristics the entity cares about."""
         raise NotImplementedError
 
+    async def async_update(self) -> None:
+        """Update the entity."""
+        await self._accessory.async_request_update()
+
 
 class AccessoryEntity(HomeKitEntity):
     """A HomeKit entity that is related to an entire accessory rather than a specific service or characteristic."""

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -124,6 +124,10 @@ class HomeKitLock(HomeKitEntity, LockEntity):
         await self.async_put_characteristics(
             {CharacteristicsTypes.LOCK_MECHANISM_TARGET_STATE: TARGET_STATE_MAP[state]}
         )
+        # Some locks need to be polled to update the current state
+        # after a target state change.
+        # https://github.com/home-assistant/core/issues/81887
+        await self._accessory.async_request_update()
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -21,6 +21,7 @@ from aiohomekit.zeroconf import HomeKitService
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.homekit_controller.const import (
     CONTROLLER,
+    DEBOUNCE_COOLDOWN,
     DOMAIN,
     HOMEKIT_ACCESSORY_DISPATCH,
     IDENTIFIER_ACCESSORY_ID,
@@ -146,6 +147,7 @@ class Helper:
             # If they are enabled, then HA will pick up the changes next time
             # we yield control
             await time_changed(self.hass, 60)
+            await time_changed(self.hass, DEBOUNCE_COOLDOWN)
 
         await self.hass.async_block_till_done()
 
@@ -165,6 +167,7 @@ class Helper:
     async def poll_and_get_state(self) -> State:
         """Trigger a time based poll and return the current entity state."""
         await time_changed(self.hass, 60)
+        await time_changed(self.hass, DEBOUNCE_COOLDOWN)
 
         state = self.hass.states.get(self.entity_id)
         assert state is not None


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes #81887


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
