### PR TITLE
Align manual_mqtt alarm control panel with manual

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -30,6 +30,8 @@ from homeassistant.helpers.typing import ConfigType
 from .const import (  # noqa: F401
     ATTR_CHANGED_BY,
     ATTR_CODE_ARM_REQUIRED,
+    ATTR_NEXT_STATE,
+    ATTR_PREVIOUS_STATE,
     DOMAIN,
     FORMAT_NUMBER,
     FORMAT_TEXT,

--- a/homeassistant/components/alarm_control_panel/const.py
+++ b/homeassistant/components/alarm_control_panel/const.py
@@ -9,6 +9,9 @@ DOMAIN: Final = "alarm_control_panel"
 ATTR_CHANGED_BY: Final = "changed_by"
 ATTR_CODE_ARM_REQUIRED: Final = "code_arm_required"
 
+ATTR_PREVIOUS_STATE: Final = "previous_state"
+ATTR_NEXT_STATE: Final = "next_state"
+
 
 class CodeFormat(StrEnum):
     """Code formats for the Alarm Control Panel."""

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -10,7 +10,11 @@ from typing import Any
 import voluptuous as vol
 
 import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
+from homeassistant.components.alarm_control_panel import (
+    ATTR_NEXT_STATE,
+    ATTR_PREVIOUS_STATE,
+    AlarmControlPanelEntityFeature,
+)
 from homeassistant.const import (
     CONF_ARMING_TIME,
     CONF_CODE,
@@ -67,9 +71,6 @@ SUPPORTED_ARMING_STATES = [
     for state in SUPPORTED_STATES
     if state not in (STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED)
 ]
-
-ATTR_PREVIOUS_STATE = "previous_state"
-ATTR_NEXT_STATE = "next_state"
 
 
 def _state_validator(config):

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -21,8 +21,10 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TRIGGER_TIME,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMED_VACATION,
     STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
@@ -46,6 +48,8 @@ CONF_PAYLOAD_DISARM = "payload_disarm"
 CONF_PAYLOAD_ARM_HOME = "payload_arm_home"
 CONF_PAYLOAD_ARM_AWAY = "payload_arm_away"
 CONF_PAYLOAD_ARM_NIGHT = "payload_arm_night"
+CONF_PAYLOAD_ARM_VACATION = "payload_arm_vacation"
+CONF_PAYLOAD_ARM_CUSTOM_BYPASS = "payload_arm_custom_bypass"
 
 DEFAULT_ALARM_NAME = "HA Alarm"
 DEFAULT_DELAY_TIME = datetime.timedelta(seconds=0)
@@ -55,6 +59,8 @@ DEFAULT_DISARM_AFTER_TRIGGER = False
 DEFAULT_ARM_AWAY = "ARM_AWAY"
 DEFAULT_ARM_HOME = "ARM_HOME"
 DEFAULT_ARM_NIGHT = "ARM_NIGHT"
+DEFAULT_ARM_VACATION = "ARM_VACATION"
+DEFAULT_ARM_CUSTOM_BYPASS = "ARM_CUSTOM_BYPASS"
 DEFAULT_DISARM = "DISARM"
 
 SUPPORTED_STATES = [
@@ -62,6 +68,8 @@ SUPPORTED_STATES = [
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMED_VACATION,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_TRIGGERED,
 ]
 
@@ -138,6 +146,12 @@ PLATFORM_SCHEMA = vol.Schema(
                 vol.Optional(STATE_ALARM_ARMED_NIGHT, default={}): _state_schema(
                     STATE_ALARM_ARMED_NIGHT
                 ),
+                vol.Optional(STATE_ALARM_ARMED_VACATION, default={}): _state_schema(
+                    STATE_ALARM_ARMED_VACATION
+                ),
+                vol.Optional(
+                    STATE_ALARM_ARMED_CUSTOM_BYPASS, default={}
+                ): _state_schema(STATE_ALARM_ARMED_CUSTOM_BYPASS),
                 vol.Optional(STATE_ALARM_DISARMED, default={}): _state_schema(
                     STATE_ALARM_DISARMED
                 ),
@@ -155,6 +169,12 @@ PLATFORM_SCHEMA = vol.Schema(
                 ): cv.string,
                 vol.Optional(
                     CONF_PAYLOAD_ARM_NIGHT, default=DEFAULT_ARM_NIGHT
+                ): cv.string,
+                vol.Optional(
+                    CONF_PAYLOAD_ARM_VACATION, default=DEFAULT_ARM_VACATION
+                ): cv.string,
+                vol.Optional(
+                    CONF_PAYLOAD_ARM_CUSTOM_BYPASS, default=DEFAULT_ARM_CUSTOM_BYPASS
                 ): cv.string,
                 vol.Optional(CONF_PAYLOAD_DISARM, default=DEFAULT_DISARM): cv.string,
             }
@@ -187,6 +207,8 @@ def setup_platform(
                 config.get(CONF_PAYLOAD_ARM_HOME),
                 config.get(CONF_PAYLOAD_ARM_AWAY),
                 config.get(CONF_PAYLOAD_ARM_NIGHT),
+                config.get(CONF_PAYLOAD_ARM_VACATION),
+                config.get(CONF_PAYLOAD_ARM_CUSTOM_BYPASS),
                 config,
             )
         ]
@@ -210,7 +232,9 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         AlarmControlPanelEntityFeature.ARM_HOME
         | AlarmControlPanelEntityFeature.ARM_AWAY
         | AlarmControlPanelEntityFeature.ARM_NIGHT
+        | AlarmControlPanelEntityFeature.ARM_VACATION
         | AlarmControlPanelEntityFeature.TRIGGER
+        | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
     )
 
     def __init__(
@@ -228,6 +252,8 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         payload_arm_home,
         payload_arm_away,
         payload_arm_night,
+        payload_arm_vacation,
+        payload_arm_custom_bypass,
         config,
     ):
         """Init the manual MQTT alarm panel."""
@@ -264,6 +290,8 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         self._payload_arm_home = payload_arm_home
         self._payload_arm_away = payload_arm_away
         self._payload_arm_night = payload_arm_night
+        self._payload_arm_vacation = payload_arm_vacation
+        self._payload_arm_custom_bypass = payload_arm_custom_bypass
 
     @property
     def state(self) -> str:
@@ -350,6 +378,24 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
 
         self._async_update_state(STATE_ALARM_ARMED_NIGHT)
 
+    async def async_alarm_arm_vacation(self, code: str | None = None) -> None:
+        """Send arm vacation command."""
+        if self.code_arm_required and not self._async_validate_code(
+            code, STATE_ALARM_ARMED_VACATION
+        ):
+            return
+
+        self._async_update_state(STATE_ALARM_ARMED_VACATION)
+
+    async def async_alarm_arm_custom_bypass(self, code: str | None = None) -> None:
+        """Send arm custom bypass command."""
+        if self.code_arm_required and not self._async_validate_code(
+            code, STATE_ALARM_ARMED_CUSTOM_BYPASS
+        ):
+            return
+
+        self._async_update_state(STATE_ALARM_ARMED_CUSTOM_BYPASS)
+
     async def async_alarm_trigger(self, code: str | None = None) -> None:
         """
         Send alarm trigger command.
@@ -434,6 +480,10 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
                 await self.async_alarm_arm_away(self._code)
             elif msg.payload == self._payload_arm_night:
                 await self.async_alarm_arm_night(self._code)
+            elif msg.payload == self._payload_arm_vacation:
+                await self.async_alarm_arm_vacation(self._code)
+            elif msg.payload == self._payload_arm_custom_bypass:
+                await self.async_alarm_arm_custom_bypass(self._code)
             else:
                 _LOGGER.warning("Received unexpected payload: %s", msg.payload)
                 return

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -453,12 +453,16 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        if self.state != STATE_ALARM_PENDING:
-            return {}
-        return {
-            ATTR_PREVIOUS_STATE: self._previous_state,
-            ATTR_NEXT_STATE: self._state,
-        }
+        if self.state == STATE_ALARM_PENDING:
+            return {
+                ATTR_PREVIOUS_STATE: self._previous_state,
+                ATTR_NEXT_STATE: self._state,
+            }
+        if self.state == STATE_ALARM_TRIGGERED:
+            return {
+                ATTR_PREVIOUS_STATE: self._previous_state,
+            }
+        return {}
 
     @callback
     def async_scheduled_update(self, now):

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -40,6 +40,7 @@ from homeassistant.helpers.event import (
     async_track_point_in_time,
     async_track_state_change_event,
 )
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
@@ -216,7 +217,7 @@ def setup_platform(
     )
 
 
-class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
+class ManualMQTTAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
     """
     Representation of an alarm status.
 
@@ -417,7 +418,10 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         self._state = state
         self._state_ts = dt_util.utcnow()
         self.async_schedule_update_ha_state()
+        self._async_set_state_update_events()
 
+    def _async_set_state_update_events(self) -> None:
+        state = self._state
         pending_time = self._pending_time(state)
         if state == STATE_ALARM_TRIGGERED:
             async_track_point_in_time(
@@ -470,7 +474,22 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
-        """Subscribe to MQTT events."""
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        if state := await self.async_get_last_state():
+            self._state_ts = state.last_updated
+            if hasattr(state, "attributes") and ATTR_NEXT_STATE in state.attributes:
+                # If in arming or pending state we record the transition,
+                # not the current state
+                self._state = state.attributes[ATTR_NEXT_STATE]
+            else:
+                self._state = state.state
+
+            if hasattr(state, "attributes") and ATTR_PREVIOUS_STATE in state.attributes:
+                self._previous_state = state.attributes[ATTR_PREVIOUS_STATE]
+                self._async_set_state_update_events()
+
+        # Now subscribe to MQTT events.
         async_track_state_change_event(
             self.hass, [self.entity_id], self._async_state_changed_listener
         )

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -11,7 +11,11 @@ import voluptuous as vol
 
 from homeassistant.components import mqtt
 import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
+from homeassistant.components.alarm_control_panel import (
+    ATTR_NEXT_STATE,
+    ATTR_PREVIOUS_STATE,
+    AlarmControlPanelEntityFeature,
+)
 from homeassistant.const import (
     CONF_CODE,
     CONF_DELAY_TIME,
@@ -80,9 +84,6 @@ SUPPORTED_PRETRIGGER_STATES = [
 SUPPORTED_PENDING_STATES = [
     state for state in SUPPORTED_STATES if state != STATE_ALARM_DISARMED
 ]
-
-ATTR_PRE_PENDING_STATE = "pre_pending_state"
-ATTR_POST_PENDING_STATE = "post_pending_state"
 
 
 def _state_validator(config):
@@ -455,8 +456,8 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         if self.state != STATE_ALARM_PENDING:
             return {}
         return {
-            ATTR_PRE_PENDING_STATE: self._previous_state,
-            ATTR_POST_PENDING_STATE: self._state,
+            ATTR_PREVIOUS_STATE: self._previous_state,
+            ATTR_NEXT_STATE: self._state,
         }
 
     @callback

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -10,11 +10,15 @@ from homeassistant.const import (
     ATTR_CODE,
     ATTR_ENTITY_ID,
     SERVICE_ALARM_ARM_AWAY,
+    SERVICE_ALARM_ARM_CUSTOM_BYPASS,
     SERVICE_ALARM_ARM_HOME,
     SERVICE_ALARM_ARM_NIGHT,
+    SERVICE_ALARM_ARM_VACATION,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMED_VACATION,
     STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
@@ -67,8 +71,10 @@ async def test_fail_setup_without_command_topic(hass, mqtt_mock_entry_with_yaml_
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_no_pending(
@@ -110,8 +116,10 @@ async def test_no_pending(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_no_pending_when_code_not_req(
@@ -154,8 +162,10 @@ async def test_no_pending_when_code_not_req(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_with_pending(
@@ -221,8 +231,10 @@ async def test_with_pending(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_with_invalid_code(
@@ -264,8 +276,10 @@ async def test_with_invalid_code(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_with_template_code(
@@ -308,8 +322,10 @@ async def test_with_template_code(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_with_specific_pending(
@@ -1258,8 +1274,10 @@ async def test_disarm_with_template_code(hass, mqtt_mock_entry_with_yaml_config)
     "config,expected_state",
     [
         ("payload_arm_away", STATE_ALARM_ARMED_AWAY),
+        ("payload_arm_custom_bypass", STATE_ALARM_ARMED_CUSTOM_BYPASS),
         ("payload_arm_home", STATE_ALARM_ARMED_HOME),
         ("payload_arm_night", STATE_ALARM_ARMED_NIGHT),
+        ("payload_arm_vacation", STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_arm_via_command_topic(

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -417,12 +417,10 @@ async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -464,7 +462,6 @@ async def test_trigger_zero_trigger_time(hass, mqtt_mock_entry_with_yaml_config)
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
@@ -495,7 +492,6 @@ async def test_trigger_zero_trigger_time_with_pending(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
@@ -524,7 +520,6 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
@@ -578,7 +573,6 @@ async def test_trigger_with_disarm_after_trigger(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -620,7 +614,6 @@ async def test_trigger_with_zero_specific_trigger_time(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
@@ -652,7 +645,6 @@ async def test_trigger_with_unused_zero_specific_trigger_time(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -693,7 +685,6 @@ async def test_trigger_with_specific_trigger_time(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -734,12 +725,10 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE, entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -754,7 +743,6 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -792,12 +780,10 @@ async def test_disarm_while_pending_trigger(hass, mqtt_mock_entry_with_yaml_conf
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
     await common.async_alarm_disarm(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
@@ -838,12 +824,10 @@ async def test_disarm_during_trigger_with_invalid_code(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
     await common.async_alarm_disarm(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
@@ -886,12 +870,10 @@ async def test_trigger_with_unused_specific_delay(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -935,12 +917,10 @@ async def test_trigger_with_specific_delay(hass, mqtt_mock_entry_with_yaml_confi
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -984,12 +964,10 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -1048,12 +1026,10 @@ async def test_trigger_with_pending_and_specific_delay(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -1106,7 +1082,6 @@ async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_con
     entity_id = "alarm_control_panel.test"
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
@@ -1158,7 +1133,6 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -1166,7 +1140,6 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
     assert state.attributes["post_pending_state"] == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -1182,7 +1155,6 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
         assert state.state == STATE_ALARM_ARMED_AWAY
 
         await common.async_alarm_trigger(hass, entity_id=entity_id)
-        await hass.async_block_till_done()
 
         state = hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
@@ -1222,19 +1194,16 @@ async def test_disarm_with_template_code(hass, mqtt_mock_entry_with_yaml_config)
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_home(hass, "def")
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_ARMED_HOME
 
     await common.async_alarm_disarm(hass, "def")
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_ARMED_HOME
 
     await common.async_alarm_disarm(hass, "abc")
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_DISARMED

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -568,7 +568,8 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ALARM_DISARMED
 
 
 async def test_trigger_with_disarm_after_trigger(

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -405,7 +405,9 @@ async def test_trigger_no_pending(hass, mqtt_mock_entry_with_yaml_config):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
 
 async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
@@ -451,6 +453,7 @@ async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -550,7 +553,9 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -590,7 +595,9 @@ async def test_trigger_with_disarm_after_trigger(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -662,7 +669,9 @@ async def test_trigger_with_unused_zero_specific_trigger_time(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -702,7 +711,9 @@ async def test_trigger_with_specific_trigger_time(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -746,7 +757,9 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -760,7 +773,9 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -855,7 +870,9 @@ async def test_disarm_during_trigger_with_invalid_code(
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
 
 async def test_trigger_with_unused_specific_delay(
@@ -904,6 +921,7 @@ async def test_trigger_with_unused_specific_delay(
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -951,6 +969,7 @@ async def test_trigger_with_specific_delay(hass, mqtt_mock_entry_with_yaml_confi
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -1010,6 +1029,7 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -1072,6 +1092,7 @@ async def test_trigger_with_pending_and_specific_delay(
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -1109,7 +1130,9 @@ async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_con
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -1154,7 +1177,9 @@ async def test_trigger_with_no_disarm_after_trigger(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -1228,6 +1253,7 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -203,7 +203,7 @@ async def test_with_pending(
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
     state = hass.states.get(entity_id)
-    assert state.attributes["post_pending_state"] == expected_state
+    assert state.attributes["next_state"] == expected_state
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -440,7 +440,7 @@ async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -540,7 +540,7 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
     state = hass.states.get(entity_id)
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=2)
     with patch(
@@ -893,7 +893,7 @@ async def test_trigger_with_unused_specific_delay(
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -940,7 +940,7 @@ async def test_trigger_with_specific_delay(hass, mqtt_mock_entry_with_yaml_confi
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -987,7 +987,7 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -999,7 +999,7 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future += timedelta(seconds=1)
     with patch(
@@ -1049,7 +1049,7 @@ async def test_trigger_with_pending_and_specific_delay(
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -1061,7 +1061,7 @@ async def test_trigger_with_pending_and_specific_delay(
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future += timedelta(seconds=1)
     with patch(
@@ -1197,15 +1197,15 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["pre_pending_state"] == STATE_ALARM_DISARMED
-    assert state.attributes["post_pending_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.attributes["next_state"] == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["pre_pending_state"] == STATE_ALARM_DISARMED
-    assert state.attributes["post_pending_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.attributes["next_state"] == STATE_ALARM_ARMED_AWAY
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with freeze_time(future):
@@ -1219,8 +1219,8 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
 
         state = hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes["pre_pending_state"] == STATE_ALARM_ARMED_AWAY
-        assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+        assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+        assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future += timedelta(seconds=1)
     with freeze_time(future):

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_ARMED_VACATION,
+    STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
@@ -92,7 +93,7 @@ async def test_no_pending(
                 "platform": "manual_mqtt",
                 "name": "test",
                 "code": CODE,
-                "pending_time": 0,
+                "arming_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -138,7 +139,7 @@ async def test_no_pending_when_code_not_req(
                 "name": "test",
                 "code": CODE,
                 "code_arm_required": False,
-                "pending_time": 0,
+                "arming_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -183,7 +184,7 @@ async def test_with_pending(
                 "platform": "manual_mqtt",
                 "name": "test",
                 "code": CODE,
-                "pending_time": 1,
+                "arming_time": 1,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -203,7 +204,7 @@ async def test_with_pending(
         blocking=True,
     )
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMING
 
     state = hass.states.get(entity_id)
     assert state.attributes["next_state"] == expected_state
@@ -252,7 +253,7 @@ async def test_with_invalid_code(
                 "platform": "manual_mqtt",
                 "name": "test",
                 "code": CODE,
-                "pending_time": 1,
+                "arming_time": 1,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -297,7 +298,7 @@ async def test_with_template_code(
                 "platform": "manual_mqtt",
                 "name": "test",
                 "code_template": '{{ "abc" }}',
-                "pending_time": 0,
+                "arming_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -342,8 +343,8 @@ async def test_with_specific_pending(
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 10,
-                expected_state: {"pending_time": 2},
+                "arming_time": 10,
+                expected_state: {"arming_time": 2},
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
             }
@@ -360,7 +361,7 @@ async def test_with_specific_pending(
         blocking=True,
     )
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMING
 
     future = dt_util.utcnow() + timedelta(seconds=2)
     with patch(
@@ -424,7 +425,7 @@ async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
                 "name": "test",
                 "code": CODE,
                 "delay_time": 1,
-                "pending_time": 0,
+                "arming_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -469,7 +470,7 @@ async def test_trigger_zero_trigger_time(hass, mqtt_mock_entry_with_yaml_config)
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 0,
+                "arming_time": 0,
                 "trigger_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
@@ -499,7 +500,7 @@ async def test_trigger_zero_trigger_time_with_pending(
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 2,
+                "arming_time": 2,
                 "trigger_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
@@ -527,7 +528,7 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 2,
+                "delay_time": 2,
                 "trigger_time": 3,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
@@ -585,7 +586,7 @@ async def test_trigger_with_unused_specific_delay(
                 "name": "test",
                 "code": CODE,
                 "delay_time": 5,
-                "pending_time": 0,
+                "arming_time": 0,
                 "armed_home": {"delay_time": 10},
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
@@ -633,7 +634,7 @@ async def test_trigger_with_specific_delay(hass, mqtt_mock_entry_with_yaml_confi
                 "name": "test",
                 "code": CODE,
                 "delay_time": 10,
-                "pending_time": 0,
+                "arming_time": 0,
                 "armed_away": {"delay_time": 1},
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
@@ -680,9 +681,8 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
                 "platform": "manual_mqtt",
                 "name": "test",
                 "code": CODE,
-                "delay_time": 1,
-                "pending_time": 0,
-                "triggered": {"pending_time": 1},
+                "delay_time": 2,
+                "arming_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -743,9 +743,8 @@ async def test_trigger_with_pending_and_specific_delay(
                 "name": "test",
                 "code": CODE,
                 "delay_time": 10,
-                "pending_time": 0,
-                "armed_away": {"delay_time": 1},
-                "triggered": {"pending_time": 1},
+                "arming_time": 0,
+                "armed_away": {"delay_time": 2},
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -802,8 +801,8 @@ async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_con
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 10,
-                "triggered": {"pending_time": 2},
+                "delay_time": 10,
+                "disarmed": {"delay_time": 2},
                 "trigger_time": 3,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
@@ -854,7 +853,7 @@ async def test_trigger_with_disarm_after_trigger(
                 "platform": "manual_mqtt",
                 "name": "test",
                 "trigger_time": 5,
-                "pending_time": 0,
+                "delay_time": 0,
                 "disarm_after_trigger": True,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -897,7 +896,7 @@ async def test_trigger_with_zero_specific_trigger_time(
                 "name": "test",
                 "trigger_time": 5,
                 "disarmed": {"trigger_time": 0},
-                "pending_time": 0,
+                "arming_time": 0,
                 "disarm_after_trigger": True,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -928,7 +927,7 @@ async def test_trigger_with_unused_zero_specific_trigger_time(
                 "name": "test",
                 "trigger_time": 5,
                 "armed_home": {"trigger_time": 0},
-                "pending_time": 0,
+                "delay_time": 0,
                 "disarm_after_trigger": True,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -970,7 +969,7 @@ async def test_trigger_with_specific_trigger_time(
                 "platform": "manual_mqtt",
                 "name": "test",
                 "disarmed": {"trigger_time": 5},
-                "pending_time": 0,
+                "delay_time": 0,
                 "disarm_after_trigger": True,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -1012,7 +1011,7 @@ async def test_trigger_with_no_disarm_after_trigger(
                 "platform": "manual_mqtt",
                 "name": "test",
                 "trigger_time": 5,
-                "pending_time": 0,
+                "arming_time": 0,
                 "delay_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
@@ -1059,7 +1058,8 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
                 "platform": "manual_mqtt",
                 "name": "test",
                 "trigger_time": 5,
-                "pending_time": 0,
+                "arming_time": 0,
+                "delay_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -1161,7 +1161,7 @@ async def test_disarm_during_trigger_with_invalid_code(
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 5,
+                "delay_time": 5,
                 "code": f"{CODE}2",
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
@@ -1206,7 +1206,7 @@ async def test_disarm_with_template_code(hass, mqtt_mock_entry_with_yaml_config)
                 "platform": "manual_mqtt",
                 "name": "test",
                 "code_template": '{{ "" if from_state == "disarmed" else "abc" }}',
-                "pending_time": 0,
+                "arming_time": 0,
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
                 "state_topic": "alarm/state",
@@ -1245,9 +1245,9 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
                 "platform": "manual_mqtt",
                 "name": "test",
                 "code": CODE,
-                "pending_time": 0,
+                "arming_time": 0,
                 "delay_time": 1,
-                "armed_away": {"pending_time": 1},
+                "armed_away": {"arming_time": 1},
                 "disarmed": {"trigger_time": 0},
                 "disarm_after_trigger": False,
                 "command_topic": "alarm/command",
@@ -1264,14 +1264,14 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
     await common.async_alarm_arm_away(hass, CODE)
 
     state = hass.states.get(entity_id)
-    assert state.state == STATE_ALARM_PENDING
+    assert state.state == STATE_ALARM_ARMING
     assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
     assert state.attributes["next_state"] == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     state = hass.states.get(entity_id)
-    assert state.state == STATE_ALARM_PENDING
+    assert state.state == STATE_ALARM_ARMING
     assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
     assert state.attributes["next_state"] == STATE_ALARM_ARMED_AWAY
 
@@ -1322,7 +1322,7 @@ async def test_arm_via_command_topic(
             alarm_control_panel.DOMAIN: {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 1,
+                "arming_time": 1,
                 "state_topic": "alarm/state",
                 "command_topic": "alarm/command",
                 config: command,
@@ -1338,7 +1338,7 @@ async def test_arm_via_command_topic(
     # Fire the arm command via MQTT; ensure state changes to arming
     async_fire_mqtt_message(hass, "alarm/command", command)
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMING
 
     # Fast-forward a little bit
     future = dt_util.utcnow() + timedelta(seconds=1)
@@ -1361,7 +1361,7 @@ async def test_disarm_pending_via_command_topic(hass, mqtt_mock_entry_with_yaml_
             alarm_control_panel.DOMAIN: {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 1,
+                "delay_time": 1,
                 "state_topic": "alarm/state",
                 "command_topic": "alarm/command",
                 "payload_disarm": "DISARM",
@@ -1397,7 +1397,7 @@ async def test_state_changes_are_published_to_mqtt(
             alarm_control_panel.DOMAIN: {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 1,
+                "arming_time": 1,
                 "trigger_time": 1,
                 "state_topic": "alarm/state",
                 "command_topic": "alarm/command",
@@ -1418,7 +1418,7 @@ async def test_state_changes_are_published_to_mqtt(
     await common.async_alarm_arm_home(hass)
     await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_called_once_with(
-        "alarm/state", STATE_ALARM_PENDING, 0, True
+        "alarm/state", STATE_ALARM_ARMING, 0, True
     )
     mqtt_mock.async_publish.reset_mock()
     # Fast-forward a little bit
@@ -1438,7 +1438,7 @@ async def test_state_changes_are_published_to_mqtt(
     await common.async_alarm_arm_away(hass)
     await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_called_once_with(
-        "alarm/state", STATE_ALARM_PENDING, 0, True
+        "alarm/state", STATE_ALARM_ARMING, 0, True
     )
     mqtt_mock.async_publish.reset_mock()
     # Fast-forward a little bit
@@ -1458,7 +1458,7 @@ async def test_state_changes_are_published_to_mqtt(
     await common.async_alarm_arm_night(hass)
     await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_called_once_with(
-        "alarm/state", STATE_ALARM_PENDING, 0, True
+        "alarm/state", STATE_ALARM_ARMING, 0, True
     )
     mqtt_mock.async_publish.reset_mock()
     # Fast-forward a little bit
@@ -1507,7 +1507,7 @@ async def test_restore_state(hass, expected_state, mqtt_mock_entry_with_yaml_con
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 0,
+                "arming_time": 0,
                 "trigger_time": 0,
                 "disarm_after_trigger": False,
                 "state_topic": "alarm/state",
@@ -1532,10 +1532,10 @@ async def test_restore_state(hass, expected_state, mqtt_mock_entry_with_yaml_con
         (STATE_ALARM_ARMED_VACATION),
     ],
 )
-async def test_restore_state_pending(
+async def test_restore_state_arming(
     hass, expected_state, mqtt_mock_entry_with_yaml_config
 ):
-    """Ensure PENDING state is restored on startup."""
+    """Ensure ARMING state is restored on startup."""
     time = dt_util.utcnow() - timedelta(seconds=15)
     entity_id = "alarm_control_panel.test"
     attributes = {
@@ -1556,7 +1556,7 @@ async def test_restore_state_pending(
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 60,
+                "arming_time": 60,
                 "trigger_time": 0,
                 "disarm_after_trigger": False,
                 "state_topic": "alarm/state",
@@ -1570,7 +1570,7 @@ async def test_restore_state_pending(
     assert state
     assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
     assert state.attributes["next_state"] == expected_state
-    assert state.state == STATE_ALARM_PENDING
+    assert state.state == STATE_ALARM_ARMING
 
     future = time + timedelta(seconds=61)
     with freeze_time(future):
@@ -1617,7 +1617,7 @@ async def test_restore_state_pending(
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 0,
+                "arming_time": 0,
                 "delay_time": 60,
                 "trigger_time": 60,
                 "disarm_after_trigger": False,
@@ -1686,7 +1686,7 @@ async def test_restore_state_triggered(
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 0,
+                "arming_time": 0,
                 "delay_time": 60,
                 "trigger_time": 60,
                 "disarm_after_trigger": False,
@@ -1734,7 +1734,7 @@ async def test_restore_state_triggered_disarm(hass, mqtt_mock_entry_with_yaml_co
             "alarm_control_panel": {
                 "platform": "manual_mqtt",
                 "name": "test",
-                "pending_time": 0,
+                "arming_time": 0,
                 "delay_time": 60,
                 "trigger_time": 60,
                 "disarm_after_trigger": True,

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -1106,6 +1106,51 @@ async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_con
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
+async def test_trigger_with_no_disarm_after_trigger(
+    hass, mqtt_mock_entry_with_yaml_config
+):
+    """Test disarm after trigger."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "trigger_time": 5,
+                "pending_time": 0,
+                "delay_time": 0,
+                "disarm_after_trigger": False,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_arm_away(hass, CODE, entity_id)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    with patch(
+        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
+        return_value=future,
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
+
+
 async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_config):
     """Test pending state with and without zero trigger time."""
     assert await async_setup_component(

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -572,313 +572,6 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_with_disarm_after_trigger(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test disarm after trigger."""
-    assert await async_setup_component(
-        hass,
-        alarm_control_panel.DOMAIN,
-        {
-            "alarm_control_panel": {
-                "platform": "manual_mqtt",
-                "name": "test",
-                "trigger_time": 5,
-                "pending_time": 0,
-                "disarm_after_trigger": True,
-                "command_topic": "alarm/command",
-                "state_topic": "alarm/state",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    entity_id = "alarm_control_panel.test"
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-    await common.async_alarm_trigger(hass, entity_id=entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
-    assert state.state == STATE_ALARM_TRIGGERED
-
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    with patch(
-        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
-        return_value=future,
-    ):
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-
-async def test_trigger_with_zero_specific_trigger_time(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test trigger method."""
-    assert await async_setup_component(
-        hass,
-        alarm_control_panel.DOMAIN,
-        {
-            "alarm_control_panel": {
-                "platform": "manual_mqtt",
-                "name": "test",
-                "trigger_time": 5,
-                "disarmed": {"trigger_time": 0},
-                "pending_time": 0,
-                "disarm_after_trigger": True,
-                "command_topic": "alarm/command",
-                "state_topic": "alarm/state",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    entity_id = "alarm_control_panel.test"
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-    await common.async_alarm_trigger(hass, entity_id=entity_id)
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-
-async def test_trigger_with_unused_zero_specific_trigger_time(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test disarm after trigger."""
-    assert await async_setup_component(
-        hass,
-        alarm_control_panel.DOMAIN,
-        {
-            "alarm_control_panel": {
-                "platform": "manual_mqtt",
-                "name": "test",
-                "trigger_time": 5,
-                "armed_home": {"trigger_time": 0},
-                "pending_time": 0,
-                "disarm_after_trigger": True,
-                "command_topic": "alarm/command",
-                "state_topic": "alarm/state",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    entity_id = "alarm_control_panel.test"
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-    await common.async_alarm_trigger(hass, entity_id=entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
-    assert state.state == STATE_ALARM_TRIGGERED
-
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    with patch(
-        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
-        return_value=future,
-    ):
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-
-async def test_trigger_with_specific_trigger_time(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test disarm after trigger."""
-    assert await async_setup_component(
-        hass,
-        alarm_control_panel.DOMAIN,
-        {
-            "alarm_control_panel": {
-                "platform": "manual_mqtt",
-                "name": "test",
-                "disarmed": {"trigger_time": 5},
-                "pending_time": 0,
-                "disarm_after_trigger": True,
-                "command_topic": "alarm/command",
-                "state_topic": "alarm/state",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    entity_id = "alarm_control_panel.test"
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-    await common.async_alarm_trigger(hass, entity_id=entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
-    assert state.state == STATE_ALARM_TRIGGERED
-
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    with patch(
-        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
-        return_value=future,
-    ):
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-
-async def test_back_to_back_trigger_with_no_disarm_after_trigger(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test no disarm after back to back trigger."""
-    assert await async_setup_component(
-        hass,
-        alarm_control_panel.DOMAIN,
-        {
-            "alarm_control_panel": {
-                "platform": "manual_mqtt",
-                "name": "test",
-                "trigger_time": 5,
-                "pending_time": 0,
-                "disarm_after_trigger": False,
-                "command_topic": "alarm/command",
-                "state_topic": "alarm/state",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    entity_id = "alarm_control_panel.test"
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-    await common.async_alarm_arm_away(hass, CODE, entity_id)
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
-
-    await common.async_alarm_trigger(hass, entity_id=entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
-    assert state.state == STATE_ALARM_TRIGGERED
-
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    with patch(
-        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
-        return_value=future,
-    ):
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
-
-    await common.async_alarm_trigger(hass, entity_id=entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
-    assert state.state == STATE_ALARM_TRIGGERED
-
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    with patch(
-        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
-        return_value=future,
-    ):
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
-
-
-async def test_disarm_while_pending_trigger(hass, mqtt_mock_entry_with_yaml_config):
-    """Test disarming while pending state."""
-    assert await async_setup_component(
-        hass,
-        alarm_control_panel.DOMAIN,
-        {
-            "alarm_control_panel": {
-                "platform": "manual_mqtt",
-                "name": "test",
-                "trigger_time": 5,
-                "disarm_after_trigger": False,
-                "command_topic": "alarm/command",
-                "state_topic": "alarm/state",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    entity_id = "alarm_control_panel.test"
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-    await common.async_alarm_trigger(hass)
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
-
-    await common.async_alarm_disarm(hass, entity_id=entity_id)
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    with patch(
-        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
-        return_value=future,
-    ):
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-
-async def test_disarm_during_trigger_with_invalid_code(
-    hass, mqtt_mock_entry_with_yaml_config
-):
-    """Test disarming while code is invalid."""
-    assert await async_setup_component(
-        hass,
-        alarm_control_panel.DOMAIN,
-        {
-            "alarm_control_panel": {
-                "platform": "manual_mqtt",
-                "name": "test",
-                "pending_time": 5,
-                "code": f"{CODE}2",
-                "disarm_after_trigger": False,
-                "command_topic": "alarm/command",
-                "state_topic": "alarm/state",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    entity_id = "alarm_control_panel.test"
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-    await common.async_alarm_trigger(hass)
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
-
-    await common.async_alarm_disarm(hass, entity_id=entity_id)
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
-
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    with patch(
-        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
-        return_value=future,
-    ):
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
-    assert state.state == STATE_ALARM_TRIGGERED
-
-
 async def test_trigger_with_unused_specific_delay(
     hass, mqtt_mock_entry_with_yaml_config
 ):
@@ -1149,6 +842,164 @@ async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_con
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
+async def test_trigger_with_disarm_after_trigger(
+    hass, mqtt_mock_entry_with_yaml_config
+):
+    """Test disarm after trigger."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "trigger_time": 5,
+                "pending_time": 0,
+                "disarm_after_trigger": True,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    with patch(
+        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
+        return_value=future,
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+
+async def test_trigger_with_zero_specific_trigger_time(
+    hass, mqtt_mock_entry_with_yaml_config
+):
+    """Test trigger method."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "trigger_time": 5,
+                "disarmed": {"trigger_time": 0},
+                "pending_time": 0,
+                "disarm_after_trigger": True,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+
+async def test_trigger_with_unused_zero_specific_trigger_time(
+    hass, mqtt_mock_entry_with_yaml_config
+):
+    """Test disarm after trigger."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "trigger_time": 5,
+                "armed_home": {"trigger_time": 0},
+                "pending_time": 0,
+                "disarm_after_trigger": True,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    with patch(
+        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
+        return_value=future,
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+
+async def test_trigger_with_specific_trigger_time(
+    hass, mqtt_mock_entry_with_yaml_config
+):
+    """Test disarm after trigger."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "disarmed": {"trigger_time": 5},
+                "pending_time": 0,
+                "disarm_after_trigger": True,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    with patch(
+        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
+        return_value=future,
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+
 async def test_trigger_with_no_disarm_after_trigger(
     hass, mqtt_mock_entry_with_yaml_config
 ):
@@ -1194,6 +1045,194 @@ async def test_trigger_with_no_disarm_after_trigger(
         await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
+
+
+async def test_back_to_back_trigger_with_no_disarm_after_trigger(
+    hass, mqtt_mock_entry_with_yaml_config
+):
+    """Test no disarm after back to back trigger."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "trigger_time": 5,
+                "pending_time": 0,
+                "disarm_after_trigger": False,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_arm_away(hass, CODE, entity_id)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    with patch(
+        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
+        return_value=future,
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    with patch(
+        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
+        return_value=future,
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
+
+
+async def test_disarm_while_pending_trigger(hass, mqtt_mock_entry_with_yaml_config):
+    """Test disarming while pending state."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "trigger_time": 5,
+                "disarm_after_trigger": False,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_trigger(hass)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
+
+    await common.async_alarm_disarm(hass, entity_id=entity_id)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    with patch(
+        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
+        return_value=future,
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+
+async def test_disarm_during_trigger_with_invalid_code(
+    hass, mqtt_mock_entry_with_yaml_config
+):
+    """Test disarming while code is invalid."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "pending_time": 5,
+                "code": f"{CODE}2",
+                "disarm_after_trigger": False,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_trigger(hass)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
+
+    await common.async_alarm_disarm(hass, entity_id=entity_id)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    with patch(
+        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
+        return_value=future,
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
+
+
+async def test_disarm_with_template_code(hass, mqtt_mock_entry_with_yaml_config):
+    """Attempt to disarm with a valid or invalid template-based code."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "code_template": '{{ "" if from_state == "disarmed" else "abc" }}',
+                "pending_time": 0,
+                "disarm_after_trigger": False,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_arm_home(hass, "def")
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ALARM_ARMED_HOME
+
+    await common.async_alarm_disarm(hass, "def")
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ALARM_ARMED_HOME
+
+    await common.async_alarm_disarm(hass, "abc")
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ALARM_DISARMED
 
 
 async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_config):
@@ -1259,45 +1298,6 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
     state = hass.states.get(entity_id)
     assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
-
-
-async def test_disarm_with_template_code(hass, mqtt_mock_entry_with_yaml_config):
-    """Attempt to disarm with a valid or invalid template-based code."""
-    assert await async_setup_component(
-        hass,
-        alarm_control_panel.DOMAIN,
-        {
-            "alarm_control_panel": {
-                "platform": "manual_mqtt",
-                "name": "test",
-                "code_template": '{{ "" if from_state == "disarmed" else "abc" }}',
-                "pending_time": 0,
-                "disarm_after_trigger": False,
-                "command_topic": "alarm/command",
-                "state_topic": "alarm/state",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    entity_id = "alarm_control_panel.test"
-
-    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
-
-    await common.async_alarm_arm_home(hass, "def")
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ALARM_ARMED_HOME
-
-    await common.async_alarm_disarm(hass, "def")
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ALARM_ARMED_HOME
-
-    await common.async_alarm_disarm(hass, "abc")
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ALARM_DISARMED
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Manual MQTT Alarm Control Panel

When going from state "disarmed" to any other (armed) state such as "armed_away", the state will be "arming" instead of "pending" during the transition time as set in the configuration.

When going from an armed state (such as "armed_away") to the "triggered" state the state will still be "pending" during the transition time as set in the configuration (as it was before).

State attribute "pre_pending_state" changed to "previous_state"

State attribute "post_pending_state" changed to "next_state"

config option "pending_time" is renamed to "arming_time", functionality is the same

The time the alarm stays at "pending" when triggered has changed from delay_time of the previous state + arming_time (previously known as pending_time) of the triggered state to only the delay_time of the previous state

This makes the manual MQTT alarm control panel integration consistent with the manual alarm control panel.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The manual_mqtt and manual alarm control panel integrations have diverged. The intention of the two is to be as similar as possible, in fact manual_mqtt documentation leaves most of the detail to manual.

This includes:
* changing pending_time to arming_time (#32950, this is the breaking change)
* adding state restore on startup
* adding MQTT payloads to set custom bypass and vacation mode

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24998

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
