### PR TITLE
Test corrections noticed during pytest upgrade

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -205,7 +205,7 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
         ]
 
         if tasks:
-            await asyncio.wait(tasks)
+            await asyncio.gather(*tasks)
 
     async_register_admin_service(
         hass, ha.DOMAIN, SERVICE_HOMEASSISTANT_STOP, async_handle_core_service

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -51,12 +51,11 @@ def setup_bans(hass: HomeAssistant, app: Application, login_threshold: int) -> N
     app.middlewares.append(ban_middleware)
     app[KEY_FAILED_LOGIN_ATTEMPTS] = defaultdict(int)
     app[KEY_LOGIN_THRESHOLD] = login_threshold
+    app[KEY_BAN_MANAGER] = IpBanManager(hass)
 
     async def ban_startup(app: Application) -> None:
         """Initialize bans when app starts up."""
-        ban_manager = IpBanManager(hass)
-        await ban_manager.async_load()
-        app[KEY_BAN_MANAGER] = ban_manager
+        await app[KEY_BAN_MANAGER].async_load()
 
     app.on_startup.append(ban_startup)
 

--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -17,9 +17,10 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     EVENT_HOMEASSISTANT_STARTED,
+    EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
@@ -163,7 +164,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         We do not want the discovery task to block startup.
         """
-        asyncio.create_task(discovery_manager.async_discovery())
+        task = asyncio.create_task(discovery_manager.async_discovery())
+
+        @callback
+        def _async_stop(_: Event) -> None:
+            if not task.done():
+                task.cancel()
+
+        # Task must be shut down when home assistant is closing
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop)
 
     # Let the system settle a bit before starting discovery
     # to reduce the risk we miss devices because the event

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -2140,12 +2140,12 @@ async def test_recursive_automation_starting_script(
         hass.bus.async_listen("automation_triggered", async_automation_triggered)
 
         hass.bus.async_fire("trigger_automation")
-        await asyncio.wait_for(script_done_event.wait(), 1)
+        await asyncio.wait_for(script_done_event.wait(), 10)
 
         # Trigger 1st stage script shutdown
         hass.state = CoreState.stopping
         hass.bus.async_fire("homeassistant_stop")
-        await asyncio.wait_for(stop_scripts_at_shutdown_called.wait(), 1)
+        await asyncio.wait_for(stop_scripts_at_shutdown_called.wait(), 10)
 
         # Trigger 2nd stage script shutdown
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -8,6 +8,7 @@ from homeassistant.components.emulated_hue.config import (
     SAVE_DELAY,
     Config,
 )
+from homeassistant.components.emulated_hue.upnp import UPNPResponderProtocol
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
 from homeassistant.util import utcnow
@@ -127,6 +128,9 @@ async def test_setup_works(hass):
     ) as mock_create_upnp_datagram_endpoint, patch(
         "homeassistant.components.emulated_hue.async_get_source_ip"
     ):
+        mock_create_upnp_datagram_endpoint.return_value = AsyncMock(
+            spec=UPNPResponderProtocol
+        )
         assert await async_setup_component(hass, "emulated_hue", {})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -529,7 +529,7 @@ async def test_pb_service_write(
         data[do_write[DATA]],
     )
     if do_return[DATA]:
-        assert caplog.messages[-1].startswith("Pymodbus:")
+        assert any(message.startswith("Pymodbus:") for message in caplog.messages)
 
 
 @pytest.fixture(name="mock_modbus_read_pymodbus")

--- a/tests/components/modem_callerid/test_init.py
+++ b/tests/components/modem_callerid/test_init.py
@@ -1,5 +1,5 @@
 """Test Modem Caller ID integration."""
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from phone_modem import exceptions
 
@@ -20,7 +20,7 @@ async def test_setup_entry(hass: HomeAssistant):
         data={CONF_DEVICE: com_port().device},
     )
     entry.add_to_hass(hass)
-    with patch("aioserial.AioSerial", return_value=AsyncMock()), patch(
+    with patch("aioserial.AioSerial", autospec=True), patch(
         "homeassistant.components.modem_callerid.PhoneModem._get_response",
         return_value="OK",
     ), patch("phone_modem.PhoneModem._modem_sm"):

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -177,6 +177,10 @@ async def test_set_config_unique_id(
             spec=DataUpdateCoordinator
         )
         data_manager.poll_data_update_coordinator.last_update_success = True
+        data_manager.subscription_update_coordinator = MagicMock(
+            spec=DataUpdateCoordinator
+        )
+        data_manager.subscription_update_coordinator.last_update_success = True
         mock.return_value = data_manager
         config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

* Corrections for warnings and errors discovered during pytest-asyncio upgrade
* [Withing trigger a call to coordinator after init](https://github.com/home-assistant/core/pull/82579/commits/f2b8a2d49f4613686b353062ac10c557214b5a45)
* [Stop discovery task on STOP event](https://github.com/home-assistant/core/pull/82579/commits/ebc1107a7570f3a4f85d80efa7660dd1e8ab38e1)'
* [Stop dsmr connection task on STOP](https://github.com/home-assistant/core/pull/82579/commits/1c3858d398718a733017af083c218c11cd189584)
* [Use autospec in modem_serial tests to avoid invalid call to expectedly non async function](https://github.com/home-assistant/core/pull/82579/commits/0319fb0db4b0ec054fe4dcdd5db1ac900484d9d8)
* [Make sure responder is specced correctly to avoid non async call to async function](https://github.com/home-assistant/core/pull/82579/commits/2de3e8aee1be99dacbbe5409cc8d631ee1dae07a)
* [Don't assume Pymodbus is the only thing logging](https://github.com/home-assistant/core/pull/82579/commits/bf40a3105d6db87af057527edb6d0cfc91aebfee)
* [Use gather instead of wait since it's deprecated](https://github.com/home-assistant/core/pull/82579/commits/90d691d5af7ed214d3c980456e42b3bf94d1b521)
* [Avoid changing app state after startup](https://github.com/home-assistant/core/pull/82579/commits/d3a839e5e54d2ef6136a432d3b5a5a669968db76)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
