### PR TITLE
Add Alexa integration support for thermostat boost and set temp for x time

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1427,7 +1427,6 @@ class AlexaModeController(AlexaCapability):
 
     def capability_resources(self):
         """Return capabilityResources object."""
-
         # Fan Direction Resource
         if self.instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
             self._resource = AlexaModeResource(
@@ -1625,7 +1624,6 @@ class AlexaRangeController(AlexaCapability):
 
     def capability_resources(self):
         """Return capabilityResources object."""
-
         # Fan Speed Percentage Resources
         if self.instance == f"{fan.DOMAIN}.{fan.ATTR_PERCENTAGE}":
             percentage_step = self.entity.attributes.get(fan.ATTR_PERCENTAGE_STEP)
@@ -1837,7 +1835,6 @@ class AlexaToggleController(AlexaCapability):
 
     def capability_resources(self):
         """Return capabilityResources object."""
-
         # Fan Oscillating Resource
         if self.instance == f"{fan.DOMAIN}.{fan.ATTR_OSCILLATING}":
             self._resource = AlexaCapabilityResource(

--- a/homeassistant/components/alexa/const.py
+++ b/homeassistant/components/alexa/const.py
@@ -81,7 +81,7 @@ API_THERMOSTAT_MODES_CUSTOM = {
     climate.HVACMode.DRY: "DEHUMIDIFY",
     climate.HVACMode.FAN_ONLY: "FAN",
 }
-API_THERMOSTAT_PRESETS = {climate.PRESET_ECO: "ECO"}
+API_THERMOSTAT_PRESETS = {climate.PRESET_ECO: "ECO", climate.PRESET_BOOST: "BOOST"}
 
 # AlexaModeController does not like a single mode for the fan preset, we add PRESET_MODE_NA if a fan has only one preset_mode
 PRESET_MODE_NA = "-"

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -828,7 +828,6 @@ class InputNumberCapabilities(AlexaEntity):
 
     def interfaces(self):
         """Yield the supported interfaces."""
-
         yield AlexaRangeController(
             self.entity, instance=f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}"
         )

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -941,11 +941,19 @@ async def async_api_set_thermostat_mode(
     """Process a set thermostat mode request."""
     entity = directive.entity
     mode = directive.payload["thermostatMode"]
+    custom_mode = mode.get("customName", None)
     mode = mode if isinstance(mode, str) else mode["value"]
 
     data = {ATTR_ENTITY_ID: entity.entity_id}
 
-    ha_preset = next((k for k, v in API_THERMOSTAT_PRESETS.items() if v == mode), None)
+    ha_preset = next(
+        (
+            k
+            for k, v in API_THERMOSTAT_PRESETS.items()
+            if v == (mode if mode != "CUSTOM" else custom_mode)
+        ),
+        None,
+    )
 
     if ha_preset:
         presets = entity.attributes.get(climate.ATTR_PRESET_MODES, [])

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -37,6 +37,7 @@ from .const import (  # noqa: F401
     ATTR_AUX_HEAT,
     ATTR_CURRENT_HUMIDITY,
     ATTR_CURRENT_TEMPERATURE,
+    ATTR_DURATION,
     ATTR_FAN_MODE,
     ATTR_FAN_MODES,
     ATTR_HUMIDITY,
@@ -125,6 +126,7 @@ SET_TEMPERATURE_SCHEMA = vol.All(
             vol.Inclusive(ATTR_TARGET_TEMP_HIGH, "temperature"): vol.Coerce(float),
             vol.Inclusive(ATTR_TARGET_TEMP_LOW, "temperature"): vol.Coerce(float),
             vol.Optional(ATTR_HVAC_MODE): vol.Coerce(HVACMode),
+            vol.Optional(ATTR_DURATION): vol.Coerce(int),
         }
     ),
 )

--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -112,6 +112,7 @@ CURRENT_HVAC_ACTIONS = [cls.value for cls in HVACAction]
 ATTR_AUX_HEAT = "aux_heat"
 ATTR_CURRENT_HUMIDITY = "current_humidity"
 ATTR_CURRENT_TEMPERATURE = "current_temperature"
+ATTR_DURATION = "duration"
 ATTR_FAN_MODES = "fan_modes"
 ATTR_FAN_MODE = "fan_mode"
 ATTR_PRESET_MODE = "preset_mode"

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2033,7 +2033,7 @@ async def test_thermostat(hass):
             "supported_features": 1 | 2 | 4 | 128,
             "hvac_modes": ["off", "heat", "cool", "auto", "dry", "fan_only"],
             "preset_mode": None,
-            "preset_modes": ["eco"],
+            "preset_modes": ["eco", "boost"],
             "min_temp": 50,
             "max_temp": 90,
         },
@@ -2109,11 +2109,13 @@ async def test_thermostat(hass):
             "targetSetpoint": {"value": 70.0, "scale": "FAHRENHEIT"},
             "lowerSetpoint": {"value": 293.15, "scale": "KELVIN"},
             "upperSetpoint": {"value": 30.0, "scale": "CELSIUS"},
+            "schedule": {"duration": "PT1H15M"},
         },
     )
     assert call.data["temperature"] == 70.0
     assert call.data["target_temp_low"] == 68.0
     assert call.data["target_temp_high"] == 86.0
+    assert call.data["duration"] == 75
     properties = ReportedProperties(msg["context"]["properties"])
     properties.assert_equal(
         "Alexa.ThermostatController",
@@ -2130,7 +2132,6 @@ async def test_thermostat(hass):
         "upperSetpoint",
         {"value": 86.0, "scale": "FAHRENHEIT"},
     )
-
     msg = await assert_request_fails(
         "Alexa.ThermostatController",
         "SetTargetTemperature",
@@ -2287,6 +2288,17 @@ async def test_thermostat(hass):
         payload={"thermostatMode": "ECO"},
     )
     assert call.data["preset_mode"] == "eco"
+
+    # Assert we can call boost preset
+    call, msg = await assert_request_calls_service(
+        "Alexa.ThermostatController",
+        "SetThermostatMode",
+        "climate#test_thermostat",
+        "climate.set_preset_mode",
+        hass,
+        payload={"thermostatMode": "BOOST"},
+    )
+    assert call.data["preset_mode"] == "boost"
 
 
 async def test_exclude_filters(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alexa smart home supports boosting a thermostat and setting a temp for a duration.  Many smart thermostats also support this capability (and their integrations) but this cannot be controlled by the Alexa HA integration.

This change adds support for those voice commands.

**Developer Notes**
Integration developers will need to support the following for their integrations to be able to use these newly supported commands.
1. Boost is required to be a supported preset mode on the integration climate entity
2. The set_temperature method on the climate entity needs to recognise the duration key in kwargs and act appropriately.

**Note**
There are also some minor linting error fixes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
