### PR TITLE
Split UniFi Protect object sensor into multiple

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -88,6 +88,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             translation_placeholders={"version": str(nvr_info.version)},
             data={"entry_id": entry.entry_id},
         )
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "deprecate_smart_sensor",
+        is_fixable=False,
+        breaks_in_ha_version="2023.2.0",
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecate_smart_sensor",
+    )
 
     try:
         await _async_setup_entry(hass, entry, data_service)

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -88,15 +88,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             translation_placeholders={"version": str(nvr_info.version)},
             data={"entry_id": entry.entry_id},
         )
-    ir.async_create_issue(
-        hass,
-        DOMAIN,
-        "deprecate_smart_sensor",
-        is_fixable=False,
-        breaks_in_ha_version="2023.2.0",
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecate_smart_sensor",
-    )
 
     try:
         await _async_setup_entry(hass, entry, data_service)

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -7,6 +7,7 @@ from homeassistant.const import Platform
 DOMAIN = "unifiprotect"
 
 ATTR_EVENT_SCORE = "event_score"
+ATTR_EVENT_ID = "event_id"
 ATTR_WIDTH = "width"
 ATTR_HEIGHT = "height"
 ATTR_FPS = "fps"
@@ -67,3 +68,5 @@ PLATFORMS = [
 DISPATCH_ADD = "add_device"
 DISPATCH_ADOPT = "adopt_device"
 DISPATCH_CHANNELS = "new_camera_channels"
+
+DEVICE_CLASS_DETECTION = "unifiprotect__detection"

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -24,10 +24,15 @@ from homeassistant.core import callback
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 
-from .const import ATTR_EVENT_SCORE, DEFAULT_ATTRIBUTION, DEFAULT_BRAND, DOMAIN
+from .const import (
+    ATTR_EVENT_ID,
+    ATTR_EVENT_SCORE,
+    DEFAULT_ATTRIBUTION,
+    DEFAULT_BRAND,
+    DOMAIN,
+)
 from .data import ProtectData
-from .models import PermRequired, ProtectRequiredKeysMixin
-from .utils import get_nested_attr
+from .models import PermRequired, ProtectEventMixin, ProtectRequiredKeysMixin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,10 +87,8 @@ def _async_device_entities(
                 ):
                     continue
 
-            if description.ufp_required_field:
-                required_field = get_nested_attr(device, description.ufp_required_field)
-                if not required_field:
-                    continue
+            if not description.has_required(device):
+                continue
 
             entities.append(
                 klass(
@@ -294,42 +297,39 @@ class ProtectNVREntity(ProtectDeviceEntity):
         self._attr_available = self.data.last_update_success
 
 
-class EventThumbnailMixin(ProtectDeviceEntity):
+class EventEntityMixin(ProtectDeviceEntity):
     """Adds motion event attributes to sensor."""
 
-    def __init__(self, *args: Any, **kwarg: Any) -> None:
+    entity_description: ProtectEventMixin
+
+    def __init__(
+        self,
+        *args: Any,
+        **kwarg: Any,
+    ) -> None:
         """Init an sensor that has event thumbnails."""
         super().__init__(*args, **kwarg)
         self._event: Event | None = None
 
     @callback
-    def _async_get_event(self) -> Event | None:
-        """Get event from Protect device.
-
-        To be overridden by child classes.
-        """
-        raise NotImplementedError()
-
-    @callback
-    def _async_thumbnail_extra_attrs(self) -> dict[str, Any]:
-        # Camera motion sensors with object detection
-        attrs: dict[str, Any] = {
-            ATTR_EVENT_SCORE: 0,
-        }
+    def _async_event_extra_attrs(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
 
         if self._event is None:
             return attrs
 
+        attrs[ATTR_EVENT_ID] = self._event.id
         attrs[ATTR_EVENT_SCORE] = self._event.score
         return attrs
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
         super()._async_update_device_from_protect(device)
-        self._event = self._async_get_event()
+        self._attr_is_on: bool | None = self.entity_description.get_is_on(device)
+        self._event = self.entity_description.get_event_obj(device)
 
         attrs = self.extra_state_attributes or {}
         self._attr_extra_state_attributes = {
             **attrs,
-            **self._async_thumbnail_extra_attrs(),
+            **self._async_event_extra_attrs(),
         }

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -8,11 +8,13 @@ from pyunifiprotect import ProtectApiClient
 from pyunifiprotect.data import NVR, Bootstrap, ProtectAdoptableDeviceModel
 from pyunifiprotect.exceptions import ClientError
 
+from homeassistant.components.unifiprotect.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers.issue_registry import IssueSeverity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +31,23 @@ async def async_migrate_data(
     _LOGGER.debug("Start Migrate: async_migrate_device_ids")
     await async_migrate_device_ids(hass, entry, protect)
     _LOGGER.debug("Completed Migrate: async_migrate_device_ids")
+
+    entity_registry = er.async_get(hass)
+    for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        if (
+            entity.domain == Platform.SENSOR
+            and entity.disabled_by is None
+            and "detected_object" in entity.unique_id
+        ):
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                "deprecate_smart_sensor",
+                is_fixable=False,
+                breaks_in_ha_version="2023.2.0",
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecate_smart_sensor",
+            )
 
 
 async def async_get_bootstrap(protect: ProtectApiClient) -> Bootstrap:

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -8,13 +8,14 @@ from pyunifiprotect import ProtectApiClient
 from pyunifiprotect.data import NVR, Bootstrap, ProtectAdoptableDeviceModel
 from pyunifiprotect.exceptions import ClientError
 
-from homeassistant.components.unifiprotect.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.helpers.issue_registry import IssueSeverity
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -5,9 +5,9 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from enum import Enum
 import logging
-from typing import Any, Generic, TypeVar, Union
+from typing import Any, Generic, TypeVar, Union, cast
 
-from pyunifiprotect.data import NVR, ProtectAdoptableDeviceModel
+from pyunifiprotect.data import NVR, Event, ProtectAdoptableDeviceModel
 
 from homeassistant.helpers.entity import EntityDescription
 
@@ -53,6 +53,41 @@ class ProtectRequiredKeysMixin(EntityDescription, Generic[T]):
         if self.ufp_enabled is not None:
             return bool(get_nested_attr(obj, self.ufp_enabled))
         return True
+
+    def has_required(self, obj: T) -> bool:
+        """Return if has required field."""
+
+        if self.ufp_required_field is None:
+            return True
+        return bool(get_nested_attr(obj, self.ufp_required_field))
+
+
+@dataclass
+class ProtectEventMixin(ProtectRequiredKeysMixin[T]):
+    """Mixin for events."""
+
+    ufp_event_obj: str | None = None
+    ufp_smart_type: str | None = None
+
+    def get_event_obj(self, obj: T) -> Event | None:
+        """Return value from UniFi Protect device."""
+
+        if self.ufp_event_obj is not None:
+            return cast(Event, get_nested_attr(obj, self.ufp_event_obj))
+        return None
+
+    def get_is_on(self, obj: T) -> bool:
+        """Return value if event is active."""
+
+        value = bool(self.get_ufp_value(obj))
+        if value:
+            event = self.get_event_obj(obj)
+            value = event is not None
+
+            if event is not None and self.ufp_smart_type is not None:
+                value = self.ufp_smart_type in event.smart_detect_types
+
+        return value
 
 
 @dataclass

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -9,7 +9,6 @@ from typing import Any, cast
 from pyunifiprotect.data import (
     NVR,
     Camera,
-    Event,
     Light,
     ModelType,
     ProtectAdoptableDeviceModel,
@@ -41,20 +40,19 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DISPATCH_ADOPT, DOMAIN
+from .const import DEVICE_CLASS_DETECTION, DISPATCH_ADOPT, DOMAIN
 from .data import ProtectData
 from .entity import (
-    EventThumbnailMixin,
+    EventEntityMixin,
     ProtectDeviceEntity,
     ProtectNVREntity,
     async_all_device_entities,
 )
-from .models import PermRequired, ProtectRequiredKeysMixin, T
+from .models import PermRequired, ProtectEventMixin, ProtectRequiredKeysMixin, T
 from .utils import async_dispatch_id as _ufpd, async_get_light_motion_current
 
 _LOGGER = logging.getLogger(__name__)
 OBJECT_TYPE_NONE = "none"
-DEVICE_CLASS_DETECTION = "unifiprotect__detection"
 
 
 @dataclass
@@ -72,6 +70,13 @@ class ProtectSensorEntityDescription(
         if isinstance(value, float) and self.precision:
             value = round(value, self.precision)
         return value
+
+
+@dataclass
+class ProtectSensorEventEntityDescription(
+    ProtectEventMixin[T], SensorEntityDescription
+):
+    """Describes UniFi Protect Sensor entity."""
 
 
 def _get_uptime(obj: ProtectDeviceModel) -> datetime | None:
@@ -513,11 +518,13 @@ NVR_DISABLED_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ),
 )
 
-MOTION_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
-    ProtectSensorEntityDescription(
+MOTION_SENSORS: tuple[ProtectSensorEventEntityDescription, ...] = (
+    ProtectSensorEventEntityDescription(
         key="detected_object",
         name="Detected Object",
         device_class=DEVICE_CLASS_DETECTION,
+        ufp_value="is_smart_detected",
+        ufp_event_obj="last_smart_detect_event",
     ),
 )
 
@@ -666,8 +673,8 @@ def _async_motion_entities(
         if not device.feature_flags.has_smart_detect:
             continue
 
-        for description in MOTION_SENSORS:
-            entities.append(ProtectEventSensor(data, device, description))
+        for event_desc in MOTION_SENSORS:
+            entities.append(ProtectEventSensor(data, device, event_desc))
             _LOGGER.debug(
                 "Adding sensor entity %s for %s",
                 description.name,
@@ -730,29 +737,24 @@ class ProtectNVRSensor(ProtectNVREntity, SensorEntity):
         self._attr_native_value = self.entity_description.get_ufp_value(self.device)
 
 
-class ProtectEventSensor(ProtectDeviceSensor, EventThumbnailMixin):
+class ProtectEventSensor(EventEntityMixin, SensorEntity):
     """A UniFi Protect Device Sensor with access tokens."""
 
-    device: Camera
+    entity_description: ProtectSensorEventEntityDescription
 
-    @callback
-    def _async_get_event(self) -> Event | None:
-        """Get event from Protect device."""
-
-        event: Event | None = None
-        if (
-            self.device.is_smart_detected
-            and self.device.last_smart_detect_event is not None
-            and len(self.device.last_smart_detect_event.smart_detect_types) > 0
-        ):
-            event = self.device.last_smart_detect_event
-
-        return event
+    def __init__(
+        self,
+        data: ProtectData,
+        device: ProtectAdoptableDeviceModel,
+        description: ProtectSensorEventEntityDescription,
+    ) -> None:
+        """Initialize an UniFi Protect sensor."""
+        super().__init__(data, device, description)
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
         # do not call ProtectDeviceSensor method since we want event to get value here
-        EventThumbnailMixin._async_update_device_from_protect(self, device)
+        EventEntityMixin._async_update_device_from_protect(self, device)
         if self._event is None:
             self._attr_native_value = OBJECT_TYPE_NONE
         else:

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -523,6 +523,7 @@ MOTION_SENSORS: tuple[ProtectSensorEventEntityDescription, ...] = (
         key="detected_object",
         name="Detected Object",
         device_class=DEVICE_CLASS_DETECTION,
+        entity_registry_enabled_default=False,
         ufp_value="is_smart_detected",
         ufp_event_obj="last_smart_detect_event",
     ),

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -78,7 +78,7 @@
     },
     "deprecate_smart_sensor": {
       "title": "Smart Detection Sensor Deprecated",
-      "description": "The unified \"Detected Object\" for smart detections is now deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly."
+      "description": "The unified \"Detected Object\" sensor for smart detections is now deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly."
     }
   }
 }

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -75,6 +75,10 @@
     "ea_setup_failed": {
       "title": "Setup error using Early Access version",
       "description": "You are using v{version} of UniFi Protect which is an Early Access version. An unrecoverable error occurred while trying to load the integration. Please [downgrade to a stable version](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) of UniFi Protect to continue using the integration.\n\nError: {error}"
+    },
+    "deprecate_smart_sensor": {
+      "title": "Smart Detection Sensor Deprecated",
+      "description": "The unified \"Detected Object\" for smart detections is now deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly."
     }
   }
 }

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -43,7 +43,7 @@
     },
     "issues": {
         "deprecate_smart_sensor": {
-            "description": "The unified \"Detected Object\" for smart detections is now deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly.",
+            "description": "The unified \"Detected Object\" sensor for smart detections is now deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly.",
             "title": "Smart Detection Sensor Deprecated"
         },
         "ea_setup_failed": {

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -42,12 +42,15 @@
         }
     },
     "issues": {
+        "deprecate_smart_sensor": {
+            "description": "The single sensor on camera devices for Smart Detections is deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly.",
+            "title": "Smart Detection Sensor Deprecated"
+        },
         "ea_setup_failed": {
             "description": "You are using v{version} of UniFi Protect which is an Early Access version. An unrecoverable error occurred while trying to load the integration. Please [downgrade to a stable version](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) of UniFi Protect to continue using the integration.\n\nError: {error}",
             "title": "Setup error using Early Access version"
         },
         "ea_warning": {
-            "description": "You are using v{version} of UniFi Protect which is an Early Access version. Early Access versions are not supported by Home Assistant and may cause your UniFi Protect integration to break or not work as expected.",
             "fix_flow": {
                 "step": {
                     "confirm": {
@@ -64,16 +67,12 @@
         }
     },
     "options": {
-        "error": {
-            "invalid_mac_list": "Must be a list of MAC addresses seperated by commas"
-        },
         "step": {
             "init": {
                 "data": {
                     "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)",
                     "allow_ea": "Allow Early Access versions of Protect (WARNING: Will mark your integration as unsupported)",
                     "disable_rtsp": "Disable the RTSP stream",
-                    "ignored_devices": "Comma separated list of MAC addresses of devices to ignore",
                     "max_media": "Max number of event to load for Media Browser (increases RAM usage)",
                     "override_connection_host": "Override Connection Host"
                 },

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -43,7 +43,7 @@
     },
     "issues": {
         "deprecate_smart_sensor": {
-            "description": "The single sensor on camera devices for Smart Detections is deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly.",
+            "description": "The unified \"Detected Object\" for smart detections is now deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly.",
             "title": "Smart Detection Sensor Deprecated"
         },
         "ea_setup_failed": {

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -50,11 +50,11 @@ async def test_binary_sensor_camera_remove(
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 3, 3)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 6, 6)
     await remove_entities(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.BINARY_SENSOR, 0, 0)
     await adopt_devices(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 3, 3)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 6, 6)
 
 
 async def test_binary_sensor_light_remove(
@@ -120,7 +120,7 @@ async def test_binary_sensor_setup_camera_all(
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 3, 3)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 6, 6)
 
     entity_registry = er.async_get(hass)
 
@@ -167,7 +167,6 @@ async def test_binary_sensor_setup_camera_all(
     assert state
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
-    assert state.attributes[ATTR_EVENT_SCORE] == 0
 
 
 async def test_binary_sensor_setup_camera_none(
@@ -263,7 +262,7 @@ async def test_binary_sensor_update_motion(
     """Test binary_sensor motion entity."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 9)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 12, 12)
 
     _, entity_id = ids_from_device_description(
         Platform.BINARY_SENSOR, doorbell, MOTION_SENSORS[0]

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -40,9 +40,12 @@ async def test_ea_warning_ignore(
     msg = await ws_client.receive_json()
 
     assert msg["success"]
-    assert len(msg["result"]["issues"]) == 1
-    issue = msg["result"]["issues"][0]
-    assert issue["issue_id"] == "ea_warning"
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"] == "ea_warning":
+            issue = i
+    assert issue is not None
 
     url = RepairsFlowIndexView.url
     resp = await client.post(url, json={"handler": DOMAIN, "issue_id": "ea_warning"})
@@ -89,9 +92,12 @@ async def test_ea_warning_fix(
     msg = await ws_client.receive_json()
 
     assert msg["success"]
-    assert len(msg["result"]["issues"]) == 1
-    issue = msg["result"]["issues"][0]
-    assert issue["issue_id"] == "ea_warning"
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"] == "ea_warning":
+            issue = i
+    assert issue is not None
 
     url = RepairsFlowIndexView.url
     resp = await client.post(url, json={"handler": DOMAIN, "issue_id": "ea_warning"})

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -6,7 +6,7 @@ from copy import copy
 from http import HTTPStatus
 from unittest.mock import Mock
 
-from pyunifiprotect.data import Version
+from pyunifiprotect.data import Camera, Version
 
 from homeassistant.components.repairs.issue_handler import (
     async_process_repairs_platforms,
@@ -16,7 +16,9 @@ from homeassistant.components.repairs.websocket_api import (
     RepairsFlowResourceView,
 )
 from homeassistant.components.unifiprotect.const import DOMAIN
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .utils import MockUFPFixture, init_entry
 
@@ -124,3 +126,53 @@ async def test_ea_warning_fix(
     data = await resp.json()
 
     assert data["type"] == "create_entry"
+
+
+async def test_deprecate_smart_default(
+    hass: HomeAssistant, ufp: MockUFPFixture, hass_ws_client, doorbell: Camera
+):
+    """Test Deprecate Sensor repair does not exist by default (new installs)."""
+
+    await init_entry(hass, ufp, [doorbell])
+
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"] == "deprecate_smart_sensor":
+            issue = i
+    assert issue is None
+
+
+async def test_deprecate_smart_active(
+    hass: HomeAssistant, ufp: MockUFPFixture, hass_ws_client, doorbell: Camera
+):
+    """Test Deprecate Sensor repair exists for existing installs."""
+
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        Platform.SENSOR,
+        DOMAIN,
+        f"{doorbell.mac}_detected_object",
+        config_entry=ufp.entry,
+    )
+
+    await init_entry(hass, ufp, [doorbell])
+
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"] == "deprecate_smart_sensor":
+            issue = i
+    assert issue is not None

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -62,11 +62,11 @@ async def test_sensor_camera_remove(
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.SENSOR, 25, 13)
+    assert_entity_counts(hass, Platform.SENSOR, 25, 12)
     await remove_entities(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.SENSOR, 12, 9)
     await adopt_devices(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.SENSOR, 25, 13)
+    assert_entity_counts(hass, Platform.SENSOR, 25, 12)
 
 
 async def test_sensor_sensor_remove(
@@ -318,7 +318,7 @@ async def test_sensor_setup_camera(
     """Test sensor entity setup for camera devices."""
 
     await init_entry(hass, ufp, [doorbell])
-    assert_entity_counts(hass, Platform.SENSOR, 25, 13)
+    assert_entity_counts(hass, Platform.SENSOR, 25, 12)
 
     entity_registry = er.async_get(hass)
 
@@ -406,6 +406,8 @@ async def test_sensor_setup_camera(
     assert entity
     assert entity.unique_id == unique_id
 
+    await enable_entity(hass, ufp.entry.entry_id, entity_id)
+
     state = hass.states.get(entity_id)
     assert state
     assert state.state == OBJECT_TYPE_NONE
@@ -450,11 +452,13 @@ async def test_sensor_update_motion(
     """Test sensor motion entity."""
 
     await init_entry(hass, ufp, [doorbell])
-    assert_entity_counts(hass, Platform.SENSOR, 25, 13)
+    assert_entity_counts(hass, Platform.SENSOR, 25, 12)
 
     _, entity_id = ids_from_device_description(
         Platform.SENSOR, doorbell, MOTION_SENSORS[0]
     )
+
+    await enable_entity(hass, ufp.entry.entry_id, entity_id)
 
     event = Event(
         id="test_event_id",

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -410,7 +410,6 @@ async def test_sensor_setup_camera(
     assert state
     assert state.state == OBJECT_TYPE_NONE
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
-    assert state.attributes[ATTR_EVENT_SCORE] == 0
 
 
 async def test_sensor_setup_camera_with_last_trip_time(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The existing "Detected Object" sensor can only detect a single object at a time. If multiple objects are detected at once (very common for package detection) Home Assistant cannot be automated using the second detected object. This splits out the single Detected Object sensor into multiple binary issues for each detection type.

The "Detected Object" sensor will be removed in a future release and a repair has been created to notify users about it. It is disabled by default now so new installs will not get it enabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25032

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
