### PR TITLE
Centralize exception handling in Plugwise

### DIFF
--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -12,11 +12,15 @@ from plugwise.exceptions import (
     UnsupportedDeviceError,
 )
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN, LOGGER
 
 
 class PlugwiseData(NamedTuple):
@@ -29,15 +33,15 @@ class PlugwiseData(NamedTuple):
 class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
     """Class to manage fetching Plugwise data from single endpoint."""
 
-    def __init__(self, hass: HomeAssistant, api: Smile) -> None:
+    _connected: bool = False
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass,
             LOGGER,
-            name=api.smile_name or DOMAIN,
-            update_interval=DEFAULT_SCAN_INTERVAL.get(
-                str(api.smile_type), timedelta(seconds=60)
-            ),
+            name=DOMAIN,
+            update_interval=timedelta(seconds=60),
             # Don't refresh immediately, give the device time to process
             # the change in state before we query it.
             request_refresh_debouncer=Debouncer(
@@ -47,22 +51,41 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
                 immediate=False,
             ),
         )
-        self.api = api
+
+        self.api = Smile(
+            host=entry.data[CONF_HOST],
+            username=entry.data.get(CONF_USERNAME, DEFAULT_USERNAME),
+            password=entry.data[CONF_PASSWORD],
+            port=entry.data.get(CONF_PORT, DEFAULT_PORT),
+            timeout=30,
+            websession=async_get_clientsession(hass, verify_ssl=False),
+        )
+
+    async def _connect(self) -> None:
+        """Connect to the Plugwise Smile."""
+        self._connected = await self.api.connect()
+        self.api.get_all_devices()
+        self.name = self.api.smile_name
+        self.update_interval = DEFAULT_SCAN_INTERVAL.get(
+            str(self.api.smile_type), timedelta(seconds=60)
+        )
 
     async def _async_update_data(self) -> PlugwiseData:
         """Fetch data from Plugwise."""
         try:
+            if not self._connected:
+                await self._connect()
             data = await self.api.async_update()
         except InvalidAuthentication as err:
-            raise UpdateFailed("Authentication failed") from err
+            raise ConfigEntryError("Invalid username or Smile ID") from err
         except (InvalidXMLError, ResponseError) as err:
             raise UpdateFailed(
                 "Invalid XML data, or error indication received for the Plugwise Adam/Smile/Stretch"
             ) from err
         except UnsupportedDeviceError as err:
-            raise UpdateFailed("Device with unsupported firmware") from err
+            raise ConfigEntryError("Device with unsupported firmware") from err
         except ConnectionFailedError as err:
-            raise UpdateFailed("Failed to connect") from err
+            raise UpdateFailed("Failed to connect to the Plugwise Smile") from err
         return PlugwiseData(
             gateway=cast(GatewayData, data[0]),
             devices=cast(dict[str, DeviceData], data[1]),

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -75,7 +75,7 @@ def mock_smile_adam() -> Generator[None, MagicMock, None]:
     chosen_env = "adam_multiple_devices_per_zone"
 
     with patch(
-        "homeassistant.components.plugwise.gateway.Smile", autospec=True
+        "homeassistant.components.plugwise.coordinator.Smile", autospec=True
     ) as smile_mock:
         smile = smile_mock.return_value
 
@@ -101,7 +101,7 @@ def mock_smile_adam_2() -> Generator[None, MagicMock, None]:
     chosen_env = "m_adam_heating"
 
     with patch(
-        "homeassistant.components.plugwise.gateway.Smile", autospec=True
+        "homeassistant.components.plugwise.coordinator.Smile", autospec=True
     ) as smile_mock:
         smile = smile_mock.return_value
 
@@ -127,7 +127,7 @@ def mock_smile_adam_3() -> Generator[None, MagicMock, None]:
     chosen_env = "m_adam_cooling"
 
     with patch(
-        "homeassistant.components.plugwise.gateway.Smile", autospec=True
+        "homeassistant.components.plugwise.coordinator.Smile", autospec=True
     ) as smile_mock:
         smile = smile_mock.return_value
 
@@ -152,7 +152,7 @@ def mock_smile_anna() -> Generator[None, MagicMock, None]:
     """Create a Mock Anna environment for testing exceptions."""
     chosen_env = "anna_heatpump_heating"
     with patch(
-        "homeassistant.components.plugwise.gateway.Smile", autospec=True
+        "homeassistant.components.plugwise.coordinator.Smile", autospec=True
     ) as smile_mock:
         smile = smile_mock.return_value
 
@@ -177,7 +177,7 @@ def mock_smile_anna_2() -> Generator[None, MagicMock, None]:
     """Create a 2nd Mock Anna environment for testing exceptions."""
     chosen_env = "m_anna_heatpump_cooling"
     with patch(
-        "homeassistant.components.plugwise.gateway.Smile", autospec=True
+        "homeassistant.components.plugwise.coordinator.Smile", autospec=True
     ) as smile_mock:
         smile = smile_mock.return_value
 
@@ -202,7 +202,7 @@ def mock_smile_anna_3() -> Generator[None, MagicMock, None]:
     """Create a 3rd Mock Anna environment for testing exceptions."""
     chosen_env = "m_anna_heatpump_idle"
     with patch(
-        "homeassistant.components.plugwise.gateway.Smile", autospec=True
+        "homeassistant.components.plugwise.coordinator.Smile", autospec=True
     ) as smile_mock:
         smile = smile_mock.return_value
 
@@ -227,7 +227,7 @@ def mock_smile_p1() -> Generator[None, MagicMock, None]:
     """Create a Mock P1 DSMR environment for testing exceptions."""
     chosen_env = "p1v3_full_option"
     with patch(
-        "homeassistant.components.plugwise.gateway.Smile", autospec=True
+        "homeassistant.components.plugwise.coordinator.Smile", autospec=True
     ) as smile_mock:
         smile = smile_mock.return_value
 
@@ -252,7 +252,7 @@ def mock_stretch() -> Generator[None, MagicMock, None]:
     """Create a Mock Stretch environment for testing exceptions."""
     chosen_env = "stretch_v31"
     with patch(
-        "homeassistant.components.plugwise.gateway.Smile", autospec=True
+        "homeassistant.components.plugwise.coordinator.Smile", autospec=True
     ) as smile_mock:
         smile = smile_mock.return_value
 

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -61,33 +61,6 @@ async def test_gateway_config_entry_not_ready(
     entry_state: ConfigEntryState,
 ) -> None:
     """Test the Plugwise configuration entry not ready."""
-    mock_smile_anna.connect.side_effect = side_effect
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert len(mock_smile_anna.connect.mock_calls) == 1
-    assert mock_config_entry.state is entry_state
-
-
-@pytest.mark.parametrize(
-    "side_effect",
-    [
-        (ConnectionFailedError),
-        (InvalidAuthentication),
-        (InvalidXMLError),
-        (ResponseError),
-        (UnsupportedDeviceError),
-    ],
-)
-async def test_coord_config_entry_not_ready(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_smile_anna: MagicMock,
-    side_effect: Exception,
-) -> None:
-    """Test the Plugwise configuration entry not ready."""
     mock_smile_anna.async_update.side_effect = side_effect
 
     mock_config_entry.add_to_hass(hass)
@@ -95,7 +68,7 @@ async def test_coord_config_entry_not_ready(
     await hass.async_block_till_done()
 
     assert len(mock_smile_anna.connect.mock_calls) == 1
-    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is entry_state
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Now the coordinator can raise `ConfigEntryError` and thus handle a config entry setup error (#82689), it means that the Plugwise integration no longer has to duplicate its error handling (and tests).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
