### PR TITLE
Remove duplicate code in hassfest model

### DIFF
--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -55,7 +55,13 @@ class Brand:
         return brands
 
     path: pathlib.Path = attr.ib()
-    brand: dict[str, Any] | None = attr.ib(default=None)
+    _brand: dict[str, Any] | None = attr.ib(default=None)
+
+    @property
+    def brand(self) -> dict[str, Any]:
+        """Guarded access to brand."""
+        assert self._brand is not None, "brand has not been loaded"
+        return self._brand
 
     @property
     def domain(self) -> str:
@@ -65,19 +71,16 @@ class Brand:
     @property
     def name(self) -> str | None:
         """Return name of the integration."""
-        assert self.brand is not None, "brand has not been loaded"
         return self.brand.get("name")
 
     @property
     def integrations(self) -> list[str]:
         """Return the sub integrations of this brand."""
-        assert self.brand is not None, "brand has not been loaded"
         return self.brand.get("integrations", [])
 
     @property
     def iot_standards(self) -> list[str]:
         """Return list of supported IoT standards."""
-        assert self.brand is not None, "brand has not been loaded"
         return self.brand.get("iot_standards", [])
 
     def load_brand(self, config: Config) -> None:
@@ -94,7 +97,7 @@ class Brand:
             )
             return
 
-        self.brand = brand
+        self._brand = brand
 
 
 @attr.s
@@ -127,10 +130,16 @@ class Integration:
         return integrations
 
     path: pathlib.Path = attr.ib()
-    manifest: dict[str, Any] | None = attr.ib(default=None)
+    _manifest: dict[str, Any] | None = attr.ib(default=None)
     errors: list[Error] = attr.ib(factory=list)
     warnings: list[Error] = attr.ib(factory=list)
     translated_name: bool = attr.ib(default=False)
+
+    @property
+    def manifest(self) -> dict[str, Any]:
+        """Guarded access to manifest."""
+        assert self._manifest is not None, "manifest has not been loaded"
+        return self._manifest
 
     @property
     def domain(self) -> str:
@@ -145,62 +154,52 @@ class Integration:
     @property
     def disabled(self) -> str | None:
         """Return if integration is disabled."""
-        assert self.manifest is not None, "manifest has not been loaded"
         return self.manifest.get("disabled")
 
     @property
     def name(self) -> str:
         """Return name of the integration."""
-        assert self.manifest is not None, "manifest has not been loaded"
         name: str = self.manifest["name"]
         return name
 
     @property
     def quality_scale(self) -> str | None:
         """Return quality scale of the integration."""
-        assert self.manifest is not None, "manifest has not been loaded"
         return self.manifest.get("quality_scale")
 
     @property
     def config_flow(self) -> bool:
         """Return if the integration has a config flow."""
-        assert self.manifest is not None, "manifest has not been loaded"
         return self.manifest.get("config_flow", False)
 
     @property
     def requirements(self) -> list[str]:
         """List of requirements."""
-        assert self.manifest is not None, "manifest has not been loaded"
         return self.manifest.get("requirements", [])
 
     @property
     def dependencies(self) -> list[str]:
         """List of dependencies."""
-        assert self.manifest is not None, "manifest has not been loaded"
         return self.manifest.get("dependencies", [])
 
     @property
     def supported_by(self) -> str:
         """Return the integration supported by this virtual integration."""
-        assert self.manifest is not None, "manifest has not been loaded"
         return self.manifest.get("supported_by", {})
 
     @property
     def integration_type(self) -> str:
         """Get integration_type."""
-        assert self.manifest is not None, "manifest has not been loaded"
         return self.manifest.get("integration_type", "hub")
 
     @property
     def iot_class(self) -> str | None:
         """Return the integration IoT Class."""
-        assert self.manifest is not None, "manifest has not been loaded"
         return self.manifest.get("iot_class")
 
     @property
     def iot_standards(self) -> list[str]:
         """Return the IoT standard supported by this virtual integration."""
-        assert self.manifest is not None, "manifest has not been loaded"
         return self.manifest.get("iot_standards", [])
 
     def add_error(self, *args: Any, **kwargs: Any) -> None:
@@ -224,4 +223,4 @@ class Integration:
             self.add_error("model", f"Manifest contains invalid JSON: {err}")
             return
 
-        self.manifest = manifest
+        self._manifest = manifest

--- a/tests/hassfest/test_version.py
+++ b/tests/hassfest/test_version.py
@@ -13,7 +13,7 @@ from script.hassfest.model import Integration
 def integration():
     """Fixture for hassfest integration model."""
     integration = Integration("")
-    integration.manifest = {
+    integration._manifest = {
         "domain": "test",
         "documentation": "https://example.com",
         "name": "test",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove duplicate code in hassfest model

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
