### PR TITLE
Allow `None` return for notify `get_service`

### DIFF
--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -41,7 +41,7 @@ class LegacyNotifyPlatform(Protocol):
         hass: HomeAssistant,
         config: ConfigType,
         discovery_info: DiscoveryInfoType | None = ...,
-    ) -> BaseNotificationService:
+    ) -> BaseNotificationService | None:
         """Set up notification service."""
 
     def get_service(
@@ -49,7 +49,7 @@ class LegacyNotifyPlatform(Protocol):
         hass: HomeAssistant,
         config: ConfigType,
         discovery_info: DiscoveryInfoType | None = ...,
-    ) -> BaseNotificationService:
+    ) -> BaseNotificationService | None:
         """Set up notification service."""
 
 
@@ -82,7 +82,7 @@ def async_setup_legacy(
         full_name = f"{DOMAIN}.{integration_name}"
         LOGGER.info("Setting up %s", full_name)
         with async_start_setup(hass, [full_name]):
-            notify_service = None
+            notify_service: BaseNotificationService | None = None
             try:
                 if hasattr(platform, "async_get_service"):
                     notify_service = await platform.async_get_service(


### PR DESCRIPTION
## Proposed change
Modify protocol typing for `LegacyNotifyPlatform` to allow `None` return for `async_get_service` and `get_service`. This is fully handled by the existing code and integrations frequently return `None`, e.g. if the `discovery_info` is None.
https://github.com/home-assistant/core/blob/32f3eb722e78eadc2ac3bdee4218f15c0fea097e/homeassistant/components/notify/legacy.py#L85-L98
https://github.com/home-assistant/core/blob/32f3eb722e78eadc2ac3bdee4218f15c0fea097e/homeassistant/components/discord/notify.py#L41-L49

The custom pylint plugin does also use the correct return type already.
https://github.com/home-assistant/core/blob/32f3eb722e78eadc2ac3bdee4218f15c0fea097e/pylint/plugins/hass_enforce_type_hints.py#L390-L401

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
