### PR TITLE
Verify comfoconnect connection with bridge

### DIFF
--- a/homeassistant/components/comfoconnect/__init__.py
+++ b/homeassistant/components/comfoconnect/__init__.py
@@ -115,6 +115,18 @@ class ComfoConnectBridge:
         _LOGGER.debug("Disconnecting from bridge")
         self.comfoconnect.disconnect()
 
+    def verify_connection(self):
+       """Verify connection and reconnect if needed"""
+       _LOGGER.debug("Bridge connection verification: %s" % self.comfoconnect.is_connected())
+       if not self.comfoconnect.is_connected():
+           _LOGGER.debug("Reconnecting to bridge")
+           self.connect()
+
+    def send_cmd(self, cmd):
+       """Send cmd to bridge"""
+       self.verify_connection()
+       self.comfoconnect.cmd_rmi_request(cmd)
+
     def sensor_callback(self, var, value):
         """Notify listeners that we have received an update."""
         _LOGGER.debug("Received update for %s: %s", var, value)

--- a/homeassistant/components/comfoconnect/__init__.py
+++ b/homeassistant/components/comfoconnect/__init__.py
@@ -117,7 +117,6 @@ class ComfoConnectBridge:
 
     def verify_connection(self):
        """Verify connection and reconnect if needed"""
-       _LOGGER.debug("Bridge connection verification: %s" % self.comfoconnect.is_connected())
        if not self.comfoconnect.is_connected():
            _LOGGER.debug("Reconnecting to bridge")
            self.connect()

--- a/homeassistant/components/comfoconnect/__init__.py
+++ b/homeassistant/components/comfoconnect/__init__.py
@@ -115,15 +115,11 @@ class ComfoConnectBridge:
         _LOGGER.debug("Disconnecting from bridge")
         self.comfoconnect.disconnect()
 
-    def verify_connection(self):
-       """Verify connection and reconnect if needed"""
+    def send_cmd(self, cmd):
+       """Send cmd to bridge"""
        if not self.comfoconnect.is_connected():
            _LOGGER.debug("Reconnecting to bridge")
            self.connect()
-
-    def send_cmd(self, cmd):
-       """Send cmd to bridge"""
-       self.verify_connection()
        self.comfoconnect.cmd_rmi_request(cmd)
 
     def sensor_callback(self, var, value):

--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -156,7 +156,7 @@ class ComfoConnectFan(FanEntity):
             speed = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
             cmd = CMD_MAPPING[speed]
 
-        self._ccb.comfoconnect.cmd_rmi_request(cmd)
+        self._ccb.send_cmd(cmd)
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
@@ -166,6 +166,6 @@ class ComfoConnectFan(FanEntity):
         _LOGGER.debug("Changing preset mode to %s", preset_mode)
         if preset_mode == PRESET_MODE_AUTO:
             # force set it to manual first
-            self._ccb.comfoconnect.cmd_rmi_request(CMD_MODE_MANUAL)
+            self._ccb.send_cmd(CMD_MODE_MANUAL)
             # now set it to auto so any previous percentage set gets undone
-            self._ccb.comfoconnect.cmd_rmi_request(CMD_MODE_AUTO)
+            self._ccb.send_cmd(CMD_MODE_AUTO)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes when connection to ComfoConnect bridge is dropped, it's no more possible to control fan. Any command fails with error shown below. This PR fixes this issue.
```
Nov 15 14:56:12 srv hass[914]: #033[31m2022-11-15 14:56:12.214 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140162098197984] Not connected!
Nov 15 14:56:12 srv hass[914]: Traceback (most recent call last):
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 200, in handle_call_service
Nov 15 14:56:12 srv hass[914]:     await hass.services.async_call(
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/core.py", line 1744, in async_call
Nov 15 14:56:12 srv hass[914]:     task.result()
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/core.py", line 1781, in _execute_service
Nov 15 14:56:12 srv hass[914]:     await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 208, in handle_service
Nov 15 14:56:12 srv hass[914]:     await service.entity_service_call(
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 678, in entity_service_call
Nov 15 14:56:12 srv hass[914]:     future.result()  # pop exception if have
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 943, in async_request_call
Nov 15 14:56:12 srv hass[914]:     await coro
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 715, in _handle_entity_call
Nov 15 14:56:12 srv hass[914]:     await result
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/components/fan/__init__.py", line 274, in async_turn_on
Nov 15 14:56:12 srv hass[914]:     await self.hass.async_add_executor_job(
Nov 15 14:56:12 srv hass[914]:   File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
Nov 15 14:56:12 srv hass[914]:     result = self.fn(*self.args, **self.kwargs)
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/components/comfoconnect/fan.py", line 141, in turn_on
Nov 15 14:56:12 srv hass[914]:     self.set_percentage(1)  # Set fan speed to low
Nov 15 14:56:12 srv hass[914]:   File "/usr/src/homeassistant/homeassistant/components/comfoconnect/fan.py", line 159, in set_percentage
Nov 15 14:56:12 srv hass[914]:     self._ccb.comfoconnect.cmd_rmi_request(cmd)
Nov 15 14:56:12 srv hass[914]:   File "/usr/local/lib/python3.10/site-packages/pycomfoconnect/comfoconnect.py", line 536, in cmd_rmi_request
Nov 15 14:56:12 srv hass[914]:     reply = self._command(
Nov 15 14:56:12 srv hass[914]:   File "/usr/local/lib/python3.10/site-packages/pycomfoconnect/comfoconnect.py", line 221, in _command
Nov 15 14:56:12 srv hass[914]:     self._bridge.write_message(message)
Nov 15 14:56:12 srv hass[914]:   File "/usr/local/lib/python3.10/site-packages/pycomfoconnect/bridge.py", line 127, in write_message
Nov 15 14:56:12 srv hass[914]:     raise Exception('Not connected!')
Nov 15 14:56:12 srv hass[914]: Exception: Not connected!#033[0m
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
