### PR TITLE
Add handler to validate_user_input

### DIFF
--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_ENTITIES
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er, selector
 from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
     SchemaConfigFlowHandler,
     SchemaFlowFormStep,
     SchemaFlowMenuStep,
@@ -104,11 +105,15 @@ def choose_options_step(options: dict[str, Any]) -> str:
     return cast(str, options["group_type"])
 
 
-def set_group_type(group_type: str) -> Callable[[dict[str, Any]], dict[str, Any]]:
+def set_group_type(
+    group_type: str,
+) -> Callable[[SchemaCommonFlowHandler, dict[str, Any]], dict[str, Any]]:
     """Set group type."""
 
     @callback
-    def _set_group_type(user_input: dict[str, Any]) -> dict[str, Any]:
+    def _set_group_type(
+        handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+    ) -> dict[str, Any]:
         """Add group type to user input."""
         return {"group_type": group_type, **user_input}
 

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import async_get_hass
 from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
     SchemaConfigFlowHandler,
     SchemaFlowError,
     SchemaFlowFormStep,
@@ -113,7 +114,9 @@ SENSOR_SETUP = {
 }
 
 
-def validate_rest_setup(user_input: dict[str, Any]) -> dict[str, Any]:
+def validate_rest_setup(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
     """Validate rest setup."""
     hass = async_get_hass()
     rest_config: dict[str, Any] = COMBINED_SCHEMA(user_input)
@@ -124,7 +127,9 @@ def validate_rest_setup(user_input: dict[str, Any]) -> dict[str, Any]:
     return user_input
 
 
-def validate_sensor_setup(user_input: dict[str, Any]) -> dict[str, Any]:
+def validate_sensor_setup(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
     """Validate sensor setup."""
     return {
         "sensor": [

--- a/homeassistant/components/threshold/config_flow.py
+++ b/homeassistant/components/threshold/config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_ENTITY_ID, CONF_NAME
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
     SchemaConfigFlowHandler,
     SchemaFlowError,
     SchemaFlowFormStep,
@@ -18,11 +19,13 @@ from homeassistant.helpers.schema_config_entry_flow import (
 from .const import CONF_HYSTERESIS, CONF_LOWER, CONF_UPPER, DEFAULT_HYSTERESIS, DOMAIN
 
 
-def _validate_mode(data: Any) -> Any:
+def _validate_mode(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
     """Validate the threshold mode, and set limits to None if not set."""
-    if CONF_LOWER not in data and CONF_UPPER not in data:
+    if CONF_LOWER not in user_input and CONF_UPPER not in user_input:
         raise SchemaFlowError("need_lower_upper")
-    return {CONF_LOWER: None, CONF_UPPER: None, **data}
+    return {CONF_LOWER: None, CONF_UPPER: None, **user_input}
 
 
 OPTIONS_SCHEMA = vol.Schema(

--- a/homeassistant/components/utility_meter/config_flow.py
+++ b/homeassistant/components/utility_meter/config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
     SchemaConfigFlowHandler,
     SchemaFlowError,
     SchemaFlowFormStep,
@@ -46,14 +47,16 @@ METER_TYPES = [
 ]
 
 
-def _validate_config(data: Any) -> Any:
+def _validate_config(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
     """Validate config."""
     try:
-        vol.Unique()(data[CONF_TARIFFS])
+        vol.Unique()(user_input[CONF_TARIFFS])
     except vol.Invalid as exc:
         raise SchemaFlowError("tariffs_not_unique") from exc
 
-    return data
+    return user_input
 
 
 OPTIONS_SCHEMA = vol.Schema(

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -44,7 +44,9 @@ class SchemaFlowFormStep(SchemaFlowStep):
     user input is requested.
     """
 
-    validate_user_input: Callable[[dict[str, Any]], dict[str, Any]] = lambda x: x
+    validate_user_input: Callable[
+        [SchemaCommonFlowHandler, dict[str, Any]], dict[str, Any]
+    ] | None = None
     """Optional function to validate user input.
 
     - The `validate_user_input` function is called if the schema validates successfully.
@@ -124,10 +126,10 @@ class SchemaCommonFlowHandler:
                     ):
                         user_input[str(key.schema)] = key.default()
 
-        if user_input is not None and form_step.schema is not None:
+        if user_input is not None and form_step.validate_user_input is not None:
             # Do extra validation of user input
             try:
-                user_input = form_step.validate_user_input(user_input)
+                user_input = form_step.validate_user_input(self, user_input)
             except SchemaFlowError as exc:
                 return self._show_next_step(step_id, exc, user_input)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add handler to validate_user_input

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
