### PR TITLE
Make HERETravelTimeSensor extend RestoreSensor

### DIFF
--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -6,8 +6,8 @@ from datetime import timedelta
 from typing import Any
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
-    SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
@@ -99,7 +99,7 @@ async def async_setup_entry(
     async_add_entities(sensors)
 
 
-class HERETravelTimeSensor(SensorEntity, CoordinatorEntity):
+class HERETravelTimeSensor(RestoreSensor, CoordinatorEntity):
     """Representation of a HERE travel time sensor."""
 
     def __init__(
@@ -121,8 +121,14 @@ class HERETravelTimeSensor(SensorEntity, CoordinatorEntity):
         )
         self._attr_has_entity_name = True
 
+    async def _async_restore_state(self) -> None:
+        """Restore state."""
+        if restored_data := await self.async_get_last_sensor_data():
+            self._attr_native_value = restored_data.native_value
+
     async def async_added_to_hass(self) -> None:
         """Wait for start so origin and destination entities can be resolved."""
+        await self._async_restore_state()
         await super().async_added_to_hass()
 
         async def _update_at_start(_):
@@ -130,12 +136,13 @@ class HERETravelTimeSensor(SensorEntity, CoordinatorEntity):
 
         self.async_on_remove(async_at_start(self.hass, _update_at_start))
 
-    @property
-    def native_value(self) -> str | float | None:
-        """Return the state of the sensor."""
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
         if self.coordinator.data is not None:
-            return self.coordinator.data.get(self.entity_description.key)
-        return None
+            self._attr_native_value = self.coordinator.data.get(
+                self.entity_description.key
+            )
+            self.async_write_ha_state()
 
     @property
     def attribution(self) -> str | None:

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -34,29 +34,37 @@ from homeassistant.components.here_travel_time.const import (
     TRAVEL_MODE_PUBLIC,
     TRAVEL_MODE_TRUCK,
 )
+from homeassistant.components.sensor import (
+    ATTR_LAST_RESET,
+    ATTR_STATE_CLASS,
+    SensorStateClass,
+)
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_ICON,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_API_KEY,
     CONF_MODE,
     CONF_NAME,
     EVENT_HOMEASSISTANT_START,
     TIME_MINUTES,
+    UnitOfLength,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .const import (
     API_KEY,
+    DEFAULT_CONFIG,
     DESTINATION_LATITUDE,
     DESTINATION_LONGITUDE,
     ORIGIN_LATITUDE,
     ORIGIN_LONGITUDE,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, mock_restore_cache_with_extra_data
 
 
 @pytest.mark.parametrize(
@@ -440,3 +448,136 @@ async def test_route_not_found(hass: HomeAssistant, caplog):
         await hass.async_block_till_done()
 
         assert "Route calculation failed: Couldn't find a route." in caplog.text
+
+
+@pytest.mark.usefixtures("valid_response")
+async def test_restore_state(hass):
+    """Test sensor restore state."""
+    # Home assistant is not running yet
+    hass.state = CoreState.not_running
+    last_reset = "2022-11-29T00:00:00.000000+00:00"
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    "sensor.test_duration",
+                    "1234",
+                    attributes={
+                        ATTR_LAST_RESET: last_reset,
+                        ATTR_UNIT_OF_MEASUREMENT: TIME_MINUTES,
+                        ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
+                    },
+                ),
+                {
+                    "native_value": 1234,
+                    "native_unit_of_measurement": TIME_MINUTES,
+                    "icon": "mdi:car",
+                    "last_reset": last_reset,
+                },
+            ),
+            (
+                State(
+                    "sensor.test_duration_in_traffic",
+                    "5678",
+                    attributes={
+                        ATTR_LAST_RESET: last_reset,
+                        ATTR_UNIT_OF_MEASUREMENT: TIME_MINUTES,
+                        ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
+                    },
+                ),
+                {
+                    "native_value": 5678,
+                    "native_unit_of_measurement": TIME_MINUTES,
+                    "icon": "mdi:car",
+                    "last_reset": last_reset,
+                },
+            ),
+            (
+                State(
+                    "sensor.test_distance",
+                    "123",
+                    attributes={
+                        ATTR_LAST_RESET: last_reset,
+                        ATTR_UNIT_OF_MEASUREMENT: UnitOfLength.KILOMETERS,
+                        ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
+                    },
+                ),
+                {
+                    "native_value": 123,
+                    "native_unit_of_measurement": UnitOfLength.KILOMETERS,
+                    "icon": "mdi:car",
+                    "last_reset": last_reset,
+                },
+            ),
+            (
+                State(
+                    "sensor.test_origin",
+                    "Origin Address 1",
+                    attributes={
+                        ATTR_LAST_RESET: last_reset,
+                        ATTR_LATITUDE: ORIGIN_LATITUDE,
+                        ATTR_LONGITUDE: ORIGIN_LONGITUDE,
+                    },
+                ),
+                {
+                    "native_value": "Origin Address 1",
+                    "native_unit_of_measurement": None,
+                    ATTR_LATITUDE: ORIGIN_LATITUDE,
+                    ATTR_LONGITUDE: ORIGIN_LONGITUDE,
+                    "icon": "mdi:store-marker",
+                    "last_reset": last_reset,
+                },
+            ),
+            (
+                State(
+                    "sensor.test_destination",
+                    "Destination Address 1",
+                    attributes={
+                        ATTR_LAST_RESET: last_reset,
+                        ATTR_LATITUDE: DESTINATION_LATITUDE,
+                        ATTR_LONGITUDE: DESTINATION_LONGITUDE,
+                    },
+                ),
+                {
+                    "native_value": "Destination Address 1",
+                    "native_unit_of_measurement": None,
+                    "icon": "mdi:store-marker",
+                    "last_reset": last_reset,
+                },
+            ),
+        ],
+    )
+
+    # create and add entry
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN, unique_id=DOMAIN, data=DEFAULT_CONFIG, options=DEFAULT_OPTIONS
+    )
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    print(hass.states.async_all())
+
+    # restore from cache
+    state = hass.states.get("sensor.test_duration")
+    assert state.state == "1234"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TIME_MINUTES
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    state = hass.states.get("sensor.test_duration_in_traffic")
+    assert state.state == "5678"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TIME_MINUTES
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    state = hass.states.get("sensor.test_distance")
+    assert state.state == "123"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.KILOMETERS
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    state = hass.states.get("sensor.test_origin")
+    assert state.state == "Origin Address 1"
+
+    state = hass.states.get("sensor.test_destination")
+    assert state.state == "Destination Address 1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Extend RestoreSensor.

Implementation as done in [landisgyr_heat_meter](https://github.com/home-assistant/core/blob/dev/homeassistant/components/landisgyr_heat_meter/sensor.py#L64) and [rainmachine](https://github.com/home-assistant/core/blob/dev/homeassistant/components/rainmachine/sensor.py#L262)

The `extra_state_attributes` `latitude` and `longitude` are not restored.
Maybe a new `LocationSensor` which implements the restore functionality makes sense. It could look like the [TrackerEntity](https://github.com/home-assistant/core/blob/64988521bbf3a40abc42861cf037476c8a6b51ad/homeassistant/components/device_tracker/config_entry.py#L210) having `location_name` as `state` and `latitude` and `longitude`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
