### PR TITLE
Failback to v4 resolver for AAAA records in DNSIP integration

### DIFF
--- a/homeassistant/components/dnsip/config_flow.py
+++ b/homeassistant/components/dnsip/config_flow.py
@@ -101,6 +101,10 @@ class DnsIPConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             validate = await async_validate_hostname(hostname, resolver, resolver_ipv6)
 
+            set_resolver = resolver
+            if validate[CONF_IPV6]:
+                set_resolver = resolver_ipv6
+
             if (
                 not validate[CONF_IPV4]
                 and not validate[CONF_IPV6]
@@ -121,9 +125,7 @@ class DnsIPConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                     options={
                         CONF_RESOLVER: resolver,
-                        CONF_RESOLVER_IPV6: resolver_ipv6
-                        if validate[CONF_IPV6]
-                        else resolver,
+                        CONF_RESOLVER_IPV6: set_resolver,
                     },
                 )
 

--- a/homeassistant/components/dnsip/config_flow.py
+++ b/homeassistant/components/dnsip/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_HOSTNAME,
     CONF_IPV4,
     CONF_IPV6,
+    CONF_IPV6_V4,
     CONF_RESOLVER,
     CONF_RESOLVER_IPV6,
     DEFAULT_HOSTNAME,
@@ -61,10 +62,12 @@ async def async_validate_hostname(
     tasks = await asyncio.gather(
         async_check(hostname, resolver_ipv4, "A"),
         async_check(hostname, resolver_ipv6, "AAAA"),
+        async_check(hostname, resolver_ipv4, "AAAA"),
     )
 
     result[CONF_IPV4] = tasks[0]
     result[CONF_IPV6] = tasks[1]
+    result[CONF_IPV6_V4] = tasks[2]
 
     return result
 
@@ -98,7 +101,11 @@ class DnsIPConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             validate = await async_validate_hostname(hostname, resolver, resolver_ipv6)
 
-            if not validate[CONF_IPV4] and not validate[CONF_IPV6]:
+            if (
+                not validate[CONF_IPV4]
+                and not validate[CONF_IPV6]
+                and not validate[CONF_IPV6_V4]
+            ):
                 errors["base"] = "invalid_hostname"
             else:
                 await self.async_set_unique_id(hostname)
@@ -110,11 +117,13 @@ class DnsIPConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_HOSTNAME: hostname,
                         CONF_NAME: name,
                         CONF_IPV4: validate[CONF_IPV4],
-                        CONF_IPV6: validate[CONF_IPV6],
+                        CONF_IPV6: validate[CONF_IPV6] or validate[CONF_IPV6_V4],
                     },
                     options={
                         CONF_RESOLVER: resolver,
-                        CONF_RESOLVER_IPV6: resolver_ipv6,
+                        CONF_RESOLVER_IPV6: resolver_ipv6
+                        if validate[CONF_IPV6]
+                        else resolver,
                     },
                 )
 

--- a/homeassistant/components/dnsip/const.py
+++ b/homeassistant/components/dnsip/const.py
@@ -9,6 +9,7 @@ CONF_RESOLVER = "resolver"
 CONF_RESOLVER_IPV6 = "resolver_ipv6"
 CONF_IPV4 = "ipv4"
 CONF_IPV6 = "ipv6"
+CONF_IPV6_V4 = "ipv6_v4"
 
 DEFAULT_HOSTNAME = "myip.opendns.com"
 DEFAULT_IPV6 = False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds failback to resolve AAAA records using ipv4 resolver if not able to use ipv6 resolver.
Not really a bugfix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #82101
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
