### PR TITLE
Update Tibber setup_entry flow

### DIFF
--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -44,12 +44,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         websession=async_get_clientsession(hass),
         time_zone=dt_util.DEFAULT_TIME_ZONE,
     )
-    hass.data[DOMAIN] = tibber_connection
-
-    async def _close(event: Event) -> None:
-        await tibber_connection.rt_disconnect()
-
-    entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
 
     try:
         await tibber_connection.update_info()
@@ -64,6 +58,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except tibber.InvalidLogin as exp:
         _LOGGER.error("Failed to login. %s", exp)
         return False
+
+    hass.data[DOMAIN] = tibber_connection
+
+    async def _close(event: Event) -> None:
+        await tibber_connection.rt_disconnect()
+
+    entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/tibber/diagnostics.py
+++ b/homeassistant/components/tibber/diagnostics.py
@@ -20,7 +20,7 @@ async def async_get_config_entry_diagnostics(
     # If the ConfigEntry is not ready there is no DOMAIN data available,
     # it can occur either if it has never been started
     # or connection to the Tibber API failed
-    tibber_connection: tibber.Tibber | None = hass.data.get(DOMAIN, None)
+    tibber_connection: tibber.Tibber | None = hass.data.get(DOMAIN)
 
     homes: dict[str, Any] = {}
     if tibber_connection:

--- a/homeassistant/components/tibber/diagnostics.py
+++ b/homeassistant/components/tibber/diagnostics.py
@@ -13,19 +13,23 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> dict:
     """Return diagnostics for a config entry."""
-    tibber_connection: tibber.Tibber = hass.data[DOMAIN]
-
     diagnostics_data = {}
 
+    tibber_connection: tibber.Tibber = hass.data.get(DOMAIN)
+
+    diagnostics_data["api_connection"] = True if tibber_connection else False
+
     homes = {}
-    for home in tibber_connection.get_homes(only_active=False):
-        homes[home.home_id] = {
-            "last_data_timestamp": home.last_data_timestamp,
-            "has_active_subscription": home.has_active_subscription,
-            "has_real_time_consumption": home.has_real_time_consumption,
-            "last_cons_data_timestamp": home.last_cons_data_timestamp,
-            "country": home.country,
-        }
+    if tibber_connection:
+        for home in tibber_connection.get_homes(only_active=False):
+            homes[home.home_id] = {
+                "last_data_timestamp": home.last_data_timestamp,
+                "has_active_subscription": home.has_active_subscription,
+                "has_real_time_consumption": home.has_real_time_consumption,
+                "last_cons_data_timestamp": home.last_cons_data_timestamp,
+                "country": home.country,
+            }
+
     diagnostics_data["homes"] = homes
 
     return diagnostics_data

--- a/homeassistant/components/tibber/diagnostics.py
+++ b/homeassistant/components/tibber/diagnostics.py
@@ -8,7 +8,6 @@ import tibber
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-
 from .const import DOMAIN
 
 

--- a/tests/components/tibber/test_common.py
+++ b/tests/components/tibber/test_common.py
@@ -60,7 +60,7 @@ def mock_get_homes(only_active=True):
 
 
 def mock_connection_with_home(access_token, websession, time_zone):
-    """Returns a mocked Tibber object with mocked home data"""
+    """Return a mocked Tibber object with mocked home data."""
     tibber_connection = AsyncMock()
 
     tibber_connection.name = "Mocked Name"
@@ -74,7 +74,7 @@ def mock_connection_with_home(access_token, websession, time_zone):
 
 
 def mock_connection(access_token, websession, time_zone):
-    """Returns a mocked Tibber object"""
+    """Return a mocked Tibber object."""
     tibber_connection = AsyncMock()
 
     tibber_connection.name = "Mocked Name"

--- a/tests/components/tibber/test_common.py
+++ b/tests/components/tibber/test_common.py
@@ -1,7 +1,6 @@
 """Test common."""
 import datetime as dt
 from unittest.mock import AsyncMock, MagicMock
-import pytest
 
 CONSUMPTION_DATA_1 = [
     {
@@ -55,7 +54,7 @@ def mock_get_homes(only_active=True):
     def get_historic_data(n_data, resolution="HOURLY", production=False):
         return PRODUCTION_DATA_1 if production else CONSUMPTION_DATA_1
 
-    tibber_home.get_historic_data.side_effect = get_historic_data
+    tibber_home.get_historic_data.side_effect = AsyncMock(side_effect=get_historic_data)
 
     return [tibber_home]
 

--- a/tests/components/tibber/test_common.py
+++ b/tests/components/tibber/test_common.py
@@ -1,6 +1,7 @@
 """Test common."""
 import datetime as dt
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
+import pytest
 
 CONSUMPTION_DATA_1 = [
     {
@@ -41,7 +42,7 @@ PRODUCTION_DATA_1 = [
 
 def mock_get_homes(only_active=True):
     """Return a list of mocked Tibber homes."""
-    tibber_home = AsyncMock()
+    tibber_home = MagicMock()
     tibber_home.name = "Name"
     tibber_home.home_id = "home_id"
     tibber_home.currency = "NOK"
@@ -57,3 +58,33 @@ def mock_get_homes(only_active=True):
     tibber_home.get_historic_data.side_effect = get_historic_data
 
     return [tibber_home]
+
+
+def mock_connection_with_home(access_token, websession, time_zone):
+    """Returns a mocked Tibber object with mocked home data"""
+    tibber_connection = AsyncMock()
+
+    tibber_connection.name = "Mocked Name"
+    tibber_connection.access_token = access_token
+    tibber_connection.websession = websession
+    tibber_connection.time_zone = time_zone
+
+    tibber_connection.update_info = AsyncMock(return_value=None)
+    tibber_connection.get_homes = mock_get_homes
+    return tibber_connection
+
+
+def mock_connection(access_token, websession, time_zone):
+    """Returns a mocked Tibber object"""
+    tibber_connection = AsyncMock()
+
+    tibber_connection.name = "Mocked Name"
+    tibber_connection.access_token = access_token
+    tibber_connection.websession = websession
+    tibber_connection.time_zone = time_zone
+
+    tibber_connection.update_info = AsyncMock(return_value=None)
+
+    tibber_connection.get_homes = MagicMock(return_value=[])
+
+    return tibber_connection

--- a/tests/components/tibber/test_diagnostics.py
+++ b/tests/components/tibber/test_diagnostics.py
@@ -3,12 +3,14 @@ from unittest.mock import patch
 
 from homeassistant.setup import async_setup_component
 
-from .test_common import mock_get_homes
+from .test_common import mock_connection, mock_connection_with_home
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
-async def test_entry_diagnostics(recorder_mock, hass, hass_client, config_entry):
+async def test_entry_diagnostics_after_failure(
+    recorder_mock, hass, hass_client, config_entry
+):
     """Test config entry diagnostics."""
     with patch(
         "tibber.Tibber.update_info",
@@ -18,23 +20,47 @@ async def test_entry_diagnostics(recorder_mock, hass, hass_client, config_entry)
 
     await hass.async_block_till_done()
 
-    with patch(
-        "tibber.Tibber.get_homes",
-        return_value=[],
-    ):
-        result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert result == {
+        "api_connection": False,
         "homes": {},
     }
 
+
+async def test_entry_diagnostics(recorder_mock, hass, hass_client, config_entry):
+    """Test config entry diagnostics."""
     with patch(
-        "tibber.Tibber.get_homes",
-        side_effect=mock_get_homes,
-    ):
-        result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+        "tibber.Tibber",
+        side_effect=mock_connection,
+    ), patch("homeassistant.components.tibber.discovery.async_load_platform"):
+        assert await async_setup_component(hass, "tibber", {})
+
+    await hass.async_block_till_done()
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert result == {
+        "api_connection": True,
+        "homes": {},
+    }
+
+
+async def test_entry_diagnostics_with_homes(
+    recorder_mock, hass, hass_client, config_entry
+):
+    """Test config entry diagnostics."""
+    with patch("tibber.Tibber", side_effect=mock_connection_with_home), patch(
+        "homeassistant.components.tibber.discovery.async_load_platform"
+    ):
+        assert await async_setup_component(hass, "tibber", {})
+
+    await hass.async_block_till_done()
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+
+    assert result == {
+        "api_connection": True,
         "homes": {
             "home_id": {
                 "last_data_timestamp": "2016-01-01T12:48:57",

--- a/tests/components/tibber/test_diagnostics.py
+++ b/tests/components/tibber/test_diagnostics.py
@@ -23,7 +23,7 @@ async def test_entry_diagnostics_after_failure(
     result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert result == {
-        "api_connection": False,
+        "tibber_connection": False,
         "homes": {},
     }
 
@@ -41,7 +41,7 @@ async def test_entry_diagnostics(recorder_mock, hass, hass_client, config_entry)
     result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert result == {
-        "api_connection": True,
+        "tibber_connection": True,
         "homes": {},
     }
 
@@ -60,7 +60,7 @@ async def test_entry_diagnostics_with_homes(
     result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert result == {
-        "api_connection": True,
+        "tibber_connection": True,
         "homes": {
             "home_id": {
                 "last_data_timestamp": "2016-01-01T12:48:57",


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Register connection data after successful API connection
* Register event listener for HA close after successful API connection


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81998
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
