### PR TITLE
Remove `b64` encoding work around for MQTT camera

### DIFF
--- a/homeassistant/components/mqtt/camera.py
+++ b/homeassistant/components/mqtt/camera.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import subscription
 from .config import MQTT_BASE_SCHEMA
-from .const import CONF_ENCODING, CONF_QOS, CONF_TOPIC, DEFAULT_ENCODING
+from .const import CONF_QOS, CONF_TOPIC
 from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
@@ -45,20 +45,6 @@ MQTT_CAMERA_ATTRIBUTES_BLOCKED = frozenset(
     }
 )
 
-
-# Using CONF_ENCODING to set b64 encoding for images is deprecated as of Home Assistant 2022.9
-# use CONF_IMAGE_ENCODING instead, support for the work-a-round will be removed with Home Assistant 2022.11
-def repair_legacy_encoding(config: ConfigType) -> ConfigType:
-    """Check incorrect deprecated config of image encoding."""
-    if config[CONF_ENCODING] == "b64":
-        config[CONF_IMAGE_ENCODING] = "b64"
-        config[CONF_ENCODING] = DEFAULT_ENCODING
-        _LOGGER.warning(
-            "Using the `encoding` parameter to set image encoding has been deprecated, use `image_encoding` instead"
-        )
-    return config
-
-
 PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -69,14 +55,12 @@ PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
 
 PLATFORM_SCHEMA_MODERN = vol.All(
     PLATFORM_SCHEMA_BASE.schema,
-    repair_legacy_encoding,
 )
 
 # Configuring MQTT Camera under the camera platform key is deprecated in HA Core 2022.6
 PLATFORM_SCHEMA = vol.All(
     cv.PLATFORM_SCHEMA.extend(PLATFORM_SCHEMA_BASE.schema),
     warn_for_legacy_schema(camera.DOMAIN),
-    repair_legacy_encoding,
 )
 
 DISCOVERY_SCHEMA = PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA)

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -95,51 +95,13 @@ async def test_run_camera_b64_encoded(
                 camera.DOMAIN: {
                     "topic": topic,
                     "name": "Test Camera",
-                    "encoding": "b64",
+                    "image_encoding": "b64",
                 }
             }
         },
     )
     await hass.async_block_till_done()
     await mqtt_mock_entry_with_yaml_config()
-
-    url = hass.states.get("camera.test_camera").attributes["entity_picture"]
-
-    async_fire_mqtt_message(hass, topic, b64encode(b"grass"))
-
-    client = await hass_client_no_auth()
-    resp = await client.get(url)
-    assert resp.status == HTTPStatus.OK
-    body = await resp.text()
-    assert body == "grass"
-
-
-# Using CONF_ENCODING to set b64 encoding for images is deprecated in Home Assistant 2022.9, use CONF_IMAGE_ENCODING instead
-async def test_legacy_camera_b64_encoded_with_availability(
-    hass, hass_client_no_auth, mqtt_mock_entry_with_yaml_config
-):
-    """Test availability works if b64 encoding (legacy mode) is turned on."""
-    topic = "test/camera"
-    topic_availability = "test/camera_availability"
-    await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
-        {
-            mqtt.DOMAIN: {
-                camera.DOMAIN: {
-                    "topic": topic,
-                    "name": "Test Camera",
-                    "encoding": "b64",
-                    "availability": {"topic": topic_availability},
-                }
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
-
-    # Make sure we are available
-    async_fire_mqtt_message(hass, topic_availability, "online")
 
     url = hass.states.get("camera.test_camera").attributes["entity_picture"]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Using the `encoding` config parameter to set `b64` payload was deprecated with #76124 (HA Core 2022.9) .
The work a round will be removed breaking installations that still use the work-a-round. User should use the `image_encoding` config parameter to set `b64` encoding instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
