### PR TITLE
Allow only specific packages to be skipped during startup dependency installation

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -97,14 +97,11 @@ def get_arguments() -> argparse.Namespace:
         help="Skips pip install of required packages on startup",
     )
     skip_pip_group.add_argument(
-        "--skip-pip-package",
-        metavar="package_name",
-        dest="skip_pip_packages",
-        action="append",
-        help=(
-            "Skip pip install of a specific package on startup. "
-            "Can be specified multiple times."
-        ),
+        "--skip-pip-packages",
+        metavar="package_names",
+        type=lambda arg: arg.split(","),
+        default=[],
+        help="Skip pip install of specific packages on startup",
     )
 
     parser.add_argument(

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -89,11 +89,24 @@ def get_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--open-ui", action="store_true", help="Open the webinterface in a browser"
     )
-    parser.add_argument(
+
+    skip_pip_group = parser.add_mutually_exclusive_group()
+    skip_pip_group.add_argument(
         "--skip-pip",
         action="store_true",
         help="Skips pip install of required packages on startup",
     )
+    skip_pip_group.add_argument(
+        "--skip-pip-package",
+        metavar="package_name",
+        dest="skip_pip_packages",
+        action="append",
+        help=(
+            "Skip pip install of a specific package on startup. "
+            "Can be specified multiple times."
+        ),
+    )
+
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable verbose logging to file."
     )
@@ -180,6 +193,7 @@ def main() -> int:
         log_file=args.log_file,
         log_no_color=args.log_no_color,
         skip_pip=args.skip_pip,
+        skip_pip_packages=args.skip_pip_packages,
         safe_mode=args.safe_mode,
         debug=args.debug,
         open_ui=args.open_ui,

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -118,7 +118,8 @@ async def async_setup_hass(
     )
 
     hass.config.skip_pip = runtime_config.skip_pip
-    if runtime_config.skip_pip:
+    hass.config.skip_pip_packages = runtime_config.skip_pip_packages
+    if runtime_config.skip_pip or runtime_config.skip_pip_packages:
         _LOGGER.warning(
             "Skipping pip installation of required modules. This may cause issues"
         )
@@ -176,6 +177,7 @@ async def async_setup_hass(
         if old_logging:
             hass.data[DATA_LOGGING] = old_logging
         hass.config.skip_pip = old_config.skip_pip
+        hass.config.skip_pip_packages = old_config.skip_pip_packages
         hass.config.internal_url = old_config.internal_url
         hass.config.external_url = old_config.external_url
         hass.config.config_dir = old_config.config_dir

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1816,6 +1816,9 @@ class Config:
         # If True, pip install is skipped for requirements on startup
         self.skip_pip: bool = False
 
+        # List of packages to skip when installing requirements on startup
+        self.skip_pip_packages: list[str] = []
+
         # List of loaded components
         self.components: set[str] = set()
 

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -7,6 +7,8 @@ import logging
 import os
 from typing import Any, cast
 
+import pkg_resources
+
 from .core import HomeAssistant, callback
 from .exceptions import HomeAssistantError
 from .helpers.typing import UNDEFINED, UndefinedType
@@ -225,6 +227,19 @@ class RequirementsManager:
         This method is a coroutine. It will raise RequirementsNotFound
         if an requirement can't be satisfied.
         """
+        if self.hass.config.skip_pip_packages:
+            skipped_requirements = [
+                req
+                for req in requirements
+                if pkg_resources.Requirement.parse(req).project_name
+                in self.hass.config.skip_pip_packages
+            ]
+
+            for req in skipped_requirements:
+                _LOGGER.warning("Skipping requirement %s. This may cause issues", req)
+
+            requirements = [r for r in requirements if r not in skipped_requirements]
+
         if not (missing := self._find_missing_requirements(requirements)):
             return
         self._raise_for_failed_requirements(name, missing)

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -36,6 +36,7 @@ class RuntimeConfig:
 
     config_dir: str
     skip_pip: bool = False
+    skip_pip_packages: list[str] = dataclasses.field(default_factory=list)
     safe_mode: bool = False
 
     verbose: bool = False

--- a/tests/common.py
+++ b/tests/common.py
@@ -289,6 +289,7 @@ async def async_test_home_assistant(loop, load_registries=True):
     hass.config.units = METRIC_SYSTEM
     hass.config.media_dirs = {"local": get_test_config_dir("media")}
     hass.config.skip_pip = True
+    hass.config.skip_pip_packages = []
 
     hass.config_entries = config_entries.ConfigEntries(
         hass,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -939,6 +939,7 @@ async def test_config_defaults():
     assert config.external_url is None
     assert config.config_source is ha.ConfigSource.DEFAULT
     assert config.skip_pip is False
+    assert config.skip_pip_packages == []
     assert config.components == set()
     assert config.api is None
     assert config.config_dir is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,3 +61,23 @@ def test_validate_python(mock_exit):
         assert mock_exit.called is False
 
     mock_exit.reset_mock()
+
+
+@patch("sys.exit")
+def test_skip_pip_mutually_exclusive(mock_exit):
+    """Test --skip-pip and --skip-pip-package are mutually exclusive."""
+
+    def parse_args(*args):
+        with patch("sys.argv", ["python"] + list(args)):
+            return main.get_arguments()
+
+    args = parse_args("--skip-pip")
+    assert args.skip_pip is True
+
+    args = parse_args("--skip-pip-package", "foo", "--skip-pip-package", "bar")
+    assert args.skip_pip is False
+    assert args.skip_pip_packages == ["foo", "bar"]
+
+    assert mock_exit.called is False
+    args = parse_args("--skip-pip", "--skip-pip-package", "foo")
+    assert mock_exit.called is True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,10 +74,14 @@ def test_skip_pip_mutually_exclusive(mock_exit):
     args = parse_args("--skip-pip")
     assert args.skip_pip is True
 
-    args = parse_args("--skip-pip-package", "foo", "--skip-pip-package", "bar")
+    args = parse_args("--skip-pip-packages", "foo")
     assert args.skip_pip is False
-    assert args.skip_pip_packages == ["foo", "bar"]
+    assert args.skip_pip_packages == ["foo"]
+
+    args = parse_args("--skip-pip-packages", "foo-asd,bar-xyz")
+    assert args.skip_pip is False
+    assert args.skip_pip_packages == ["foo-asd", "bar-xyz"]
 
     assert mock_exit.called is False
-    args = parse_args("--skip-pip", "--skip-pip-package", "foo")
+    args = parse_args("--skip-pip", "--skip-pip-packages", "foo")
     assert mock_exit.called is True

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,4 +1,5 @@
 """Test requirements module."""
+import logging
 import os
 from unittest.mock import call, patch
 
@@ -91,6 +92,23 @@ async def test_install_missing_package(hass):
         await async_process_requirements(hass, "test_component", ["hello==1.0.0"])
 
     assert len(mock_inst.mock_calls) == 3
+
+
+async def test_install_skipped_package(hass, caplog):
+    """Test an install attempt on a dependency that should be skipped."""
+    with patch(
+        "homeassistant.util.package.install_package", return_value=True
+    ) as mock_inst:
+        hass.config.skip_pip_packages = ["hello"]
+        with caplog.at_level(logging.WARNING):
+            await async_process_requirements(
+                hass, "test_component", ["hello==1.0.0", "not_skipped==1.2.3"]
+            )
+
+    assert "Skipping requirement hello==1.0.0" in caplog.text
+
+    assert len(mock_inst.mock_calls) == 1
+    assert mock_inst.mock_calls[0].args[0] == "not_skipped==1.2.3"
 
 
 async def test_get_integration_with_requirements(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a `--skip-pip-packages` command line argument for more granular control over runtime package installation than `--skip-pip`.

I use the `--skip-pip` option because I frequently test upgraded/downgraded packages at runtime. When upgrading HA Core, I have to re-launch Core without `--skip-pip`, let it install updated dependencies for other integrations, manually re-install my own, and then re-launch with `--skip-pip`.

Example:

```bash
hass --skip-pip-packages zigpy,zha-quirks,bellows,zigpy-znp,zigpy-deconz,zigpy-zigate,zigpy-xbee
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1555

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
