### PR TITLE
2022.11.4

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -7,7 +7,7 @@
   "quality_scale": "internal",
   "requirements": [
     "bleak==0.19.2",
-    "bleak-retry-connector==2.8.4",
+    "bleak-retry-connector==2.8.5",
     "bluetooth-adapters==0.7.0",
     "bluetooth-auto-recovery==0.3.6",
     "dbus-fast==1.61.1"

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -612,7 +612,7 @@ class TimeSMAFilter(Filter, SensorEntity):
 
         moving_sum = 0
         start = new_state.timestamp - self._time_window
-        prev_state = self.last_leak or self.queue[0]
+        prev_state = self.last_leak if self.last_leak is not None else self.queue[0]
         for state in self.queue:
             moving_sum += (state.timestamp - start).total_seconds() * prev_state.state
             start = state.timestamp

--- a/homeassistant/components/flo/device.py
+++ b/homeassistant/components/flo/device.py
@@ -1,7 +1,6 @@
 """Flo device object."""
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -40,14 +39,10 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update data via library."""
         try:
-            async with timeout(10):
-                await asyncio.gather(
-                    *[
-                        self.send_presence_ping(),
-                        self._update_device(),
-                        self._update_consumption_data(),
-                    ]
-                )
+            async with timeout(20):
+                await self.send_presence_ping()
+                await self._update_device()
+                await self._update_consumption_data()
         except (RequestError) as error:
             raise UpdateFailed(error) from error
 

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.28.32"],
+  "requirements": ["flux_led==0.28.34"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch", "@bdraco"],
   "iot_class": "local_push",

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -3,7 +3,7 @@
   "name": "KNX",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==1.2.0"],
+  "requirements": ["xknx==1.2.1"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "quality_scale": "platinum",
   "iot_class": "local_push",

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -375,4 +375,3 @@ async def async_reset_platform(hass: HomeAssistant, integration_name: str) -> No
     hubs = hass.data[DOMAIN]
     for name in hubs:
         await hubs[name].async_close()
-    del hass.data[DOMAIN]

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -132,6 +132,12 @@ async def async_modbus_setup(
 
     await async_setup_reload_service(hass, DOMAIN, [DOMAIN])
 
+    if DOMAIN in hass.data and config[DOMAIN] == []:
+        hubs = hass.data[DOMAIN]
+        for name in hubs:
+            if not await hubs[name].async_setup():
+                return False
+
     hass.data[DOMAIN] = hub_collect = {}
     for conf_hub in config[DOMAIN]:
         my_hub = ModbusHub(hass, conf_hub)

--- a/homeassistant/components/netatmo/netatmo_entity_base.py
+++ b/homeassistant/components/netatmo/netatmo_entity_base.py
@@ -29,7 +29,7 @@ class NetatmoBase(Entity):
         self._device_name: str = ""
         self._id: str = ""
         self._model: str = ""
-        self._config_url: str = ""
+        self._config_url: str | None = None
         self._attr_name = None
         self._attr_unique_id = None
         self._attr_extra_state_attributes = {}

--- a/homeassistant/components/nibe_heatpump/sensor.py
+++ b/homeassistant/components/nibe_heatpump/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     ENERGY_MEGA_WATT_HOUR,
     ENERGY_WATT_HOUR,
+    POWER_KILO_WATT,
     POWER_WATT,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
@@ -79,6 +80,13 @@ UNIT_DESCRIPTIONS = {
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=POWER_WATT,
+    ),
+    "kW": SensorEntityDescription(
+        key="kW",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=POWER_KILO_WATT,
     ),
     "Wh": SensorEntityDescription(
         key="Wh",

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -18,7 +18,7 @@ from tesla_powerwall import (
 from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -218,6 +218,17 @@ def _fetch_powerwall_data(power_wall: Powerwall) -> PowerwallData:
         grid_services_active=power_wall.is_grid_services_active(),
         grid_status=power_wall.get_grid_status(),
         backup_reserve=backup_reserve,
+    )
+
+
+@callback
+def async_last_update_was_successful(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Return True if the last update was successful."""
+    return bool(
+        (domain_data := hass.data.get(DOMAIN))
+        and (entry_data := domain_data.get(entry.entry_id))
+        and (coordinator := entry_data.get(POWERWALL_COORDINATOR))
+        and coordinator.last_update_success
     )
 
 

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -20,9 +20,16 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.util.network import is_ip_address
 
+from . import async_last_update_was_successful
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+ENTRY_FAILURE_STATES = {
+    config_entries.ConfigEntryState.SETUP_ERROR,
+    config_entries.ConfigEntryState.SETUP_RETRY,
+}
 
 
 def _login_and_fetch_site_info(
@@ -32,6 +39,17 @@ def _login_and_fetch_site_info(
     if password is not None:
         power_wall.login(password)
     return power_wall.get_site_info(), power_wall.get_gateway_din()
+
+
+def _powerwall_is_reachable(ip_address: str, password: str) -> bool:
+    """Check if the powerwall is reachable."""
+    try:
+        Powerwall(ip_address).login(password)
+    except AccessDeniedError:
+        return True
+    except PowerwallUnreachableError:
+        return False
+    return True
 
 
 async def validate_input(
@@ -69,13 +87,31 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.title: str | None = None
         self.reauth_entry: config_entries.ConfigEntry | None = None
 
+    async def _async_powerwall_is_offline(
+        self, entry: config_entries.ConfigEntry
+    ) -> bool:
+        """Check if the power wall is offline.
+
+        We define offline by the config entry
+        is in a failure/retry state or the updates
+        are failing and the powerwall is unreachable
+        since device may be updating.
+        """
+        ip_address = entry.data[CONF_IP_ADDRESS]
+        password = entry.data[CONF_PASSWORD]
+        return bool(
+            entry.state in ENTRY_FAILURE_STATES
+            or not async_last_update_was_successful(self.hass, entry)
+        ) and not await self.hass.async_add_executor_job(
+            _powerwall_is_reachable, ip_address, password
+        )
+
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Handle dhcp discovery."""
         self.ip_address = discovery_info.ip
         gateway_din = discovery_info.hostname.upper()
         # The hostname is the gateway_din (unique_id)
         await self.async_set_unique_id(gateway_din)
-        self._abort_if_unique_id_configured(updates={CONF_IP_ADDRESS: self.ip_address})
         for entry in self._async_current_entries(include_ignore=False):
             if entry.data[CONF_IP_ADDRESS] == discovery_info.ip:
                 if entry.unique_id is not None and is_ip_address(entry.unique_id):
@@ -86,6 +122,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             self.hass.config_entries.async_reload(entry.entry_id)
                         )
                 return self.async_abort(reason="already_configured")
+            if entry.unique_id == gateway_din:
+                if await self._async_powerwall_is_offline(entry):
+                    if self.hass.config_entries.async_update_entry(
+                        entry, data={**entry.data, CONF_IP_ADDRESS: self.ip_address}
+                    ):
+                        self.hass.async_create_task(
+                            self.hass.config_entries.async_reload(entry.entry_id)
+                        )
+                return self.async_abort(reason="already_configured")
+        # Still need to abort for ignored entries
+        self._abort_if_unique_id_configured()
         self.context["title_placeholders"] = {
             "name": gateway_din,
             "ip_address": self.ip_address,

--- a/homeassistant/components/rainmachine/manifest.json
+++ b/homeassistant/components/rainmachine/manifest.json
@@ -3,7 +3,7 @@
   "name": "RainMachine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rainmachine",
-  "requirements": ["regenmaschine==2022.10.0"],
+  "requirements": ["regenmaschine==2022.11.0"],
   "codeowners": ["@bachya"],
   "iot_class": "local_polling",
   "homekit": {

--- a/homeassistant/components/sma/manifest.json
+++ b/homeassistant/components/sma/manifest.json
@@ -3,7 +3,7 @@
   "name": "SMA Solar",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sma",
-  "requirements": ["pysma==0.7.2"],
+  "requirements": ["pysma==0.7.3"],
   "codeowners": ["@kellerza", "@rklomp"],
   "iot_class": "local_polling",
   "loggers": ["pysma"]

--- a/homeassistant/components/vicare/manifest.json
+++ b/homeassistant/components/vicare/manifest.json
@@ -3,7 +3,7 @@
   "name": "Viessmann ViCare",
   "documentation": "https://www.home-assistant.io/integrations/vicare",
   "codeowners": ["@oischinger"],
-  "requirements": ["PyViCare==2.17.0"],
+  "requirements": ["PyViCare==2.19.0"],
   "iot_class": "cloud_polling",
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,7 @@ from .backports.enum import StrEnum
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 11
-PATCH_VERSION: Final = "3"
+PATCH_VERSION: Final = "4"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -10,7 +10,7 @@ atomicwrites-homeassistant==1.4.1
 attrs==21.2.0
 awesomeversion==22.9.0
 bcrypt==3.1.7
-bleak-retry-connector==2.8.4
+bleak-retry-connector==2.8.5
 bleak==0.19.2
 bluetooth-adapters==0.7.0
 bluetooth-auto-recovery==0.3.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2022.11.3"
+version     = "2022.11.4"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -413,7 +413,7 @@ bimmer_connected==0.10.4
 bizkaibus==0.1.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.8.4
+bleak-retry-connector==2.8.5
 
 # homeassistant.components.bluetooth
 bleak==0.19.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2563,7 +2563,7 @@ xboxapi==2.0.1
 xiaomi-ble==0.10.0
 
 # homeassistant.components.knx
-xknx==1.2.0
+xknx==1.2.1
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2153,7 +2153,7 @@ raincloudy==0.0.7
 raspyrfm-client==1.2.8
 
 # homeassistant.components.rainmachine
-regenmaschine==2022.10.0
+regenmaschine==2022.11.0
 
 # homeassistant.components.renault
 renault-api==0.1.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ fjaraskupan==2.2.0
 flipr-api==1.4.2
 
 # homeassistant.components.flux_led
-flux_led==0.28.32
+flux_led==0.28.34
 
 # homeassistant.components.homekit
 # homeassistant.components.recorder

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1893,7 +1893,7 @@ pysignalclirestapi==0.3.18
 pyskyqhub==0.1.4
 
 # homeassistant.components.sma
-pysma==0.7.2
+pysma==0.7.3
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -47,7 +47,7 @@ PyTransportNSW==0.1.1
 PyTurboJPEG==1.6.7
 
 # homeassistant.components.vicare
-PyViCare==2.17.0
+PyViCare==2.19.0
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.14.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -337,7 +337,7 @@ bellows==0.34.2
 bimmer_connected==0.10.4
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.8.4
+bleak-retry-connector==2.8.5
 
 # homeassistant.components.bluetooth
 bleak==0.19.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -43,7 +43,7 @@ PyTransportNSW==0.1.1
 PyTurboJPEG==1.6.7
 
 # homeassistant.components.vicare
-PyViCare==2.17.0
+PyViCare==2.19.0
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.14.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -515,7 +515,7 @@ fjaraskupan==2.2.0
 flipr-api==1.4.2
 
 # homeassistant.components.flux_led
-flux_led==0.28.32
+flux_led==0.28.34
 
 # homeassistant.components.homekit
 # homeassistant.components.recorder

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1334,7 +1334,7 @@ pysiaalarm==3.0.2
 pysignalclirestapi==0.3.18
 
 # homeassistant.components.sma
-pysma==0.7.2
+pysma==0.7.3
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1776,7 +1776,7 @@ xbox-webapi==2.0.11
 xiaomi-ble==0.10.0
 
 # homeassistant.components.knx
-xknx==1.2.0
+xknx==1.2.1
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1489,7 +1489,7 @@ radios==0.1.1
 radiotherm==2.1.0
 
 # homeassistant.components.rainmachine
-regenmaschine==2022.10.0
+regenmaschine==2022.11.0
 
 # homeassistant.components.renault
 renault-api==0.1.11


### PR DESCRIPTION
- Fix moving average for 0 values ([@daanbeverdam] - [#80476]) ([filter docs])
- Solve Modbus reload issue ([@janiversen] - [#82253]) ([modbus docs])
- Add kilo watts unit mapping for nibe_heatpump ([@elupus] - [#82284]) ([nibe_heatpump docs])
- Bump `regenmaschine` to 2022.11.0 ([@bachya] - [#82337]) ([rainmachine docs])
- Bump pysma to version 0.7.3 ([@rklomp] - [#82343]) ([sma docs])
- Bump flux_led to 0.28.34 ([@bdraco] - [#82347]) ([flux_led docs])
- Fix invalid configuration_url in Netatmo ([@mib1185] - [#82372]) ([netatmo docs])
- Bump PyViCare to 2.19.0 ([@TheJulianJES] - [#82381]) ([vicare docs])
- Bump bleak-retry-connector to 2.8.5 ([@bdraco] - [#82387]) ([bluetooth docs])
- Update xknx to 1.2.1 ([@marvin-w] - [#82404]) ([knx docs])
- Attempt to fix occasional Flo timeouts ([@dmulcahey] - [#82408]) ([flo docs])
- Prevent powerwall from switching addresses if its online ([@bdraco] - [#82410]) ([powerwall docs])

[#80476]: https://github.com/home-assistant/core/pull/80476
[#81423]: https://github.com/home-assistant/core/pull/81423
[#81488]: https://github.com/home-assistant/core/pull/81488
[#81780]: https://github.com/home-assistant/core/pull/81780
[#82197]: https://github.com/home-assistant/core/pull/82197
[#82253]: https://github.com/home-assistant/core/pull/82253
[#82284]: https://github.com/home-assistant/core/pull/82284
[#82337]: https://github.com/home-assistant/core/pull/82337
[#82343]: https://github.com/home-assistant/core/pull/82343
[#82347]: https://github.com/home-assistant/core/pull/82347
[#82372]: https://github.com/home-assistant/core/pull/82372
[#82381]: https://github.com/home-assistant/core/pull/82381
[#82387]: https://github.com/home-assistant/core/pull/82387
[#82404]: https://github.com/home-assistant/core/pull/82404
[#82408]: https://github.com/home-assistant/core/pull/82408
[#82410]: https://github.com/home-assistant/core/pull/82410
[3_day_blinds docs]: https://www.home-assistant.io/integrations/3_day_blinds/
[@TheJulianJES]: https://github.com/TheJulianJES
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@daanbeverdam]: https://github.com/daanbeverdam
[@dmulcahey]: https://github.com/dmulcahey
[@elupus]: https://github.com/elupus
[@frenck]: https://github.com/frenck
[@janiversen]: https://github.com/janiversen
[@marvin-w]: https://github.com/marvin-w
[@mib1185]: https://github.com/mib1185
[@rklomp]: https://github.com/rklomp
[abode docs]: https://www.home-assistant.io/integrations/abode/
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/
[bluetooth docs]: https://www.home-assistant.io/integrations/bluetooth/
[filter docs]: https://www.home-assistant.io/integrations/filter/
[flo docs]: https://www.home-assistant.io/integrations/flo/
[flux_led docs]: https://www.home-assistant.io/integrations/flux_led/
[knx docs]: https://www.home-assistant.io/integrations/knx/
[modbus docs]: https://www.home-assistant.io/integrations/modbus/
[netatmo docs]: https://www.home-assistant.io/integrations/netatmo/
[nibe_heatpump docs]: https://www.home-assistant.io/integrations/nibe_heatpump/
[powerwall docs]: https://www.home-assistant.io/integrations/powerwall/
[rainmachine docs]: https://www.home-assistant.io/integrations/rainmachine/
[sma docs]: https://www.home-assistant.io/integrations/sma/
[vicare docs]: https://www.home-assistant.io/integrations/vicare/