### PR TITLE
Enforce LightEntityFeature

### DIFF
--- a/homeassistant/components/control4/light.py
+++ b/homeassistant/components/control4/light.py
@@ -192,11 +192,11 @@ class Control4Light(Control4Entity, LightEntity):
         return None
 
     @property
-    def supported_features(self) -> LightEntityFeature | int:
+    def supported_features(self) -> LightEntityFeature:
         """Flag supported features."""
         if self._is_dimmer:
             return LightEntityFeature.TRANSITION
-        return 0
+        return LightEntityFeature(0)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -112,11 +112,11 @@ class DecoraWifiLight(LightEntity):
         return {self.color_mode}
 
     @property
-    def supported_features(self) -> LightEntityFeature | int:
+    def supported_features(self) -> LightEntityFeature:
         """Return supported features."""
         if self._switch.canSetLevel:
             return LightEntityFeature.TRANSITION
-        return 0
+        return LightEntityFeature(0)
 
     @property
     def name(self):

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -287,7 +287,7 @@ class LightGroup(GroupEntity, LightEntity):
                 set[str], set().union(*all_supported_color_modes)
             )
 
-        self._attr_supported_features = 0
+        self._attr_supported_features = LightEntityFeature(0)
         for support in find_state_attributes(states, ATTR_SUPPORTED_FEATURES):
             # Merge supported features by emulating support for every feature
             # we find.

--- a/homeassistant/components/hue/v1/light.py
+++ b/homeassistant/components/hue/v1/light.py
@@ -108,7 +108,7 @@ def create_light(item_class, coordinator, bridge, is_group, rooms, api, item_id)
 
     if is_group:
         supported_color_modes = set()
-        supported_features = 0
+        supported_features = LightEntityFeature(0)
         for light_id in api_item.lights:
             if light_id not in bridge.api.lights:
                 continue

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -100,9 +100,9 @@ class HassAqualinkLight(AqualinkEntity, LightEntity):
         return {self.color_mode}
 
     @property
-    def supported_features(self) -> LightEntityFeature | int:
+    def supported_features(self) -> LightEntityFeature:
         """Return the list of features supported by the light."""
         if self.dev.supports_effect:
             return LightEntityFeature.EFFECT
 
-        return 0
+        return LightEntityFeature(0)

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -793,7 +793,7 @@ class LightEntity(ToggleEntity):
     _attr_rgbw_color: tuple[int, int, int, int] | None = None
     _attr_rgbww_color: tuple[int, int, int, int, int] | None = None
     _attr_supported_color_modes: set[ColorMode] | set[str] | None = None
-    _attr_supported_features: LightEntityFeature | int = 0
+    _attr_supported_features: LightEntityFeature = LightEntityFeature(0)
     _attr_xy_color: tuple[float, float] | None = None
 
     @property
@@ -1060,6 +1060,6 @@ class LightEntity(ToggleEntity):
         return self._attr_supported_color_modes
 
     @property
-    def supported_features(self) -> LightEntityFeature | int:
+    def supported_features(self) -> LightEntityFeature:
         """Flag supported features."""
         return self._attr_supported_features

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -415,11 +415,9 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             supported_color_modes
         )
 
-        supported_features: int = 0
-        supported_features |= (
-            topic[CONF_EFFECT_COMMAND_TOPIC] is not None and LightEntityFeature.EFFECT
-        )
-        self._attr_supported_features = supported_features
+        self._attr_supported_features = LightEntityFeature(0)
+        if topic[CONF_EFFECT_COMMAND_TOPIC] is not None:
+            self._attr_supported_features |= LightEntityFeature.EFFECT
 
     def _is_optimistic(self, attribute: str) -> bool:
         """Return True if the attribute is optimistically updated."""

--- a/homeassistant/components/osramlightify/light.py
+++ b/homeassistant/components/osramlightify/light.py
@@ -221,9 +221,9 @@ class Luminary(LightEntity):
 
         return color_modes
 
-    def _get_supported_features(self) -> LightEntityFeature | int:
+    def _get_supported_features(self) -> LightEntityFeature:
         """Get list of supported features."""
-        features = 0
+        features = LightEntityFeature(0)
         if "lum" in self._luminary.supported_features():
             features = features | LightEntityFeature.TRANSITION
 
@@ -435,7 +435,7 @@ class OsramLightifyGroup(Luminary):
         #       users.
         return f"{self._luminary.lights()}"
 
-    def _get_supported_features(self) -> LightEntityFeature | int:
+    def _get_supported_features(self) -> LightEntityFeature:
         """Get list of supported features."""
         features = super()._get_supported_features()
         if self._luminary.scenes():

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -101,9 +101,9 @@ class SmartThingsLight(SmartThingsEntity, LightEntity):
 
         return color_modes
 
-    def _determine_features(self) -> LightEntityFeature | int:
+    def _determine_features(self) -> LightEntityFeature:
         """Get features supported by the device."""
-        features = 0
+        features = LightEntityFeature(0)
         # Transition
         if Capability.switch_level in self._device.capabilities:
             features |= LightEntityFeature.TRANSITION

--- a/homeassistant/components/tasmota/light.py
+++ b/homeassistant/components/tasmota/light.py
@@ -120,7 +120,7 @@ class TasmotaLight(
     def _setup_from_entity(self) -> None:
         """(Re)Setup the entity."""
         self._supported_color_modes = set()
-        supported_features = 0
+        supported_features = LightEntityFeature(0)
         light_type = self._tasmota_entity.light_type
 
         if light_type in [LIGHT_TYPE_RGB, LIGHT_TYPE_RGBW, LIGHT_TYPE_RGBCW]:

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -254,9 +254,9 @@ class LightTemplate(TemplateEntity, LightEntity):
         return self._supported_color_modes
 
     @property
-    def supported_features(self) -> LightEntityFeature | int:
+    def supported_features(self) -> LightEntityFeature:
         """Flag supported features."""
-        supported_features = 0
+        supported_features = LightEntityFeature(0)
         if self._effect_script is not None:
             supported_features |= LightEntityFeature.EFFECT
         if self._supports_transition is True:

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -312,7 +312,7 @@ class TPLinkSmartLightStrip(TPLinkSmartBulb):
     device: SmartLightStrip
 
     @property
-    def supported_features(self) -> LightEntityFeature | int:
+    def supported_features(self) -> LightEntityFeature:
         """Flag supported features."""
         return super().supported_features | LightEntityFeature.EFFECT
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -1002,9 +1002,9 @@ class YeelightNightLightMode(YeelightGenericLight):
         return PowerMode.MOONLIGHT
 
     @property
-    def supported_features(self) -> int:
+    def supported_features(self) -> LightEntityFeature:
         """Flag no supported features."""
-        return 0
+        return LightEntityFeature(0)
 
 
 class YeelightNightLightModeWithAmbientSupport(YeelightNightLightMode):

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -18,6 +18,7 @@ from zigpy.zcl.foundation import Status
 from homeassistant.components import light
 from homeassistant.components.light import (
     ColorMode,
+    LightEntityFeature,
     brightness_supported,
     filter_supported_color_modes,
 )
@@ -1078,7 +1079,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
                 set[str], set().union(*all_supported_color_modes)
             )
 
-        self._attr_supported_features = 0
+        self._attr_supported_features = LightEntityFeature(0)
         for support in helpers.find_state_attributes(states, ATTR_SUPPORTED_FEATURES):
             # Merge supported features by emulating support for every feature
             # we find.

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -1520,7 +1520,7 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
                 ),
                 TypeHintMatch(
                     function_name="supported_features",
-                    return_type=["LightEntityFeature", "int"],
+                    return_type="LightEntityFeature",
                 ),
                 TypeHintMatch(
                     function_name="turn_on",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove int from Light supported features

Linked to #82273, as draft in case #82313 is closed in favor of #82312

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
