### PR TITLE
Add support for controlling HomeWizard Energy Socket status light level

### DIFF
--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -10,7 +10,7 @@ from homewizard_energy.models import Data, Device, State
 from homeassistant.const import Platform
 
 DOMAIN = "homewizard"
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]
 
 # Platform config.
 CONF_API_ENABLED = "api_enabled"

--- a/homeassistant/components/homewizard/number.py
+++ b/homeassistant/components/homewizard/number.py
@@ -62,6 +62,8 @@ class HWEnergyNumberEntity(
         await self.coordinator.async_refresh()
 
     @property
-    def native_value(self) -> float:
+    def native_value(self) -> float | None:
         """Return the current value."""
+        if self.coordinator.data["state"].brightness is None:
+            return None
         return round(self.coordinator.data["state"].brightness * (100 / 255))

--- a/homeassistant/components/homewizard/number.py
+++ b/homeassistant/components/homewizard/number.py
@@ -44,8 +44,8 @@ class HWEnergyNumberEntity(
     ) -> None:
         """Initialize the control number."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{entry.unique_id}_status_light_level"
-        self._attr_name = "Light level"
+        self._attr_unique_id = f"{entry.unique_id}_status_light_brightness"
+        self._attr_name = "Status light brightness"
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_icon = "mdi:lightbulb-on"
         self._attr_device_info = {

--- a/homeassistant/components/homewizard/number.py
+++ b/homeassistant/components/homewizard/number.py
@@ -49,10 +49,6 @@ class HWEnergyNumberEntity(
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_icon = "mdi:lightbulb-on"
         self._attr_device_info = {
-            "name": entry.title,
-            "manufacturer": "HomeWizard",
-            "sw_version": coordinator.data["device"].firmware_version,
-            "model": coordinator.data["device"].product_type,
             "identifiers": {(DOMAIN, coordinator.data["device"].serial)},
         }
 

--- a/homeassistant/components/homewizard/number.py
+++ b/homeassistant/components/homewizard/number.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
 class HWEnergyNumberEntity(
     CoordinatorEntity[HWEnergyDeviceUpdateCoordinator], NumberEntity
 ):
-    """Representation switchable entity."""
+    """Representation of status light number."""
 
     _attr_entity_category = EntityCategory.CONFIG
     _attr_has_entity_name = True
@@ -42,7 +42,7 @@ class HWEnergyNumberEntity(
         coordinator: HWEnergyDeviceUpdateCoordinator,
         entry: ConfigEntry,
     ) -> None:
-        """Initialize the switch."""
+        """Initialize the control number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{entry.unique_id}_status_light_level"
         self._attr_name = "Light level"

--- a/homeassistant/components/homewizard/number.py
+++ b/homeassistant/components/homewizard/number.py
@@ -1,0 +1,67 @@
+"""Creates HomeWizard Number entities."""
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import HWEnergyDeviceUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up numbers for device."""
+    coordinator: HWEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    if coordinator.data["state"]:
+        async_add_entities(
+            [
+                HWEnergyNumberEntity(coordinator, entry),
+            ]
+        )
+
+
+class HWEnergyNumberEntity(
+    CoordinatorEntity[HWEnergyDeviceUpdateCoordinator], NumberEntity
+):
+    """Representation switchable entity."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HWEnergyDeviceUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.unique_id}_status_light_level"
+        self._attr_name = "Light level"
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_icon = "mdi:lightbulb-on"
+        self._attr_device_info = {
+            "name": entry.title,
+            "manufacturer": "HomeWizard",
+            "sw_version": coordinator.data["device"].firmware_version,
+            "model": coordinator.data["device"].product_type,
+            "identifiers": {(DOMAIN, coordinator.data["device"].serial)},
+        }
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a new value."""
+        await self.coordinator.api.state_set(brightness=value * (255 / 100))
+        await self.coordinator.async_refresh()
+
+    @property
+    def native_value(self) -> float:
+        """Return the current value."""
+        return round(self.coordinator.data["state"].brightness * (100 / 255))

--- a/tests/components/homewizard/test_number.py
+++ b/tests/components/homewizard/test_number.py
@@ -30,7 +30,10 @@ async def test_number_entity_not_loaded_when_not_available(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert hass.states.get("number.product_name_aabbccddeeff_light_level") is None
+    assert (
+        hass.states.get("number.product_name_aabbccddeeff_status_light_brightness")
+        is None
+    )
 
 
 async def test_number_loads_entities(hass, mock_config_entry_data, mock_config_entry):
@@ -52,17 +55,19 @@ async def test_number_loads_entities(hass, mock_config_entry_data, mock_config_e
 
     entity_registry = er.async_get(hass)
 
-    state = hass.states.get("number.product_name_aabbccddeeff_light_level")
+    state = hass.states.get("number.product_name_aabbccddeeff_status_light_brightness")
     assert state
     assert state.state == "100"
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Product Name (aabbccddeeff) Light level"
+        == "Product Name (aabbccddeeff) Status light brightness"
     )
 
-    entry = entity_registry.async_get("number.product_name_aabbccddeeff_light_level")
+    entry = entity_registry.async_get(
+        "number.product_name_aabbccddeeff_status_light_brightness"
+    )
     assert entry
-    assert entry.unique_id == "aabbccddeeff_status_light_level"
+    assert entry.unique_id == "aabbccddeeff_status_light_brightness"
     assert not entry.disabled
 
 
@@ -89,7 +94,9 @@ async def test_brightness_level_set(hass, mock_config_entry_data, mock_config_en
         await hass.async_block_till_done()
 
         assert (
-            hass.states.get("number.product_name_aabbccddeeff_light_level").state
+            hass.states.get(
+                "number.product_name_aabbccddeeff_status_light_brightness"
+            ).state
             == "100"
         )
 
@@ -98,7 +105,7 @@ async def test_brightness_level_set(hass, mock_config_entry_data, mock_config_en
             number.DOMAIN,
             SERVICE_SET_VALUE,
             {
-                ATTR_ENTITY_ID: "number.product_name_aabbccddeeff_light_level",
+                ATTR_ENTITY_ID: "number.product_name_aabbccddeeff_status_light_brightness",
                 ATTR_VALUE: 50,
             },
             blocking=True,
@@ -106,7 +113,9 @@ async def test_brightness_level_set(hass, mock_config_entry_data, mock_config_en
 
         await hass.async_block_till_done()
         assert (
-            hass.states.get("number.product_name_aabbccddeeff_light_level").state
+            hass.states.get(
+                "number.product_name_aabbccddeeff_status_light_brightness"
+            ).state
             == "50"
         )
         assert len(api.state_set.mock_calls) == 1
@@ -116,7 +125,7 @@ async def test_brightness_level_set(hass, mock_config_entry_data, mock_config_en
             number.DOMAIN,
             SERVICE_SET_VALUE,
             {
-                ATTR_ENTITY_ID: "number.product_name_aabbccddeeff_light_level",
+                ATTR_ENTITY_ID: "number.product_name_aabbccddeeff_status_light_brightness",
                 ATTR_VALUE: 0,
             },
             blocking=True,
@@ -124,6 +133,9 @@ async def test_brightness_level_set(hass, mock_config_entry_data, mock_config_en
 
         await hass.async_block_till_done()
         assert (
-            hass.states.get("number.product_name_aabbccddeeff_light_level").state == "0"
+            hass.states.get(
+                "number.product_name_aabbccddeeff_status_light_brightness"
+            ).state
+            == "0"
         )
         assert len(api.state_set.mock_calls) == 2

--- a/tests/components/homewizard/test_number.py
+++ b/tests/components/homewizard/test_number.py
@@ -1,0 +1,129 @@
+"""Test the update coordinator for HomeWizard."""
+
+from unittest.mock import AsyncMock, patch
+
+from homewizard_energy.models import State
+
+from homeassistant.components import number
+from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
+from homeassistant.helpers import entity_registry as er
+
+from .generator import get_mock_device
+
+
+async def test_number_entity_not_loaded_when_not_available(
+    hass, mock_config_entry_data, mock_config_entry
+):
+    """Test entity does not load number when brightness is not available."""
+
+    api = get_mock_device()
+
+    with patch(
+        "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("number.product_name_aabbccddeeff_light_level") is None
+
+
+async def test_number_loads_entities(hass, mock_config_entry_data, mock_config_entry):
+    """Test entity does load number when brightness is available."""
+
+    api = get_mock_device()
+    api.state = AsyncMock(return_value=State.from_dict({"brightness": 255}))
+
+    with patch(
+        "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get("number.product_name_aabbccddeeff_light_level")
+    assert state
+    assert state.state == "100"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == "Product Name (aabbccddeeff) Light level"
+    )
+
+    entry = entity_registry.async_get("number.product_name_aabbccddeeff_light_level")
+    assert entry
+    assert entry.unique_id == "aabbccddeeff_status_light_level"
+    assert not entry.disabled
+
+
+async def test_brightness_level_set(hass, mock_config_entry_data, mock_config_entry):
+    """Test entity turns sets light level."""
+
+    api = get_mock_device()
+    api.state = AsyncMock(return_value=State.from_dict({"brightness": 255}))
+
+    def state_set(brightness):
+        api.state = AsyncMock(return_value=State.from_dict({"brightness": brightness}))
+
+    api.state_set = AsyncMock(side_effect=state_set)
+
+    with patch(
+        "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert (
+            hass.states.get("number.product_name_aabbccddeeff_light_level").state
+            == "100"
+        )
+
+        # Set level halfway
+        await hass.services.async_call(
+            number.DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.product_name_aabbccddeeff_light_level",
+                ATTR_VALUE: 50,
+            },
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert (
+            hass.states.get("number.product_name_aabbccddeeff_light_level").state
+            == "50"
+        )
+        assert len(api.state_set.mock_calls) == 1
+
+        # Turn off level
+        await hass.services.async_call(
+            number.DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.product_name_aabbccddeeff_light_level",
+                ATTR_VALUE: 0,
+            },
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert (
+            hass.states.get("number.product_name_aabbccddeeff_light_level").state == "0"
+        )
+        assert len(api.state_set.mock_calls) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for setting Energy Socket 'on state' light level.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] → https://github.com/home-assistant/home-assistant.io/pull/25000

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
