### PR TITLE
Support commands and broadcast to Google Assistant

### DIFF
--- a/homeassistant/components/google_assistant/manifest.json
+++ b/homeassistant/components/google_assistant/manifest.json
@@ -2,6 +2,7 @@
   "domain": "google_assistant",
   "name": "Google Assistant",
   "documentation": "https://www.home-assistant.io/integrations/google_assistant",
+  "requirements": ["gassist-text==0.0.3"],
   "dependencies": ["http"],
   "after_dependencies": ["camera"],
   "codeowners": ["@home-assistant/cloud"],

--- a/homeassistant/components/google_assistant/notify.py
+++ b/homeassistant/components/google_assistant/notify.py
@@ -1,0 +1,42 @@
+"""Support for Google Assistant broadcast notifications."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.notify import ATTR_TARGET, BaseNotificationService
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .const import CONF_SERVICE_ACCOUNT, DATA_CONFIG, DOMAIN
+from .helpers import async_send_text_command
+
+
+async def async_get_service(
+    hass: HomeAssistant,
+    config: ConfigType,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> BaseNotificationService:
+    """Get the broadcast notification service."""
+    return BroadcastNotificationService(hass)
+
+
+class BroadcastNotificationService(BaseNotificationService):
+    """Implement broadcast notification service."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the service."""
+        self.hass = hass
+
+    async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
+        """Send a message."""
+        if not message:
+            return
+        service_account_info = self.hass.data[DOMAIN][DATA_CONFIG][CONF_SERVICE_ACCOUNT]
+        targets = kwargs.get(ATTR_TARGET)
+        if not targets:
+            command = f"broadcast {message}"
+            await async_send_text_command(service_account_info, command)
+        else:
+            for target in targets:
+                command = f"broadcast to {target} {message}"
+                await async_send_text_command(service_account_info, command)

--- a/homeassistant/components/google_assistant/services.yaml
+++ b/homeassistant/components/google_assistant/services.yaml
@@ -7,3 +7,13 @@ request_sync:
       description: "Only needed for automations. Specific Home Assistant user id (not username, ID in configuration > users > under username) to sync with Google Assistant. Do not need when you call this service through Home Assistant front end or API. Used in automation script or other place where context.user_id is missing."
       selector:
         text:
+send_text_command:
+  name: Send text command
+  description: Send a command as a text query to Google Assistant.
+  fields:
+    command:
+      name: Command
+      description: Command to send to Google Assistant.
+      example: turn off kitchen TV
+      selector:
+        text:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -739,6 +739,9 @@ gTTS==2.2.4
 # homeassistant.components.garages_amsterdam
 garages-amsterdam==3.0.0
 
+# homeassistant.components.google_assistant
+gassist-text==0.0.3
+
 # homeassistant.components.google
 gcal-sync==4.0.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -555,6 +555,9 @@ gTTS==2.2.4
 # homeassistant.components.garages_amsterdam
 garages-amsterdam==3.0.0
 
+# homeassistant.components.google_assistant
+gassist-text==0.0.3
+
 # homeassistant.components.google
 gcal-sync==4.0.2
 

--- a/tests/components/google_assistant/test_init.py
+++ b/tests/components/google_assistant/test_init.py
@@ -1,5 +1,6 @@
 """The tests for google-assistant init."""
 from http import HTTPStatus
+from unittest.mock import patch
 
 from homeassistant.components import google_assistant as ga
 from homeassistant.core import Context, HomeAssistant
@@ -69,3 +70,21 @@ async def test_request_sync_service(aioclient_mock, hass):
     )
 
     assert aioclient_mock.call_count == 2  # token + request
+
+
+async def test_send_text_command_service(hass):
+    """Test send_text_command calls TextAssistant."""
+    await async_setup_component(hass, ga.DOMAIN, {ga.DOMAIN: DUMMY_CONFIG})
+    await hass.async_block_till_done()
+
+    command = "turn on home assistant unsupported device"
+    with patch(
+        "homeassistant.components.google_assistant.helpers.TextAssistant.assist"
+    ) as mock_assist_call:
+        await hass.services.async_call(
+            ga.DOMAIN,
+            ga.SERVICE_SEND_TEXT_COMMAND,
+            {ga.SERVICE_SEND_TEXT_COMMAND_FIELD_COMMAND: command},
+            blocking=True,
+        )
+    mock_assist_call.assert_called_once_with(command)

--- a/tests/components/google_assistant/test_notify.py
+++ b/tests/components/google_assistant/test_notify.py
@@ -1,0 +1,99 @@
+"""Tests for the Google Assistant notify."""
+from unittest.mock import call, patch
+
+from homeassistant.components import google_assistant as ga, notify
+from homeassistant.components.google_assistant import GOOGLE_ASSISTANT_SCHEMA
+from homeassistant.setup import async_setup_component
+
+from .test_http import DUMMY_CONFIG
+
+
+async def setup_notify(hass):
+    """Test setup."""
+    await async_setup_component(hass, ga.DOMAIN, {ga.DOMAIN: DUMMY_CONFIG})
+    await hass.async_block_till_done()
+    assert hass.services.has_service(notify.DOMAIN, ga.DOMAIN)
+
+
+async def test_broadcast_no_targets(hass):
+    """Test broadcast to all."""
+    await setup_notify(hass)
+
+    message = "time for dinner"
+    expected_command = "broadcast time for dinner"
+    with patch(
+        "homeassistant.components.google_assistant.helpers.TextAssistant.assist"
+    ) as mock_assist_call:
+        await hass.services.async_call(
+            notify.DOMAIN, ga.DOMAIN, {notify.ATTR_MESSAGE: message}
+        )
+        await hass.async_block_till_done()
+    mock_assist_call.assert_called_once_with(expected_command)
+
+
+async def test_broadcast_one_target(hass):
+    """Test broadcast to one target."""
+    await setup_notify(hass)
+
+    message = "time for dinner"
+    target = "basement"
+    expected_command = "broadcast to basement time for dinner"
+    with patch(
+        "homeassistant.components.google_assistant.helpers.TextAssistant.assist"
+    ) as mock_assist_call:
+        await hass.services.async_call(
+            notify.DOMAIN,
+            ga.DOMAIN,
+            {notify.ATTR_MESSAGE: message, notify.ATTR_TARGET: [target]},
+        )
+        await hass.async_block_till_done()
+    mock_assist_call.assert_called_once_with(expected_command)
+
+
+async def test_broadcast_two_targets(hass):
+    """Test broadcast to two targets."""
+    await setup_notify(hass)
+
+    message = "time for dinner"
+    target1 = "basement"
+    target2 = "master bedroom"
+    expected_command1 = "broadcast to basement time for dinner"
+    expected_command2 = "broadcast to master bedroom time for dinner"
+    with patch(
+        "homeassistant.components.google_assistant.helpers.TextAssistant.assist"
+    ) as mock_assist_call:
+        await hass.services.async_call(
+            notify.DOMAIN,
+            ga.DOMAIN,
+            {notify.ATTR_MESSAGE: message, notify.ATTR_TARGET: [target1, target2]},
+        )
+        await hass.async_block_till_done()
+    mock_assist_call.assert_has_calls(
+        [call(expected_command1), call(expected_command2)]
+    )
+
+
+async def test_broadcast_empty_message(hass):
+    """Test broadcast empty message."""
+    await setup_notify(hass)
+
+    message = ""
+    with patch(
+        "homeassistant.components.google_assistant.helpers.TextAssistant.assist"
+    ) as mock_assist_call:
+        await hass.services.async_call(
+            notify.DOMAIN,
+            ga.DOMAIN,
+            {notify.ATTR_MESSAGE: message},
+        )
+        await hass.async_block_till_done()
+    mock_assist_call.assert_not_called()
+
+
+async def test_no_broadcast_service(hass):
+    """Test no broadcast service when there is no service_account in config."""
+    await async_setup_component(
+        hass, ga.DOMAIN, {ga.DOMAIN: GOOGLE_ASSISTANT_SCHEMA({"project_id": "1234"})}
+    )
+    await hass.async_block_till_done()
+    assert not hass.services.has_service(notify.DOMAIN, ga.DOMAIN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow sending commands and broadcast messages to Google Assistant.
- Sending commands is useful to control devices supported by Google Assistant but not Home Assistant.
- Broadcasting messages is useful to not interrupt music playback. Broadcast service is setup as a notify service to be able to use it in alerts etc. It optionally supports targets (Google Assistant currently seems to only support rooms as targets).

Requirements for this to work:
- Enable [Google Assistant API](https://console.developers.google.com/apis/api/embeddedassistant.googleapis.com/overview) for your project similar to how [Enable Device Sync](https://www.home-assistant.io/integrations/google_assistant/#enable-device-sync) enables HomeGraph API.
- Have `service_account` in the config. Not needed if [Enable Device Sync](https://www.home-assistant.io/integrations/google_assistant/#enable-device-sync) section from the documentation has already been done.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
