### PR TITLE
Add type hint to template wrapper

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -27,6 +27,7 @@ import weakref
 from awesomeversion import AwesomeVersion
 import jinja2
 from jinja2 import pass_context, pass_environment, pass_eval_context
+from jinja2.nodes import EvalContext
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace
 from typing_extensions import Concatenate, ParamSpec
@@ -2085,13 +2086,13 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         # at compile time and the value stored. The context itself
         # can be discarded, we only need to get at the hass object.
         def hassfunction(
-            func: Callable[Concatenate[HomeAssistant | None, _P], _R]
-        ) -> Callable[_P, _R]:
+            func: Callable[Concatenate[HomeAssistant, _P], _R]
+        ) -> Callable[Concatenate[EvalContext, _P], _R]:
             """Wrap function that depend on hass."""
 
             @wraps(func)
-            def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-                return func(hass, *args[1:], **kwargs)  # type: ignore[arg-type]
+            def wrapper(_: EvalContext, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+                return func(hass, *args, **kwargs)
 
             return pass_context(wrapper)
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -96,9 +96,8 @@ _COLLECTABLE_STATE_ATTRIBUTES = {
     "name",
 }
 
-_R = TypeVar("_R")
 _P = ParamSpec("_P")
-_ContextT = TypeVar("_ContextT")
+_R = TypeVar("_R")
 _T = TypeVar("_T")
 
 ALL_STATES_RATE_LIMIT = timedelta(minutes=1)
@@ -2086,12 +2085,14 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         # at compile time and the value stored. The context itself
         # can be discarded, we only need to get at the hass object.
         def hassfunction(
-            func: Callable[Concatenate[HomeAssistant, _P], _R]
-        ) -> Callable[Concatenate[_ContextT, _P], _R]:
+            func: Callable[Concatenate[HomeAssistant, _P], _R],
+        ) -> Callable[Concatenate[jinja2.runtime.Context, _P], _R]:
             """Wrap function that depend on hass."""
 
             @wraps(func)
-            def wrapper(_: _ContextT, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+            def wrapper(
+                context: jinja2.runtime.Context, *args: _P.args, **kwargs: _P.kwargs
+            ) -> _R:
                 return func(hass, *args, **kwargs)
 
             return pass_context(wrapper)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2086,7 +2086,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         # can be discarded, we only need to get at the hass object.
         def hassfunction(
             func: Callable[Concatenate[HomeAssistant, _P], _R],
-        ) -> Callable[Concatenate[jinja2.runtime.Context, _P], _R]:
+        ) -> Callable[Concatenate[Any, _P], _R]:
             """Wrap function that depend on hass."""
 
             @wraps(func)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -27,7 +27,7 @@ import weakref
 from awesomeversion import AwesomeVersion
 import jinja2
 from jinja2 import pass_context, pass_environment, pass_eval_context
-from jinja2.nodes import EvalContext
+from jinja2.runtime import Context
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace
 from typing_extensions import Concatenate, ParamSpec
@@ -2087,11 +2087,11 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         # can be discarded, we only need to get at the hass object.
         def hassfunction(
             func: Callable[Concatenate[HomeAssistant, _P], _R]
-        ) -> Callable[Concatenate[EvalContext, _P], _R]:
+        ) -> Callable[Concatenate[Context, _P], _R]:
             """Wrap function that depend on hass."""
 
             @wraps(func)
-            def wrapper(_: EvalContext, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+            def wrapper(_: Context, *args: _P.args, **kwargs: _P.kwargs) -> _R:
                 return func(hass, *args, **kwargs)
 
             return pass_context(wrapper)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -96,9 +96,9 @@ _COLLECTABLE_STATE_ATTRIBUTES = {
     "name",
 }
 
-_P = ParamSpec("_P")
-_R = TypeVar("_R")
 _T = TypeVar("_T")
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 ALL_STATES_RATE_LIMIT = timedelta(minutes=1)
 DOMAIN_STATES_RATE_LIMIT = timedelta(seconds=1)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2090,9 +2090,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
             """Wrap function that depend on hass."""
 
             @wraps(func)
-            def wrapper(
-                context: jinja2.runtime.Context, *args: _P.args, **kwargs: _P.kwargs
-            ) -> _R:
+            def wrapper(_: Any, *args: _P.args, **kwargs: _P.kwargs) -> _R:
                 return func(hass, *args, **kwargs)
 
             return pass_context(wrapper)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -27,7 +27,6 @@ import weakref
 from awesomeversion import AwesomeVersion
 import jinja2
 from jinja2 import pass_context, pass_environment, pass_eval_context
-from jinja2.runtime import Context
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace
 from typing_extensions import Concatenate, ParamSpec
@@ -99,6 +98,7 @@ _COLLECTABLE_STATE_ATTRIBUTES = {
 
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
+_ContextT = TypeVar("_ContextT")
 _T = TypeVar("_T")
 
 ALL_STATES_RATE_LIMIT = timedelta(minutes=1)
@@ -2087,11 +2087,11 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         # can be discarded, we only need to get at the hass object.
         def hassfunction(
             func: Callable[Concatenate[HomeAssistant, _P], _R]
-        ) -> Callable[Concatenate[Context, _P], _R]:
+        ) -> Callable[Concatenate[_ContextT, _P], _R]:
             """Wrap function that depend on hass."""
 
             @wraps(func)
-            def wrapper(_: Context, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+            def wrapper(_: _ContextT, *args: _P.args, **kwargs: _P.kwargs) -> _R:
                 return func(hass, *args, **kwargs)
 
             return pass_context(wrapper)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to `TemplateEnvironment.hassfunction` wrapper.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
