### PR TITLE
Add unique id for Scrape config entry entities

### DIFF
--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
+import uuid
 
 import voluptuous as vol
 
@@ -24,6 +25,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_RESOURCE,
     CONF_TIMEOUT,
+    CONF_UNIQUE_ID,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_USERNAME,
     CONF_VALUE_TEMPLATE,
@@ -125,7 +127,15 @@ def validate_rest_setup(user_input: dict[str, Any]) -> dict[str, Any]:
 
 def validate_sensor_setup(user_input: dict[str, Any]) -> dict[str, Any]:
     """Validate sensor setup."""
-    return {"sensor": [{**user_input, CONF_INDEX: int(user_input[CONF_INDEX])}]}
+    return {
+        "sensor": [
+            {
+                **user_input,
+                CONF_INDEX: int(user_input[CONF_INDEX]),
+                CONF_UNIQUE_ID: uuid.uuid1(),
+            }
+        ]
+    }
 
 
 DATA_SCHEMA_RESOURCE = vol.Schema(RESOURCE_SETUP)

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -26,11 +26,13 @@ from homeassistant.const import (
     CONF_RESOURCE,
     CONF_TIMEOUT,
     CONF_UNIQUE_ID,
+    CONF_UNIT_OF_MEASUREMENT,
     CONF_USERNAME,
     CONF_VALUE_TEMPLATE,
     CONF_VERIFY_SSL,
     HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
+    UnitOfTemperature,
 )
 from homeassistant.core import async_get_hass
 from homeassistant.helpers.schema_config_entry_flow import (
@@ -99,6 +101,13 @@ SENSOR_SETUP = {
     vol.Optional(CONF_STATE_CLASS): SelectSelector(
         SelectSelectorConfig(
             options=[cls.value for cls in SensorStateClass],
+            mode=SelectSelectorMode.DROPDOWN,
+        )
+    ),
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): SelectSelector(
+        SelectSelectorConfig(
+            options=[cls.value for cls in UnitOfTemperature],
+            custom_value=True,
             mode=SelectSelectorMode.DROPDOWN,
         )
     ),

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -26,13 +26,11 @@ from homeassistant.const import (
     CONF_RESOURCE,
     CONF_TIMEOUT,
     CONF_UNIQUE_ID,
-    CONF_UNIT_OF_MEASUREMENT,
     CONF_USERNAME,
     CONF_VALUE_TEMPLATE,
     CONF_VERIFY_SSL,
     HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
-    UnitOfTemperature,
 )
 from homeassistant.core import async_get_hass
 from homeassistant.helpers.schema_config_entry_flow import (
@@ -104,13 +102,6 @@ SENSOR_SETUP = {
             mode=SelectSelectorMode.DROPDOWN,
         )
     ),
-    vol.Optional(CONF_UNIT_OF_MEASUREMENT): SelectSelector(
-        SelectSelectorConfig(
-            options=[cls.value for cls in UnitOfTemperature],
-            custom_value=True,
-            mode=SelectSelectorMode.DROPDOWN,
-        )
-    ),
 }
 
 
@@ -132,7 +123,7 @@ def validate_sensor_setup(user_input: dict[str, Any]) -> dict[str, Any]:
             {
                 **user_input,
                 CONF_INDEX: int(user_input[CONF_INDEX]),
-                CONF_UNIQUE_ID: uuid.uuid1(),
+                CONF_UNIQUE_ID: str(uuid.uuid1()),
             }
         ]
     }

--- a/homeassistant/components/scrape/sensor.py
+++ b/homeassistant/components/scrape/sensor.py
@@ -163,6 +163,7 @@ async def async_setup_entry(
         attr: str | None = sensor_config.get(CONF_ATTRIBUTE)
         index: int = int(sensor_config[CONF_INDEX])
         value_string: str | None = sensor_config.get(CONF_VALUE_TEMPLATE)
+        unique_id: str = sensor_config[CONF_UNIQUE_ID]
 
         value_template: Template | None = (
             Template(value_string, hass) if value_string is not None else None
@@ -173,7 +174,7 @@ async def async_setup_entry(
                 coordinator,
                 sensor_config,
                 name,
-                None,
+                unique_id,
                 select,
                 attr,
                 index,

--- a/tests/components/scrape/conftest.py
+++ b/tests/components/scrape/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 from unittest.mock import patch
+import uuid
 
 import pytest
 
@@ -87,6 +88,6 @@ def uuid_fixture() -> str:
     """Automatically path uuid generator."""
     with patch(
         "homeassistant.components.scrape.config_flow.uuid.uuid1",
-        return_value="3699ef88-69e6-11ed-a1eb-0242ac120002",
+        return_value=uuid.UUID("3699ef88-69e6-11ed-a1eb-0242ac120002"),
     ):
         yield

--- a/tests/components/scrape/conftest.py
+++ b/tests/components/scrape/conftest.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_RESOURCE,
     CONF_TIMEOUT,
+    CONF_UNIQUE_ID,
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant
@@ -41,6 +42,7 @@ async def get_config_to_integration_load() -> dict[str, Any]:
                 CONF_NAME: "Current version",
                 CONF_SELECT: ".current-version h1",
                 CONF_INDEX: 0,
+                CONF_UNIQUE_ID: "3699ef88-69e6-11ed-a1eb-0242ac120002",
             }
         ],
     }
@@ -78,3 +80,13 @@ async def load_integration(
         await hass.async_block_till_done()
 
     return config_entry
+
+
+@pytest.fixture(autouse=True)
+def uuid_fixture() -> str:
+    """Automatically path uuid generator."""
+    with patch(
+        "homeassistant.components.scrape.config_flow.uuid.uuid1",
+        return_value="3699ef88-69e6-11ed-a1eb-0242ac120002",
+    ):
+        yield

--- a/tests/components/scrape/test_config_flow.py
+++ b/tests/components/scrape/test_config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_RESOURCE,
     CONF_TIMEOUT,
+    CONF_UNIQUE_ID,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
@@ -78,6 +79,7 @@ async def test_form(hass: HomeAssistant, get_data: MockRestData) -> None:
                 CONF_NAME: "Current version",
                 CONF_SELECT: ".current-version h1",
                 CONF_INDEX: 0.0,
+                CONF_UNIQUE_ID: "3699ef88-69e6-11ed-a1eb-0242ac120002",
             }
         ],
     }
@@ -148,6 +150,7 @@ async def test_flow_fails(hass: HomeAssistant, get_data: MockRestData) -> None:
                 CONF_NAME: "Current version",
                 CONF_SELECT: ".current-version h1",
                 CONF_INDEX: 0.0,
+                CONF_UNIQUE_ID: "3699ef88-69e6-11ed-a1eb-0242ac120002",
             }
         ],
     }
@@ -192,6 +195,7 @@ async def test_options_flow(hass: HomeAssistant, loaded_entry: MockConfigEntry) 
                     CONF_NAME: "Current version",
                     CONF_SELECT: ".current-version h1",
                     CONF_INDEX: 0.0,
+                    CONF_UNIQUE_ID: "3699ef88-69e6-11ed-a1eb-0242ac120002",
                 }
             ],
         }

--- a/tests/components/scrape/test_sensor.py
+++ b/tests/components/scrape/test_sensor.py
@@ -414,3 +414,8 @@ async def test_setup_config_entry(
 
     state = hass.states.get("sensor.current_version")
     assert state.state == "Current Version: 2021.12.10"
+
+    entity_reg = er.async_get(hass)
+    entity = entity_reg.async_get("sensor.current_version")
+
+    assert entity.unique_id == "3699ef88-69e6-11ed-a1eb-0242ac120002"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use uuid to generate automatically unique id's for Scrape sensors made by config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
