### PR TITLE
Fix mqtt typo

### DIFF
--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -482,8 +482,8 @@ async def async_get_broker_settings(
             return False
         certificate_id: str | None = user_input.get(CONF_CERTIFICATE)
         if certificate_id:
-            with process_uploaded_file(hass, certificate_id) as certiticate_file:
-                certificate = certiticate_file.read_text(encoding=DEFAULT_ENCODING)
+            with process_uploaded_file(hass, certificate_id) as certificate_file:
+                certificate = certificate_file.read_text(encoding=DEFAULT_ENCODING)
 
         # Return to form for file upload CA cert or client cert and key
         if (
@@ -499,8 +499,8 @@ async def async_get_broker_settings(
         if client_certificate_id:
             with process_uploaded_file(
                 hass, client_certificate_id
-            ) as client_certiticate_file:
-                client_certificate = client_certiticate_file.read_text(
+            ) as client_certificate_file:
+                client_certificate = client_certificate_file.read_text(
                     encoding=DEFAULT_ENCODING
                 )
         if client_key_id:
@@ -704,10 +704,10 @@ def try_connection(
 
 def check_certicate_chain() -> str | None:
     """Check the MQTT certificates."""
-    if client_certiticate := get_file_path(CONF_CLIENT_CERT):
+    if client_certificate := get_file_path(CONF_CLIENT_CERT):
         try:
-            with open(client_certiticate, "rb") as client_certiticate_file:
-                load_pem_x509_certificate(client_certiticate_file.read())
+            with open(client_certificate, "rb") as client_certificate_file:
+                load_pem_x509_certificate(client_certificate_file.read())
         except ValueError:
             return "bad_client_cert"
     # Check we can serialize the private key file
@@ -719,9 +719,9 @@ def check_certicate_chain() -> str | None:
             return "bad_client_key"
     # Check the certificate chain
     context = SSLContext(PROTOCOL_TLS)
-    if client_certiticate and private_key:
+    if client_certificate and private_key:
         try:
-            context.load_cert_chain(client_certiticate, private_key)
+            context.load_cert_chain(client_certificate, private_key)
         except SSLError:
             return "bad_client_cert_key"
     # try to load the custom CA file

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -47,7 +47,7 @@
       "bad_will": "Invalid will topic",
       "bad_discovery_prefix": "Invalid discovery prefix",
       "bad_certificate": "The CA certificate is invalid",
-      "bad_client_cert": "Invalid client certiticate, ensure a PEM coded file is supplied",
+      "bad_client_cert": "Invalid client certificate, ensure a PEM coded file is supplied",
       "bad_client_key": "Invalid private key, ensure a PEM coded file is supplied without password",
       "bad_client_cert_key": "Client certificate and private are no valid pair",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/homeassistant/components/mqtt/translations/en.json
+++ b/homeassistant/components/mqtt/translations/en.json
@@ -7,7 +7,7 @@
         "error": {
             "bad_birth": "Invalid birth topic",
             "bad_certificate": "The CA certificate is invalid",
-            "bad_client_cert": "Invalid client certiticate, ensure a PEM coded file is supplied",
+            "bad_client_cert": "Invalid client certificate, ensure a PEM coded file is supplied",
             "bad_client_cert_key": "Client certificate and private are no valid pair",
             "bad_client_key": "Invalid private key, ensure a PEM coded file is supplied without password",
             "bad_discovery_prefix": "Invalid discovery prefix",
@@ -81,7 +81,7 @@
         "error": {
             "bad_birth": "Invalid birth topic",
             "bad_certificate": "The CA certificate is invalid",
-            "bad_client_cert": "Invalid client certiticate, ensure a PEM coded file is supplied",
+            "bad_client_cert": "Invalid client certificate, ensure a PEM coded file is supplied",
             "bad_client_cert_key": "Client certificate and private are no valid pair",
             "bad_client_key": "Invalid private key, ensure a PEM coded file is supplied without password",
             "bad_discovery_prefix": "Invalid discovery prefix",

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -191,7 +191,7 @@ def migrate_certificate_file_to_content(file_name_or_auto: str) -> str | None:
     if file_name_or_auto == "auto":
         return "auto"
     try:
-        with open(file_name_or_auto, encoding=DEFAULT_ENCODING) as certiticate_file:
-            return certiticate_file.read()
+        with open(file_name_or_auto, encoding=DEFAULT_ENCODING) as certificate_file:
+            return certificate_file.read()
     except OSError:
         return None


### PR DESCRIPTION
## Proposed change

Fix a repeated typo "certiticate" to "certificate".

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
