### PR TITLE
Bump bluetooth-auto-recovery to 0.5.2

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -9,7 +9,7 @@
     "bleak==0.19.2",
     "bleak-retry-connector==2.8.5",
     "bluetooth-adapters==0.8.0",
-    "bluetooth-auto-recovery==0.5.0",
+    "bluetooth-auto-recovery==0.5.1",
     "bluetooth-data-tools==0.3.0",
     "dbus-fast==1.75.0"
   ],

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -9,7 +9,7 @@
     "bleak==0.19.2",
     "bleak-retry-connector==2.8.5",
     "bluetooth-adapters==0.8.0",
-    "bluetooth-auto-recovery==0.5.1",
+    "bluetooth-auto-recovery==0.5.2",
     "bluetooth-data-tools==0.3.0",
     "dbus-fast==1.75.0"
   ],

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -9,7 +9,7 @@
     "bleak==0.19.2",
     "bleak-retry-connector==2.8.5",
     "bluetooth-adapters==0.8.0",
-    "bluetooth-auto-recovery==0.4.0",
+    "bluetooth-auto-recovery==0.5.0",
     "bluetooth-data-tools==0.3.0",
     "dbus-fast==1.75.0"
   ],

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,7 @@ bcrypt==3.1.7
 bleak-retry-connector==2.8.5
 bleak==0.19.2
 bluetooth-adapters==0.8.0
-bluetooth-auto-recovery==0.4.0
+bluetooth-auto-recovery==0.5.0
 bluetooth-data-tools==0.3.0
 certifi>=2021.5.30
 ciso8601==2.2.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,7 @@ bcrypt==3.1.7
 bleak-retry-connector==2.8.5
 bleak==0.19.2
 bluetooth-adapters==0.8.0
-bluetooth-auto-recovery==0.5.1
+bluetooth-auto-recovery==0.5.2
 bluetooth-data-tools==0.3.0
 certifi>=2021.5.30
 ciso8601==2.2.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,7 @@ bcrypt==3.1.7
 bleak-retry-connector==2.8.5
 bleak==0.19.2
 bluetooth-adapters==0.8.0
-bluetooth-auto-recovery==0.5.0
+bluetooth-auto-recovery==0.5.1
 bluetooth-data-tools==0.3.0
 certifi>=2021.5.30
 ciso8601==2.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -450,7 +450,7 @@ bluemaestro-ble==0.2.0
 bluetooth-adapters==0.8.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==0.4.0
+bluetooth-auto-recovery==0.5.0
 
 # homeassistant.components.bluetooth
 # homeassistant.components.led_ble

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -450,7 +450,7 @@ bluemaestro-ble==0.2.0
 bluetooth-adapters==0.8.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==0.5.0
+bluetooth-auto-recovery==0.5.1
 
 # homeassistant.components.bluetooth
 # homeassistant.components.led_ble

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -450,7 +450,7 @@ bluemaestro-ble==0.2.0
 bluetooth-adapters==0.8.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==0.5.1
+bluetooth-auto-recovery==0.5.2
 
 # homeassistant.components.bluetooth
 # homeassistant.components.led_ble

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -364,7 +364,7 @@ bluemaestro-ble==0.2.0
 bluetooth-adapters==0.8.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==0.4.0
+bluetooth-auto-recovery==0.5.0
 
 # homeassistant.components.bluetooth
 # homeassistant.components.led_ble

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -364,7 +364,7 @@ bluemaestro-ble==0.2.0
 bluetooth-adapters==0.8.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==0.5.0
+bluetooth-auto-recovery==0.5.1
 
 # homeassistant.components.bluetooth
 # homeassistant.components.led_ble

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -364,7 +364,7 @@ bluemaestro-ble==0.2.0
 bluetooth-adapters==0.8.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==0.5.1
+bluetooth-auto-recovery==0.5.2
 
 # homeassistant.components.bluetooth
 # homeassistant.components.led_ble


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements the generic usb reset in user space since the kernel will take a long time to get it:
https://lore.kernel.org/netdev/20221006170915.v3.1.I46e98b47be875d0b9abff2d19417c612077d1909@changeid/T/

changelog: https://github.com/Bluetooth-Devices/bluetooth-auto-recovery/compare/v0.4.0...v0.5.2


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
