### PR TITLE
Fix html5 Firefox Notifications

### DIFF
--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -544,7 +544,7 @@ class HTML5NotificationService(BaseNotificationService):
                     _LOGGER.error("Error saving registration")
                 else:
                     _LOGGER.info("Configuration saved")
-            elif response.status_code != 201:
+            elif response.status_code > 399:
                 _LOGGER.error(
                     "There was an issue sending the notification %s: %s",
                     response.status,

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -546,7 +546,8 @@ class HTML5NotificationService(BaseNotificationService):
                     _LOGGER.info("Configuration saved")
             elif response.status_code != 201:
                 _LOGGER.error(
-                    "There was an issue sending the notification:\n%s",
+                    "There was an issue sending the notification %s: %s",
+                    response.status,
                     response.text,
                 )
 

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -99,6 +99,7 @@ SCHEMA_WS_APPKEY = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 # The number of days after the moment a notification is sent that a JWT
 # is valid.
 JWT_VALID_DAYS = 7
+VAPID_CLAIM_VALID_HOURS = 12
 
 KEYS_SCHEMA = vol.All(
     dict,
@@ -514,7 +515,10 @@ class HTML5NotificationService(BaseNotificationService):
             webpusher = WebPusher(info[ATTR_SUBSCRIPTION])
             if self._vapid_prv and self._vapid_email:
                 vapid_headers = create_vapid_headers(
-                    self._vapid_email, info[ATTR_SUBSCRIPTION], self._vapid_prv
+                    self._vapid_email,
+                    info[ATTR_SUBSCRIPTION],
+                    self._vapid_prv,
+                    timestamp,
                 )
                 vapid_headers.update({"urgency": priority, "priority": priority})
                 response = webpusher.send(
@@ -540,6 +544,11 @@ class HTML5NotificationService(BaseNotificationService):
                     _LOGGER.error("Error saving registration")
                 else:
                     _LOGGER.info("Configuration saved")
+            elif response.status_code != 201:
+                _LOGGER.error(
+                    "There was an issue sending the notification:\n%s",
+                    response.text,
+                )
 
 
 def add_jwt(timestamp, target, tag, jwt_secret):
@@ -556,14 +565,23 @@ def add_jwt(timestamp, target, tag, jwt_secret):
     return jwt.encode(jwt_claims, jwt_secret)
 
 
-def create_vapid_headers(vapid_email, subscription_info, vapid_private_key):
+def create_vapid_headers(vapid_email, subscription_info, vapid_private_key, timestamp):
     """Create encrypted headers to send to WebPusher."""
 
-    if vapid_email and vapid_private_key and ATTR_ENDPOINT in subscription_info:
+    if (
+        vapid_email
+        and vapid_private_key
+        and ATTR_ENDPOINT in subscription_info
+        and timestamp
+    ):
+        vapid_exp = datetime.fromtimestamp(timestamp) + timedelta(
+            hours=VAPID_CLAIM_VALID_HOURS
+        )
         url = urlparse(subscription_info.get(ATTR_ENDPOINT))
         vapid_claims = {
             "sub": f"mailto:{vapid_email}",
             "aud": f"{url.scheme}://{url.netloc}",
+            "exp": int(vapid_exp.timestamp()),
         }
         vapid = Vapid.from_string(private_key=vapid_private_key)
         return vapid.sign(vapid_claims)

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -93,6 +93,7 @@ class TestHtml5Notify:
     def test_dismissing_message(self, mock_wp):
         """Test dismissing message."""
         hass = MagicMock()
+        mock_wp().send().status_code = 201
 
         data = {"device": SUBSCRIPTION_1}
 
@@ -104,16 +105,13 @@ class TestHtml5Notify:
 
         service.dismiss(target=["device", "non_existing"], data={"tag": "test"})
 
-        assert len(mock_wp.mock_calls) == 8
+        assert len(mock_wp.mock_calls) == 4
 
         # WebPusher constructor
-        assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_1["subscription"]
-        # Third mock_call checks the status_code of the response.
-        assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
+        assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_1["subscription"]
 
         # Call to send
-        payload = json.loads(mock_wp.mock_calls[1][1][0])
+        payload = json.loads(mock_wp.mock_calls[3][1][0])
 
         assert payload["dismiss"] is True
         assert payload["tag"] == "test"
@@ -122,6 +120,7 @@ class TestHtml5Notify:
     def test_sending_message(self, mock_wp):
         """Test sending message."""
         hass = MagicMock()
+        mock_wp().send().status_code = 201
 
         data = {"device": SUBSCRIPTION_1}
 
@@ -135,16 +134,13 @@ class TestHtml5Notify:
             "Hello", target=["device", "non_existing"], data={"icon": "beer.png"}
         )
 
-        assert len(mock_wp.mock_calls) == 8
+        assert len(mock_wp.mock_calls) == 4
 
         # WebPusher constructor
-        assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_1["subscription"]
-        # Third mock_call checks the status_code of the response.
-        assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
+        assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_1["subscription"]
 
         # Call to send
-        payload = json.loads(mock_wp.mock_calls[1][1][0])
+        payload = json.loads(mock_wp.mock_calls[3][1][0])
 
         assert payload["body"] == "Hello"
         assert payload["icon"] == "beer.png"
@@ -153,6 +149,7 @@ class TestHtml5Notify:
     def test_gcm_key_include(self, mock_wp):
         """Test if the gcm_key is only included for GCM endpoints."""
         hass = MagicMock()
+        mock_wp().send().status_code = 201
 
         data = {"chrome": SUBSCRIPTION_1, "firefox": SUBSCRIPTION_2}
 
@@ -166,26 +163,21 @@ class TestHtml5Notify:
 
         service.send_message("Hello", target=["chrome", "firefox"])
 
-        assert len(mock_wp.mock_calls) == 16
+        assert len(mock_wp.mock_calls) == 6
 
         # WebPusher constructor
-        assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_1["subscription"]
-        assert mock_wp.mock_calls[8][1][0] == SUBSCRIPTION_2["subscription"]
-
-        # Third mock_call checks the status_code of the response.
-        assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
-        assert mock_wp.mock_calls[10][0] == "().send().status_code.__eq__"
-        assert mock_wp.mock_calls[11][0] == "().send().status_code.__ne__"
+        assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_1["subscription"]
+        assert mock_wp.mock_calls[4][1][0] == SUBSCRIPTION_2["subscription"]
 
         # Get the keys passed to the WebPusher's send method
-        assert mock_wp.mock_calls[1][2]["gcm_key"] is not None
-        assert mock_wp.mock_calls[9][2]["gcm_key"] is None
+        assert mock_wp.mock_calls[3][2]["gcm_key"] is not None
+        assert mock_wp.mock_calls[5][2]["gcm_key"] is None
 
     @patch("homeassistant.components.html5.notify.WebPusher")
     def test_fcm_key_include(self, mock_wp):
         """Test if the FCM header is included."""
         hass = MagicMock()
+        mock_wp().send().status_code = 201
 
         data = {"chrome": SUBSCRIPTION_5}
 
@@ -197,21 +189,18 @@ class TestHtml5Notify:
 
         service.send_message("Hello", target=["chrome"])
 
-        assert len(mock_wp.mock_calls) == 8
+        assert len(mock_wp.mock_calls) == 4
         # WebPusher constructor
-        assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
-
-        # Third mock_call checks the status_code of the response.
-        assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
+        assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_5["subscription"]
 
         # Get the keys passed to the WebPusher's send method
-        assert mock_wp.mock_calls[1][2]["headers"]["Authorization"] is not None
+        assert mock_wp.mock_calls[3][2]["headers"]["Authorization"] is not None
 
     @patch("homeassistant.components.html5.notify.WebPusher")
     def test_fcm_send_with_unknown_priority(self, mock_wp):
         """Test if the gcm_key is only included for GCM endpoints."""
         hass = MagicMock()
+        mock_wp().send().status_code = 201
 
         data = {"chrome": SUBSCRIPTION_5}
 
@@ -223,21 +212,18 @@ class TestHtml5Notify:
 
         service.send_message("Hello", target=["chrome"], priority="undefined")
 
-        assert len(mock_wp.mock_calls) == 8
+        assert len(mock_wp.mock_calls) == 4
         # WebPusher constructor
-        assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
-
-        # Third mock_call checks the status_code of the response.
-        assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
+        assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_5["subscription"]
 
         # Get the keys passed to the WebPusher's send method
-        assert mock_wp.mock_calls[1][2]["headers"]["priority"] == "normal"
+        assert mock_wp.mock_calls[3][2]["headers"]["priority"] == "normal"
 
     @patch("homeassistant.components.html5.notify.WebPusher")
     def test_fcm_no_targets(self, mock_wp):
         """Test if the gcm_key is only included for GCM endpoints."""
         hass = MagicMock()
+        mock_wp().send().status_code = 201
 
         data = {"chrome": SUBSCRIPTION_5}
 
@@ -249,21 +235,18 @@ class TestHtml5Notify:
 
         service.send_message("Hello")
 
-        assert len(mock_wp.mock_calls) == 8
+        assert len(mock_wp.mock_calls) == 4
         # WebPusher constructor
-        assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
-
-        # Third mock_call checks the status_code of the response.
-        assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
+        assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_5["subscription"]
 
         # Get the keys passed to the WebPusher's send method
-        assert mock_wp.mock_calls[1][2]["headers"]["priority"] == "normal"
+        assert mock_wp.mock_calls[3][2]["headers"]["priority"] == "normal"
 
     @patch("homeassistant.components.html5.notify.WebPusher")
     def test_fcm_additional_data(self, mock_wp):
         """Test if the gcm_key is only included for GCM endpoints."""
         hass = MagicMock()
+        mock_wp().send().status_code = 201
 
         data = {"chrome": SUBSCRIPTION_5}
 
@@ -275,16 +258,12 @@ class TestHtml5Notify:
 
         service.send_message("Hello", data={"mykey": "myvalue"})
 
-        assert len(mock_wp.mock_calls) == 8
+        assert len(mock_wp.mock_calls) == 4
         # WebPusher constructor
-        assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
-
-        # Third mock_call checks the status_code of the response.
-        assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
+        assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_5["subscription"]
 
         # Get the keys passed to the WebPusher's send method
-        assert mock_wp.mock_calls[1][2]["headers"]["priority"] == "normal"
+        assert mock_wp.mock_calls[3][2]["headers"]["priority"] == "normal"
 
 
 def test_create_vapid_withoutvapid():
@@ -486,6 +465,7 @@ async def test_callback_view_with_jwt(hass, hass_client):
     client = await mock_client(hass, hass_client, registrations)
 
     with patch("homeassistant.components.html5.notify.WebPusher") as mock_wp:
+        mock_wp().send().status_code = 201
         await hass.services.async_call(
             "notify",
             "notify",
@@ -493,16 +473,13 @@ async def test_callback_view_with_jwt(hass, hass_client):
             blocking=True,
         )
 
-    assert len(mock_wp.mock_calls) == 8
+    assert len(mock_wp.mock_calls) == 4
 
     # WebPusher constructor
-    assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_1["subscription"]
-    # Third mock_call checks the status_code of the response.
-    assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-    assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
+    assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_1["subscription"]
 
     # Call to send
-    push_payload = json.loads(mock_wp.mock_calls[1][1][0])
+    push_payload = json.loads(mock_wp.mock_calls[3][1][0])
 
     assert push_payload["body"] == "Hello"
     assert push_payload["icon"] == "beer.png"
@@ -523,6 +500,7 @@ async def test_send_fcm_without_targets(hass, hass_client):
     registrations = {"device": SUBSCRIPTION_5}
     await mock_client(hass, hass_client, registrations)
     with patch("homeassistant.components.html5.notify.WebPusher") as mock_wp:
+        mock_wp().send().status_code = 201
         await hass.services.async_call(
             "notify",
             "notify",
@@ -530,13 +508,10 @@ async def test_send_fcm_without_targets(hass, hass_client):
             blocking=True,
         )
 
-    assert len(mock_wp.mock_calls) == 8
+    assert len(mock_wp.mock_calls) == 4
 
     # WebPusher constructor
-    assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
-    # Third mock_call checks the status_code of the response.
-    assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-    assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
+    assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_5["subscription"]
 
 
 async def test_send_fcm_expired(hass, hass_client):

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -282,7 +282,7 @@ class TestHtml5Notify:
 def test_create_vapid_withoutvapid():
     """Test creating empty vapid."""
     resp = html5.create_vapid_headers(
-        vapid_email=None, vapid_private_key=None, subscription_info=None
+        vapid_email=None, vapid_private_key=None, subscription_info=None, timestamp=None
     )
     assert resp is None
 

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -104,12 +104,13 @@ class TestHtml5Notify:
 
         service.dismiss(target=["device", "non_existing"], data={"tag": "test"})
 
-        assert len(mock_wp.mock_calls) == 3
+        assert len(mock_wp.mock_calls) == 8
 
         # WebPusher constructor
         assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_1["subscription"]
         # Third mock_call checks the status_code of the response.
         assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
+        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
 
         # Call to send
         payload = json.loads(mock_wp.mock_calls[1][1][0])
@@ -134,12 +135,13 @@ class TestHtml5Notify:
             "Hello", target=["device", "non_existing"], data={"icon": "beer.png"}
         )
 
-        assert len(mock_wp.mock_calls) == 3
+        assert len(mock_wp.mock_calls) == 8
 
         # WebPusher constructor
         assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_1["subscription"]
         # Third mock_call checks the status_code of the response.
         assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
+        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
 
         # Call to send
         payload = json.loads(mock_wp.mock_calls[1][1][0])
@@ -164,19 +166,21 @@ class TestHtml5Notify:
 
         service.send_message("Hello", target=["chrome", "firefox"])
 
-        assert len(mock_wp.mock_calls) == 6
+        assert len(mock_wp.mock_calls) == 16
 
         # WebPusher constructor
         assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_1["subscription"]
-        assert mock_wp.mock_calls[3][1][0] == SUBSCRIPTION_2["subscription"]
+        assert mock_wp.mock_calls[8][1][0] == SUBSCRIPTION_2["subscription"]
 
         # Third mock_call checks the status_code of the response.
         assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
-        assert mock_wp.mock_calls[5][0] == "().send().status_code.__eq__"
+        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
+        assert mock_wp.mock_calls[10][0] == "().send().status_code.__eq__"
+        assert mock_wp.mock_calls[11][0] == "().send().status_code.__ne__"
 
         # Get the keys passed to the WebPusher's send method
         assert mock_wp.mock_calls[1][2]["gcm_key"] is not None
-        assert mock_wp.mock_calls[4][2]["gcm_key"] is None
+        assert mock_wp.mock_calls[9][2]["gcm_key"] is None
 
     @patch("homeassistant.components.html5.notify.WebPusher")
     def test_fcm_key_include(self, mock_wp):
@@ -193,12 +197,13 @@ class TestHtml5Notify:
 
         service.send_message("Hello", target=["chrome"])
 
-        assert len(mock_wp.mock_calls) == 3
+        assert len(mock_wp.mock_calls) == 8
         # WebPusher constructor
         assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
 
         # Third mock_call checks the status_code of the response.
         assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
+        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
 
         # Get the keys passed to the WebPusher's send method
         assert mock_wp.mock_calls[1][2]["headers"]["Authorization"] is not None
@@ -218,12 +223,13 @@ class TestHtml5Notify:
 
         service.send_message("Hello", target=["chrome"], priority="undefined")
 
-        assert len(mock_wp.mock_calls) == 3
+        assert len(mock_wp.mock_calls) == 8
         # WebPusher constructor
         assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
 
         # Third mock_call checks the status_code of the response.
         assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
+        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
 
         # Get the keys passed to the WebPusher's send method
         assert mock_wp.mock_calls[1][2]["headers"]["priority"] == "normal"
@@ -243,12 +249,13 @@ class TestHtml5Notify:
 
         service.send_message("Hello")
 
-        assert len(mock_wp.mock_calls) == 3
+        assert len(mock_wp.mock_calls) == 8
         # WebPusher constructor
         assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
 
         # Third mock_call checks the status_code of the response.
         assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
+        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
 
         # Get the keys passed to the WebPusher's send method
         assert mock_wp.mock_calls[1][2]["headers"]["priority"] == "normal"
@@ -268,12 +275,13 @@ class TestHtml5Notify:
 
         service.send_message("Hello", data={"mykey": "myvalue"})
 
-        assert len(mock_wp.mock_calls) == 3
+        assert len(mock_wp.mock_calls) == 8
         # WebPusher constructor
         assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
 
         # Third mock_call checks the status_code of the response.
         assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
+        assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
 
         # Get the keys passed to the WebPusher's send method
         assert mock_wp.mock_calls[1][2]["headers"]["priority"] == "normal"
@@ -485,12 +493,13 @@ async def test_callback_view_with_jwt(hass, hass_client):
             blocking=True,
         )
 
-    assert len(mock_wp.mock_calls) == 3
+    assert len(mock_wp.mock_calls) == 8
 
     # WebPusher constructor
     assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_1["subscription"]
     # Third mock_call checks the status_code of the response.
     assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
+    assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
 
     # Call to send
     push_payload = json.loads(mock_wp.mock_calls[1][1][0])
@@ -521,12 +530,13 @@ async def test_send_fcm_without_targets(hass, hass_client):
             blocking=True,
         )
 
-    assert len(mock_wp.mock_calls) == 3
+    assert len(mock_wp.mock_calls) == 8
 
     # WebPusher constructor
     assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
     # Third mock_call checks the status_code of the response.
     assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
+    assert mock_wp.mock_calls[3][0] == "().send().status_code.__ne__"
 
 
 async def test_send_fcm_expired(hass, hass_client):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Vapid claims did not include an `exp` key and Firefox expects this key or it refuses to send a notification. This is mentioned [here](https://github.com/web-push-libs/vapid#tldr) showing that the vapid claim should include this key. This matches the spec now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #82286
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
