### PR TITLE
Add additional overrides to universal media player

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -334,22 +334,22 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     @property
     def media_content_id(self):
         """Return the content ID of current playing media."""
-        return self._child_attr(ATTR_MEDIA_CONTENT_ID)
+        return self._override_or_child_attr(ATTR_MEDIA_CONTENT_ID)
 
     @property
     def media_content_type(self):
         """Return the content type of current playing media."""
-        return self._child_attr(ATTR_MEDIA_CONTENT_TYPE)
+        return self._override_or_child_attr(ATTR_MEDIA_CONTENT_TYPE)
 
     @property
     def media_duration(self):
         """Return the duration of current playing media in seconds."""
-        return self._child_attr(ATTR_MEDIA_DURATION)
+        return self._override_or_child_attr(ATTR_MEDIA_DURATION)
 
     @property
     def media_image_url(self):
         """Image url of current playing media."""
-        return self._child_attr(ATTR_ENTITY_PICTURE)
+        return self._override_or_child_attr(ATTR_ENTITY_PICTURE)
 
     @property
     def entity_picture(self):
@@ -365,62 +365,62 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     @property
     def media_title(self):
         """Title of current playing media."""
-        return self._child_attr(ATTR_MEDIA_TITLE)
+        return self._override_or_child_attr(ATTR_MEDIA_TITLE)
 
     @property
     def media_artist(self):
         """Artist of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ARTIST)
+        return self._override_or_child_attr(ATTR_MEDIA_ARTIST)
 
     @property
     def media_album_name(self):
         """Album name of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ALBUM_NAME)
+        return self._override_or_child_attr(ATTR_MEDIA_ALBUM_NAME)
 
     @property
     def media_album_artist(self):
         """Album artist of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ALBUM_ARTIST)
+        return self._override_or_child_attr(ATTR_MEDIA_ALBUM_ARTIST)
 
     @property
     def media_track(self):
         """Track number of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_TRACK)
+        return self._override_or_child_attr(ATTR_MEDIA_TRACK)
 
     @property
     def media_series_title(self):
         """Return the title of the series of current playing media (TV)."""
-        return self._child_attr(ATTR_MEDIA_SERIES_TITLE)
+        return self._override_or_child_attr(ATTR_MEDIA_SERIES_TITLE)
 
     @property
     def media_season(self):
         """Season of current playing media (TV Show only)."""
-        return self._child_attr(ATTR_MEDIA_SEASON)
+        return self._override_or_child_attr(ATTR_MEDIA_SEASON)
 
     @property
     def media_episode(self):
         """Episode of current playing media (TV Show only)."""
-        return self._child_attr(ATTR_MEDIA_EPISODE)
+        return self._override_or_child_attr(ATTR_MEDIA_EPISODE)
 
     @property
     def media_channel(self):
         """Channel currently playing."""
-        return self._child_attr(ATTR_MEDIA_CHANNEL)
+        return self._override_or_child_attr(ATTR_MEDIA_CHANNEL)
 
     @property
     def media_playlist(self):
         """Title of Playlist currently playing."""
-        return self._child_attr(ATTR_MEDIA_PLAYLIST)
+        return self._override_or_child_attr(ATTR_MEDIA_PLAYLIST)
 
     @property
     def app_id(self):
         """ID of the current running app."""
-        return self._child_attr(ATTR_APP_ID)
+        return self._override_or_child_attr(ATTR_APP_ID)
 
     @property
     def app_name(self):
         """Name of the current running app."""
-        return self._child_attr(ATTR_APP_NAME)
+        return self._override_or_child_attr(ATTR_APP_NAME)
 
     @property
     def sound_mode(self):
@@ -521,12 +521,12 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
-        return self._child_attr(ATTR_MEDIA_POSITION)
+        return self._override_or_child_attr(ATTR_MEDIA_POSITION)
 
     @property
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
-        return self._child_attr(ATTR_MEDIA_POSITION_UPDATED_AT)
+        return self._override_or_child_attr(ATTR_MEDIA_POSITION_UPDATED_AT)
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This adds additional overrides to the universal media player to allow users to override additional state attributes that were not able to have set overrides previously.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
