### PR TITLE
Do not delete issue when aborting repairs fix flow

### DIFF
--- a/homeassistant/components/repairs/issue_handler.py
+++ b/homeassistant/components/repairs/issue_handler.py
@@ -85,7 +85,8 @@ class RepairsFlowManager(data_entry_flow.FlowManager):
         self, flow: data_entry_flow.FlowHandler, result: data_entry_flow.FlowResult
     ) -> data_entry_flow.FlowResult:
         """Complete a fix flow."""
-        async_delete_issue(self.hass, flow.handler, flow.init_data["issue_id"])
+        if result.get("type") != data_entry_flow.FlowResultType.ABORT:
+            async_delete_issue(self.hass, flow.handler, flow.init_data["issue_id"])
         if "result" not in result:
             result["result"] = None
         return result

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -72,10 +72,7 @@ async def create_issues(hass, ws_client, issues=None):
     return issues
 
 
-EXPECTED_DATA = {
-    "issue_1": None,
-    "issue_2": {"blah": "bleh"},
-}
+EXPECTED_DATA = {"issue_1": None, "issue_2": {"blah": "bleh"}, "abort_issue1": None}
 
 
 class MockFixFlow(RepairsFlow):
@@ -101,6 +98,16 @@ class MockFixFlow(RepairsFlow):
         return self.async_show_form(step_id="custom_step", data_schema=vol.Schema({}))
 
 
+class MockFixFlowAbort(RepairsFlow):
+    """Handler for an issue fixing flow that aborts."""
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        return self.async_abort(reason="not_given")
+
+
 @pytest.fixture(autouse=True)
 async def mock_repairs_integration(hass):
     """Mock a repairs integration."""
@@ -110,6 +117,8 @@ async def mock_repairs_integration(hass):
         assert issue_id in EXPECTED_DATA
         assert data == EXPECTED_DATA[issue_id]
 
+        if issue_id == "abort_issue1":
+            return MockFixFlowAbort()
         return MockFixFlow()
 
     mock_platform(
@@ -491,3 +500,64 @@ async def test_list_issues(hass: HomeAssistant, hass_storage, hass_ws_client) ->
             for issue in issues
         ]
     }
+
+
+async def test_fix_issue_aborted(
+    hass: HomeAssistant,
+    hass_client,
+    hass_ws_client,
+) -> None:
+    """Test we can fix an issue."""
+    assert await async_setup_component(hass, "http", {})
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await create_issues(
+        hass,
+        ws_client,
+        issues=[
+            {
+                **DEFAULT_ISSUES[0],
+                "domain": "fake_integration",
+                "issue_id": "abort_issue1",
+            }
+        ],
+    )
+
+    await ws_client.send_json({"id": 3, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 1
+
+    first_issue = msg["result"]["issues"][0]
+
+    assert first_issue["domain"] == "fake_integration"
+    assert first_issue["issue_id"] == "abort_issue1"
+
+    resp = await client.post(
+        "/api/repairs/issues/fix",
+        json={"handler": "fake_integration", "issue_id": "abort_issue1"},
+    )
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    flow_id = data["flow_id"]
+    assert data == {
+        "type": "abort",
+        "flow_id": flow_id,
+        "handler": "fake_integration",
+        "reason": "not_given",
+        "description_placeholders": None,
+        "result": None,
+    }
+
+    await ws_client.send_json({"id": 4, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 1
+    assert msg["result"]["issues"][0] == first_issue

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -72,7 +72,11 @@ async def create_issues(hass, ws_client, issues=None):
     return issues
 
 
-EXPECTED_DATA = {"issue_1": None, "issue_2": {"blah": "bleh"}, "abort_issue1": None}
+EXPECTED_DATA = {
+    "issue_1": None,
+    "issue_2": {"blah": "bleh"},
+    "abort_issue1": None,
+}
 
 
 class MockFixFlow(RepairsFlow):

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -1,9 +1,11 @@
 """Test the repairs websocket API."""
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from unittest.mock import ANY, AsyncMock, Mock
 
+from aiohttp import ClientSession, ClientWebSocketResponse
 from freezegun import freeze_time
 import pytest
 import voluptuous as vol
@@ -508,8 +510,8 @@ async def test_list_issues(hass: HomeAssistant, hass_storage, hass_ws_client) ->
 
 async def test_fix_issue_aborted(
     hass: HomeAssistant,
-    hass_client,
-    hass_ws_client,
+    hass_client: Callable[..., Awaitable[ClientSession]],
+    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
 ) -> None:
     """Test we can fix an issue."""
     assert await async_setup_component(hass, "http", {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When aborting a fix flow for repair issues, the issue still got deleted.
With this PR aborting that flow will no longer delete the issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
