### PR TITLE
Handle serial port enumeration within the USB integration

### DIFF
--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -9,8 +9,6 @@ from crownstone_cloud.exceptions import (
     CrownstoneAuthenticationError,
     CrownstoneUnknownError,
 )
-import serial.tools.list_ports
-from serial.tools.list_ports_common import ListPortInfo
 import voluptuous as vol
 
 from homeassistant.components import usb
@@ -55,9 +53,7 @@ class BaseCrownstoneFlowHandler(FlowHandler):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Set up a Crownstone USB dongle."""
-        list_of_ports = await self.hass.async_add_executor_job(
-            serial.tools.list_ports.comports
-        )
+        list_of_ports = await self.hass.async_add_executor_job(usb.list_serial_ports)
         if self.flow_type == CONFIG_FLOW:
             ports_as_string = list_ports_as_str(list_of_ports)
         else:
@@ -76,7 +72,7 @@ class BaseCrownstoneFlowHandler(FlowHandler):
                 else:
                     index = ports_as_string.index(selection) - 1
 
-                selected_port: ListPortInfo = list_of_ports[index]
+                selected_port: usb.USBDevice = list_of_ports[index]
                 self.usb_path = await self.hass.async_add_executor_job(
                     usb.get_serial_by_id, selected_port.device
                 )

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -14,7 +14,7 @@ from crownstone_sse import CrownstoneSSEAsync
 from crownstone_uart import CrownstoneUart, UartEventBus
 from crownstone_uart.Exceptions import UartException
 
-from homeassistant.components import persistent_notification
+from homeassistant.components import persistent_notification, usb
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
@@ -31,7 +31,6 @@ from .const import (
     SSE_LISTENERS,
     UART_LISTENERS,
 )
-from .helpers import get_port
 from .listeners import setup_sse_listeners, setup_uart_listeners
 
 _LOGGER = logging.getLogger(__name__)
@@ -124,7 +123,7 @@ class CrownstoneEntryManager:
         """Attempt setup of a Crownstone usb dongle."""
         # Trace by-id symlink back to the serial port
         serial_port = await self.hass.async_add_executor_job(
-            get_port, self.config_entry.options[CONF_USB_PATH]
+            usb.get_serial_by_id, self.config_entry.options[CONF_USB_PATH]
         )
         if serial_port is None:
             return

--- a/homeassistant/components/crownstone/helpers.py
+++ b/homeassistant/components/crownstone/helpers.py
@@ -1,17 +1,13 @@
 """Helper functions for the Crownstone integration."""
 from __future__ import annotations
 
-import os
-
-from serial.tools.list_ports_common import ListPortInfo
-
 from homeassistant.components import usb
 
 from .const import DONT_USE_USB, MANUAL_PATH, REFRESH_LIST
 
 
 def list_ports_as_str(
-    serial_ports: list[ListPortInfo], no_usb_option: bool = True
+    serial_ports: list[usb.USBDevice], no_usb_option: bool = True
 ) -> list[str]:
     """
     Represent currently available serial ports as string.
@@ -25,33 +21,11 @@ def list_ports_as_str(
         ports_as_string.append(DONT_USE_USB)
 
     for port in serial_ports:
-        ports_as_string.append(
-            usb.human_readable_device_name(
-                port.device,
-                port.serial_number,
-                port.manufacturer,
-                port.description,
-                f"{hex(port.vid)[2:]:0>4}".upper() if port.vid else None,
-                f"{hex(port.pid)[2:]:0>4}".upper() if port.pid else None,
-            )
-        )
+        ports_as_string.append(usb.human_readable_device_name(port))
     ports_as_string.append(MANUAL_PATH)
     ports_as_string.append(REFRESH_LIST)
 
     return ports_as_string
-
-
-def get_port(dev_path: str) -> str | None:
-    """Get the port that the by-id link points to."""
-    # not a by-id link, but just given path
-    by_id = "/dev/serial/by-id"
-    if by_id not in dev_path:
-        return dev_path
-
-    try:
-        return f"/dev/{os.path.basename(os.readlink(dev_path))}"
-    except FileNotFoundError:
-        return None
 
 
 def map_from_to(val: int, in_min: int, in_max: int, out_min: int, out_max: int) -> int:

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -15,23 +15,18 @@ class HomeAssistantSkyConnectConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_usb(self, discovery_info: usb.UsbServiceInfo) -> FlowResult:
         """Handle usb discovery."""
-        device = discovery_info.device
-        vid = discovery_info.vid
-        pid = discovery_info.pid
-        serial_number = discovery_info.serial_number
-        manufacturer = discovery_info.manufacturer
-        description = discovery_info.description
-        unique_id = f"{vid}:{pid}_{serial_number}_{manufacturer}_{description}"
-        if await self.async_set_unique_id(unique_id):
-            self._abort_if_unique_id_configured(updates={"device": device})
+        if await self.async_set_unique_id(usb.generate_unique_id(discovery_info)):
+            self._abort_if_unique_id_configured(
+                updates={"device": discovery_info.device}
+            )
         return self.async_create_entry(
             title="Home Assistant Sky Connect",
             data={
-                "device": device,
-                "vid": vid,
-                "pid": pid,
-                "serial_number": serial_number,
-                "manufacturer": manufacturer,
-                "description": description,
+                "device": discovery_info.device,
+                "vid": discovery_info.vid,
+                "pid": discovery_info.pid,
+                "serial_number": discovery_info.serial_number,
+                "manufacturer": discovery_info.manufacturer,
+                "description": discovery_info.description,
             },
         )

--- a/homeassistant/components/insteon/config_flow.py
+++ b/homeassistant/components/insteon/config_flow.py
@@ -194,18 +194,8 @@ class InsteonFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 
-        dev_path = await self.hass.async_add_executor_job(
-            usb.get_serial_by_id, discovery_info.device
-        )
-        self._device_path = dev_path
-        self._device_name = usb.human_readable_device_name(
-            dev_path,
-            discovery_info.serial_number,
-            discovery_info.manufacturer,
-            discovery_info.description,
-            discovery_info.vid,
-            discovery_info.pid,
-        )
+        self._device_path = discovery_info.device
+        self._device_name = usb.human_readable_device_name(discovery_info)
         self._set_confirm_only()
         self.context["title_placeholders"] = {
             CONF_NAME: f"Insteon PLM {self._device_name}"

--- a/homeassistant/components/landisgyr_heat_meter/config_flow.py
+++ b/homeassistant/components/landisgyr_heat_meter/config_flow.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import async_timeout
 import serial
-from serial.tools import list_ports
 import ultraheat_api
 import voluptuous as vol
 
@@ -119,22 +118,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 async def get_usb_ports(hass: HomeAssistant) -> dict[str, str]:
     """Return a dict of USB ports and their friendly names."""
-    ports = await hass.async_add_executor_job(list_ports.comports)
+    ports = await hass.async_add_executor_job(usb.list_serial_ports)
     port_descriptions = {}
     for port in ports:
         # this prevents an issue with usb_device_from_port not working for ports without vid on RPi
         if port.vid:
-            usb_device = usb.usb_device_from_port(port)
-            dev_path = usb.get_serial_by_id(usb_device.device)
-            human_name = usb.human_readable_device_name(
-                dev_path,
-                usb_device.serial_number,
-                usb_device.manufacturer,
-                usb_device.description,
-                usb_device.vid,
-                usb_device.pid,
-            )
-            port_descriptions[dev_path] = human_name
+            port_descriptions[port.device] = usb.human_readable_device_name(port)
 
     return port_descriptions
 

--- a/homeassistant/components/usb/models.py
+++ b/homeassistant/components/usb/models.py
@@ -9,8 +9,8 @@ class USBDevice:
     """A usb device."""
 
     device: str
-    vid: str
-    pid: str
+    vid: str | None
+    pid: str | None
     serial_number: str | None
     manufacturer: str | None
     description: str | None

--- a/homeassistant/components/usb/models.py
+++ b/homeassistant/components/usb/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class USBDevice:
     """A usb device."""
 

--- a/homeassistant/components/usb/utils.py
+++ b/homeassistant/components/usb/utils.py
@@ -1,6 +1,9 @@
 """The USB Discovery integration."""
 from __future__ import annotations
 
+import os.path
+
+from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
 
 from .models import USBDevice
@@ -10,9 +13,36 @@ def usb_device_from_port(port: ListPortInfo) -> USBDevice:
     """Convert serial ListPortInfo to USBDevice."""
     return USBDevice(
         device=port.device,
-        vid=f"{hex(port.vid)[2:]:0>4}".upper(),
-        pid=f"{hex(port.pid)[2:]:0>4}".upper(),
+        vid=f"{port.vid:04X}" if port.vid is not None else None,
+        pid=f"{port.pid:04X}" if port.pid is not None else None,
         serial_number=port.serial_number,
         manufacturer=port.manufacturer,
         description=port.description,
     )
+
+
+def get_by_id_symlinks() -> dict[str, str]:
+    """Map all `by-id` symlinks to their resolved location."""
+    by_id = "/dev/serial/by-id"
+
+    if not os.path.isdir(by_id):
+        return {}
+
+    return {
+        os.path.realpath(path): path
+        for path in (entry.path for entry in os.scandir(by_id) if entry.is_symlink())
+    }
+
+
+def list_serial_ports() -> list[USBDevice]:
+    """List all available serial ports."""
+    ports = []
+    by_id_symlinks = get_by_id_symlinks()
+
+    for port in comports():
+        if port.device in by_id_symlinks:
+            port.device = by_id_symlinks[port.device]
+
+        ports.append(usb_device_from_port(port))
+
+    return ports

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -71,19 +71,14 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_usb(self, discovery_info: usb.UsbServiceInfo) -> FlowResult:
         """Handle USB Discovery."""
-        await self.async_set_unique_id(
-            f"{discovery_info.vid}:{discovery_info.pid}_{discovery_info.serial_number}_{discovery_info.manufacturer}_{discovery_info.description}"
-        )
-        dev_path = await self.hass.async_add_executor_job(
-            usb.get_serial_by_id, discovery_info.device
-        )
+        await self.async_set_unique_id(usb.generate_unique_id(discovery_info))
         # check if this device is not already configured
-        self._async_abort_entries_match({CONF_PORT: dev_path})
+        self._async_abort_entries_match({CONF_PORT: discovery_info.device})
         # check if we can make a valid velbus connection
-        if not await self._test_connection(dev_path):
+        if not await self._test_connection(discovery_info.device):
             return self.async_abort(reason="cannot_connect")
         # store the data for the config step
-        self._device = dev_path
+        self._device = discovery_info.device
         self._title = "Velbus USB"
         # call the config step
         self._set_confirm_only()

--- a/tests/components/landisgyr_heat_meter/test_config_flow.py
+++ b/tests/components/landisgyr_heat_meter/test_config_flow.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 from unittest.mock import patch
 
 import serial
-import serial.tools.list_ports
 
 from homeassistant import config_entries
+from homeassistant.components import usb
 from homeassistant.components.landisgyr_heat_meter import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -16,16 +16,15 @@ API_HEAT_METER_SERVICE = "homeassistant.components.landisgyr_heat_meter.config_f
 
 
 def mock_serial_port():
-    """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo("/dev/ttyUSB1234")
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = "/dev/ttyUSB1234"
-    port.description = "Some serial port"
-    port.pid = 9876
-    port.vid = 5678
-
-    return port
+    """Mock USB serial port."""
+    return usb.USBDevice(
+        serial_number="1234",
+        manufacturer="Virtual serial port",
+        device="/dev/ttyUSB1234",
+        description="Some serial port",
+        pid=9876,
+        vid=5678,
+    )
 
 
 @dataclass
@@ -75,7 +74,9 @@ async def test_manual_entry(mock_heat_meter, hass: HomeAssistant) -> None:
 
 
 @patch(API_HEAT_METER_SERVICE)
-@patch("serial.tools.list_ports.comports", return_value=[mock_serial_port()])
+@patch(
+    "homeassistant.components.usb.list_serial_ports", return_value=[mock_serial_port()]
+)
 async def test_list_entry(mock_port, mock_heat_meter, hass: HomeAssistant) -> None:
     """Test select from list entry."""
 
@@ -136,7 +137,9 @@ async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
 
 
 @patch(API_HEAT_METER_SERVICE)
-@patch("serial.tools.list_ports.comports", return_value=[mock_serial_port()])
+@patch(
+    "homeassistant.components.usb.list_serial_ports", return_value=[mock_serial_port()]
+)
 async def test_list_entry_fail(mock_port, mock_heat_meter, hass: HomeAssistant) -> None:
     """Test select from list entry fails."""
 
@@ -159,7 +162,9 @@ async def test_list_entry_fail(mock_port, mock_heat_meter, hass: HomeAssistant) 
 
 
 @patch(API_HEAT_METER_SERVICE)
-@patch("serial.tools.list_ports.comports", return_value=[mock_serial_port()])
+@patch(
+    "homeassistant.components.usb.list_serial_ports", return_value=[mock_serial_port()]
+)
 async def test_already_configured(
     mock_port, mock_heat_meter, hass: HomeAssistant
 ) -> None:

--- a/tests/components/modem_callerid/__init__.py
+++ b/tests/components/modem_callerid/__init__.py
@@ -3,7 +3,8 @@
 from unittest.mock import patch
 
 from phone_modem import DEFAULT_PORT
-from serial.tools.list_ports_common import ListPortInfo
+
+from homeassistant.components.usb import USBDevice
 
 
 def patch_init_modem():
@@ -20,12 +21,13 @@ def patch_config_flow_modem():
     )
 
 
-def com_port():
+def serial_port():
     """Mock of a serial port."""
-    port = ListPortInfo(DEFAULT_PORT)
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = DEFAULT_PORT
-    port.description = "Some serial port"
-
-    return port
+    return USBDevice(
+        device=DEFAULT_PORT,
+        vid=None,
+        pid=None,
+        serial_number="1234",
+        manufacturer="Virtual serial port",
+        description="Some serial port",
+    )

--- a/tests/components/modem_callerid/test_init.py
+++ b/tests/components/modem_callerid/test_init.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICE
 from homeassistant.core import HomeAssistant
 
-from . import com_port, patch_init_modem
+from . import patch_init_modem, serial_port
 
 from tests.common import MockConfigEntry
 
@@ -17,7 +17,7 @@ async def test_setup_entry(hass: HomeAssistant):
     """Test Modem Caller ID entry setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_DEVICE: com_port().device},
+        data={CONF_DEVICE: serial_port().device},
     )
     entry.add_to_hass(hass)
     with patch("aioserial.AioSerial", autospec=True), patch(
@@ -32,7 +32,7 @@ async def test_async_setup_entry_not_ready(hass: HomeAssistant):
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_DEVICE: com_port().device},
+        data={CONF_DEVICE: serial_port().device},
     )
     entry.add_to_hass(hass)
 
@@ -48,7 +48,7 @@ async def test_unload_entry(hass: HomeAssistant):
     """Test unload."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_DEVICE: com_port().device},
+        data={CONF_DEVICE: serial_port().device},
     )
     entry.add_to_hass(hass)
     with patch_init_modem():

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -63,8 +63,8 @@ async def test_observer_discovery(hass, hass_ws_client, venv):
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -88,7 +88,7 @@ async def test_observer_discovery(hass, hass_ws_client, venv):
     ), patch("pyudev.Monitor.filter_by"), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -126,8 +126,8 @@ async def test_removal_by_observer_before_started(hass, operating_system):
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -137,7 +137,7 @@ async def test_removal_by_observer_before_started(hass, operating_system):
     with patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch(
         "pyudev.MonitorObserver", new=_create_mock_monitor_observer
     ), patch.object(
@@ -146,7 +146,7 @@ async def test_removal_by_observer_before_started(hass, operating_system):
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
 
-    with patch("homeassistant.components.usb.comports", return_value=[]):
+    with patch("homeassistant.components.usb.list_serial_ports", return_value=[]):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
@@ -163,8 +163,8 @@ async def test_discovered_by_websocket_scan(hass, hass_ws_client):
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -174,7 +174,7 @@ async def test_discovered_by_websocket_scan(hass, hass_ws_client):
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -203,8 +203,8 @@ async def test_discovered_by_websocket_scan_limited_by_description_matcher(
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -214,7 +214,7 @@ async def test_discovered_by_websocket_scan_limited_by_description_matcher(
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -242,8 +242,8 @@ async def test_most_targeted_matcher_wins(hass, hass_ws_client):
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -253,7 +253,7 @@ async def test_most_targeted_matcher_wins(hass, hass_ws_client):
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -282,8 +282,8 @@ async def test_discovered_by_websocket_scan_rejected_by_description_matcher(
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -293,7 +293,7 @@ async def test_discovered_by_websocket_scan_rejected_by_description_matcher(
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -326,8 +326,8 @@ async def test_discovered_by_websocket_scan_limited_by_serial_number_matcher(
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -337,7 +337,7 @@ async def test_discovered_by_websocket_scan_limited_by_serial_number_matcher(
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -366,8 +366,8 @@ async def test_discovered_by_websocket_scan_rejected_by_serial_number_matcher(
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -377,7 +377,7 @@ async def test_discovered_by_websocket_scan_rejected_by_serial_number_matcher(
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -410,8 +410,8 @@ async def test_discovered_by_websocket_scan_limited_by_manufacturer_matcher(
     mock_comports = [
         MagicMock(
             device=conbee_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=conbee_device.serial_number,
             manufacturer=conbee_device.manufacturer,
             description=conbee_device.description,
@@ -421,7 +421,7 @@ async def test_discovered_by_websocket_scan_limited_by_manufacturer_matcher(
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -455,8 +455,8 @@ async def test_discovered_by_websocket_scan_rejected_by_manufacturer_matcher(
     mock_comports = [
         MagicMock(
             device=conbee_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=conbee_device.serial_number,
             manufacturer=conbee_device.manufacturer,
             description=conbee_device.description,
@@ -466,7 +466,7 @@ async def test_discovered_by_websocket_scan_rejected_by_manufacturer_matcher(
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -494,8 +494,8 @@ async def test_discovered_by_websocket_rejected_with_empty_serial_number_only(
     mock_comports = [
         MagicMock(
             device=conbee_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=None,
             manufacturer=None,
             description=None,
@@ -505,7 +505,7 @@ async def test_discovered_by_websocket_rejected_with_empty_serial_number_only(
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -529,8 +529,8 @@ async def test_discovered_by_websocket_scan_match_vid_only(hass, hass_ws_client)
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -540,7 +540,7 @@ async def test_discovered_by_websocket_scan_match_vid_only(hass, hass_ws_client)
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -565,8 +565,8 @@ async def test_discovered_by_websocket_scan_match_vid_wrong_pid(hass, hass_ws_cl
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -576,7 +576,7 @@ async def test_discovered_by_websocket_scan_match_vid_wrong_pid(hass, hass_ws_cl
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -611,7 +611,7 @@ async def test_discovered_by_websocket_no_vid_pid(hass, hass_ws_client):
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -638,8 +638,8 @@ async def test_non_matching_discovered_by_scanner_after_started(
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -649,7 +649,7 @@ async def test_non_matching_discovered_by_scanner_after_started(
     with patch("pyudev.Context", side_effect=exception_type), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -679,8 +679,8 @@ async def test_observer_on_wsl_fallback_without_throwing_exception(
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -690,7 +690,7 @@ async def test_observer_on_wsl_fallback_without_throwing_exception(
     with patch("pyudev.Context"), patch(
         "pyudev.Monitor.filter_by", side_effect=ValueError
     ), patch("homeassistant.components.usb.async_get_usb", return_value=new_usb), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow:
@@ -729,8 +729,8 @@ async def test_not_discovered_by_observer_before_started_on_docker(hass, docker)
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -740,16 +740,16 @@ async def test_not_discovered_by_observer_before_started_on_docker(hass, docker)
     with patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch(
         "pyudev.MonitorObserver", new=_create_mock_monitor_observer
     ):
         assert await async_setup_component(hass, "usb", {"usb": {}})
         await hass.async_block_till_done()
 
-    with patch("homeassistant.components.usb.comports", return_value=[]), patch.object(
-        hass.config_entries.flow, "async_init"
-    ) as mock_config_flow:
+    with patch(
+        "homeassistant.components.usb.list_serial_ports", return_value=[]
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_config_flow:
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
@@ -806,12 +806,14 @@ def test_get_serial_by_id():
 def test_human_readable_device_name():
     """Test human readable device name includes the passed data."""
     name = usb.human_readable_device_name(
-        "/dev/null",
-        "612020FD",
-        "Silicon Labs",
-        "HubZ Smart Home Controller - HubZ Z-Wave Com Port",
-        "10C4",
-        "8A2A",
+        usb.UsbServiceInfo(
+            device="/dev/null",
+            vid="612020FD",
+            pid="Silicon Labs",
+            serial_number="HubZ Smart Home Controller - HubZ Z-Wave Com Port",
+            manufacturer="10C4",
+            description="8A2A",
+        )
     )
     assert "/dev/null" in name
     assert "612020FD" in name
@@ -821,12 +823,14 @@ def test_human_readable_device_name():
     assert "8A2A" in name
 
     name = usb.human_readable_device_name(
-        "/dev/null",
-        "612020FD",
-        "Silicon Labs",
-        None,
-        "10C4",
-        "8A2A",
+        usb.UsbServiceInfo(
+            device="/dev/null",
+            vid="612020FD",
+            pid="Silicon Labs",
+            serial_number=None,
+            manufacturer="10C4",
+            description="8A2A",
+        )
     )
     assert "/dev/null" in name
     assert "612020FD" in name
@@ -842,8 +846,8 @@ async def test_async_is_plugged_in(hass, hass_ws_client):
     mock_comports = [
         MagicMock(
             device=slae_sh_device.device,
-            vid=12345,
-            pid=12345,
+            vid="3039",
+            pid="3039",
             serial_number=slae_sh_device.serial_number,
             manufacturer=slae_sh_device.manufacturer,
             description=slae_sh_device.description,
@@ -857,7 +861,9 @@ async def test_async_is_plugged_in(hass, hass_ws_client):
 
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
-    ), patch("homeassistant.components.usb.comports", return_value=[]), patch.object(
+    ), patch(
+        "homeassistant.components.usb.list_serial_ports", return_value=[]
+    ), patch.object(
         hass.config_entries.flow, "async_init"
     ):
         assert await async_setup_component(hass, "usb", {"usb": {}})
@@ -867,7 +873,7 @@ async def test_async_is_plugged_in(hass, hass_ws_client):
         assert not usb.async_is_plugged_in(hass, matcher)
 
     with patch(
-        "homeassistant.components.usb.comports", return_value=mock_comports
+        "homeassistant.components.usb.list_serial_ports", return_value=mock_comports
     ), patch.object(hass.config_entries.flow, "async_init"):
         ws_client = await hass_ws_client(hass)
         await ws_client.send_json({"id": 1, "type": "usb/scan"})
@@ -894,7 +900,9 @@ async def test_async_is_plugged_in_case_enforcement(hass, matcher):
 
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
-    ), patch("homeassistant.components.usb.comports", return_value=[]), patch.object(
+    ), patch(
+        "homeassistant.components.usb.list_serial_ports", return_value=[]
+    ), patch.object(
         hass.config_entries.flow, "async_init"
     ):
         assert await async_setup_component(hass, "usb", {"usb": {}})
@@ -912,7 +920,9 @@ async def test_web_socket_triggers_discovery_request_callbacks(hass, hass_ws_cli
 
     with patch("pyudev.Context", side_effect=ImportError), patch(
         "homeassistant.components.usb.async_get_usb", return_value=[]
-    ), patch("homeassistant.components.usb.comports", return_value=[]), patch.object(
+    ), patch(
+        "homeassistant.components.usb.list_serial_ports", return_value=[]
+    ), patch.object(
         hass.config_entries.flow, "async_init"
     ):
         assert await async_setup_component(hass, "usb", {"usb": {}})

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -2,7 +2,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import serial.tools.list_ports
 from velbusaio.exceptions import VelbusConnectionFailed
 
 from homeassistant import data_entry_flow
@@ -26,14 +25,16 @@ DISCOVERY_INFO = usb.UsbServiceInfo(
 )
 
 
-def com_port():
+def serial_port():
     """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo(PORT_SERIAL)
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = PORT_SERIAL
-    port.description = "Some serial port"
-    return port
+    return usb.USBDevice(
+        serial_number="1234",
+        manufacturer="Virtual serial port",
+        device=PORT_SERIAL,
+        description="Some serial port",
+        vid=None,
+        pid=None,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -125,7 +126,10 @@ async def test_abort_if_already_setup(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("controller")
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.usb.list_serial_ports",
+    MagicMock(return_value=[serial_port()]),
+)
 async def test_flow_usb(hass: HomeAssistant):
     """Test usb discovery flow."""
     result = await hass.config_entries.flow.async_init(
@@ -161,7 +165,10 @@ async def test_flow_usb(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("controller_connection_failed")
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.usb.list_serial_ports",
+    MagicMock(return_value=[serial_port()]),
+)
 async def test_flow_usb_failed(hass: HomeAssistant):
     """Test usb discovery flow with a failed velbus test."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -4,7 +4,6 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
-import serial.tools.list_ports
 from zigpy.backups import BackupManager
 import zigpy.config
 from zigpy.config import CONF_DEVICE_PATH
@@ -68,17 +67,6 @@ def mock_detect_radio_type(radio_type=RadioType.ezsp, ret=True):
         return ret
 
     return detect
-
-
-def com_port(device="/dev/ttyUSB1234"):
-    """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo("/dev/ttyUSB1234")
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = device
-    port.description = "Some serial port"
-
-    return port
 
 
 @pytest.fixture()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The handful of integrations using serial ports rely on duplicated variants of the following code in order to function:

```Python
import serial.tools.list_ports

# Scan for ports
ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)

# Format the ports, to be shown in config flows
list_of_ports = {}

for port in ports:
    list_of_ports[
        port.device
    ] = f"{port}, s/n: {port.serial_number or 'n/a'}" + (
        f" - {port.manufacturer}" if port.manufacturer else ""
    )

# After a port is chosen, obtain its stable /by-id/ symlink
unique_path = await self.hass.async_add_executor_job(usb.get_serial_by_id, device)
```

This PR introduces a few new functions:

 - `homeassistant.components.usb.list_serial_ports`: returns a list of `USBDevice` objects, all using the `/dev/serial/by-id/` symlink as the serial port path (if possible).
 - `homeassistant.components.usb.generate_unique_id`: creates a unique ID for a `USBDevice`. Used by many config flows.

A potential future use case is hiding serial ports if addons are currently using them, until we can figure out a more granular hardware locking API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
