### PR TITLE
Add deconz_relative_rotary event for Hue Tap Dial

### DIFF
--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -57,3 +57,6 @@ POWER_PLUGS = [
 
 CONF_ANGLE = "angle"
 CONF_GESTURE = "gesture"
+
+ATTR_DURATION = "duration"
+ATTR_ROTATION = "rotation"

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -10,6 +10,7 @@ from pydeconz.models.sensor.ancillary_control import (
     AncillaryControlAction,
 )
 from pydeconz.models.sensor.presence import Presence, PresenceStatePresenceEvent
+from pydeconz.models.sensor.relative_rotary import RelativeRotary, RelativeRotaryEvent
 from pydeconz.models.sensor.switch import Switch
 
 from homeassistant.const import (
@@ -23,13 +24,14 @@ from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.util import slugify
 
-from .const import CONF_ANGLE, CONF_GESTURE, LOGGER
+from .const import ATTR_DURATION, ATTR_ROTATION, CONF_ANGLE, CONF_GESTURE, LOGGER
 from .deconz_device import DeconzBase
 from .gateway import DeconzGateway
 
 CONF_DECONZ_EVENT = "deconz_event"
 CONF_DECONZ_ALARM_EVENT = "deconz_alarm_event"
 CONF_DECONZ_PRESENCE_EVENT = "deconz_presence_event"
+CONF_DECONZ_RELATIVE_ROTARY_EVENT = "deconz_relative_rotary_event"
 
 SUPPORTED_DECONZ_ALARM_EVENTS = {
     AncillaryControlAction.EMERGENCY,
@@ -47,6 +49,10 @@ SUPPORTED_DECONZ_PRESENCE_EVENTS = {
     PresenceStatePresenceEvent.APPROACHING,
     PresenceStatePresenceEvent.ABSENTING,
 }
+RELATIVE_ROTARY_DECONZ_TO_EVENT = {
+    RelativeRotaryEvent.NEW: "new",
+    RelativeRotaryEvent.REPEAT: "repeat",
+}
 
 
 async def async_setup_events(gateway: DeconzGateway) -> None:
@@ -55,7 +61,7 @@ async def async_setup_events(gateway: DeconzGateway) -> None:
     @callback
     def async_add_sensor(_: EventType, sensor_id: str) -> None:
         """Create DeconzEvent."""
-        new_event: DeconzAlarmEvent | DeconzEvent | DeconzPresenceEvent
+        new_event: DeconzAlarmEvent | DeconzEvent | DeconzPresenceEvent | DeconzRelativeRotaryEvent
         sensor = gateway.api.sensors[sensor_id]
 
         if isinstance(sensor, Switch):
@@ -68,6 +74,9 @@ async def async_setup_events(gateway: DeconzGateway) -> None:
             if sensor.presence_event is None:
                 return
             new_event = DeconzPresenceEvent(sensor, gateway)
+
+        elif isinstance(sensor, RelativeRotary):
+            new_event = DeconzRelativeRotaryEvent(sensor, gateway)
 
         gateway.hass.async_create_task(new_event.async_update_device_registry())
         gateway.events.append(new_event)
@@ -83,6 +92,10 @@ async def async_setup_events(gateway: DeconzGateway) -> None:
     gateway.register_platform_add_device_callback(
         async_add_sensor,
         gateway.api.sensors.presence,
+    )
+    gateway.register_platform_add_device_callback(
+        async_add_sensor,
+        gateway.api.sensors.relative_rotary,
     )
 
 
@@ -104,7 +117,7 @@ class DeconzEventBase(DeconzBase):
 
     def __init__(
         self,
-        device: AncillaryControl | Presence | Switch,
+        device: AncillaryControl | Presence | RelativeRotary | Switch,
         gateway: DeconzGateway,
     ) -> None:
         """Register callback that will be used for signals."""
@@ -227,3 +240,29 @@ class DeconzPresenceEvent(DeconzEventBase):
         }
 
         self.gateway.hass.bus.async_fire(CONF_DECONZ_PRESENCE_EVENT, data)
+
+
+class DeconzRelativeRotaryEvent(DeconzEventBase):
+    """Relative rotary event."""
+
+    _device: RelativeRotary
+
+    @callback
+    def async_update_callback(self) -> None:
+        """Fire the event if reason is new action is updated."""
+        if (
+            self.gateway.ignore_state_updates
+            or "rotaryevent" not in self._device.changed_keys
+        ):
+            return
+
+        data = {
+            CONF_ID: self.event_id,
+            CONF_UNIQUE_ID: self.serial,
+            CONF_DEVICE_ID: self.device_id,
+            CONF_EVENT: RELATIVE_ROTARY_DECONZ_TO_EVENT[self._device.rotary_event],
+            ATTR_ROTATION: self._device.expected_rotation,
+            ATTR_DURATION: self._device.expected_event_duration,
+        }
+
+        self.gateway.hass.bus.async_fire(CONF_DECONZ_RELATIVE_ROTARY_EVENT, data)

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -28,6 +28,7 @@ from .deconz_event import (
     DeconzAlarmEvent,
     DeconzEvent,
     DeconzPresenceEvent,
+    DeconzRelativeRotaryEvent,
 )
 from .gateway import DeconzGateway
 
@@ -635,7 +636,7 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 def _get_deconz_event_from_device(
     hass: HomeAssistant,
     device: dr.DeviceEntry,
-) -> DeconzAlarmEvent | DeconzEvent | DeconzPresenceEvent:
+) -> DeconzAlarmEvent | DeconzEvent | DeconzPresenceEvent | DeconzRelativeRotaryEvent:
     """Resolve deconz event from device."""
     gateways: dict[str, DeconzGateway] = hass.data.get(DOMAIN, {})
     for gateway in gateways.values():

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -41,7 +41,12 @@ from .const import (
 from .errors import AuthenticationRequired, CannotConnect
 
 if TYPE_CHECKING:
-    from .deconz_event import DeconzAlarmEvent, DeconzEvent, DeconzPresenceEvent
+    from .deconz_event import (
+        DeconzAlarmEvent,
+        DeconzEvent,
+        DeconzPresenceEvent,
+        DeconzRelativeRotaryEvent,
+    )
 
 SENSORS = (
     sensors.SensorResourceManager,
@@ -93,7 +98,12 @@ class DeconzGateway:
 
         self.deconz_ids: dict[str, str] = {}
         self.entities: dict[str, set[str]] = {}
-        self.events: list[DeconzAlarmEvent | DeconzEvent | DeconzPresenceEvent] = []
+        self.events: list[
+            DeconzAlarmEvent
+            | DeconzEvent
+            | DeconzPresenceEvent
+            | DeconzRelativeRotaryEvent
+        ] = []
         self.clip_sensors: set[tuple[Callable[[EventType, str], None], str]] = set()
         self.deconz_groups: set[tuple[Callable[[EventType, str], None], str]] = set()
         self.ignored_devices: set[tuple[Callable[[EventType, str], None], str]] = set()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for Hue Tap Dial switch events
Requested here: https://github.com/Kane610/deconz/issues/359

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
