### PR TITLE
Remove unnecessary truthiness checks for integration.manifest

### DIFF
--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -262,10 +262,6 @@ def gather_requirements_from_manifests(
     for domain in sorted(integrations):
         integration = integrations[domain]
 
-        if not integration.manifest:
-            errors.append(f"The manifest for integration {domain} is invalid.")
-            continue
-
         if integration.disabled:
             continue
 

--- a/script/hassfest/bluetooth.py
+++ b/script/hassfest/bluetooth.py
@@ -10,12 +10,7 @@ def generate_and_validate(integrations: list[dict[str, str]]):
     match_list = []
 
     for domain in sorted(integrations):
-        integration = integrations[domain]
-
-        if not integration.manifest or not integration.config_flow:
-            continue
-
-        match_types = integration.manifest.get("bluetooth", [])
+        match_types = integrations[domain].manifest.get("bluetooth", [])
 
         if not match_types:
             continue

--- a/script/hassfest/config_flow.py
+++ b/script/hassfest/config_flow.py
@@ -69,8 +69,7 @@ def _generate_and_validate(integrations: dict[str, Integration], config: Config)
 
     for domain in sorted(integrations):
         integration = integrations[domain]
-
-        if not integration.manifest or not integration.config_flow:
+        if not integration.config_flow:
             continue
 
         _validate_integration(config, integration)

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -246,9 +246,6 @@ def validate(integrations: dict[str, Integration], config):
     """Handle dependencies for integrations."""
     # check for non-existing dependencies
     for integration in integrations.values():
-        if not integration.manifest:
-            continue
-
         validate_dependencies(integrations, integration)
 
         if config.specific_integrations:

--- a/script/hassfest/dhcp.py
+++ b/script/hassfest/dhcp.py
@@ -10,12 +10,7 @@ def generate_and_validate(integrations: list[dict[str, str]]):
     match_list = []
 
     for domain in sorted(integrations):
-        integration = integrations[domain]
-
-        if not integration.manifest or not integration.config_flow:
-            continue
-
-        match_types = integration.manifest.get("dhcp", [])
+        match_types = integrations[domain].manifest.get("dhcp", [])
 
         if not match_types:
             continue

--- a/script/hassfest/json.py
+++ b/script/hassfest/json.py
@@ -27,7 +27,4 @@ def validate(integrations: dict[str, Integration], config):
         return
 
     for integration in integrations.values():
-        if not integration.manifest:
-            continue
-
         validate_json_files(integration)

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -299,9 +299,6 @@ def validate_version(integration: Integration):
 
 def validate_manifest(integration: Integration, core_components_dir: Path) -> None:
     """Validate manifest."""
-    if not integration.manifest:
-        return
-
     try:
         if integration.core:
             manifest_schema(integration.manifest)

--- a/script/hassfest/mqtt.py
+++ b/script/hassfest/mqtt.py
@@ -13,12 +13,7 @@ def generate_and_validate(integrations: dict[str, Integration]):
     data = defaultdict(list)
 
     for domain in sorted(integrations):
-        integration = integrations[domain]
-
-        if not integration.manifest or not integration.config_flow:
-            continue
-
-        mqtt = integration.manifest.get("mqtt")
+        mqtt = integrations[domain].manifest.get("mqtt")
 
         if not mqtt:
             continue

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -66,9 +66,6 @@ def validate(integrations: dict[str, Integration], config: Config):
     disable_tqdm = config.specific_integrations or os.environ.get("CI", False)
 
     for integration in tqdm(integrations.values(), disable=disable_tqdm):
-        if not integration.manifest:
-            continue
-
         validate_requirements(integration)
 
 

--- a/script/hassfest/services.py
+++ b/script/hassfest/services.py
@@ -96,7 +96,4 @@ def validate(integrations: dict[str, Integration], config):
     """Handle dependencies for integrations."""
     # check services.yaml is cool
     for integration in integrations.values():
-        if not integration.manifest:
-            continue
-
         validate_services(integration)

--- a/script/hassfest/ssdp.py
+++ b/script/hassfest/ssdp.py
@@ -13,12 +13,7 @@ def generate_and_validate(integrations: dict[str, Integration]):
     data = defaultdict(list)
 
     for domain in sorted(integrations):
-        integration = integrations[domain]
-
-        if not integration.manifest or not integration.config_flow:
-            continue
-
-        ssdp = integration.manifest.get("ssdp")
+        ssdp = integrations[domain].manifest.get("ssdp")
 
         if not ssdp:
             continue

--- a/script/hassfest/usb.py
+++ b/script/hassfest/usb.py
@@ -10,12 +10,7 @@ def generate_and_validate(integrations: list[dict[str, str]]) -> str:
     match_list = []
 
     for domain in sorted(integrations):
-        integration = integrations[domain]
-
-        if not integration.manifest or not integration.config_flow:
-            continue
-
-        match_types = integration.manifest.get("usb", [])
+        match_types = integrations[domain].manifest.get("usb", [])
 
         if not match_types:
             continue

--- a/script/hassfest/zeroconf.py
+++ b/script/hassfest/zeroconf.py
@@ -16,10 +16,6 @@ def generate_and_validate(integrations: dict[str, Integration]):
 
     for domain in sorted(integrations):
         integration = integrations[domain]
-
-        if not integration.manifest or not integration.config_flow:
-            continue
-
         service_types = integration.manifest.get("zeroconf", [])
         homekit = integration.manifest.get("homekit", {})
         homekit_models = homekit.get("models", [])


### PR DESCRIPTION
Following #82203, integration.manifest can not be falsy, so no point in checking for it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
  - Nothing new.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
