### PR TITLE
Roborock mop features

### DIFF
--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -299,6 +299,8 @@ SERVICE_SET_POWER_MODE = "switch_set_power_mode"
 SERVICE_SET_POWER_PRICE = "switch_set_power_price"
 
 # Vacuum Services
+SERVICE_SET_MOP_MODE = "set_mop_mode"
+SERVICE_SET_MOP_INTENSITY = "set_mop_intensity"
 SERVICE_MOVE_REMOTE_CONTROL = "vacuum_remote_control_move"
 SERVICE_MOVE_REMOTE_CONTROL_STEP = "vacuum_remote_control_move_step"
 SERVICE_START_REMOTE_CONTROL = "vacuum_remote_control_start"

--- a/homeassistant/components/xiaomi_miio/services.yaml
+++ b/homeassistant/components/xiaomi_miio/services.yaml
@@ -173,6 +173,32 @@ remote_set_led_off:
       integration: xiaomi_miio
       domain: remote
 
+set_mop_mode:
+  name: Set mop mode
+  description: "Set the mop mode of a vacuum."
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: vacuum
+  fields:
+    mop_mode:
+      name: Mop mode
+      description: "Define the mop mode to set in the vacuum."
+      required: true
+
+set_mop_intensity:
+  name: Set mop intensity
+  description: "Set the mop intensity of a vacuum."
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: vacuum
+  fields:
+    mop_intensity:
+      name: Mop intensity
+      description: "Define the mop intensity to set in the vacuum."
+      required: true
+
 switch_set_wifi_led_on:
   name: Switch set Wi-fi LED on
   description: Turn the wifi led on.


### PR DESCRIPTION
## Proposed change
Add mop features to `xiaomi_miio` integration: `mop_mode` and `mop_intensity`.

## Type of change
It includes both attributes (`mop_mode` and `mop_intensity`) as an attribute of the vacuum entity and two services (`set_mop_mode` and `set_mop_intensity`) to change them.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #69869
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
