### PR TITLE
Add support for HomeWizard enable/disable cloud feature

### DIFF
--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from typing import TypedDict
 
 # Set up.
-from homewizard_energy.models import Data, Device, State
+from homewizard_energy.models import Data, Device, State, System
 
 from homeassistant.const import Platform
 
@@ -30,3 +30,4 @@ class DeviceResponseEntry(TypedDict):
     device: Device
     data: Data
     state: State
+    system: System

--- a/homeassistant/components/homewizard/coordinator.py
+++ b/homeassistant/components/homewizard/coordinator.py
@@ -39,7 +39,12 @@ class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]
                 "device": await self.api.device(),
                 "data": await self.api.data(),
                 "state": await self.api.state(),
+                "system": None,
             }
+
+            features = await self.api.features()
+            if features.has_system:
+                data["system"] = await self.api.system()
 
         except RequestError as ex:
             raise UpdateFailed("Device did not respond as expected") from ex

--- a/homeassistant/components/homewizard/diagnostics.py
+++ b/homeassistant/components/homewizard/diagnostics.py
@@ -27,6 +27,9 @@ async def async_get_config_entry_diagnostics(
         "state": asdict(coordinator.data["state"])
         if coordinator.data["state"] is not None
         else None,
+        "system": asdict(coordinator.data["system"])
+        if coordinator.data["system"] is not None
+        else None,
     }
 
     return {

--- a/homeassistant/components/homewizard/manifest.json
+++ b/homeassistant/components/homewizard/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/homewizard",
   "codeowners": ["@DCSBL"],
   "dependencies": [],
-  "requirements": ["python-homewizard-energy==1.3.0"],
+  "requirements": ["python-homewizard-energy==1.3.1"],
   "zeroconf": ["_hwenergy._tcp.local."],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/homewizard/manifest.json
+++ b/homeassistant/components/homewizard/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/homewizard",
   "codeowners": ["@DCSBL"],
   "dependencies": [],
-  "requirements": ["python-homewizard-energy==1.1.0"],
+  "requirements": ["python-homewizard-energy==1.3.0"],
   "zeroconf": ["_hwenergy._tcp.local."],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -142,7 +142,7 @@ class HWEnergyEnableCloudEntity(HWEnergySwitchEntity):
     At this point, the device is fully local.
     """
 
-    _attr_name = "Enable Cloud"
+    _attr_name = "Enable cloud"
     _attr_device_class = SwitchDeviceClass.SWITCH
     _attr_entity_category = EntityCategory.CONFIG
 
@@ -153,13 +153,13 @@ class HWEnergyEnableCloudEntity(HWEnergySwitchEntity):
         entry: ConfigEntry,
     ) -> None:
         """Initialize the switch."""
-        super().__init__(coordinator, entry, "enable_cloud")
+        super().__init__(coordinator, entry, "cloud_enabled")
         self.hass = hass
         self.entry = entry
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn switch-lock on."""
-        await self.coordinator.api.system_set(enable_cloud=True)
+        await self.coordinator.api.system_set(cloud_enabled=True)
         await self.coordinator.async_refresh()
 
         persistent_notification.async_dismiss(
@@ -168,7 +168,7 @@ class HWEnergyEnableCloudEntity(HWEnergySwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn switch-lock off."""
-        await self.coordinator.api.system_set(enable_cloud=False)
+        await self.coordinator.api.system_set(cloud_enabled=False)
         await self.coordinator.async_refresh()
 
         persistent_notification.async_create(

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components import persistent_notification
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -162,24 +161,10 @@ class HWEnergyEnableCloudEntity(HWEnergySwitchEntity):
         await self.coordinator.api.system_set(cloud_enabled=True)
         await self.coordinator.async_refresh()
 
-        persistent_notification.async_dismiss(
-            self.hass, f"{DOMAIN}_cloud_disabled_for_{self.unique_id}"
-        )
-
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn switch-lock off."""
         await self.coordinator.api.system_set(cloud_enabled=False)
         await self.coordinator.async_refresh()
-
-        persistent_notification.async_create(
-            self.hass,
-            title="HomeWizard Energy",
-            message=(
-                f"Cloud communication for HomeWizard Energy has been disabled for {self.entry.title}. "
-                "Keep in mind that this makes the HomeWizard Energy app unusable for this device."
-            ),
-            notification_id=f"{DOMAIN}_cloud_disabled_for_{self.unique_id}",
-        )
 
     @property
     def icon(self) -> str | None:

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -137,11 +137,11 @@ class HWEnergyEnableCloudEntity(HWEnergySwitchEntity):
     """
     Representation of the enable cloud configuration.
 
-    Disable cloud turns off all communication to HomeWizard Cloud.
+    Turning off 'cloud connection' turns off all communication to HomeWizard Cloud.
     At this point, the device is fully local.
     """
 
-    _attr_name = "Enable cloud"
+    _attr_name = "Cloud connection"
     _attr_device_class = SwitchDeviceClass.SWITCH
     _attr_entity_category = EntityCategory.CONFIG
 
@@ -152,17 +152,17 @@ class HWEnergyEnableCloudEntity(HWEnergySwitchEntity):
         entry: ConfigEntry,
     ) -> None:
         """Initialize the switch."""
-        super().__init__(coordinator, entry, "cloud_enabled")
+        super().__init__(coordinator, entry, "cloud_connection")
         self.hass = hass
         self.entry = entry
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn switch-lock on."""
+        """Turn cloud connection on."""
         await self.coordinator.api.system_set(cloud_enabled=True)
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn switch-lock off."""
+        """Turn cloud connection off."""
         await self.coordinator.api.system_set(cloud_enabled=False)
         await self.coordinator.async_refresh()
 
@@ -173,5 +173,5 @@ class HWEnergyEnableCloudEntity(HWEnergySwitchEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return true if switch is on."""
+        """Return true if cloud connection is active."""
         return bool(self.coordinator.data["system"].cloud_enabled)

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -30,6 +30,13 @@ async def async_setup_entry(
             ]
         )
 
+    if coordinator.data["system"]:
+        async_add_entities(
+            [
+                HWEnergyEnableCloudEntity(coordinator, entry),
+            ]
+        )
+
 
 class HWEnergySwitchEntity(
     CoordinatorEntity[HWEnergyDeviceUpdateCoordinator], SwitchEntity
@@ -124,3 +131,42 @@ class HWEnergySwitchLockEntity(HWEnergySwitchEntity):
     def is_on(self) -> bool:
         """Return true if switch is on."""
         return bool(self.coordinator.data["state"].switch_lock)
+
+
+class HWEnergyEnableCloudEntity(HWEnergySwitchEntity):
+    """
+    Representation of the enable cloud configuration.
+
+    Disable cloud turns off all communication to HomeWizard Cloud.
+    At this point, the device is fully local.
+    """
+
+    _attr_name = "Enable Cloud"
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self, coordinator: HWEnergyDeviceUpdateCoordinator, entry: ConfigEntry
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, entry, "enable_cloud")
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn switch-lock on."""
+        await self.coordinator.api.system_set(enable_cloud=True)
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn switch-lock off."""
+        await self.coordinator.api.system_set(enable_cloud=False)
+        await self.coordinator.async_refresh()
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon."""
+        return "mdi:cloud" if self.is_on else "mdi:cloud-off-outline"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if switch is on."""
+        return bool(self.coordinator.data["system"].cloud_enabled)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2006,7 +2006,7 @@ python-gc100==1.0.3a0
 python-gitlab==1.6.0
 
 # homeassistant.components.homewizard
-python-homewizard-energy==1.1.0
+python-homewizard-energy==1.3.0
 
 # homeassistant.components.hp_ilo
 python-hpilo==4.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2006,7 +2006,7 @@ python-gc100==1.0.3a0
 python-gitlab==1.6.0
 
 # homeassistant.components.homewizard
-python-homewizard-energy==1.3.0
+python-homewizard-energy==1.3.1
 
 # homeassistant.components.hp_ilo
 python-hpilo==4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1402,7 +1402,7 @@ python-forecastio==1.4.0
 python-fullykiosk==0.0.11
 
 # homeassistant.components.homewizard
-python-homewizard-energy==1.3.0
+python-homewizard-energy==1.3.1
 
 # homeassistant.components.izone
 python-izone==1.2.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1402,7 +1402,7 @@ python-forecastio==1.4.0
 python-fullykiosk==0.0.11
 
 # homeassistant.components.homewizard
-python-homewizard-energy==1.1.0
+python-homewizard-energy==1.3.0
 
 # homeassistant.components.izone
 python-izone==1.2.9

--- a/tests/components/homewizard/conftest.py
+++ b/tests/components/homewizard/conftest.py
@@ -2,7 +2,8 @@
 import json
 from unittest.mock import AsyncMock, patch
 
-from homewizard_energy.models import Data, Device, State
+from homewizard_energy.features import Features
+from homewizard_energy.models import Data, Device, State, System
 import pytest
 
 from homeassistant.components.homewizard.const import DOMAIN
@@ -37,11 +38,12 @@ def mock_config_entry() -> MockConfigEntry:
 
 @pytest.fixture
 def mock_homewizardenergy():
-    """Return a mocked P1 meter."""
+    """Return a mocked all-feature device."""
     with patch(
         "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
     ) as device:
         client = device.return_value
+        client.features = AsyncMock(return_value=Features("HWE-SKT", "3.01"))
         client.device = AsyncMock(
             return_value=Device.from_dict(
                 json.loads(load_fixture("homewizard/device.json"))
@@ -55,6 +57,11 @@ def mock_homewizardenergy():
         client.state = AsyncMock(
             return_value=State.from_dict(
                 json.loads(load_fixture("homewizard/state.json"))
+            )
+        )
+        client.system = AsyncMock(
+            return_value=System.from_dict(
+                json.loads(load_fixture("homewizard/system.json"))
             )
         )
         yield device

--- a/tests/components/homewizard/conftest.py
+++ b/tests/components/homewizard/conftest.py
@@ -45,22 +45,22 @@ def mock_homewizardenergy():
         client = device.return_value
         client.features = AsyncMock(return_value=Features("HWE-SKT", "3.01"))
         client.device = AsyncMock(
-            return_value=Device.from_dict(
+            side_effect=lambda: Device.from_dict(
                 json.loads(load_fixture("homewizard/device.json"))
             )
         )
         client.data = AsyncMock(
-            return_value=Data.from_dict(
+            side_effect=lambda: Data.from_dict(
                 json.loads(load_fixture("homewizard/data.json"))
             )
         )
         client.state = AsyncMock(
-            return_value=State.from_dict(
+            side_effect=lambda: State.from_dict(
                 json.loads(load_fixture("homewizard/state.json"))
             )
         )
         client.system = AsyncMock(
-            return_value=System.from_dict(
+            side_effect=lambda: System.from_dict(
                 json.loads(load_fixture("homewizard/system.json"))
             )
         )

--- a/tests/components/homewizard/fixtures/system.json
+++ b/tests/components/homewizard/fixtures/system.json
@@ -1,0 +1,3 @@
+{
+  "cloud_enabled": true
+}

--- a/tests/components/homewizard/generator.py
+++ b/tests/components/homewizard/generator.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+from homewizard_energy.features import Features
 from homewizard_energy.models import Device
 
 
@@ -10,6 +11,7 @@ def get_mock_device(
     host="1.2.3.4",
     product_name="P1 meter",
     product_type="HWE-P1",
+    firmware_version="1.00",
 ):
     """Return a mock bridge."""
     mock_device = AsyncMock()
@@ -21,11 +23,15 @@ def get_mock_device(
             product_type=product_type,
             serial=serial,
             api_version="V1",
-            firmware_version="1.00",
+            firmware_version=firmware_version,
         )
     )
     mock_device.data = AsyncMock(return_value=None)
     mock_device.state = AsyncMock(return_value=None)
+    mock_device.system = AsyncMock(return_value=None)
+    mock_device.features = AsyncMock(
+        return_value=Features(product_type, firmware_version)
+    )
 
     mock_device.close = AsyncMock()
 

--- a/tests/components/homewizard/test_diagnostics.py
+++ b/tests/components/homewizard/test_diagnostics.py
@@ -45,5 +45,6 @@ async def test_diagnostics(
                 "total_liter_m3": 1234.567,
             },
             "state": {"power_on": True, "switch_lock": False, "brightness": 255},
+            "system": {"cloud_enabled": True},
         },
     }

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -288,7 +288,7 @@ async def test_switch_lock_sets_power_on_unavailable(
         assert len(api.state_set.mock_calls) == 2
 
 
-async def test_enabled_cloud_on_off(hass, mock_config_entry_data, mock_config_entry):
+async def test_cloud_connection_on_off(hass, mock_config_entry_data, mock_config_entry):
     """Test entity turns switch on and off."""
 
     api = get_mock_device(product_type="HWE-SKT", firmware_version="3.02")
@@ -313,7 +313,7 @@ async def test_enabled_cloud_on_off(hass, mock_config_entry_data, mock_config_en
         await hass.async_block_till_done()
 
         assert (
-            hass.states.get("switch.product_name_aabbccddeeff_enable_cloud").state
+            hass.states.get("switch.product_name_aabbccddeeff_cloud_connection").state
             == STATE_OFF
         )
 
@@ -321,14 +321,14 @@ async def test_enabled_cloud_on_off(hass, mock_config_entry_data, mock_config_en
         await hass.services.async_call(
             switch.DOMAIN,
             SERVICE_TURN_ON,
-            {"entity_id": "switch.product_name_aabbccddeeff_enable_cloud"},
+            {"entity_id": "switch.product_name_aabbccddeeff_cloud_connection"},
             blocking=True,
         )
 
         await hass.async_block_till_done()
         assert len(api.system_set.mock_calls) == 1
         assert (
-            hass.states.get("switch.product_name_aabbccddeeff_enable_cloud").state
+            hass.states.get("switch.product_name_aabbccddeeff_cloud_connection").state
             == STATE_ON
         )
 
@@ -336,13 +336,13 @@ async def test_enabled_cloud_on_off(hass, mock_config_entry_data, mock_config_en
         await hass.services.async_call(
             switch.DOMAIN,
             SERVICE_TURN_OFF,
-            {"entity_id": "switch.product_name_aabbccddeeff_enable_cloud"},
+            {"entity_id": "switch.product_name_aabbccddeeff_cloud_connection"},
             blocking=True,
         )
 
         await hass.async_block_till_done()
         assert (
-            hass.states.get("switch.product_name_aabbccddeeff_enable_cloud").state
+            hass.states.get("switch.product_name_aabbccddeeff_cloud_connection").state
             == STATE_OFF
         )
         assert len(api.system_set.mock_calls) == 2

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
-from homewizard_energy.models import State
+from homewizard_energy.models import State, System
 
 from homeassistant.components import switch
 from homeassistant.components.switch import SwitchDeviceClass
@@ -286,3 +286,63 @@ async def test_switch_lock_sets_power_on_unavailable(
             == STATE_OFF
         )
         assert len(api.state_set.mock_calls) == 2
+
+
+async def test_enabled_cloud_on_off(hass, mock_config_entry_data, mock_config_entry):
+    """Test entity turns switch on and off."""
+
+    api = get_mock_device(product_type="HWE-SKT", firmware_version="3.02")
+    api.system = AsyncMock(return_value=System.from_dict({"cloud_enabled": False}))
+
+    def system_set(cloud_enabled):
+        api.system = AsyncMock(
+            return_value=System.from_dict({"cloud_enabled": cloud_enabled})
+        )
+
+    api.system_set = AsyncMock(side_effect=system_set)
+
+    with patch(
+        "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_enable_cloud").state
+            == STATE_OFF
+        )
+
+        # Enable cloud
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {"entity_id": "switch.product_name_aabbccddeeff_enable_cloud"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert len(api.system_set.mock_calls) == 1
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_enable_cloud").state
+            == STATE_ON
+        )
+
+        # Disable cloud
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_OFF,
+            {"entity_id": "switch.product_name_aabbccddeeff_enable_cloud"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_enable_cloud").state
+            == STATE_OFF
+        )
+        assert len(api.system_set.mock_calls) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
# Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for disabling cloud communication.

This bumbs `python-homewizard-energy` to 1.3.1:
- https://github.com/DCSBL/python-homewizard-energy/releases/tag/v1.3.1
- https://github.com/DCSBL/python-homewizard-energy/compare/v1.1.0...v1.3.1

I've convinced HomeWizard to make the HomeWizard Energy platform more local. After the local API itself, they now added support to fully disable all communication from the device to the HomeWizard cloud, making it fully local. Before this it was possible to block the data in a firewall, but then the device started to flash a red light saying it has troubles.

~A persistent notification is created when the cloud is disabled.~ HomeWizard is a bit afraid that users just click the toggle without known what it _really_ does and reach out to HomeWizard support asking why the app is broken. I preferred a popup saying "Are you sure" or something, but that is not possible to my knowledge.

Note: same as https://github.com/home-assistant/core/pull/82375, this feature is slowly being rolled out to the Energy Socket, and is planned to be added to other devices in the near future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] → https://github.com/home-assistant/home-assistant.io/pull/25029

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
