### PR TITLE
Configure autoflake for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,15 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py39-plus]
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v1.7.7
+    hooks:
+      - id: autoflake
+        args:
+          - --in-place
+          - --remove-duplicate-keys
+          - --ignore-init-module-imports
+          - --remove-all-unused-imports
   - repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       - id: autoflake
         args:
           - --in-place
-          - --remove-duplicate-keys
           - --remove-all-unused-imports
   - repo: https://github.com/psf/black
     rev: 22.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
         args:
           - --in-place
           - --remove-duplicate-keys
-          - --ignore-init-module-imports
           - --remove-all-unused-imports
   - repo: https://github.com/psf/black
     rev: 22.10.0

--- a/homeassistant/components/zha/core/__init__.py
+++ b/homeassistant/components/zha/core/__init__.py
@@ -1,5 +1,6 @@
 """Core module for Zigbee Home Automation."""
 
-# flake8: noqa
 from .device import ZHADevice
 from .gateway import ZHAGateway
+
+__all__ = ["ZHADevice", "ZHAGateway"]

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,6 @@
 # Automatically generated from .pre-commit-config.yaml by gen_requirements_all.py, do not edit
 
+autoflake==1.7.7
 bandit==1.7.4
 black==22.10.0
 codespell==2.1.0

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -215,7 +215,6 @@ class MockBleakClient(BleakClient):
 
     async def disconnect(self, *args, **kwargs):
         """Mock disconnect."""
-        pass
 
     async def get_services(self, *args, **kwargs):
         """Mock get_services."""

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -31,7 +31,6 @@ class MockBleakClient:
 
     def __init__(self, *args, **kwargs):
         """Mock BleakClient."""
-        pass
 
     async def __aenter__(self, *args, **kwargs):
         """Mock BleakClient.__aenter__."""
@@ -39,7 +38,6 @@ class MockBleakClient:
 
     async def __aexit__(self, *args, **kwargs):
         """Mock BleakClient.__aexit__."""
-        pass
 
 
 class MockBleakClientTimesOut(MockBleakClient):

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -69,7 +69,6 @@ async def test_get_entries(hass, client, clear_handlers):
         @callback
         def async_get_options_flow(config_entry):
             """Get options flow."""
-            pass
 
         @classmethod
         @callback

--- a/tests/components/fido/test_sensor.py
+++ b/tests/components/fido/test_sensor.py
@@ -17,7 +17,6 @@ class FidoClientMock:
 
     def __init__(self, username, password, timeout=None, httpsession=None):
         """Fake Fido client init."""
-        pass
 
     def get_phone_numbers(self):
         """Return Phone numbers."""
@@ -29,7 +28,6 @@ class FidoClientMock:
 
     async def fetch_data(self):
         """Return fake fetching data."""
-        pass
 
 
 class FidoClientMockError(FidoClientMock):

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -27,7 +27,6 @@ from tests.components.recorder.common import (
 def test_setup():
     """Test setup method of history."""
     # Verification occurs in the fixture
-    pass
 
 
 def test_get_significant_states(hass_history):

--- a/tests/components/kodi/util.py
+++ b/tests/components/kodi/util.py
@@ -68,7 +68,6 @@ class MockConnection:
 
     async def connect(self):
         """Mock connect."""
-        pass
 
     @property
     def connected(self):
@@ -82,7 +81,6 @@ class MockConnection:
 
     async def close(self):
         """Mock close."""
-        pass
 
     @property
     def server(self):
@@ -99,7 +97,6 @@ class MockWSConnection:
 
     async def connect(self):
         """Mock connect."""
-        pass
 
     @property
     def connected(self):
@@ -113,7 +110,6 @@ class MockWSConnection:
 
     async def close(self):
         """Mock close."""
-        pass
 
     @property
     def server(self):

--- a/tests/components/lastfm/test_sensor.py
+++ b/tests/components/lastfm/test_sensor.py
@@ -30,7 +30,6 @@ class MockUser:
 
     def get_image(self):
         """Get mock image."""
-        pass
 
     def get_recent_tracks(self, limit):
         """Get mock recent tracks."""

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -18,7 +18,6 @@ from homeassistant.setup import async_setup_component
 @pytest.fixture(autouse=True)
 def mock_dev_track(mock_device_tracker_conf):
     """Mock device tracker config loading."""
-    pass
 
 
 @pytest.fixture

--- a/tests/components/mqtt/test_subscription.py
+++ b/tests/components/mqtt/test_subscription.py
@@ -139,7 +139,6 @@ async def test_qos_encoding_default(hass, mqtt_mock_entry_no_yaml_config, caplog
     @callback
     def msg_callback(*args):
         """Do nothing."""
-        pass
 
     sub_state = None
     sub_state = async_prepare_subscribe_topics(
@@ -158,7 +157,6 @@ async def test_qos_encoding_custom(hass, mqtt_mock_entry_no_yaml_config, caplog)
     @callback
     def msg_callback(*args):
         """Do nothing."""
-        pass
 
     sub_state = None
     sub_state = async_prepare_subscribe_topics(

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -210,43 +210,33 @@ class MockClient:
 
     async def panic(self, code):
         """Handle panic."""
-        pass
 
     async def disarm(self, code):
         """Handle disarm."""
-        pass
 
     async def arm_away(self, code):
         """Handle arm_away."""
-        pass
 
     async def arm_home(self, code):
         """Handle arm_home."""
-        pass
 
     async def aux(self, output_id, state):
         """Handle auxiliary control."""
-        pass
 
     async def keepalive(self):
         """Handle keepalive."""
-        pass
 
     async def update(self):
         """Handle update."""
-        pass
 
     def on_zone_change(self):
         """Handle on_zone_change."""
-        pass
 
     def on_state_change(self):
         """Handle on_state_change."""
-        pass
 
     async def close(self):
         """Handle close."""
-        pass
 
 
 @pytest.fixture

--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -35,7 +35,6 @@ LOCATION_MESSAGE = {
 @pytest.fixture(autouse=True)
 def mock_dev_track(mock_device_tracker_conf):
     """Mock device tracker config loading."""
-    pass
 
 
 @pytest.fixture

--- a/tests/components/tellduslive/test_config_flow.py
+++ b/tests/components/tellduslive/test_config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.components.tellduslive import (
 from homeassistant.config_entries import SOURCE_DISCOVERY
 from homeassistant.const import CONF_HOST
 
-from tests.common import MockConfigEntry, mock_coro
+from tests.common import MockConfigEntry
 
 
 def init_config_flow(hass, side_effect=None):

--- a/tests/components/xiaomi_ble/conftest.py
+++ b/tests/components/xiaomi_ble/conftest.py
@@ -20,7 +20,6 @@ class MockBleakClient:
 
     def __init__(self, *args, **kwargs):
         """Mock BleakClient."""
-        pass
 
     async def __aenter__(self, *args, **kwargs):
         """Mock BleakClient.__aenter__."""
@@ -28,15 +27,12 @@ class MockBleakClient:
 
     async def __aexit__(self, *args, **kwargs):
         """Mock BleakClient.__aexit__."""
-        pass
 
     async def connect(self, *args, **kwargs):
         """Mock BleakClient.connect."""
-        pass
 
     async def disconnect(self, *args, **kwargs):
         """Mock BleakClient.disconnect."""
-        pass
 
 
 class MockBleakClientBattery5(MockBleakClient):

--- a/tests/testing_config/custom_components/test_embedded/switch.py
+++ b/tests/testing_config/custom_components/test_embedded/switch.py
@@ -5,4 +5,3 @@ async def async_setup_platform(
     hass, config, async_add_entities_callback, discovery_info=None
 ):
     """Find and return test switches."""
-    pass


### PR DESCRIPTION
## Proposed change

This PR configures the [autoflake](https://github.com/PyCQA/autoflake) linter in the pre-commit configuration and runs it. (I checked with `git log -S autoflake` that this hadn't been considered before.)

The main benefit is that `autoflake` can clean up unused imports and variables that other linters down the line would complain about.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
