### PR TITLE
Redact more credentials in stream URL query params

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -20,7 +20,6 @@ import asyncio
 from collections.abc import Callable, Mapping
 import copy
 import logging
-import re
 import secrets
 import threading
 import time
@@ -28,6 +27,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
@@ -91,17 +91,18 @@ __all__ = [
 
 _LOGGER = logging.getLogger(__name__)
 
-STREAM_SOURCE_REDACT_PATTERN = [
-    (re.compile(r"//.*:.*@"), "//****:****@"),
-    (re.compile(r"\?auth=.*"), "?auth=****"),
-]
 
-
-def redact_credentials(data: str) -> str:
+def redact_credentials(url: str) -> str:
     """Redact credentials from string data."""
-    for (pattern, repl) in STREAM_SOURCE_REDACT_PATTERN:
-        data = pattern.sub(repl, data)
-    return data
+    yurl = URL(url)
+    if yurl.user is not None:
+        yurl = yurl.with_user("****")
+    if yurl.password is not None:
+        yurl = yurl.with_password("****")
+    redacted_query_params = {
+        key: "****" for key in {"auth", "user", "password"} & yurl.query.keys()
+    }
+    return str(yurl.update_query(redacted_query_params))
 
 
 def create_stream(

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -99,9 +99,9 @@ def redact_credentials(url: str) -> str:
         yurl = yurl.with_user("****")
     if yurl.password is not None:
         yurl = yurl.with_password("****")
-    redacted_query_params = {
-        key: "****" for key in {"auth", "user", "password"} & yurl.query.keys()
-    }
+    redacted_query_params = dict.fromkeys(
+        {"auth", "user", "password"} & yurl.query.keys(), "****"
+    )
     return str(yurl.update_query(redacted_query_params))
 
 

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -734,10 +734,6 @@ test_worker_log_cases = (
         "https://foo.bar/baz?user=****&password=****",
     ),
     (
-        "https://foo.bar/baz?user=abcd&password=efgh",
-        "https://foo.bar/baz?user=****&password=****",
-    ),
-    (
         "https://foo.bar/baz?param1=abcd&param2=efgh",
         "https://foo.bar/baz?param1=abcd&param2=efgh",
     ),

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -727,33 +727,47 @@ async def test_update_stream_source(hass):
         await stream.stop()
 
 
-async def test_worker_log(hass, caplog):
-    """Test that the worker logs the url without username and password."""
-    for stream_url, redacted_url in (
-        ("https://abcd:efgh@foo.bar", "https://****:****@foo.bar"),
-        (
-            "https://foo.bar/baz?user=abcd&password=efgh",
-            "https://foo.bar/baz?user=****&password=****",
-        ),
-    ):
-        stream = Stream(
-            hass,
-            stream_url,
-            {},
-            hass.data[DOMAIN][ATTR_SETTINGS],
-            dynamic_stream_settings(),
-        )
-        stream.add_provider(HLS_PROVIDER)
+test_worker_log_cases = (
+    ("https://abcd:efgh@foo.bar", "https://****:****@foo.bar"),
+    (
+        "https://foo.bar/baz?user=abcd&password=efgh",
+        "https://foo.bar/baz?user=****&password=****",
+    ),
+    (
+        "https://foo.bar/baz?user=abcd&password=efgh",
+        "https://foo.bar/baz?user=****&password=****",
+    ),
+    (
+        "https://foo.bar/baz?param1=abcd&param2=efgh",
+        "https://foo.bar/baz?param1=abcd&param2=efgh",
+    ),
+    (
+        "https://foo.bar/baz?param1=abcd&password=efgh",
+        "https://foo.bar/baz?param1=abcd&password=****",
+    ),
+)
 
-        with patch("av.open") as av_open, pytest.raises(StreamWorkerError) as err:
-            av_open.side_effect = av.error.InvalidDataError(-2, "error")
-            run_worker(hass, stream, stream_url)
-            await hass.async_block_till_done()
-        assert (
-            str(err.value)
-            == f"Error opening stream (ERRORTYPE_-2, error) {redacted_url}"
-        )
-        assert stream_url not in caplog.text
+
+@pytest.mark.parametrize("stream_url, redacted_url", test_worker_log_cases)
+async def test_worker_log(hass, caplog, stream_url, redacted_url):
+    """Test that the worker logs the url without username and password."""
+    stream = Stream(
+        hass,
+        stream_url,
+        {},
+        hass.data[DOMAIN][ATTR_SETTINGS],
+        dynamic_stream_settings(),
+    )
+    stream.add_provider(HLS_PROVIDER)
+
+    with patch("av.open") as av_open, pytest.raises(StreamWorkerError) as err:
+        av_open.side_effect = av.error.InvalidDataError(-2, "error")
+        run_worker(hass, stream, stream_url)
+        await hass.async_block_till_done()
+    assert (
+        str(err.value) == f"Error opening stream (ERRORTYPE_-2, error) {redacted_url}"
+    )
+    assert stream_url not in caplog.text
 
 
 @pytest.fixture


### PR DESCRIPTION
## Proposed change
<!--  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some camera URLs include credentials in query parameters. Although we won't redact all fields, obvious fields like `user` and `password` can be easily redacted.
This PR changes the `redact_credentials` function in stream to use `yarl` instead of regular expressions, and it adds the fields "user" and "password" to the set of the query params to redact.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #82029
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
