### PR TITLE
Bump plugwise to v0.25.12

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
     {
       "label": "Pytest",
       "type": "shell",
-      "command": "pytest --timeout=10 tests/components/plugwise",
+      "command": "pytest --timeout=10 tests",
       "dependsOn": ["Install all Test Requirements"],
       "group": {
         "kind": "test",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
     {
       "label": "Pytest",
       "type": "shell",
-      "command": "pytest --timeout=10 tests",
+      "command": "pytest --timeout=10 tests/components/plugwise",
       "dependsOn": ["Install all Test Requirements"],
       "group": {
         "kind": "test",

--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -37,6 +37,12 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PlugwiseBinarySensorEntityDescription(
+        key="cooling_enabled",
+        name="Cooling enabled",
+        icon="mdi:snowflake-thermometer",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    PlugwiseBinarySensorEntityDescription(
         key="dhw_state",
         name="DHW state",
         icon="mdi:water-pump",

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -6,6 +6,7 @@ from typing import Any
 from plugwise.exceptions import (
     ConnectionFailedError,
     InvalidAuthentication,
+    InvalidSetupError,
     InvalidXMLError,
     ResponseError,
     UnsupportedDeviceError,
@@ -180,10 +181,12 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors[CONF_BASE] = "cannot_connect"
             except InvalidAuthentication:
                 errors[CONF_BASE] = "invalid_auth"
+            except InvalidSetupError:
+                errors[CONF_BASE] = "invalid_setup"
             except (InvalidXMLError, ResponseError):
                 errors[CONF_BASE] = "response_error"
             except UnsupportedDeviceError:
-                errors[CONF_BASE] = "warn_code_owner"
+                errors[CONF_BASE] = "unsupported"
             except Exception:  # pylint: disable=broad-except
                 errors[CONF_BASE] = "unknown"
             else:

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 
 from typing import Any
 
+from aiohttp import ClientError
 from plugwise.exceptions import (
+    ConnectionFailedError,
     InvalidAuthentication,
     InvalidSetupError,
-    PlugwiseException,
+    InvalidXMLError,
+    ResponseError,
+    XMLDataMissingError,
 )
 from plugwise.smile import Smile
 import voluptuous as vol
@@ -179,8 +183,15 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors[CONF_BASE] = "invalid_setup"
             except InvalidAuthentication:
                 errors[CONF_BASE] = "invalid_auth"
-            except PlugwiseException:
+            except (
+                ClientError,
+                ConnectionFailedError,
+                InvalidXMLError,
+                ResponseError,
+            ):
                 errors[CONF_BASE] = "cannot_connect"
+            except XMLDataMissingError:
+                errors[CONF_BASE] = "retry"
             except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("Unexpected exception")
                 errors[CONF_BASE] = "unknown"

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -6,6 +6,7 @@ from plugwise import Smile
 from plugwise.constants import DeviceData, GatewayData
 from plugwise.exceptions import (
     ConnectionFailedError,
+    InvalidAuthentication,
     InvalidXMLError,
     ResponseError,
     UnsupportedDeviceError,
@@ -52,16 +53,16 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
         """Fetch data from Plugwise."""
         try:
             data = await self.api.async_update()
+        except InvalidAuthentication as err:
+            raise UpdateFailed("Authentication failed") from err
         except (InvalidXMLError, ResponseError) as err:
             raise UpdateFailed(
                 "Invalid XML data, or error indication received for the Plugwise Adam/Smile/Stretch"
             ) from err
         except UnsupportedDeviceError as err:
-            raise UpdateFailed(
-                "Unsupported device found, please create an Issue in the Home Assistant Core github"
-            ) from err
+            raise UpdateFailed("Device with unsupported firmware") from err
         except ConnectionFailedError as err:
-            raise UpdateFailed from err
+            raise UpdateFailed("Failed to connect") from err
         return PlugwiseData(
             gateway=cast(GatewayData, data[0]),
             devices=cast(dict[str, DeviceData], data[1]),

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -54,7 +54,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
             data = await self.api.async_update()
         except (InvalidXMLError, ResponseError, XMLDataMissingError) as err:
             raise UpdateFailed(
-                "No or invalid XML data, or error indication received for the Plugwise Adam/Smile/Stretch"
+                "Missing or invalid XML data, or error indication received from the Plugwise Adam/Smile/Stretch"
             ) from err
         except ConnectionFailedError as err:
             raise UpdateFailed from err

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -8,7 +8,7 @@ from plugwise.exceptions import (
     ConnectionFailedError,
     InvalidXMLError,
     ResponseError,
-    XMLDataMissingError,
+    UnsupportedDeviceError,
 )
 
 from homeassistant.core import HomeAssistant
@@ -52,13 +52,16 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
         """Fetch data from Plugwise."""
         try:
             data = await self.api.async_update()
-        except (InvalidXMLError, ResponseError, XMLDataMissingError) as err:
+        except (InvalidXMLError, ResponseError) as err:
             raise UpdateFailed(
-                "Missing or invalid XML data, or error indication received from the Plugwise Adam/Smile/Stretch"
+                "Invalid XML data, or error indication received for the Plugwise Adam/Smile/Stretch"
+            ) from err
+        except UnsupportedDeviceError as err:
+            raise UpdateFailed(
+                "Unsupported device found, please create an Issue in the Home Assistant Core github"
             ) from err
         except ConnectionFailedError as err:
             raise UpdateFailed from err
-
         return PlugwiseData(
             gateway=cast(GatewayData, data[0]),
             devices=cast(dict[str, DeviceData], data[1]),

--- a/homeassistant/components/plugwise/gateway.py
+++ b/homeassistant/components/plugwise/gateway.py
@@ -55,9 +55,7 @@ async def async_setup_entry_gw(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Error while communicating to the Plugwise Smile"
         ) from err
     except UnsupportedDeviceError as err:
-        raise HomeAssistantError(
-            "Unsupported device found: please create an Issue in the HA Core github"
-        ) from err
+        raise HomeAssistantError("Device with unsupported firmware") from err
 
     if not connected:
         raise ConfigEntryNotReady("Unable to connect to Smile")

--- a/homeassistant/components/plugwise/gateway.py
+++ b/homeassistant/components/plugwise/gateway.py
@@ -1,17 +1,21 @@
 """Plugwise platform for Home Assistant Core."""
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
-from aiohttp import ClientConnectionError
-from plugwise.exceptions import InvalidAuthentication, PlugwiseException
+from plugwise.exceptions import (
+    ConnectionFailedError,
+    InvalidAuthentication,
+    InvalidXMLError,
+    ResponseError,
+    UnsupportedDeviceError,
+)
 from plugwise.smile import Smile
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -42,16 +46,17 @@ async def async_setup_entry_gw(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         connected = await api.connect()
-    except InvalidAuthentication:
-        LOGGER.error("Invalid username or Smile ID")
-        return False
-    except (ClientConnectionError, PlugwiseException) as err:
+    except ConnectionFailedError as err:
+        raise ConfigEntryNotReady("Failed to connect to the Plugwise Smile") from err
+    except InvalidAuthentication as err:
+        raise HomeAssistantError("Invalid username or Smile ID") from err
+    except (InvalidXMLError, ResponseError) as err:
         raise ConfigEntryNotReady(
-            f"Error while communicating to device {api.smile_name}"
+            "Error while communicating to the Plugwise Smile"
         ) from err
-    except asyncio.TimeoutError as err:
-        raise ConfigEntryNotReady(
-            f"Timeout while connecting to Smile {api.smile_name}"
+    except UnsupportedDeviceError as err:
+        raise HomeAssistantError(
+            "Unsupported device found: please create an Issue in the HA Core github"
         ) from err
 
     if not connected:

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["plugwise==0.25.11"],
+  "requirements": ["plugwise==0.25.12"],
   "codeowners": ["@CoMPaTech", "@bouwew", "@brefra", "@frenck"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true,

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["plugwise==0.25.7"],
+  "requirements": ["plugwise==0.25.10"],
   "codeowners": ["@CoMPaTech", "@bouwew", "@brefra", "@frenck"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true,

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["plugwise==0.25.10"],
+  "requirements": ["plugwise==0.25.11"],
   "codeowners": ["@CoMPaTech", "@bouwew", "@brefra", "@frenck"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true,

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -16,6 +16,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_setup": "Add your Adam instead of your Anna, see the Home Assistant Plugwise integration documentation for more information",
+      "retry": "Something went wrong, please retry",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -15,9 +15,9 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_setup": "Add your Adam instead of your Anna, see the Home Assistant Plugwise integration documentation for more information",
-      "retry": "Something went wrong, please retry",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "response_error": "Invalid XML data, or error indication received",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "warn_code_owner": "Unsupported device found, please create an Issue in the HA Core github"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -15,9 +15,10 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_setup": "Add your Adam instead of your Anna, see the documentation",
       "response_error": "Invalid XML data, or error indication received",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "warn_code_owner": "Unsupported device found, please create an Issue in the HA Core github"
+      "unsupported": "Device with unsupported firmware"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",

--- a/homeassistant/components/plugwise/translations/en.json
+++ b/homeassistant/components/plugwise/translations/en.json
@@ -7,14 +7,14 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
-            "invalid_setup": "Add your Adam instead of your Anna, see the Home Assistant Plugwise integration documentation for more information",
-            "unknown": "Unexpected error"
+            "invalid_setup": "Add your Adam instead of your Anna, see the documentation",
+            "response_error": "Invalid XML data, or error indication received",
+            "unknown": "Unexpected error",
+            "unsupported": "Device with unsupported firmware"
         },
-        "flow_title": "{name}",
         "step": {
             "user": {
                 "data": {
-                    "flow_type": "Connection type",
                     "host": "IP Address",
                     "password": "Smile ID",
                     "port": "Port",
@@ -22,26 +22,6 @@
                 },
                 "description": "Please enter",
                 "title": "Connect to the Smile"
-            },
-            "user_gateway": {
-                "data": {
-                    "host": "IP Address",
-                    "password": "Smile ID",
-                    "port": "Port",
-                    "username": "Smile Username"
-                },
-                "description": "Please enter",
-                "title": "Connect to the Smile"
-            }
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Scan Interval (seconds)"
-                },
-                "description": "Adjust Plugwise Options"
             }
         }
     }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1331,7 +1331,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.25.11
+plugwise==0.25.12
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1331,7 +1331,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.25.7
+plugwise==0.25.10
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1331,7 +1331,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.25.10
+plugwise==0.25.11
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -958,7 +958,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.25.11
+plugwise==0.25.12
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -958,7 +958,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.25.10
+plugwise==0.25.11
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -958,7 +958,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.25.7
+plugwise==0.25.10
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/tests/components/plugwise/fixtures/anna_heatpump_heating/all_data.json
+++ b/tests/components/plugwise/fixtures/anna_heatpump_heating/all_data.json
@@ -3,7 +3,7 @@
     "smile_name": "Smile Anna",
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "cooling_present": true,
+    "cooling_present": false,
     "notifications": {}
   },
   {
@@ -21,10 +21,10 @@
       },
       "available": true,
       "binary_sensors": {
+        "cooling_enabled": false,
         "dhw_state": false,
         "heating_state": true,
         "compressor_state": true,
-        "cooling_state": false,
         "slave_boiler_state": false,
         "flame_state": false
       },
@@ -66,13 +66,11 @@
       "name": "Anna",
       "vendor": "Plugwise",
       "thermostat": {
-        "setpoint_low": 20.5,
-        "setpoint_high": 24.0,
+        "setpoint": 20.5,
         "lower_bound": 4.0,
         "upper_bound": 30.0,
         "resolution": 0.1
       },
-      "available": true,
       "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
       "active_preset": "home",
       "available_schedules": ["standaard"],
@@ -81,11 +79,10 @@
       "mode": "auto",
       "sensors": {
         "temperature": 19.3,
+        "setpoint": 20.5,
         "illuminance": 86.0,
         "cooling_activation_outdoor_temperature": 21.0,
-        "cooling_deactivation_threshold": 4.0,
-        "setpoint_low": 20.5,
-        "setpoint_high": 24.0
+        "cooling_deactivation_threshold": 4.0
       }
     }
   }

--- a/tests/components/plugwise/fixtures/m_anna_heatpump_cooling/all_data.json
+++ b/tests/components/plugwise/fixtures/m_anna_heatpump_cooling/all_data.json
@@ -21,6 +21,7 @@
       },
       "available": true,
       "binary_sensors": {
+        "cooling_enabled": true,
         "dhw_state": false,
         "heating_state": false,
         "compressor_state": true,
@@ -72,7 +73,6 @@
         "upper_bound": 30.0,
         "resolution": 0.1
       },
-      "available": true,
       "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
       "active_preset": "home",
       "available_schedules": ["standaard"],

--- a/tests/components/plugwise/fixtures/m_anna_heatpump_idle/all_data.json
+++ b/tests/components/plugwise/fixtures/m_anna_heatpump_idle/all_data.json
@@ -21,6 +21,7 @@
       },
       "available": true,
       "binary_sensors": {
+        "cooling_enabled": true,
         "dhw_state": false,
         "heating_state": false,
         "compressor_state": false,
@@ -72,7 +73,6 @@
         "upper_bound": 30.0,
         "resolution": 0.1
       },
-      "available": true,
       "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
       "active_preset": "home",
       "available_schedules": ["standaard"],

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -26,7 +26,7 @@ async def test_anna_climate_binary_sensor_entities(
     assert state
     assert state.state == STATE_ON
 
-    state = hass.states.get("binary_sensor.opentherm_cooling")
+    state = hass.states.get("binary_sensor.opentherm_cooling_enabled")
     assert state
     assert state.state == STATE_OFF
 

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -202,7 +202,7 @@ async def test_anna_climate_entity_attributes(
     assert state.state == HVACMode.AUTO
     assert state.attributes["hvac_action"] == "heating"
     assert state.attributes["hvac_modes"] == [
-        HVACMode.HEAT_COOL,
+        HVACMode.HEAT,
         HVACMode.AUTO,
     ]
 
@@ -211,9 +211,8 @@ async def test_anna_climate_entity_attributes(
 
     assert state.attributes["current_temperature"] == 19.3
     assert state.attributes["preset_mode"] == "home"
-    assert state.attributes["supported_features"] == 18
-    assert state.attributes["target_temp_high"] == 24.0
-    assert state.attributes["target_temp_low"] == 20.5
+    assert state.attributes["supported_features"] == 17
+    assert state.attributes["temperature"] == 20.5
     assert state.attributes["min_temp"] == 4.0
     assert state.attributes["max_temp"] == 30.0
     assert state.attributes["target_temp_step"] == 0.1
@@ -286,7 +285,7 @@ async def test_anna_climate_entity_climate_changes(
     await hass.services.async_call(
         "climate",
         "set_hvac_mode",
-        {"entity_id": "climate.anna", "hvac_mode": "heat_cool"},
+        {"entity_id": "climate.anna", "hvac_mode": "heat"},
         blocking=True,
     )
 

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from plugwise.exceptions import (
     ConnectionFailedError,
     InvalidAuthentication,
+    InvalidSetupError,
     InvalidXMLError,
     ResponseError,
     UnsupportedDeviceError,
@@ -100,6 +101,7 @@ def mock_smile():
     ) as smile_mock:
         smile_mock.ConnectionFailedError = ConnectionFailedError
         smile_mock.InvalidAuthentication = InvalidAuthentication
+        smile_mock.InvalidSetupError = InvalidSetupError
         smile_mock.InvalidXMLError = InvalidXMLError
         smile_mock.ResponseError = ResponseError
         smile_mock.UnsupportedDeviceError = UnsupportedDeviceError
@@ -273,10 +275,11 @@ async def test_zercoconf_discovery_update_configuration(
     [
         (ConnectionFailedError, "cannot_connect"),
         (InvalidAuthentication, "invalid_auth"),
+        (InvalidSetupError, "invalid_setup"),
         (InvalidXMLError, "response_error"),
         (ResponseError, "response_error"),
         (RuntimeError, "unknown"),
-        (UnsupportedDeviceError, "warn_code_owner"),
+        (UnsupportedDeviceError, "unsupported"),
     ],
 )
 async def test_flow_errors(

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -6,7 +6,7 @@ from plugwise.exceptions import (
     InvalidAuthentication,
     InvalidXMLError,
     ResponseError,
-    XMLDataMissingError,
+    UnsupportedDeviceError,
 )
 import pytest
 
@@ -102,7 +102,7 @@ def mock_smile():
         smile_mock.InvalidAuthentication = InvalidAuthentication
         smile_mock.InvalidXMLError = InvalidXMLError
         smile_mock.ResponseError = ResponseError
-        smile_mock.XMLDataMissingError = XMLDataMissingError
+        smile_mock.UnsupportedDeviceError = UnsupportedDeviceError
         smile_mock.return_value.connect.return_value = True
         yield smile_mock.return_value
 
@@ -269,14 +269,14 @@ async def test_zercoconf_discovery_update_configuration(
 
 
 @pytest.mark.parametrize(
-    "side_effect,reason",
+    "side_effect, reason",
     [
         (ConnectionFailedError, "cannot_connect"),
         (InvalidAuthentication, "invalid_auth"),
-        (InvalidXMLError, "cannot_connect"),
-        (ResponseError, "cannot_connect"),
+        (InvalidXMLError, "response_error"),
+        (ResponseError, "response_error"),
         (RuntimeError, "unknown"),
-        (XMLDataMissingError, "retry"),
+        (UnsupportedDeviceError, "warn_code_owner"),
     ],
 )
 async def test_flow_errors(

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from plugwise.exceptions import (
     ConnectionFailedError,
     InvalidAuthentication,
-    InvalidSetupError,
-    PlugwiseException,
+    InvalidXMLError,
+    ResponseError,
+    XMLDataMissingError,
 )
 import pytest
 
@@ -97,9 +98,11 @@ def mock_smile():
     with patch(
         "homeassistant.components.plugwise.config_flow.Smile",
     ) as smile_mock:
-        smile_mock.PlugwiseException = PlugwiseException
-        smile_mock.InvalidAuthentication = InvalidAuthentication
         smile_mock.ConnectionFailedError = ConnectionFailedError
+        smile_mock.InvalidAuthentication = InvalidAuthentication
+        smile_mock.InvalidXMLError = InvalidXMLError
+        smile_mock.ResponseError = ResponseError
+        smile_mock.XMLDataMissingError = XMLDataMissingError
         smile_mock.return_value.connect.return_value = True
         yield smile_mock.return_value
 
@@ -268,11 +271,12 @@ async def test_zercoconf_discovery_update_configuration(
 @pytest.mark.parametrize(
     "side_effect,reason",
     [
-        (InvalidAuthentication, "invalid_auth"),
-        (InvalidSetupError, "invalid_setup"),
         (ConnectionFailedError, "cannot_connect"),
-        (PlugwiseException, "cannot_connect"),
+        (InvalidAuthentication, "invalid_auth"),
+        (InvalidXMLError, "cannot_connect"),
+        (ResponseError, "cannot_connect"),
         (RuntimeError, "unknown"),
+        (XMLDataMissingError, "retry"),
     ],
 )
 async def test_flow_errors(

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -71,9 +71,9 @@ async def test_config_entry_not_ready(
     await hass.async_block_till_done()
 
     assert len(mock_smile_anna.connect.mock_calls) == 1
-    assert (
-        mock_config_entry.state is ConfigEntryState.SETUP_ERROR
-        or mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state in (
+        ConfigEntryState.SETUP_ERROR,
+        ConfigEntryState.SETUP_RETRY,
     )
 
 

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -53,7 +53,7 @@ async def test_load_unload_config_entry(
         (UnsupportedDeviceError, ConfigEntryState.SETUP_ERROR),
     ],
 )
-async def test_config_entry_not_ready(
+async def test_gateway_config_entry_not_ready(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_smile_anna: MagicMock,
@@ -69,6 +69,33 @@ async def test_config_entry_not_ready(
 
     assert len(mock_smile_anna.connect.mock_calls) == 1
     assert mock_config_entry.state == entry_state
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        (ConnectionFailedError),
+        (InvalidAuthentication),
+        (InvalidXMLError),
+        (ResponseError),
+        (UnsupportedDeviceError),
+    ],
+)
+async def test_coord_config_entry_not_ready(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smile_anna: MagicMock,
+    side_effect: Exception,
+) -> None:
+    """Test the Plugwise configuration entry not ready."""
+    mock_smile_anna.async_update.side_effect = side_effect
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(mock_smile_anna.connect.mock_calls) == 1
+    assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -68,7 +68,7 @@ async def test_gateway_config_entry_not_ready(
     await hass.async_block_till_done()
 
     assert len(mock_smile_anna.connect.mock_calls) == 1
-    assert mock_config_entry.state == entry_state
+    assert mock_config_entry.state is entry_state
 
 
 @pytest.mark.parametrize(

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -95,7 +95,7 @@ async def test_coord_config_entry_not_ready(
     await hass.async_block_till_done()
 
     assert len(mock_smile_anna.connect.mock_calls) == 1
-    assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -71,7 +71,10 @@ async def test_config_entry_not_ready(
     await hass.async_block_till_done()
 
     assert len(mock_smile_anna.connect.mock_calls) == 1
-    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+        or mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock
 import aiohttp
 from plugwise.exceptions import (
     ConnectionFailedError,
-    PlugwiseException,
+    InvalidAuthentication,
+    InvalidXMLError,
+    ResponseError,
     XMLDataMissingError,
 )
 import pytest
@@ -47,10 +49,12 @@ async def test_load_unload_config_entry(
     "side_effect",
     [
         (ConnectionFailedError),
-        (PlugwiseException),
+        (InvalidAuthentication),
+        (InvalidXMLError),
+        (ResponseError),
         (XMLDataMissingError),
+        (aiohttp.ClientError),
         (asyncio.TimeoutError),
-        (aiohttp.ClientConnectionError),
     ],
 )
 async def test_config_entry_not_ready(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump plugwise to v0.25.12 and adapt code & tests

https://github.com/plugwise/python-plugwise/releases/tag/v0.25.12
https://github.com/plugwise/python-plugwise/releases/tag/v0.25.11
https://github.com/plugwise/python-plugwise/releases/tag/v0.25.10
https://github.com/plugwise/python-plugwise/releases/tag/v0.25.9
https://github.com/plugwise/python-plugwise/releases/tag/v0.25.8
https://github.com/plugwise/python-plugwise/compare/v0.25.7...v0.25.12

This update adds a cooling_enabled binary_sensor, only for Anna + Elga heatpump systems.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81716, #81839, #81712, https://github.com/plugwise/python-plugwise/issues/240, https://github.com/plugwise/python-plugwise/issues/241
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24955

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
