### PR TITLE
Allow next_step to be a string

### DIFF
--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -134,7 +134,7 @@ DATA_SCHEMA_SENSOR = vol.Schema(SENSOR_SETUP)
 CONFIG_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
     "user": SchemaFlowFormStep(
         schema=DATA_SCHEMA_RESOURCE,
-        next_step=lambda _: "sensor",
+        next_step="sensor",
         validate_user_input=validate_rest_setup,
     ),
     "sensor": SchemaFlowFormStep(

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -32,19 +32,21 @@ class SchemaFlowFormStep:
         vol.Schema | None,
     ] | None
 
-    # Optional function to validate user input.
-    # The validate_user_input function is called if the schema validates successfully.
-    # The validate_user_input function is passed the user input from the current step.
-    # The validate_user_input should raise SchemaFlowError is user input is invalid.
     validate_user_input: Callable[[dict[str, Any]], dict[str, Any]] = lambda x: x
+    """Optional function to validate user input.
+
+    - The `validate_user_input` function is called if the schema validates successfully.
+    - The `validate_user_input` function is passed the user input from the current step.
+    - The `validate_user_input` should raise `SchemaFlowError` is user input is invalid.
+    """
 
     next_step: Callable[[dict[str, Any]], str] | str | None = None
     """Optional property to identify next step.
 
-    If `next_step` is a function, it is called if the schema validates successfully or
+    - If `next_step` is a function, it is called if the schema validates successfully or
     if no schema is defined. The `next_step` function is passed the union of config entry
     options and user input from previous steps.
-    If `next_step` is None, the flow is ended with `FlowResultType.CREATE_ENTRY`.
+    - If `next_step` is None, the flow is ended with `FlowResultType.CREATE_ENTRY`.
     """
 
     # Optional function to allow amending a form schema.

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -38,12 +38,14 @@ class SchemaFlowFormStep:
     # The validate_user_input should raise SchemaFlowError is user input is invalid.
     validate_user_input: Callable[[dict[str, Any]], dict[str, Any]] = lambda x: x
 
-    # Optional function to identify next step.
-    # The next_step function is called if the schema validates successfully or if no
-    # schema is defined. The next_step function is passed the union of config entry
-    # options and user input from previous steps.
-    # If next_step is None, the flow is ended with FlowResultType.CREATE_ENTRY.
-    next_step: Callable[[dict[str, Any]], str] | None = None
+    next_step: Callable[[dict[str, Any]], str] | str | None = None
+    """Optional property to identify next step.
+
+    If `next_step` is a function, it is called if the schema validates successfully or
+    if no schema is defined. The `next_step` function is passed the union of config entry
+    options and user input from previous steps.
+    If `next_step` is None, the flow is ended with `FlowResultType.CREATE_ENTRY`.
+    """
 
     # Optional function to allow amending a form schema.
     # The update_form_schema function is called before async_show_form is called. The
@@ -140,7 +142,10 @@ class SchemaCommonFlowHandler:
                 # Flow done, create entry or update config entry options
                 return self._handler.async_create_entry(data=self._options)
 
-            next_step_id = form_step.next_step(self._options)
+            if isinstance(form_step.next_step, str):
+                next_step_id = form_step.next_step
+            else:
+                next_step_id = form_step.next_step(self._options)
 
         return self._show_next_step(next_step_id)
 

--- a/tests/helpers/test_schema_config_entry_flow.py
+++ b/tests/helpers/test_schema_config_entry_flow.py
@@ -29,7 +29,8 @@ async def test_menu_step(hass: HomeAssistant) -> None:
         "user": SchemaFlowMenuStep(MENU_1),
         "option1": SchemaFlowFormStep(vol.Schema({}), next_step=lambda _: "menu2"),
         "menu2": SchemaFlowMenuStep(MENU_2),
-        "option3": SchemaFlowFormStep(vol.Schema({})),
+        "option3": SchemaFlowFormStep(vol.Schema({}), next_step="option4"),
+        "option4": SchemaFlowFormStep(vol.Schema({})),
     }
 
     class TestConfigFlow(SchemaConfigFlowHandler, domain=TEST_DOMAIN):
@@ -62,6 +63,10 @@ async def test_menu_step(hass: HomeAssistant) -> None:
         )
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "option3"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "option4"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] == FlowResultType.CREATE_ENTRY


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow next_step to be a string

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
