### PR TITLE
Add tests for Shelly sensor platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1113,7 +1113,6 @@ omit =
     homeassistant/components/shelly/coordinator.py
     homeassistant/components/shelly/entity.py
     homeassistant/components/shelly/number.py
-    homeassistant/components/shelly/sensor.py
     homeassistant/components/shelly/utils.py
     homeassistant/components/shiftr/*
     homeassistant/components/shodan/sensor.py

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -63,10 +63,16 @@ def mock_light_set_state(
 
 MOCK_BLOCKS = [
     Mock(
-        sensor_ids={"inputEvent": "S", "inputEventCnt": 2, "overpower": 0},
+        sensor_ids={
+            "inputEvent": "S",
+            "inputEventCnt": 2,
+            "overpower": 0,
+            "power": 53.4,
+        },
         channel="0",
         type="relay",
         overpower=0,
+        power=53.4,
         description="relay_0",
         set_state=AsyncMock(side_effect=lambda turn: {"ison": turn == "on"}),
     ),
@@ -91,8 +97,9 @@ MOCK_BLOCKS = [
         set_state=AsyncMock(side_effect=mock_light_set_state),
     ),
     Mock(
-        sensor_ids={"motion": 0},
+        sensor_ids={"motion": 0, "temp": 22.1},
         motion=0,
+        temp=22.1,
         description="sensor_0",
         type="sensor",
     ),
@@ -138,6 +145,7 @@ MOCK_STATUS_COAP = {
         "old_version": "some_old_version",
     },
     "uptime": 5 * REST_SENSORS_UPDATE_INTERVAL,
+    "wifi_sta": {"rssi": -64},
 }
 
 
@@ -150,6 +158,7 @@ MOCK_STATUS_RPC = {
         "current_pos": 50,
         "apower": 85.3,
     },
+    "temperature:0": {"tC": 22.9},
     "sys": {
         "available_updates": {
             "beta": {"version": "some_beta_version"},

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1,0 +1,161 @@
+"""Tests for Shelly sensor platform."""
+
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import State
+
+from . import (
+    init_integration,
+    mock_rest_update,
+    mutate_rpc_device_status,
+    register_device,
+    register_entity,
+)
+
+from tests.common import mock_restore_cache
+
+RELAY_BLOCK_ID = 0
+SENSOR_BLOCK_ID = 3
+
+
+async def test_block_sensor(hass, mock_block_device, monkeypatch):
+    """Test block sensor."""
+    entity_id = f"{SENSOR_DOMAIN}.test_name_channel_1_power"
+    await init_integration(hass, 1)
+
+    assert hass.states.get(entity_id).state == "53.4"
+
+    monkeypatch.setattr(mock_block_device.blocks[RELAY_BLOCK_ID], "power", 60.1)
+    mock_block_device.mock_update()
+
+    assert hass.states.get(entity_id).state == "60.1"
+
+
+async def test_block_rest_sensor(hass, mock_block_device, monkeypatch):
+    """Test block REST sensor."""
+    entity_id = register_entity(hass, SENSOR_DOMAIN, "test_name_rssi", "rssi")
+    await init_integration(hass, 1)
+
+    assert hass.states.get(entity_id).state == "-64"
+
+    monkeypatch.setitem(mock_block_device.status["wifi_sta"], "rssi", -71)
+    await mock_rest_update(hass)
+
+    assert hass.states.get(entity_id).state == "-71"
+
+
+async def test_block_sleeping_sensor(hass, mock_block_device, monkeypatch):
+    """Test block sleeping sensor."""
+    entity_id = f"{SENSOR_DOMAIN}.test_name_temperature"
+    await init_integration(hass, 1, sleep_period=1000)
+
+    # Sensor should be created when device is online
+    assert hass.states.get(entity_id) is None
+
+    # Make device online
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "22.1"
+
+    monkeypatch.setattr(mock_block_device.blocks[SENSOR_BLOCK_ID], "temp", 23.4)
+    mock_block_device.mock_update()
+
+    assert hass.states.get(entity_id).state == "23.4"
+
+
+async def test_block_restored_sleeping_sensor(
+    hass, mock_block_device, device_reg, monkeypatch
+):
+    """Test block restored sleeping sensor."""
+    entry = await init_integration(hass, 1, sleep_period=1000, skip_setup=True)
+    register_device(device_reg, entry)
+    entity_id = register_entity(
+        hass, SENSOR_DOMAIN, "test_name_temperature", "sensor_0-temp", entry
+    )
+    mock_restore_cache(hass, [State(entity_id, "20.4")])
+    monkeypatch.setattr(mock_block_device, "initialized", False)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "20.4"
+
+    # Make device online
+    monkeypatch.setattr(mock_block_device, "initialized", True)
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "22.1"
+
+
+async def test_rpc_sensor(hass, mock_rpc_device, monkeypatch) -> None:
+    """Test RPC sensor."""
+    entity_id = f"{SENSOR_DOMAIN}.test_cover_0_power"
+    await init_integration(hass, 2)
+
+    assert hass.states.get(entity_id).state == "85.3"
+
+    mutate_rpc_device_status(monkeypatch, mock_rpc_device, "cover:0", "apower", "88.2")
+    mock_rpc_device.mock_update()
+
+    assert hass.states.get(entity_id).state == "88.2"
+
+
+async def test_rpc_sleeping_sensor(
+    hass, mock_rpc_device, device_reg, monkeypatch
+) -> None:
+    """Test RPC online sleeping sensor."""
+    entity_id = f"{SENSOR_DOMAIN}.test_name_temperature"
+    entry = await init_integration(hass, 2, sleep_period=1000)
+
+    # Sensor should be created when device is online
+    assert hass.states.get(entity_id) is None
+
+    register_entity(
+        hass,
+        SENSOR_DOMAIN,
+        "test_name_temperature",
+        "temperature:0-temperature_0",
+        entry,
+    )
+
+    # Make device online
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "22.9"
+
+    mutate_rpc_device_status(monkeypatch, mock_rpc_device, "temperature:0", "tC", 23.4)
+    mock_rpc_device.mock_update()
+
+    assert hass.states.get(entity_id).state == "23.4"
+
+
+async def test_rpc_restored_sleeping_sensor(
+    hass, mock_rpc_device, device_reg, monkeypatch
+):
+    """Test RPC restored sensor."""
+    entry = await init_integration(hass, 2, sleep_period=1000, skip_setup=True)
+    register_device(device_reg, entry)
+    entity_id = register_entity(
+        hass,
+        SENSOR_DOMAIN,
+        "test_name_temperature",
+        "temperature:0-temperature_0",
+        entry,
+    )
+
+    mock_restore_cache(hass, [State(entity_id, "21.0")])
+    monkeypatch.setattr(mock_rpc_device, "initialized", False)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "21.0"
+
+    # Make device online
+    monkeypatch.setattr(mock_rpc_device, "initialized", True)
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "22.9"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add 100% tests coverage for `sensor` platform, based on https://github.com/home-assistant/core/pull/82367 modified for `sensor` platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
