### PR TITLE
Add matter server add-on flow

### DIFF
--- a/homeassistant/components/matter/addon.py
+++ b/homeassistant/components/matter/addon.py
@@ -1,0 +1,17 @@
+"""Provide add-on management."""
+from __future__ import annotations
+
+from homeassistant.components.hassio import AddonManager
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.singleton import singleton
+
+from .const import ADDON_SLUG, DOMAIN, LOGGER
+
+DATA_ADDON_MANAGER = f"{DOMAIN}_addon_manager"
+
+
+@singleton(DATA_ADDON_MANAGER)
+@callback
+def get_addon_manager(hass: HomeAssistant) -> AddonManager:
+    """Get the add-on manager."""
+    return AddonManager(hass, LOGGER, "Matter Server", ADDON_SLUG)

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -45,7 +45,6 @@ def get_manual_schema(user_input: dict[str, Any]) -> vol.Schema:
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     """Validate the user input allows us to connect."""
-
     client = Client(data[CONF_URL], aiohttp_client.async_get_clientsession(hass))
     await client.connect()
 
@@ -178,7 +177,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
     async def _async_get_addon_info(self) -> AddonInfo:
-        """Return and cache Matter Server add-on info."""
+        """Return Matter Server add-on info."""
         addon_manager: AddonManager = get_addon_manager(self.hass)
         try:
             addon_info: AddonInfo = await addon_manager.async_get_addon_info()
@@ -279,11 +278,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_finish_addon_setup(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Prepare info needed to complete the config entry.
-
-        Get add-on discovery info and server version info.
-        Set unique id and abort if already configured.
-        """
+        """Prepare info needed to complete the config entry."""
         if not self.ws_address:
             discovery_info = await self._async_get_addon_discovery_info()
             ws_address = self.ws_address = build_ws_address(

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -33,7 +33,7 @@ from .const import (
 
 ADDON_SETUP_TIMEOUT = 5
 ADDON_SETUP_TIMEOUT_ROUNDS = 40
-DEFAULT_URL = "ws://172.30.32.1:5580/chip_ws"
+DEFAULT_URL = "ws://localhost:5580/chip_ws"
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
 
 

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -170,7 +170,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     break
             else:
-                raise CannotConnect("Failed to start Z-Wave JS add-on: timeout")
+                raise CannotConnect("Failed to start Matter Server add-on: timeout")
         finally:
             # Continue the flow after show progress when the task is done.
             self.hass.async_create_task(

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Matter integration."""
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from matter_server.client.client import Client
@@ -8,28 +9,50 @@ from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.hassio import (
+    AddonError,
+    AddonInfo,
+    AddonManager,
+    AddonState,
+    HassioServiceInfo,
+    is_hassio,
+)
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN, LOGGER
-
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_URL, default="http://172.30.32.1:5580/chip_ws"): str,
-    }
+from .addon import get_addon_manager
+from .const import (
+    ADDON_SLUG,
+    CONF_INTEGRATION_CREATED_ADDON,
+    CONF_USE_ADDON,
+    DOMAIN,
+    LOGGER,
 )
+
+ADDON_SETUP_TIMEOUT = 5
+ADDON_SETUP_TIMEOUT_ROUNDS = 40
+DEFAULT_URL = "ws://172.30.32.1:5580/chip_ws"
+ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
+
+
+def get_manual_schema(user_input: dict[str, Any]) -> vol.Schema:
+    """Return a schema for the manual step."""
+    default_url = user_input.get(CONF_URL, DEFAULT_URL)
+    return vol.Schema({vol.Required(CONF_URL, default=default_url): str})
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
-    """Validate the user input allows us to connect.
-
-    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
-    """
+    """Validate the user input allows us to connect."""
 
     client = Client(data[CONF_URL], aiohttp_client.async_get_clientsession(hass))
     await client.connect()
+
+
+def build_ws_address(host: str, port: int) -> str:
+    """Return the websocket address."""
+    return f"ws://{host}:{port}/chip_ws"
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -37,17 +60,150 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        """Set up flow instance."""
+        self.ws_address: str | None = None
+        # If we install the add-on we should uninstall it on entry remove.
+        self.integration_created_addon = False
+        self.install_task: asyncio.Task | None = None
+        self.start_task: asyncio.Task | None = None
+        self.use_addon = False
+
+    async def async_step_install_addon(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Install Matter Server add-on."""
+        if not self.install_task:
+            self.install_task = self.hass.async_create_task(self._async_install_addon())
+            return self.async_show_progress(
+                step_id="install_addon", progress_action="install_addon"
+            )
+
+        try:
+            await self.install_task
+        except AddonError as err:
+            self.install_task = None
+            LOGGER.error(err)
+            return self.async_show_progress_done(next_step_id="install_failed")
+
+        self.integration_created_addon = True
+        self.install_task = None
+
+        return self.async_show_progress_done(next_step_id="start_addon")
+
+    async def async_step_install_failed(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Add-on installation failed."""
+        return self.async_abort(reason="addon_install_failed")
+
+    async def _async_install_addon(self) -> None:
+        """Install the Matter Server add-on."""
+        addon_manager: AddonManager = get_addon_manager(self.hass)
+        try:
+            await addon_manager.async_schedule_install_addon()
+        finally:
+            # Continue the flow after show progress when the task is done.
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+            )
+
+    async def _async_get_addon_discovery_info(self) -> dict:
+        """Return add-on discovery info."""
+        addon_manager: AddonManager = get_addon_manager(self.hass)
+        try:
+            discovery_info_config = await addon_manager.async_get_addon_discovery_info()
+        except AddonError as err:
+            LOGGER.error(err)
+            raise AbortFlow("addon_get_discovery_info_failed") from err
+
+        return discovery_info_config
+
+    async def async_step_start_addon(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Start Matter Server add-on."""
+        if not self.start_task:
+            self.start_task = self.hass.async_create_task(self._async_start_addon())
+            return self.async_show_progress(
+                step_id="start_addon", progress_action="start_addon"
+            )
+
+        try:
+            await self.start_task
+        except (CannotConnect, AddonError, AbortFlow) as err:
+            self.start_task = None
+            LOGGER.error(err)
+            return self.async_show_progress_done(next_step_id="start_failed")
+
+        self.start_task = None
+        return self.async_show_progress_done(next_step_id="finish_addon_setup")
+
+    async def async_step_start_failed(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Add-on start failed."""
+        return self.async_abort(reason="addon_start_failed")
+
+    async def _async_start_addon(self) -> None:
+        """Start the Matter Server add-on."""
+        addon_manager: AddonManager = get_addon_manager(self.hass)
+
+        try:
+            await addon_manager.async_schedule_start_addon()
+            # Sleep some seconds to let the add-on start properly before connecting.
+            for _ in range(ADDON_SETUP_TIMEOUT_ROUNDS):
+                await asyncio.sleep(ADDON_SETUP_TIMEOUT)
+                try:
+                    if not (ws_address := self.ws_address):
+                        discovery_info = await self._async_get_addon_discovery_info()
+                        ws_address = self.ws_address = build_ws_address(
+                            discovery_info["host"], discovery_info["port"]
+                        )
+                    await validate_input(self.hass, {CONF_URL: ws_address})
+                except (AbortFlow, CannotConnect) as err:
+                    LOGGER.debug(
+                        "Add-on not ready yet, waiting %s seconds: %s",
+                        ADDON_SETUP_TIMEOUT,
+                        err,
+                    )
+                else:
+                    break
+            else:
+                raise CannotConnect("Failed to start Z-Wave JS add-on: timeout")
+        finally:
+            # Continue the flow after show progress when the task is done.
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+            )
+
+    async def _async_get_addon_info(self) -> AddonInfo:
+        """Return and cache Matter Server add-on info."""
+        addon_manager: AddonManager = get_addon_manager(self.hass)
+        try:
+            addon_info: AddonInfo = await addon_manager.async_get_addon_info()
+        except AddonError as err:
+            LOGGER.error(err)
+            raise AbortFlow("addon_info_failed") from err
+
+        return addon_info
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
-        # For now because we use services and they can't distinguish between entries
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
+        if is_hassio(self.hass):
+            return await self.async_step_on_supervisor()
 
+        return await self.async_step_manual()
+
+    async def async_step_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a manual configuration."""
         if user_input is None:
             return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+                step_id="manual", data_schema=get_manual_schema({})
             )
 
         errors = {}
@@ -62,8 +218,113 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            return self.async_create_entry(title=user_input[CONF_URL], data=user_input)
+            self.ws_address = user_input[CONF_URL]
+
+            return await self._async_create_entry_or_abort()
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="manual", data_schema=get_manual_schema(user_input), errors=errors
+        )
+
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
+        """Receive configuration from add-on discovery info.
+
+        This flow is triggered by the Matter Server add-on.
+        """
+        if discovery_info.slug != ADDON_SLUG:
+            return self.async_abort(reason="not_matter_addon")
+
+        await self._async_handle_discovery_without_unique_id()
+
+        self.ws_address = build_ws_address(
+            discovery_info.config["host"], discovery_info.config["port"]
+        )
+
+        return await self.async_step_hassio_confirm()
+
+    async def async_step_hassio_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm the add-on discovery."""
+        if user_input is not None:
+            return await self.async_step_on_supervisor(
+                user_input={CONF_USE_ADDON: True}
+            )
+
+        return self.async_show_form(step_id="hassio_confirm")
+
+    async def async_step_on_supervisor(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle logic when on Supervisor host."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="on_supervisor", data_schema=ON_SUPERVISOR_SCHEMA
+            )
+        if not user_input[CONF_USE_ADDON]:
+            return await self.async_step_manual()
+
+        self.use_addon = True
+
+        addon_info = await self._async_get_addon_info()
+
+        if addon_info.state == AddonState.RUNNING:
+            return await self.async_step_finish_addon_setup()
+
+        if addon_info.state == AddonState.NOT_RUNNING:
+            return await self.async_step_start_addon()
+
+        return await self.async_step_install_addon()
+
+    async def async_step_finish_addon_setup(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Prepare info needed to complete the config entry.
+
+        Get add-on discovery info and server version info.
+        Set unique id and abort if already configured.
+        """
+        if not self.ws_address:
+            discovery_info = await self._async_get_addon_discovery_info()
+            ws_address = self.ws_address = build_ws_address(
+                discovery_info["host"], discovery_info["port"]
+            )
+            # Check that we can connect to the address.
+            try:
+                await validate_input(self.hass, {CONF_URL: ws_address})
+            except CannotConnect:
+                return self.async_abort(reason="cannot_connect")
+
+        return await self._async_create_entry_or_abort()
+
+    async def _async_create_entry_or_abort(self) -> FlowResult:
+        """Return a config entry for the flow or abort if already configured."""
+        assert self.ws_address is not None
+
+        if existing_config_entries := self._async_current_entries():
+            config_entry = existing_config_entries[0]
+            self.hass.config_entries.async_update_entry(
+                config_entry,
+                data={
+                    **config_entry.data,
+                    CONF_URL: self.ws_address,
+                    CONF_USE_ADDON: self.use_addon,
+                    CONF_INTEGRATION_CREATED_ADDON: self.integration_created_addon,
+                },
+                title=self.ws_address,
+            )
+            await self.hass.config_entries.async_reload(config_entry.entry_id)
+            raise AbortFlow("reconfiguration_successful")
+
+        # Abort any other flows that may be in progress
+        for progress in self._async_in_progress():
+            self.hass.config_entries.flow.async_abort(progress["flow_id"])
+
+        return self.async_create_entry(
+            title=self.ws_address,
+            data={
+                CONF_URL: self.ws_address,
+                CONF_USE_ADDON: self.use_addon,
+                CONF_INTEGRATION_CREATED_ADDON: self.integration_created_addon,
+            },
         )

--- a/homeassistant/components/matter/const.py
+++ b/homeassistant/components/matter/const.py
@@ -1,5 +1,10 @@
 """Constants for the Matter integration."""
 import logging
 
+ADDON_SLUG = "core_matter_server"
+
+CONF_INTEGRATION_CREATED_ADDON = "integration_created_addon"
+CONF_USE_ADDON = "use_addon"
+
 DOMAIN = "matter"
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -1,10 +1,27 @@
 {
   "config": {
+    "flow_title": "{name}",
     "step": {
-      "user": {
+      "manual": {
         "data": {
           "url": "[%key:common::config_flow::data::url%]"
         }
+      },
+      "on_supervisor": {
+        "title": "Select connection method",
+        "description": "Do you want to use the official Matter Server Supervisor add-on?\n\nIf you are already running the Matter Server in another add-on, in a custom container, natively etc., then do not select this option.",
+        "data": {
+          "use_addon": "Use the official Matter Server Supervisor add-on"
+        }
+      },
+      "install_addon": {
+        "title": "The add-on installation has started"
+      },
+      "start_addon": {
+        "title": "Starting add-on."
+      },
+      "hassio_confirm": {
+        "title": "Set up the Matter integration with the Matter Server add-on"
       }
     },
     "error": {
@@ -13,7 +30,18 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "addon_get_discovery_info_failed": "Failed to get Matter Server add-on discovery info.",
+      "addon_info_failed": "Failed to get Matter Server add-on info.",
+      "addon_install_failed": "Failed to install the Matter Server add-on.",
+      "addon_start_failed": "Failed to start the Matter Server add-on.",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "not_matter_addon": "Discovered add-on is not the official Matter Server add-on.",
+      "reconfiguration_successful": "Successfully reconfigured the Matter integration."
+    },
+    "progress": {
+      "install_addon": "Please wait while the Matter Server add-on installation finishes. This can take several minutes.",
+      "start_addon": "Please wait while the Matter Server add-on starts. This add-on is what powers Matter in Home Assistant. This may take some seconds."
     }
   }
 }

--- a/homeassistant/components/matter/translations/en.json
+++ b/homeassistant/components/matter/translations/en.json
@@ -1,18 +1,46 @@
 {
     "config": {
         "abort": {
-            "single_instance_allowed": "Already configured. Only a single configuration possible."
+            "addon_get_discovery_info_failed": "Failed to get Matter Server add-on discovery info.",
+            "addon_info_failed": "Failed to get Matter Server add-on info.",
+            "addon_install_failed": "Failed to install the Matter Server add-on.",
+            "addon_start_failed": "Failed to start the Matter Server add-on.",
+            "already_configured": "Device is already configured",
+            "already_in_progress": "Configuration flow is already in progress",
+            "not_matter_addon": "Discovered add-on is not the official Matter Server add-on.",
+            "reconfiguration_successful": "Successfully reconfigured the Matter integration."
         },
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_server_version": "The Matter server is not the correct version",
             "unknown": "Unexpected error"
         },
+        "flow_title": "{name}",
+        "progress": {
+            "install_addon": "Please wait while the Matter Server add-on installation finishes. This can take several minutes.",
+            "start_addon": "Please wait while the Matter Server add-on starts. This add-on is what powers Matter in Home Assistant. This may take some seconds."
+        },
         "step": {
-            "user": {
+            "hassio_confirm": {
+                "title": "Set up the Matter integration with the Matter Server add-on"
+            },
+            "install_addon": {
+                "title": "The add-on installation has started"
+            },
+            "manual": {
                 "data": {
                     "url": "URL"
                 }
+            },
+            "on_supervisor": {
+                "data": {
+                    "use_addon": "Use the official Matter Server Supervisor add-on"
+                },
+                "description": "Do you want to use the official Matter Server Supervisor add-on?\n\nIf you are already running the Matter Server in another add-on, in a custom container, natively etc., then do not select this option.",
+                "title": "Select connection method"
+            },
+            "start_addon": {
+                "title": "Starting add-on."
             }
         }
     }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3047,9 +3047,10 @@
       "iot_class": "cloud_push"
     },
     "matter": {
+      "name": "Matter",
+      "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push",
-      "name": "Matter"
+      "iot_class": "local_push"
     },
     "mazda": {
       "name": "Mazda Connected Services",

--- a/tests/components/matter/conftest.py
+++ b/tests/components/matter/conftest.py
@@ -1,0 +1,95 @@
+"""Provide common fixtures."""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture(name="addon_store_info")
+def addon_store_info_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock Supervisor add-on store info."""
+    with patch(
+        "homeassistant.components.hassio.addon_manager.async_get_addon_store_info"
+    ) as addon_store_info:
+        addon_store_info.return_value = {
+            "installed": None,
+            "state": None,
+            "version": "1.0.0",
+        }
+        yield addon_store_info
+
+
+@pytest.fixture(name="addon_info")
+def addon_info_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock Supervisor add-on info."""
+    with patch(
+        "homeassistant.components.hassio.addon_manager.async_get_addon_info",
+    ) as addon_info:
+        addon_info.return_value = {
+            "hostname": None,
+            "options": {},
+            "state": None,
+            "update_available": False,
+            "version": None,
+        }
+        yield addon_info
+
+
+@pytest.fixture(name="addon_not_installed")
+def addon_not_installed_fixture(
+    addon_store_info: AsyncMock, addon_info: AsyncMock
+) -> AsyncMock:
+    """Mock add-on not installed."""
+    return addon_info
+
+
+@pytest.fixture(name="addon_installed")
+def addon_installed_fixture(
+    addon_store_info: AsyncMock, addon_info: AsyncMock
+) -> AsyncMock:
+    """Mock add-on already installed but not running."""
+    addon_store_info.return_value = {
+        "installed": "1.0.0",
+        "state": "stopped",
+        "version": "1.0.0",
+    }
+    addon_info.return_value["hostname"] = "core-matter-server"
+    addon_info.return_value["state"] = "stopped"
+    addon_info.return_value["version"] = "1.0.0"
+    return addon_info
+
+
+@pytest.fixture(name="addon_running")
+def addon_running_fixture(
+    addon_store_info: AsyncMock, addon_info: AsyncMock
+) -> AsyncMock:
+    """Mock add-on already running."""
+    addon_store_info.return_value = {
+        "installed": "1.0.0",
+        "state": "started",
+        "version": "1.0.0",
+    }
+    addon_info.return_value["hostname"] = "core-matter-server"
+    addon_info.return_value["state"] = "started"
+    addon_info.return_value["version"] = "1.0.0"
+    return addon_info
+
+
+@pytest.fixture(name="install_addon")
+def install_addon_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock install add-on."""
+    with patch(
+        "homeassistant.components.hassio.addon_manager.async_install_addon"
+    ) as install_addon:
+        yield install_addon
+
+
+@pytest.fixture(name="start_addon")
+def start_addon_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock start add-on."""
+    with patch(
+        "homeassistant.components.hassio.addon_manager.async_start_addon"
+    ) as start_addon:
+        yield start_addon

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -1,18 +1,87 @@
 """Test the Matter config flow."""
-from unittest.mock import patch
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import DEFAULT, AsyncMock, MagicMock, call, patch
 
 from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.matter.const import DOMAIN
+from homeassistant.components.hassio import HassioAPIError, HassioServiceInfo
+from homeassistant.components.matter.const import ADDON_SLUG, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
+ADDON_DISCOVERY_INFO = {
+    "addon": "Matter Server",
+    "host": "host1",
+    "port": 5581,
+}
 
-async def test_user_create_entry(hass: HomeAssistant) -> None:
+
+@pytest.fixture(name="setup_entry", autouse=True)
+def setup_entry_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock entry setup."""
+    with patch(
+        "homeassistant.components.matter.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture(name="client_connect", autouse=True)
+def client_connect_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock server version."""
+    with patch(
+        "homeassistant.components.matter.config_flow.Client.connect"
+    ) as client_connect:
+        yield client_connect
+
+
+@pytest.fixture(name="supervisor")
+def supervisor_fixture() -> Generator[MagicMock, None, None]:
+    """Mock Supervisor."""
+    with patch(
+        "homeassistant.components.matter.config_flow.is_hassio", return_value=True
+    ) as is_hassio:
+        yield is_hassio
+
+
+@pytest.fixture(name="discovery_info")
+def discovery_info_fixture() -> Any:
+    """Return the discovery info from the supervisor."""
+    return DEFAULT
+
+
+@pytest.fixture(name="get_addon_discovery_info", autouse=True)
+def get_addon_discovery_info_fixture(
+    discovery_info: Any,
+) -> Generator[AsyncMock, None, None]:
+    """Mock get add-on discovery info."""
+    with patch(
+        "homeassistant.components.hassio.addon_manager.async_get_addon_discovery_info",
+        return_value=discovery_info,
+    ) as get_addon_discovery_info:
+        yield get_addon_discovery_info
+
+
+@pytest.fixture(name="addon_setup_time", autouse=True)
+def addon_setup_time_fixture() -> Generator[int, None, None]:
+    """Mock add-on setup sleep time."""
+    with patch(
+        "homeassistant.components.matter.config_flow.ADDON_SETUP_TIMEOUT", new=0
+    ) as addon_setup_time:
+        yield addon_setup_time
+
+
+async def test_manual_create_entry(
+    hass: HomeAssistant,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
     """Test user step create entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -20,24 +89,23 @@ async def test_user_create_entry(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] is None
 
-    with patch("homeassistant.components.matter.config_flow.Client.connect",), patch(
-        "homeassistant.components.matter.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "url": "http://172.30.32.1:5580/chip_ws",
-            },
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "url": "ws://localhost:5580/chip_ws",
+        },
+    )
+    await hass.async_block_till_done()
 
+    assert client_connect.call_count == 1
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "http://172.30.32.1:5580/chip_ws"
+    assert result["title"] == "ws://localhost:5580/chip_ws"
     assert result["data"] == {
-        "url": "http://172.30.32.1:5580/chip_ws",
+        "url": "ws://localhost:5580/chip_ws",
+        "integration_created_addon": False,
+        "use_addon": False,
     }
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert setup_entry.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -48,33 +116,38 @@ async def test_user_create_entry(hass: HomeAssistant) -> None:
         ("unknown", Exception("Unknown boom")),
     ],
 )
-async def test_user_errors(
-    hass: HomeAssistant, error: str, side_effect: Exception
+async def test_manual_errors(
+    hass: HomeAssistant,
+    client_connect: AsyncMock,
+    error: str,
+    side_effect: Exception,
 ) -> None:
     """Test user step cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.matter.config_flow.Client.connect",
-        side_effect=side_effect,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "url": "http://172.30.32.1:5580/chip_ws",
-            },
-        )
+    client_connect.side_effect = side_effect
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "url": "ws://localhost:5580/chip_ws",
+        },
+    )
 
+    assert client_connect.call_count == 1
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": error}
 
 
-async def test_user_abort_single_instance_allowed(hass: HomeAssistant) -> None:
-    """Test user step abort as single instance only allowed."""
+async def test_manual_already_configured(
+    hass: HomeAssistant,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test manual step abort if already configured."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data={"url": "http://172.30.32.1:5580/chip_ws"}, title="Matter"
+        domain=DOMAIN, data={"url": "ws://host1:5581/chip_ws"}, title="Matter"
     )
     entry.add_to_hass(hass)
 
@@ -82,5 +155,825 @@ async def test_user_abort_single_instance_allowed(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "url": "ws://localhost:5580/chip_ws",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert client_connect.call_count == 1
     assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "single_instance_allowed"
+    assert result["reason"] == "reconfiguration_successful"
+    assert entry.data["url"] == "ws://localhost:5580/chip_ws"
+    assert entry.data["use_addon"] is False
+    assert entry.data["integration_created_addon"] is False
+    assert entry.title == "ws://localhost:5580/chip_ws"
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_supervisor_discovery(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test flow started from Supervisor discovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config=ADDON_DISCOVERY_INFO,
+            name="Matter Server",
+            slug=ADDON_SLUG,
+        ),
+    )
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
+
+    assert addon_info.call_count == 1
+    assert client_connect.call_count == 0
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ws://host1:5581/chip_ws"
+    assert result["data"] == {
+        "url": "ws://host1:5581/chip_ws",
+        "use_addon": True,
+        "integration_created_addon": False,
+    }
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "discovery_info, error",
+    [({"config": ADDON_DISCOVERY_INFO}, HassioAPIError())],
+)
+async def test_supervisor_discovery_addon_info_failed(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+    error: Exception,
+) -> None:
+    """Test Supervisor discovery and addon info failed."""
+    addon_info.side_effect = error
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config=ADDON_DISCOVERY_INFO,
+            name="Matter Server",
+            slug=ADDON_SLUG,
+        ),
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "hassio_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert addon_info.call_count == 1
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "addon_info_failed"
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_clean_supervisor_discovery_on_user_create(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test discovery flow is cleaned up when a user flow is finished."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config=ADDON_DISCOVERY_INFO,
+            name="Matter Server",
+            slug=ADDON_SLUG,
+        ),
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "hassio_confirm"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": False}
+    )
+
+    assert addon_info.call_count == 0
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "manual"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "url": "ws://localhost:5580/chip_ws",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.config_entries.flow.async_progress()) == 0
+    assert client_connect.call_count == 1
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ws://localhost:5580/chip_ws"
+    assert result["data"] == {
+        "url": "ws://localhost:5580/chip_ws",
+        "use_addon": False,
+        "integration_created_addon": False,
+    }
+    assert setup_entry.call_count == 1
+
+
+async def test_abort_supervisor_discovery_with_existing_entry(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+) -> None:
+    """Test discovery flow is aborted if an entry already exists."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"url": "ws://localhost:5580/chip_ws"},
+        title="ws://localhost:5580/chip_ws",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config=ADDON_DISCOVERY_INFO,
+            name="Matter Server",
+            slug=ADDON_SLUG,
+        ),
+    )
+
+    assert addon_info.call_count == 0
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_abort_supervisor_discovery_with_existing_flow(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_installed: AsyncMock,
+    addon_info: AsyncMock,
+) -> None:
+    """Test hassio discovery flow is aborted when another flow is in progress."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config=ADDON_DISCOVERY_INFO,
+            name="Matter Server",
+            slug=ADDON_SLUG,
+        ),
+    )
+
+    assert addon_info.call_count == 0
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_in_progress"
+
+
+async def test_abort_supervisor_discovery_for_other_addon(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_installed: AsyncMock,
+    addon_info: AsyncMock,
+) -> None:
+    """Test hassio discovery flow is aborted for a non official add-on discovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config={
+                "addon": "Other Matter Server",
+                "host": "host1",
+                "port": 3001,
+            },
+            name="Other Matter Server",
+            slug="other_addon",
+        ),
+    )
+
+    assert addon_info.call_count == 0
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "not_matter_addon"
+
+
+async def test_supervisor_discovery_addon_not_running(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_installed: AsyncMock,
+    addon_info: AsyncMock,
+    start_addon: AsyncMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test discovery with add-on already installed but not running."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config=ADDON_DISCOVERY_INFO,
+            name="Matter Server",
+            slug=ADDON_SLUG,
+        ),
+    )
+
+    assert addon_info.call_count == 0
+    assert result["step_id"] == "hassio_confirm"
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert addon_info.call_count == 1
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_matter_server")
+    assert client_connect.call_count == 1
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ws://host1:5581/chip_ws"
+    assert result["data"] == {
+        "url": "ws://host1:5581/chip_ws",
+        "use_addon": True,
+        "integration_created_addon": False,
+    }
+    assert setup_entry.call_count == 1
+
+
+async def test_supervisor_discovery_addon_not_installed(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_not_installed: AsyncMock,
+    install_addon: AsyncMock,
+    addon_info: AsyncMock,
+    addon_store_info: AsyncMock,
+    start_addon: AsyncMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test discovery with add-on not installed."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config=ADDON_DISCOVERY_INFO,
+            name="Matter Server",
+            slug=ADDON_SLUG,
+        ),
+    )
+
+    assert addon_info.call_count == 0
+    assert addon_store_info.call_count == 0
+    assert result["step_id"] == "hassio_confirm"
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert addon_info.call_count == 0
+    assert addon_store_info.call_count == 1
+    assert result["step_id"] == "install_addon"
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert install_addon.call_args == call(hass, "core_matter_server")
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_matter_server")
+    assert client_connect.call_count == 1
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ws://host1:5581/chip_ws"
+    assert result["data"] == {
+        "url": "ws://host1:5581/chip_ws",
+        "use_addon": True,
+        "integration_created_addon": True,
+    }
+    assert setup_entry.call_count == 1
+
+
+async def test_not_addon(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test opting out of add-on on Supervisor."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": False}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "manual"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "url": "ws://localhost:5581/chip_ws",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert client_connect.call_count == 1
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ws://localhost:5581/chip_ws"
+    assert result["data"] == {
+        "url": "ws://localhost:5581/chip_ws",
+        "use_addon": False,
+        "integration_created_addon": False,
+    }
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_addon_running(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test add-on already running on Supervisor."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+    await hass.async_block_till_done()
+
+    assert addon_info.call_count == 1
+    assert client_connect.call_count == 1
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ws://host1:5581/chip_ws"
+    assert result["data"] == {
+        "url": "ws://host1:5581/chip_ws",
+        "use_addon": True,
+        "integration_created_addon": False,
+    }
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "discovery_info, discovery_info_error, client_connect_error, addon_info_error, "
+    "abort_reason, discovery_info_called, client_connect_called",
+    [
+        (
+            {"config": ADDON_DISCOVERY_INFO},
+            HassioAPIError(),
+            None,
+            None,
+            "addon_get_discovery_info_failed",
+            True,
+            False,
+        ),
+        (
+            {"config": ADDON_DISCOVERY_INFO},
+            None,
+            CannotConnect(Exception("Boom")),
+            None,
+            "cannot_connect",
+            True,
+            True,
+        ),
+        (
+            None,
+            None,
+            None,
+            None,
+            "addon_get_discovery_info_failed",
+            True,
+            False,
+        ),
+        (
+            {"config": ADDON_DISCOVERY_INFO},
+            None,
+            None,
+            HassioAPIError(),
+            "addon_info_failed",
+            False,
+            False,
+        ),
+    ],
+)
+async def test_addon_running_failures(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+    get_addon_discovery_info: AsyncMock,
+    client_connect: AsyncMock,
+    discovery_info_error: Exception | None,
+    client_connect_error: Exception | None,
+    addon_info_error: Exception | None,
+    abort_reason: str,
+    discovery_info_called: bool,
+    client_connect_called: bool,
+) -> None:
+    """Test all failures when add-on is running."""
+    get_addon_discovery_info.side_effect = discovery_info_error
+    client_connect.side_effect = client_connect_error
+    addon_info.side_effect = addon_info_error
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+
+    assert addon_info.call_count == 1
+    assert get_addon_discovery_info.called is discovery_info_called
+    assert client_connect.called is client_connect_called
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == abort_reason
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_addon_running_already_configured(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test that only one instance is allowed when add-on is running."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "url": "ws://localhost:5580/chip_ws",
+        },
+        title="ws://localhost:5580/chip_ws",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+    await hass.async_block_till_done()
+
+    assert addon_info.call_count == 1
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfiguration_successful"
+    assert entry.data["url"] == "ws://host1:5581/chip_ws"
+    assert entry.title == "ws://host1:5581/chip_ws"
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_addon_installed(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_installed: AsyncMock,
+    addon_info: AsyncMock,
+    start_addon: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test add-on already installed but not running on Supervisor."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+
+    assert addon_info.call_count == 1
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_matter_server")
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ws://host1:5581/chip_ws"
+    assert result["data"] == {
+        "url": "ws://host1:5581/chip_ws",
+        "use_addon": True,
+        "integration_created_addon": False,
+    }
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "discovery_info, start_addon_error, client_connect_error, "
+    "discovery_info_called, client_connect_called",
+    [
+        (
+            {"config": ADDON_DISCOVERY_INFO},
+            HassioAPIError(),
+            None,
+            False,
+            False,
+        ),
+        (
+            {"config": ADDON_DISCOVERY_INFO},
+            None,
+            CannotConnect(Exception("Boom")),
+            True,
+            True,
+        ),
+        (
+            None,
+            None,
+            None,
+            True,
+            False,
+        ),
+    ],
+)
+async def test_addon_installed_failures(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_installed: AsyncMock,
+    addon_info: AsyncMock,
+    start_addon: AsyncMock,
+    get_addon_discovery_info: AsyncMock,
+    client_connect: AsyncMock,
+    start_addon_error: Exception | None,
+    client_connect_error: Exception | None,
+    discovery_info_called: bool,
+    client_connect_called: bool,
+) -> None:
+    """Test add-on start failure when add-on is installed."""
+    start_addon.side_effect = start_addon_error
+    client_connect.side_effect = client_connect_error
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+
+    assert addon_info.call_count == 1
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert start_addon.call_args == call(hass, "core_matter_server")
+    assert get_addon_discovery_info.called is discovery_info_called
+    assert client_connect.called is client_connect_called
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "addon_start_failed"
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_addon_installed_already_configured(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_installed: AsyncMock,
+    addon_info: AsyncMock,
+    start_addon: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test that only one instance is allowed when add-on is installed."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "url": "ws://localhost:5580/chip_ws",
+        },
+        title="ws://localhost:5580/chip_ws",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+
+    assert addon_info.call_count == 1
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_matter_server")
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfiguration_successful"
+    assert entry.data["url"] == "ws://host1:5581/chip_ws"
+    assert entry.title == "ws://host1:5581/chip_ws"
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_addon_not_installed(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_not_installed: AsyncMock,
+    install_addon: AsyncMock,
+    addon_info: AsyncMock,
+    addon_store_info: AsyncMock,
+    start_addon: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test add-on not installed."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+
+    assert addon_info.call_count == 0
+    assert addon_store_info.call_count == 1
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "install_addon"
+
+    # Make sure the flow continues when the progress task is done.
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert install_addon.call_args == call(hass, "core_matter_server")
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_matter_server")
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ws://host1:5581/chip_ws"
+    assert result["data"] == {
+        "url": "ws://host1:5581/chip_ws",
+        "use_addon": True,
+        "integration_created_addon": True,
+    }
+    assert setup_entry.call_count == 1
+
+
+async def test_addon_not_installed_failures(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_not_installed: AsyncMock,
+    addon_info: AsyncMock,
+    install_addon: AsyncMock,
+) -> None:
+    """Test add-on install failure."""
+    install_addon.side_effect = HassioAPIError()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "install_addon"
+
+    # Make sure the flow continues when the progress task is done.
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert install_addon.call_args == call(hass, "core_matter_server")
+    assert addon_info.call_count == 0
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "addon_install_failed"
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_addon_not_installed_already_configured(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_not_installed: AsyncMock,
+    addon_info: AsyncMock,
+    addon_store_info: AsyncMock,
+    install_addon: AsyncMock,
+    start_addon: AsyncMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+) -> None:
+    """Test that only one instance is allowed when add-on is not installed."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "url": "ws://localhost:5580/chip_ws",
+        },
+        title="ws://localhost:5580/chip_ws",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+
+    assert addon_info.call_count == 0
+    assert addon_store_info.call_count == 1
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "install_addon"
+
+    # Make sure the flow continues when the progress task is done.
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert install_addon.call_args == call(hass, "core_matter_server")
+    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_matter_server")
+    assert client_connect.call_count == 1
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfiguration_successful"
+    assert entry.data["url"] == "ws://host1:5581/chip_ws"
+    assert entry.title == "ws://host1:5581/chip_ws"
+    assert setup_entry.call_count == 1


### PR DESCRIPTION
Co-authored-by: Marcel van der Veldt <m.vanderveldt@outlook.com><!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add matter server add-on flow.
- Use add-on manager to install and start the add-on as needed during the config flow.
- Managing the add-on when setting up the config entry is TODO and not part of this PR.
- Note that this PR targets a separate branch and not the dev branch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
