### PR TITLE
Fix litejet tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -400,7 +400,7 @@ def async_fire_time_changed_exact(
 
 @ha.callback
 def async_fire_time_changed(
-    hass: HomeAssistant, datetime_: datetime = None, fire_all: bool = False
+    hass: HomeAssistant, datetime_: datetime | None = None, fire_all: bool = False
 ) -> None:
     """Fire a time changed event.
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -381,7 +381,7 @@ fire_mqtt_message = threadsafe_callback_factory(async_fire_mqtt_message)
 
 @ha.callback
 def async_fire_time_changed_exact(
-    hass: HomeAssistant, datetime_: datetime = None, fire_all: bool = False
+    hass: HomeAssistant, datetime_: datetime | None = None, fire_all: bool = False
 ) -> None:
     """Fire a time changed event at an exact microsecond.
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -380,10 +380,35 @@ fire_mqtt_message = threadsafe_callback_factory(async_fire_mqtt_message)
 
 
 @ha.callback
+def async_fire_time_changed_exact(
+    hass: HomeAssistant, datetime_: datetime = None, fire_all: bool = False
+) -> None:
+    """Fire a time changed event at an exact microsecond.
+
+    Consider that its not possible to actually achieve an exact microsecond
+    in production as the event loop is not precise enough. If your code
+    relies on this level of precision, consider a different approach
+    as this is only for testing.
+    """
+    if datetime_ is None:
+        utc_datetime = date_util.utcnow()
+    else:
+        utc_datetime = date_util.as_utc(datetime_)
+
+    _async_fire_time_changed(hass, utc_datetime, fire_all)
+
+
+@ha.callback
 def async_fire_time_changed(
     hass: HomeAssistant, datetime_: datetime = None, fire_all: bool = False
 ) -> None:
-    """Fire a time changed event."""
+    """Fire a time changed event.
+
+    This function will ensure microseconds at at least 500000
+    to account for the synchronization repeating listeners.
+
+    If you need to fire an exact microsecond, use async_fire_time_changed_exact.
+    """
     if datetime_ is None:
         utc_datetime = date_util.utcnow()
     else:
@@ -396,8 +421,14 @@ def async_fire_time_changed(
         # staggering to avoid thundering herd.
         utc_datetime = utc_datetime.replace(microsecond=500000)
 
-    timestamp = date_util.utc_to_timestamp(utc_datetime)
+    _async_fire_time_changed(hass, utc_datetime, fire_all)
 
+
+@ha.callback
+def _async_fire_time_changed(
+    hass: HomeAssistant, utc_datetime: datetime = None, fire_all: bool = False
+) -> None:
+    timestamp = date_util.utc_to_timestamp(utc_datetime)
     for task in list(hass.loop._scheduled):
         if not isinstance(task, asyncio.TimerHandle):
             continue

--- a/tests/common.py
+++ b/tests/common.py
@@ -426,7 +426,7 @@ def async_fire_time_changed(
 
 @ha.callback
 def _async_fire_time_changed(
-    hass: HomeAssistant, utc_datetime: datetime = None, fire_all: bool = False
+    hass: HomeAssistant, utc_datetime: datetime | None, fire_all: bool
 ) -> None:
     timestamp = date_util.utc_to_timestamp(utc_datetime)
     for task in list(hass.loop._scheduled):

--- a/tests/components/litejet/test_trigger.py
+++ b/tests/components/litejet/test_trigger.py
@@ -12,7 +12,7 @@ import homeassistant.util.dt as dt_util
 
 from . import async_init_integration
 
-from tests.common import async_fire_time_changed, async_mock_service
+from tests.common import async_fire_time_changed_exact, async_mock_service
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ async def simulate_time(hass, mock_litejet, delta):
         return_value=mock_litejet.start_time + delta,
     ):
         _LOGGER.info("now=%s", dt_util.utcnow())
-        async_fire_time_changed(hass, mock_litejet.start_time + delta)
+        async_fire_time_changed_exact(hass, mock_litejet.start_time + delta)
         await hass.async_block_till_done()
         _LOGGER.info("done with now=%s", dt_util.utcnow())
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
These tests rely on sub-second delivery of events which is not reliable in production since the event loop can easily be blocked for a few milliseconds. This change adjusts the tests to use a new async_fire_time_changed_exact.

This integration is simulating short and long button presses, however the underlying api doesn't deliver these events which can make this unreliable in production if the host running HA is loaded because it can fall behind and you get the long button press when a short is expected.  In practice it probably works fine until it doesn't.

If this integration ever gets converted to async this design will likely become noticeably unreliable since threading interrupts where-as async is cooperative.

tests were broken in #82233

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
