### PR TITLE
Improve Selector typing

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -466,6 +466,7 @@ class EntitySelectorConfig(SingleEntitySelectorConfig, total=False):
 class EntitySelector(Selector):
     """Selector of a single or list of entities."""
 
+    config: EntitySelectorConfig
     selector_type = "entity"
 
     CONFIG_SCHEMA = SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA.extend(
@@ -476,7 +477,7 @@ class EntitySelector(Selector):
         }
     )
 
-    def __init__(self, config: EntitySelectorConfig | None = None) -> None:
+    def __init__(self, config: EntitySelectorConfig) -> None:
         """Instantiate a selector."""
         super().__init__(config)
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Literal, TypedDict, cast
+from typing import Any, Generic, Literal, TypedDict, TypeVar, cast
 from uuid import UUID
 
 import voluptuous as vol
@@ -16,6 +16,8 @@ from homeassistant.util.yaml import dumper
 from . import config_validation as cv
 
 SELECTORS: decorator.Registry[str, type[Selector]] = decorator.Registry()
+
+_T = TypeVar("_T", bound=Mapping[str, Any])
 
 
 def _get_selector_class(config: Any) -> type[Selector]:
@@ -56,11 +58,11 @@ def validate_selector(config: Any) -> dict:
     }
 
 
-class Selector:
+class Selector(Generic[_T]):
     """Base class for selectors."""
 
     CONFIG_SCHEMA: Callable
-    config: Mapping[str, Any]
+    config: _T
     selector_type: str
 
     def __init__(self, config: Mapping[str, Any] | None = None) -> None:
@@ -71,7 +73,7 @@ class Selector:
 
         self.config = self.CONFIG_SCHEMA(config)
 
-    def serialize(self) -> dict[str, dict[str, Mapping[str, Any]]]:
+    def serialize(self) -> dict[str, dict[str, _T]]:
         """Serialize Selector for voluptuous_serialize."""
         return {"selector": {self.selector_type: self.config}}
 
@@ -124,7 +126,7 @@ class ActionSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("action")
-class ActionSelector(Selector):
+class ActionSelector(Selector[ActionSelectorConfig]):
     """Selector of an action sequence (script syntax)."""
 
     selector_type = "action"
@@ -148,7 +150,7 @@ class AddonSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("addon")
-class AddonSelector(Selector):
+class AddonSelector(Selector[AddonSelectorConfig]):
     """Selector of a add-on."""
 
     selector_type = "addon"
@@ -179,7 +181,7 @@ class AreaSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("area")
-class AreaSelector(Selector):
+class AreaSelector(Selector[AreaSelectorConfig]):
     """Selector of a single or list of areas."""
 
     selector_type = "area"
@@ -214,7 +216,7 @@ class AttributeSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("attribute")
-class AttributeSelector(Selector):
+class AttributeSelector(Selector[AttributeSelectorConfig]):
     """Selector for an entity attribute."""
 
     selector_type = "attribute"
@@ -243,7 +245,7 @@ class BooleanSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("boolean")
-class BooleanSelector(Selector):
+class BooleanSelector(Selector[BooleanSelectorConfig]):
     """Selector of a boolean value."""
 
     selector_type = "boolean"
@@ -265,7 +267,7 @@ class ColorRGBSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("color_rgb")
-class ColorRGBSelector(Selector):
+class ColorRGBSelector(Selector[ColorRGBSelectorConfig]):
     """Selector of an RGB color value."""
 
     selector_type = "color_rgb"
@@ -290,7 +292,7 @@ class ColorTempSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("color_temp")
-class ColorTempSelector(Selector):
+class ColorTempSelector(Selector[ColorTempSelectorConfig]):
     """Selector of an color temperature."""
 
     selector_type = "color_temp"
@@ -325,7 +327,7 @@ class ConfigEntrySelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("config_entry")
-class ConfigEntrySelector(Selector):
+class ConfigEntrySelector(Selector[ConfigEntrySelectorConfig]):
     """Selector of a config entry."""
 
     selector_type = "config_entry"
@@ -351,7 +353,7 @@ class DateSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("date")
-class DateSelector(Selector):
+class DateSelector(Selector[DateSelectorConfig]):
     """Selector of a date."""
 
     selector_type = "date"
@@ -373,7 +375,7 @@ class DateTimeSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("datetime")
-class DateTimeSelector(Selector):
+class DateTimeSelector(Selector[DateTimeSelectorConfig]):
     """Selector of a datetime."""
 
     selector_type = "datetime"
@@ -401,7 +403,7 @@ class DeviceSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("device")
-class DeviceSelector(Selector):
+class DeviceSelector(Selector[DeviceSelectorConfig]):
     """Selector of a single or list of devices."""
 
     selector_type = "device"
@@ -431,7 +433,7 @@ class DurationSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("duration")
-class DurationSelector(Selector):
+class DurationSelector(Selector[DurationSelectorConfig]):
     """Selector for a duration."""
 
     selector_type = "duration"
@@ -463,7 +465,7 @@ class EntitySelectorConfig(SingleEntitySelectorConfig, total=False):
 
 
 @SELECTORS.register("entity")
-class EntitySelector(Selector):
+class EntitySelector(Selector[EntitySelectorConfig]):
     """Selector of a single or list of entities."""
 
     selector_type = "entity"
@@ -517,7 +519,7 @@ class IconSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("icon")
-class IconSelector(Selector):
+class IconSelector(Selector[IconSelectorConfig]):
     """Selector for an icon."""
 
     selector_type = "icon"
@@ -545,7 +547,7 @@ class LocationSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("location")
-class LocationSelector(Selector):
+class LocationSelector(Selector[LocationSelectorConfig]):
     """Selector for a location."""
 
     selector_type = "location"
@@ -576,7 +578,7 @@ class MediaSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("media")
-class MediaSelector(Selector):
+class MediaSelector(Selector[MediaSelectorConfig]):
     """Selector for media."""
 
     selector_type = "media"
@@ -636,7 +638,7 @@ def validate_slider(data: Any) -> Any:
 
 
 @SELECTORS.register("number")
-class NumberSelector(Selector):
+class NumberSelector(Selector[NumberSelectorConfig]):
     """Selector of a numeric value."""
 
     selector_type = "number"
@@ -682,7 +684,7 @@ class ObjectSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("object")
-class ObjectSelector(Selector):
+class ObjectSelector(Selector[ObjectSelectorConfig]):
     """Selector for an arbitrary object."""
 
     selector_type = "object"
@@ -733,7 +735,7 @@ class SelectSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("select")
-class SelectSelector(Selector):
+class SelectSelector(Selector[SelectSelectorConfig]):
     """Selector for an single-choice input select."""
 
     selector_type = "select"
@@ -755,12 +757,15 @@ class SelectSelector(Selector):
 
     def __call__(self, data: Any) -> Any:
         """Validate the passed selection."""
-        options = []
-        if self.config["options"]:
-            if isinstance(self.config["options"][0], str):
-                options = self.config["options"]
+        options: Sequence[str] = []
+        if config_options := self.config["options"]:
+            if isinstance(config_options[0], str):
+                options = cast(Sequence[str], config_options)
             else:
-                options = [option["value"] for option in self.config["options"]]
+                options = [
+                    option["value"]
+                    for option in cast(Sequence[SelectOptionDict], config_options)
+                ]
 
         parent_schema = vol.In(options)
         if self.config["custom_value"]:
@@ -787,7 +792,7 @@ class StateSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("state")
-class StateSelector(Selector):
+class StateSelector(Selector[StateSelectorConfig]):
     """Selector for an entity state."""
 
     selector_type = "state"
@@ -814,7 +819,7 @@ class StateSelector(Selector):
 
 
 @SELECTORS.register("target")
-class TargetSelector(Selector):
+class TargetSelector(Selector[TargetSelectorConfig]):
     """Selector of a target value (area ID, device ID, entity ID etc).
 
     Value should follow cv.TARGET_SERVICE_FIELDS format.
@@ -846,7 +851,7 @@ class TemplateSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("template")
-class TemplateSelector(Selector):
+class TemplateSelector(Selector[TemplateSelectorConfig]):
     """Selector for an template."""
 
     selector_type = "template"
@@ -891,7 +896,7 @@ class TextSelectorType(StrEnum):
 
 
 @SELECTORS.register("text")
-class TextSelector(Selector):
+class TextSelector(Selector[TextSelectorConfig]):
     """Selector for a multi-line text string."""
 
     selector_type = "text"
@@ -924,7 +929,7 @@ class ThemeSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("theme")
-class ThemeSelector(Selector):
+class ThemeSelector(Selector[ThemeSelectorConfig]):
     """Selector for an theme."""
 
     selector_type = "theme"
@@ -946,7 +951,7 @@ class TimeSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("time")
-class TimeSelector(Selector):
+class TimeSelector(Selector[TimeSelectorConfig]):
     """Selector of a time value."""
 
     selector_type = "time"
@@ -970,7 +975,7 @@ class FileSelectorConfig(TypedDict):
 
 
 @SELECTORS.register("file")
-class FileSelector(Selector):
+class FileSelector(Selector[FileSelectorConfig]):
     """Selector of a file."""
 
     selector_type = "file"

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1,7 +1,7 @@
 """Selectors for Home Assistant."""
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal, TypedDict, cast
 from uuid import UUID
 
@@ -60,10 +60,10 @@ class Selector:
     """Base class for selectors."""
 
     CONFIG_SCHEMA: Callable
-    config: Any
+    config: Mapping[str, Any]
     selector_type: str
 
-    def __init__(self, config: Any = None) -> None:
+    def __init__(self, config: Mapping[str, Any] | None = None) -> None:
         """Instantiate a selector."""
         # Selectors can be empty
         if config is None:
@@ -71,7 +71,7 @@ class Selector:
 
         self.config = self.CONFIG_SCHEMA(config)
 
-    def serialize(self) -> Any:
+    def serialize(self) -> dict[str, dict[str, Mapping[str, Any]]]:
         """Serialize Selector for voluptuous_serialize."""
         return {"selector": {self.selector_type: self.config}}
 
@@ -466,7 +466,6 @@ class EntitySelectorConfig(SingleEntitySelectorConfig, total=False):
 class EntitySelector(Selector):
     """Selector of a single or list of entities."""
 
-    config: EntitySelectorConfig
     selector_type = "entity"
 
     CONFIG_SCHEMA = SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA.extend(
@@ -477,7 +476,7 @@ class EntitySelector(Selector):
         }
     )
 
-    def __init__(self, config: EntitySelectorConfig) -> None:
+    def __init__(self, config: EntitySelectorConfig | None = None) -> None:
         """Instantiate a selector."""
         super().__init__(config)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve Selector typing.
Without this, `self.config` is always typed as `Any`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
