### PR TITLE
Deprecate Python 3.9

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -17,7 +17,7 @@ import voluptuous as vol
 import yarl
 
 from . import config as conf_util, config_entries, core, loader
-from .components import http, persistent_notification
+from .components import http
 from .const import (
     REQUIRED_NEXT_PYTHON_HA_RELEASE,
     REQUIRED_NEXT_PYTHON_VER,
@@ -268,16 +268,31 @@ async def async_from_config_dict(
         REQUIRED_NEXT_PYTHON_HA_RELEASE
         and sys.version_info[:3] < REQUIRED_NEXT_PYTHON_VER
     ):
-        msg = (
-            "Support for the running Python version "
-            f"{'.'.join(str(x) for x in sys.version_info[:3])} is deprecated and will "
-            f"be removed in Home Assistant {REQUIRED_NEXT_PYTHON_HA_RELEASE}. "
-            "Please upgrade Python to "
-            f"{'.'.join(str(x) for x in REQUIRED_NEXT_PYTHON_VER[:2])}."
+        current_python_version = ".".join(str(x) for x in sys.version_info[:3])
+        required_python_version = ".".join(str(x) for x in REQUIRED_NEXT_PYTHON_VER[:2])
+        _LOGGER.warning(
+            (
+                "Support for the running Python version %s is deprecated and "
+                "will be removed in Home Assistant %s; "
+                "Please upgrade Python to %s"
+            ),
+            current_python_version,
+            REQUIRED_NEXT_PYTHON_HA_RELEASE,
+            required_python_version,
         )
-        _LOGGER.warning(msg)
-        persistent_notification.async_create(
-            hass, msg, "Python version", "python_version"
+        issue_registry.async_create_issue(
+            hass,
+            core.DOMAIN,
+            "python_version",
+            is_fixable=False,
+            severity=issue_registry.IssueSeverity.WARNING,
+            breaks_in_ha_version=REQUIRED_NEXT_PYTHON_HA_RELEASE,
+            translation_key="python_version",
+            translation_placeholders={
+                "current_python_version": current_python_version,
+                "required_python_version": required_python_version,
+                "breaks_in_ha_version": REQUIRED_NEXT_PYTHON_HA_RELEASE,
+            },
         )
 
     return hass

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -3,6 +3,10 @@
     "historic_currency": {
       "title": "The configured currency is no longer in use",
       "description": "The currency {currency} is no longer in use, please reconfigure the currency configuration."
+    },
+    "python_version": {
+      "title": "Support for Python {current_python_version} is being removed",
+      "description": "Support for running Home Assistant in the current used Python version {current_python_version} is deprecated and will be removed in Home Assistant {breaks_in_ha_version}. Please upgrade Python to {required_python_version} to prevent your Home Assistant instance from breaking."
     }
   },
   "system_health": {

--- a/homeassistant/components/homeassistant/translations/en.json
+++ b/homeassistant/components/homeassistant/translations/en.json
@@ -3,6 +3,10 @@
         "historic_currency": {
             "description": "The currency {currency} is no longer in use, please reconfigure the currency configuration.",
             "title": "The configured currency is no longer in use"
+        },
+        "python_version": {
+            "description": "Support for running Home Assistant in the current used Python version {current_python_version} is deprecated and will be removed in Home Assistant {breaks_in_ha_version}. Please upgrade Python to {required_python_version} to prevent your Home Assistant instance from breaking.",
+            "title": "Support for Python {current_python_version} is being removed"
         }
     },
     "system_health": {

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -12,9 +12,9 @@ PATCH_VERSION: Final = "0.dev0"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)
-REQUIRED_NEXT_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)
+REQUIRED_NEXT_PYTHON_VER: Final[tuple[int, int, int]] = (3, 10, 0)
 # Truthy date string triggers showing related deprecation warning messages.
-REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = ""
+REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = "2023.2"
 
 # Format for platform files
 PLATFORM_FORMAT: Final = "{platform}.{domain}"

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -32,7 +32,8 @@ SUPPORTED_PYTHON_TUPLES = [
 ]
 if REQUIRED_PYTHON_VER[0] == REQUIRED_NEXT_PYTHON_VER[0]:
     for minor in range(REQUIRED_PYTHON_VER[1] + 1, REQUIRED_NEXT_PYTHON_VER[1] + 1):
-        SUPPORTED_PYTHON_TUPLES.append((REQUIRED_PYTHON_VER[0], minor))
+        if minor < 10:  # stdlib list does not support 3.10+
+            SUPPORTED_PYTHON_TUPLES.append((REQUIRED_PYTHON_VER[0], minor))
 SUPPORTED_PYTHON_VERSIONS = [
     ".".join(map(str, version_tuple)) for version_tuple in SUPPORTED_PYTHON_TUPLES
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR deprecates support for Python 3.9

As per [ADR-002](https://github.com/home-assistant/architecture/blob/master/adr/0002-minimum-supported-python-version.md)

![image](https://user-images.githubusercontent.com/195327/202187836-94bde3b1-f778-4662-bd3e-a3ba246558eb.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
