### PR TITLE
Add config flow to the statistics integration

### DIFF
--- a/homeassistant/components/statistics/__init__.py
+++ b/homeassistant/components/statistics/__init__.py
@@ -1,6 +1,26 @@
 """The statistics component."""
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 
-DOMAIN = "statistics"
 PLATFORMS = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Min/Max from a config entry."""
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
+
+    return True
+
+
+async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update listener, called when the config entry options are changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/statistics/config_flow.py
+++ b/homeassistant/components/statistics/config_flow.py
@@ -1,0 +1,214 @@
+"""Config flow for Min/Max integration."""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.core import callback
+from homeassistant.helpers import selector
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
+    SchemaConfigFlowHandler,
+    SchemaFlowFormStep,
+    SchemaFlowMenuStep,
+)
+
+from .const import (
+    CONF_PRECISION,
+    CONF_STATE_CHARACTERISTIC,
+    DOMAIN,
+    STAT_AVERAGE_STEP_LTS,
+    STAT_SUM_DIFFERENCES_LTS,
+    STAT_VALUE_MAX_LTS,
+    STAT_VALUE_MIN_LTS,
+)
+
+_CALENDAR_PERIODS = [
+    selector.SelectOptionDict(value="hour", label="Hour"),
+    selector.SelectOptionDict(value="day", label="Day"),
+    selector.SelectOptionDict(value="week", label="Week"),
+    selector.SelectOptionDict(value="month", label="Month"),
+    selector.SelectOptionDict(value="year", label="Year"),
+]
+
+_STATISTIC_CHARACTERISTICS = [
+    selector.SelectOptionDict(value=STAT_VALUE_MIN_LTS, label="Minimum"),
+    selector.SelectOptionDict(value=STAT_VALUE_MAX_LTS, label="Maximum"),
+    selector.SelectOptionDict(value=STAT_AVERAGE_STEP_LTS, label="Arithmetic mean"),
+    selector.SelectOptionDict(
+        value=STAT_SUM_DIFFERENCES_LTS, label="Sum of differences (change)"
+    ),
+]
+
+PERIOD_TYPES = [
+    "calendar",
+    "fixed_period",
+    "rolling_window",
+]
+
+OPTIONS_SCHEMA_STEP_1 = vol.Schema(
+    {
+        vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
+        ),
+        vol.Required(CONF_STATE_CHARACTERISTIC): selector.SelectSelector(
+            selector.SelectSelectorConfig(options=_STATISTIC_CHARACTERISTICS),
+        ),
+        vol.Required(CONF_PRECISION, default=2): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0, max=6, mode=selector.NumberSelectorMode.BOX
+            ),
+        ),
+    }
+)
+
+CONFIG_SCHEMA_STEP_1 = vol.Schema(
+    {
+        vol.Required("name"): selector.TextSelector(),
+    }
+).extend(OPTIONS_SCHEMA_STEP_1.schema)
+
+CALENDAR_PERIOD_SCHEMA = vol.Schema(
+    {
+        vol.Required("calendar_period"): selector.SelectSelector(
+            selector.SelectSelectorConfig(options=_CALENDAR_PERIODS),
+        ),
+        vol.Required("calendar_offset", default=0): selector.NumberSelector(
+            selector.NumberSelectorConfig(min=0, mode=selector.NumberSelectorMode.BOX),
+        ),
+    }
+)
+
+FIXED_PERIOD_SCHEMA = vol.Schema(
+    {
+        vol.Required("fixed_period_start_time"): selector.DateTimeSelector(),
+        vol.Required("fixed_period_end_time"): selector.DateTimeSelector(),
+    }
+)
+
+ROLLING_WINDOW_PERIOD_SCHEMA = vol.Schema(
+    {
+        vol.Required("rolling_window_duration"): selector.DurationSelector(
+            selector.DurationSelectorConfig(enable_day=True)
+        ),
+        vol.Required("rolling_window_offset"): selector.DurationSelector(
+            selector.DurationSelectorConfig(enable_day=True)
+        ),
+    }
+)
+
+
+@callback
+def choose_initial_config_step(options: dict[str, Any]) -> str | None:
+    """Choose the initial config step."""
+    return "step_1" if not options else None
+
+
+@callback
+def set_period_suggested_values(options: dict[str, Any]) -> str:
+    """Add suggested values for editing the period."""
+
+    if calendar_period := options["period"].get("calendar"):
+        options["calendar_offset"] = calendar_period["offset"]
+        options["calendar_period"] = calendar_period["period"]
+    elif fixed_period := options["period"].get("fixed_period"):
+        options["fixed_period_start_time"] = fixed_period["start_time"]
+        options["fixed_period_end_time"] = fixed_period["end_time"]
+    else:  # rolling_window
+        rolling_window_period = options["period"]["rolling_window"]
+        options["rolling_window_duration"] = rolling_window_period["duration"]
+        options["rolling_window_offset"] = rolling_window_period["offset"]
+
+    return "period_type"
+
+
+@callback
+def set_period(
+    period_type: str,
+) -> Callable[[SchemaCommonFlowHandler, dict[str, Any]], dict[str, Any]]:
+    """Set period."""
+
+    @callback
+    def _set_period_type(
+        handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Add period to user input."""
+        # pylint: disable-next=protected-access
+        handler._options.pop("calendar_offset", None)
+        # pylint: disable-next=protected-access
+        handler._options.pop("calendar_period", None)
+        # pylint: disable-next=protected-access
+        handler._options.pop("fixed_period_start_time", None)
+        # pylint: disable-next=protected-access
+        handler._options.pop("fixed_period_end_time", None)
+        # pylint: disable-next=protected-access
+        handler._options.pop("rolling_window_duration", None)
+        # pylint: disable-next=protected-access
+        handler._options.pop("rolling_window_offset", None)
+
+        if period_type == "calendar":
+            period = {
+                "calendar": {
+                    "offset": user_input.pop("calendar_offset"),
+                    "period": user_input.pop("calendar_period"),
+                }
+            }
+        elif period_type == "fixed_period":
+            period = {
+                "fixed_period": {
+                    "start_time": user_input.pop("fixed_period_start_time"),
+                    "end_time": user_input.pop("fixed_period_end_time"),
+                }
+            }
+        else:  # period_type = rolling_window
+            period = {
+                "rolling_window": {
+                    "duration": user_input.pop("rolling_window_duration"),
+                    "offset": user_input.pop("rolling_window_offset"),
+                }
+            }
+        user_input["period"] = period
+        return user_input
+
+    return _set_period_type
+
+
+CONFIG_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
+    "user": SchemaFlowFormStep(None, next_step=choose_initial_config_step),
+    "step_1": SchemaFlowFormStep(
+        CONFIG_SCHEMA_STEP_1, next_step=lambda _: "period_type"
+    ),
+    "period_type": SchemaFlowMenuStep(PERIOD_TYPES),
+    "calendar": SchemaFlowFormStep(CALENDAR_PERIOD_SCHEMA, set_period("calendar")),
+    "fixed_period": SchemaFlowFormStep(FIXED_PERIOD_SCHEMA, set_period("fixed_period")),
+    "rolling_window": SchemaFlowFormStep(
+        ROLLING_WINDOW_PERIOD_SCHEMA, set_period("rolling_window")
+    ),
+}
+
+OPTIONS_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
+    "init": SchemaFlowFormStep(
+        OPTIONS_SCHEMA_STEP_1, next_step=set_period_suggested_values
+    ),
+    "period_type": SchemaFlowMenuStep(PERIOD_TYPES),
+    "calendar": SchemaFlowFormStep(CALENDAR_PERIOD_SCHEMA, set_period("calendar")),
+    "fixed_period": SchemaFlowFormStep(FIXED_PERIOD_SCHEMA, set_period("fixed_period")),
+    "rolling_window": SchemaFlowFormStep(
+        ROLLING_WINDOW_PERIOD_SCHEMA, set_period("rolling_window")
+    ),
+}
+
+
+class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config or options flow for Min/Max."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return cast(str, options["name"]) if "name" in options else ""

--- a/homeassistant/components/statistics/const.py
+++ b/homeassistant/components/statistics/const.py
@@ -1,0 +1,11 @@
+"""Constants for the statistics integration."""
+
+DOMAIN = "statistics"
+
+CONF_PRECISION = "precision"
+CONF_STATE_CHARACTERISTIC = "state_characteristic"
+
+STAT_AVERAGE_STEP_LTS = "average_step_lts"
+STAT_VALUE_MAX_LTS = "value_max_lts"
+STAT_VALUE_MIN_LTS = "value_min_lts"
+STAT_SUM_DIFFERENCES_LTS = "sum_differences_lts"

--- a/homeassistant/components/statistics/const.py
+++ b/homeassistant/components/statistics/const.py
@@ -2,6 +2,7 @@
 
 DOMAIN = "statistics"
 
+CONF_PERIOD = "period"
 CONF_PRECISION = "precision"
 CONF_STATE_CHARACTERISTIC = "state_characteristic"
 

--- a/homeassistant/components/statistics/manifest.json
+++ b/homeassistant/components/statistics/manifest.json
@@ -5,5 +5,7 @@
   "after_dependencies": ["recorder"],
   "codeowners": ["@fabaff", "@ThomDietrich"],
   "quality_scale": "internal",
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "config_flow": true,
+  "integration_type": "helper"
 }

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -107,8 +107,6 @@ STAT_VALUE_MAX = "value_max"
 STAT_VALUE_MIN = "value_min"
 STAT_VARIANCE = "variance"
 
-CONF_PERIOD = "period"
-
 # Statistics supported by a sensor source (numeric)
 STATS_NUMERIC_SUPPORT = {
     STAT_AVERAGE_LINEAR,

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.components.recorder import (
 )
 from homeassistant.components.recorder.models import StatisticPeriod
 from homeassistant.components.recorder.statistics import (
-    get_metadata,
+    list_statistic_ids,
     statistic_during_period,
 )
 from homeassistant.components.recorder.util import PERIOD_SCHEMA, resolve_period
@@ -886,14 +886,11 @@ class LTSStatisticsSensor(SensorEntity):
     def _unit_of_measurement(self) -> str | None:
         """Return unit_of_measurement."""
 
-        metadata_result = get_metadata(
-            self.hass,
-            statistic_ids=[self._source_entity_id],
-        ).get(self._source_entity_id)
+        metadata_result = list_statistic_ids(self.hass, [self._source_entity_id])
         if not metadata_result:
             return None
 
-        return metadata_result[1].get("unit_of_measurement")
+        return metadata_result[0].get("display_unit_of_measurement")
 
     def _update_long_term_stats_from_database(self) -> None:
         """Update the long term statistics from the database."""

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -9,6 +9,7 @@ FLOWS = {
         "group",
         "integration",
         "min_max",
+        "statistics",
         "switch_as_x",
         "threshold",
         "tod",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5099,12 +5099,6 @@
       "config_flow": false,
       "iot_class": "cloud_polling"
     },
-    "statistics": {
-      "name": "Statistics",
-      "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "local_polling"
-    },
     "statsd": {
       "name": "StatsD",
       "integration_type": "hub",
@@ -6351,6 +6345,12 @@
     "schedule": {
       "integration_type": "helper",
       "config_flow": false
+    },
+    "statistics": {
+      "name": "Statistics",
+      "integration_type": "helper",
+      "config_flow": true,
+      "iot_class": "local_polling"
     },
     "switch_as_x": {
       "integration_type": "helper",

--- a/tests/components/statistics/common.py
+++ b/tests/components/statistics/common.py
@@ -1,0 +1,45 @@
+"""Test helpers for the statistics integration."""
+from datetime import datetime, timedelta
+
+from homeassistant.components import recorder
+from homeassistant.components.recorder.db_schema import Statistics
+from homeassistant.core import HomeAssistant
+
+from tests.components.recorder.common import async_wait_recording_done
+
+
+async def generate_statistics(
+    hass: HomeAssistant,
+    entity_id: str,
+    start: datetime,
+    count: int,
+    start_value: float = 0.0,
+) -> None:
+    """Generate LTS data."""
+
+    imported_stats = [
+        {
+            "start": (start + timedelta(hours=i)),
+            "max": start_value + i * 2,
+            "mean": start_value + i,
+            "min": -(start_value + count * 2) + i * 2,
+            "sum": start_value + i,
+        }
+        for i in range(0, count)
+    ]
+
+    imported_metadata = {
+        "has_mean": True,
+        "has_sum": False,
+        "name": None,
+        "source": "recorder",
+        "statistic_id": entity_id,
+        "unit_of_measurement": "°C",
+    }
+
+    recorder.get_instance(hass).async_import_statistics(
+        imported_metadata,
+        imported_stats,
+        Statistics,
+    )
+    await async_wait_recording_done(hass)

--- a/tests/components/statistics/test_config_flow.py
+++ b/tests/components/statistics/test_config_flow.py
@@ -1,0 +1,294 @@
+"""Test the Statistics config flow."""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from freezegun import freeze_time
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.statistics.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+import homeassistant.util.dt as dt_util
+
+from .common import generate_statistics
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    "period_type, period_input, period_data",
+    (
+        (
+            "calendar",
+            {
+                "calendar_offset": 2,
+                "calendar_period": "day",
+            },
+            {"offset": 2, "period": "day"},
+        ),
+        (
+            "fixed_period",
+            {
+                "fixed_period_end_time": "2022-03-24 00:00",
+                "fixed_period_start_time": "2022-03-24 00:00",
+            },
+            {"end_time": "2022-03-24 00:00", "start_time": "2022-03-24 00:00"},
+        ),
+        (
+            "rolling_window",
+            {
+                "rolling_window_duration": {"days": 365},
+                "rolling_window_offset": {"days": -365},
+            },
+            {"duration": {"days": 365}, "offset": {"days": -365}},
+        ),
+    ),
+)
+async def test_config_flow(
+    hass: HomeAssistant, period_type, period_input, period_data
+) -> None:
+    """Test the config flow."""
+    input_sensor = "sensor.input_one"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "name": "My statistics",
+            "entity_id": input_sensor,
+            "state_characteristic": "value_max_lts",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"next_step_id": period_type},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == period_type
+
+    with patch(
+        "homeassistant.components.statistics.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            period_input,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My statistics"
+    assert result["data"] == {}
+    assert result["options"] == {
+        "entity_id": input_sensor,
+        "name": "My statistics",
+        "period": {period_type: period_data},
+        "precision": 2.0,
+        "state_characteristic": "value_max_lts",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        "entity_id": input_sensor,
+        "name": "My statistics",
+        "period": {period_type: period_data},
+        "precision": 2.0,
+        "state_characteristic": "value_max_lts",
+    }
+    assert config_entry.title == "My statistics"
+
+
+@pytest.mark.parametrize(
+    "period_type, period_definition",
+    (
+        (
+            "calendar",
+            {
+                "period": "day",
+                "offset": 2,
+            },
+        ),
+        (
+            "fixed_period",
+            {
+                "start_time": "2022-03-24 00:00",
+                "end_time": "2022-03-24 00:00",
+            },
+        ),
+        (
+            "rolling_window",
+            {
+                "duration": {"days": 365},
+                "offset": {"days": -365},
+            },
+        ),
+    ),
+)
+async def test_config_flow_import(
+    hass: HomeAssistant, period_type, period_definition
+) -> None:
+    """Test the config flow."""
+    input_sensor = "sensor.input_one"
+
+    with patch(
+        "homeassistant.components.statistics.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={
+                "entity_id": input_sensor,
+                "name": "My statistics",
+                "period": {period_type: period_definition},
+                "precision": 2.0,
+                "state_characteristic": "value_max_lts",
+            },
+        )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My statistics"
+    assert result["data"] == {}
+    assert result["options"] == {
+        "entity_id": input_sensor,
+        "name": "My statistics",
+        "period": {period_type: period_definition},
+        "precision": 2.0,
+        "state_characteristic": "value_max_lts",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        "entity_id": input_sensor,
+        "name": "My statistics",
+        "period": {period_type: period_definition},
+        "precision": 2.0,
+        "state_characteristic": "value_max_lts",
+    }
+    assert config_entry.title == "My statistics"
+
+
+def get_suggested(schema, key):
+    """Get suggested value for key in voluptuous schema."""
+    for k in schema.keys():
+        if k == key:
+            if k.description is None or "suggested_value" not in k.description:
+                return None
+            return k.description["suggested_value"]
+    # Wanted key absent from schema
+    raise Exception
+
+
+@freeze_time(datetime(2022, 10, 21, 7, 25, tzinfo=timezone.utc))
+async def test_options(recorder_mock, hass: HomeAssistant) -> None:
+    """Test reconfiguring."""
+
+    now = dt_util.utcnow()
+
+    zero = now
+    start = zero.replace(minute=0, second=0, microsecond=0) + timedelta(days=-2)
+
+    await generate_statistics(hass, "sensor.input_one", start, 6)
+    await generate_statistics(hass, "sensor.input_two", start, 6)
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "entity_id": "sensor.input_one",
+            "name": "My statistics",
+            "period": {"calendar": {"offset": -2, "period": "day"}},
+            "precision": 2.0,
+            "state_characteristic": "value_max_lts",
+        },
+        title="My statistics",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the state of the entity is reflecting the initial settings
+    state = hass.states.get("sensor.my_statistics")
+    assert state.state == "10.0"
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    schema = result["data_schema"].schema
+    assert get_suggested(schema, "entity_id") == "sensor.input_one"
+    assert get_suggested(schema, "precision") == 2.0
+    assert get_suggested(schema, "state_characteristic") == "value_max_lts"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "entity_id": "sensor.input_two",
+            "precision": 1,
+            "state_characteristic": "value_min_lts",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.MENU
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"next_step_id": "rolling_window"},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "rolling_window"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "rolling_window_duration": {"days": 2},
+            "rolling_window_offset": {"hours": -1},
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        "entity_id": "sensor.input_two",
+        "name": "My statistics",
+        "period": {
+            "rolling_window": {"duration": {"days": 2}, "offset": {"hours": -1}}
+        },
+        "precision": 1.0,
+        "state_characteristic": "value_min_lts",
+    }
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        "entity_id": "sensor.input_two",
+        "name": "My statistics",
+        "period": {
+            "rolling_window": {"duration": {"days": 2}, "offset": {"hours": -1}}
+        },
+        "precision": 1.0,
+        "state_characteristic": "value_min_lts",
+    }
+    assert config_entry.title == "My statistics"
+
+    # Check config entry is reloaded with new options
+    await hass.async_block_till_done()
+
+    # Check the entity was updated, no new entity was created
+    assert len(hass.states.async_all()) == 1
+
+    # Check the state of the entity has changed as expected
+    state = hass.states.get("sensor.my_statistics")
+    assert state.state == "-12.0"

--- a/tests/components/statistics/test_config_flow.py
+++ b/tests/components/statistics/test_config_flow.py
@@ -138,11 +138,11 @@ async def test_config_flow_import(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
             data={
-                "entity_id": input_sensor,
+                "entity": input_sensor,
                 "name": "My statistics",
                 "period": {period_type: period_definition},
                 "precision": 2.0,
-                "state_characteristic": "value_max_lts",
+                "state_type": "max",
             },
         )
     assert result["type"] == FlowResultType.CREATE_ENTRY

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
-from homeassistant.components.statistics import DOMAIN as STATISTICS_DOMAIN
+from homeassistant.components.statistics.const import DOMAIN as STATISTICS_DOMAIN
 from homeassistant.components.statistics.sensor import StatisticsSensor
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config flow to the statistics integration.

Also teach the statistics sensor to fetch data from the recorder's long term statistics tables with the following new state characteristic:
- `average_step_lts`
- `value_max_lts`
- `value_min_lts`
- `sum_differences_lts`

The config flow in the PR only supports creating a statistics sensor which sources data from the recorder's long term statistic tables.

The main driver is to make it possible to create a statistic sensor from a frontend statistic card.

TODO:
- Add translation strings

In follow-up PRs:
- Combine data from the recorder with the last 5 minutes of events
- Make it possible to use the new characteristic from YAML

Needs https://github.com/home-assistant/core/pull/82870

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
