### PR TITLE
Fix Growatt incorrect energy dashboard values for grid import

### DIFF
--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -299,7 +299,8 @@ class GrowattData:
             # however if the value is low e.g. 0.2 and drops by 0.1 it classes as a reset.
             if -(entity_description.previous_value_drop_threshold) <= diff < 0:
                 _LOGGER.debug(
-                    "Diff is negative, but only by a small amount therefore not a nightly reset, using previous value (%s) instead of api value (%s)",
+                    "Diff is negative, but only by a small amount therefore not a nightly reset, "
+                    "using previous value (%s) instead of api value (%s)",
                     previous_value,
                     api_value,
                 )

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -159,7 +159,7 @@ class GrowattInverter(SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        result = self.probe.get_data(self.entity_description.api_key)
+        result = self.probe.get_data(self.entity_description)
         if self.entity_description.precision is not None:
             result = round(result, self.entity_description.precision)
         return result
@@ -168,7 +168,7 @@ class GrowattInverter(SensorEntity):
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of the sensor, if any."""
         if self.entity_description.currency:
-            return self.probe.get_data("currency")
+            return self.probe.get_currency()
         return super().native_unit_of_measurement
 
     def update(self) -> None:
@@ -187,6 +187,7 @@ class GrowattData:
         self.device_id = device_id
         self.plant_id = None
         self.data = {}
+        self.previous_values = {}
         self.username = username
         self.password = password
 
@@ -257,6 +258,45 @@ class GrowattData:
         except json.decoder.JSONDecodeError:
             _LOGGER.error("Unable to fetch data from Growatt server")
 
-    def get_data(self, variable):
+    def get_currency(self):
+        """Get the currency."""
+        return self.data.get("currency")
+
+    def get_data(self, entity_description):
         """Get the data."""
-        return self.data.get(variable)
+        variable = entity_description.api_key
+        api_value = self.data.get(variable)
+        previous_value = self.previous_values.get(variable, None)
+        return_value = api_value
+
+        # If we have a 'drop threshold' specified, then check it and correct if needed
+        if (
+            entity_description.previous_value_drop_threshold is not None
+            and previous_value is not None
+        ):
+            _LOGGER.debug(
+                "%s - Drop threshold specified (%s), checking for drop... API Value: %s, Previous Value: %s",
+                entity_description.name,
+                entity_description.previous_value_drop_threshold,
+                api_value,
+                previous_value,
+            )
+            diff = float(api_value) - float(previous_value)
+
+            # Check if the value has dropped (negative value i.e. < 0) and it has only dropped by a small amount, if so, use the previous value
+            # Note - The energy dashboard takes care of drops within 10% of the current value, however if the value is low e.g. 0.2 and drops by 0.1 it classes as a reset.
+            if -(entity_description.previous_value_drop_threshold) <= diff < 0:
+                _LOGGER.debug(
+                    "Diff is negative, but only by a small amount therefore not a nightly reset, using previous value (%s) instead of api value (%s)",
+                    previous_value,
+                    api_value,
+                )
+                return_value = previous_value
+            else:
+                _LOGGER.debug(
+                    "%s - No drop detected, using API value", entity_description.name
+                )
+
+        self.previous_values[variable] = return_value
+
+        return return_value

--- a/homeassistant/components/growatt_server/sensor_types/mix.py
+++ b/homeassistant/components/growatt_server/sensor_types/mix.py
@@ -224,6 +224,7 @@ MIX_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
         api_key="etouser",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
+        previous_value_drop_threshold=0.2,
     ),
     # This sensor is manually created using the most recent X-Axis value from the chartData
     GrowattSensorEntityDescription(
@@ -240,5 +241,6 @@ MIX_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        previous_value_drop_threshold=0.2,
     ),
 )

--- a/homeassistant/components/growatt_server/sensor_types/mix.py
+++ b/homeassistant/components/growatt_server/sensor_types/mix.py
@@ -224,6 +224,7 @@ MIX_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
         api_key="etouser",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         previous_value_drop_threshold=0.2,
     ),
     # This sensor is manually created using the most recent X-Axis value from the chartData

--- a/homeassistant/components/growatt_server/sensor_types/mix.py
+++ b/homeassistant/components/growatt_server/sensor_types/mix.py
@@ -224,8 +224,6 @@ MIX_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
         api_key="etouser",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        previous_value_drop_threshold=0.2,
     ),
     # This sensor is manually created using the most recent X-Axis value from the chartData
     GrowattSensorEntityDescription(

--- a/homeassistant/components/growatt_server/sensor_types/sensor_entity_description.py
+++ b/homeassistant/components/growatt_server/sensor_types/sensor_entity_description.py
@@ -19,3 +19,4 @@ class GrowattSensorEntityDescription(SensorEntityDescription, GrowattRequiredKey
 
     precision: int | None = None
     currency: bool = False
+    previous_value_drop_threshold: float | None = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements fix for #80905 by tracking previous values returned for each entity and comparing them against the latest values returned from the API.
This comparison is only performed for api values that are known to behave incorrectly i.e. monotonically increasing values that randomly drop by small amounts.
The implementation allows for an acceptable 'drop threshold' to be reached without considering the whole value to have reset. This works around the issue where for small decreases e.g. 0.1 when the value is less than 1 being handled correctly rather than being considered as a 'meter reset' by the energy dashboard.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80905
- This PR is related to issue: #80905
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
