### PR TITLE
edl21: Make scan interval configurable

### DIFF
--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -1,8 +1,10 @@
 """Support for EDL21 Smart Meters."""
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
 from datetime import timedelta
 import logging
+from typing import Any
 
 from sml import SmlGetListResponse
 from sml.asyncio import SmlProtocol
@@ -39,6 +41,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "edl21"
 CONF_SERIAL_PORT = "serial_port"
+CONF_SCAN_INTERVAL_SECONDS = "scan_interval_seconds"
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 SIGNAL_EDL21_TELEGRAM = "edl21_telegram"
 
@@ -302,6 +305,17 @@ class EDL21:
         self._proto = SmlProtocol(config[CONF_SERIAL_PORT])
         self._proto.add_listener(self.event, ["SmlGetListResponse"])
 
+        if (scan_interval_seconds := config[CONF_SCAN_INTERVAL_SECONDS]) is not None:
+            # EDL21 pushes one data package per second. In order to not lose
+            # packages, when time passed since last package is an iota earlier than
+            # the configured interval (if 1 second is selected), make the actual scan
+            # interval a bit smaller.
+            self._min_time = timedelta(
+                seconds=scan_interval_seconds - 1, milliseconds=900
+            )
+        else:
+            self._min_time = MIN_TIME_BETWEEN_UPDATES
+
     async def connect(self):
         """Connect to an EDL21 reader."""
         await self._proto.connect(self._hass.loop)
@@ -338,7 +352,12 @@ class EDL21:
 
                     new_entities.append(
                         EDL21Entity(
-                            electricity_id, obis, name, entity_description, telegram
+                            electricity_id,
+                            obis,
+                            name,
+                            entity_description,
+                            telegram,
+                            self._min_time,
                         )
                     )
                     self._registered_obis.add((electricity_id, obis))
@@ -382,14 +401,22 @@ class EDL21Entity(SensorEntity):
 
     _attr_should_poll = False
 
-    def __init__(self, electricity_id, obis, name, entity_description, telegram):
+    def __init__(
+        self,
+        electricity_id,
+        obis,
+        name,
+        entity_description,
+        telegram,
+        min_time: timedelta = MIN_TIME_BETWEEN_UPDATES,
+    ):
         """Initialize an EDL21Entity."""
         self._electricity_id = electricity_id
         self._obis = obis
         self._name = name
         self._unique_id = f"{electricity_id}_{obis}"
         self._telegram = telegram
-        self._min_time = MIN_TIME_BETWEEN_UPDATES
+        self._min_time = min_time
         self._last_update = utcnow()
         self._state_attrs = {
             "status": "status",
@@ -397,7 +424,7 @@ class EDL21Entity(SensorEntity):
             "scaler": "scaler",
             "valueSignature": "value_signature",
         }
-        self._async_remove_dispatcher = None
+        self._async_remove_dispatcher: Callable[[], None] | None = None
         self.entity_description = entity_description
 
     async def async_added_to_hass(self) -> None:
@@ -451,7 +478,7 @@ class EDL21Entity(SensorEntity):
         return self._telegram.get("value")
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> Mapping[str, Any]:
         """Enumerate supported attributes."""
         return {
             self._state_attrs[k]: v
@@ -460,7 +487,7 @@ class EDL21Entity(SensorEntity):
         }
 
     @property
-    def native_unit_of_measurement(self):
+    def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
         if (unit := self._telegram.get("unit")) is None or unit == 0:
             return None

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -49,6 +49,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_SERIAL_PORT): cv.string,
         vol.Optional(CONF_NAME, default=""): cv.string,
+        vol.Optional(
+            CONF_SCAN_INTERVAL_SECONDS, default=MIN_TIME_BETWEEN_UPDATES
+        ): cv.positive_int,
     },
 )
 


### PR DESCRIPTION
the EDL21 integration to read german smart meters had a hard-coded interval of 60 seconds to accept incoming measurements.

This PR adds a config setting for this. I also added typings here and there to pass mypy linting.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
nothing, if config setting absent, old default value is used


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
adds a config item


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

working on it
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
