### PR TITLE
Use _attr_supported_features in osram light

### DIFF
--- a/homeassistant/components/osramlightify/light.py
+++ b/homeassistant/components/osramlightify/light.py
@@ -187,7 +187,6 @@ class Luminary(LightEntity):
         self._changed = changed
 
         self._unique_id = None
-        self._supported_features = []
         self._effect_list = []
         self._is_on = False
         self._available = True
@@ -205,9 +204,9 @@ class Luminary(LightEntity):
         """Get a unique ID (not implemented)."""
         raise NotImplementedError
 
-    def _get_supported_color_modes(self):
+    def _get_supported_color_modes(self) -> set[ColorMode]:
         """Get supported color modes."""
-        color_modes = set()
+        color_modes: set[ColorMode] = set()
         if "temp" in self._luminary.supported_features():
             color_modes.add(ColorMode.COLOR_TEMP)
 
@@ -222,7 +221,7 @@ class Luminary(LightEntity):
 
         return color_modes
 
-    def _get_supported_features(self):
+    def _get_supported_features(self) -> LightEntityFeature | int:
         """Get list of supported features."""
         features = 0
         if "lum" in self._luminary.supported_features():
@@ -270,11 +269,6 @@ class Luminary(LightEntity):
     def is_on(self):
         """Return True if the device is on."""
         return self._is_on
-
-    @property
-    def supported_features(self):
-        """List of supported features."""
-        return self._supported_features
 
     @property
     def effect_list(self):
@@ -360,11 +354,11 @@ class Luminary(LightEntity):
         self._luminary = luminary
         self.update_static_attributes()
 
-    def update_static_attributes(self):
+    def update_static_attributes(self) -> None:
         """Update static attributes of the luminary."""
         self._unique_id = self._get_unique_id()
         self._attr_supported_color_modes = self._get_supported_color_modes()
-        self._supported_features = self._get_supported_features()
+        self._attr_supported_features = self._get_supported_features()
         self._effect_list = self._get_effect_list()
         if ColorMode.COLOR_TEMP in self._attr_supported_color_modes:
             self._min_mireds = color_util.color_temperature_kelvin_to_mired(
@@ -441,11 +435,11 @@ class OsramLightifyGroup(Luminary):
         #       users.
         return f"{self._luminary.lights()}"
 
-    def _get_supported_features(self):
+    def _get_supported_features(self) -> LightEntityFeature | int:
         """Get list of supported features."""
         features = super()._get_supported_features()
         if self._luminary.scenes():
-            features = features | LightEntityFeature.EFFECT
+            features |= LightEntityFeature.EFFECT
 
         return features
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #82251

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
