### PR TITLE
Use async with to fetch HTTP streams in tests

### DIFF
--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -327,35 +327,35 @@ async def test_stream(hass, mock_api_client):
     """Test the stream."""
     listen_count = _listen_count(hass)
 
-    resp = await mock_api_client.get(const.URL_API_STREAM)
-    assert resp.status == HTTPStatus.OK
-    assert listen_count + 1 == _listen_count(hass)
+    async with mock_api_client.get(const.URL_API_STREAM) as resp:
+        assert resp.status == HTTPStatus.OK
+        assert listen_count + 1 == _listen_count(hass)
 
-    hass.bus.async_fire("test_event")
+        hass.bus.async_fire("test_event")
 
-    data = await _stream_next_event(resp.content)
+        data = await _stream_next_event(resp.content)
 
-    assert data["event_type"] == "test_event"
+        assert data["event_type"] == "test_event"
 
 
 async def test_stream_with_restricted(hass, mock_api_client):
     """Test the stream with restrictions."""
     listen_count = _listen_count(hass)
 
-    resp = await mock_api_client.get(
+    async with mock_api_client.get(
         f"{const.URL_API_STREAM}?restrict=test_event1,test_event3"
-    )
-    assert resp.status == HTTPStatus.OK
-    assert listen_count + 1 == _listen_count(hass)
+    ) as resp:
+        assert resp.status == HTTPStatus.OK
+        assert listen_count + 1 == _listen_count(hass)
 
-    hass.bus.async_fire("test_event1")
-    data = await _stream_next_event(resp.content)
-    assert data["event_type"] == "test_event1"
+        hass.bus.async_fire("test_event1")
+        data = await _stream_next_event(resp.content)
+        assert data["event_type"] == "test_event1"
 
-    hass.bus.async_fire("test_event2")
-    hass.bus.async_fire("test_event3")
-    data = await _stream_next_event(resp.content)
-    assert data["event_type"] == "test_event3"
+        hass.bus.async_fire("test_event2")
+        hass.bus.async_fire("test_event3")
+        data = await _stream_next_event(resp.content)
+        assert data["event_type"] == "test_event3"
 
 
 async def _stream_next_event(stream):

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -503,15 +503,17 @@ async def test_camera_proxy_stream(hass, mock_camera, hass_client):
 
     client = await hass_client()
 
-    response = await client.get("/api/camera_proxy_stream/camera.demo_camera")
-    assert response.status == HTTPStatus.OK
+    async with client.get("/api/camera_proxy_stream/camera.demo_camera") as response:
+        assert response.status == HTTPStatus.OK
 
     with patch(
         "homeassistant.components.demo.camera.DemoCamera.handle_async_mjpeg_stream",
         return_value=None,
     ):
-        response = await client.get("/api/camera_proxy_stream/camera.demo_camera")
-        assert response.status == HTTPStatus.BAD_GATEWAY
+        async with await client.get(
+            "/api/camera_proxy_stream/camera.demo_camera"
+        ) as response:
+            assert response.status == HTTPStatus.BAD_GATEWAY
 
 
 async def test_websocket_web_rtc_offer(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With aiohttp 3.8.3, tests that check the status of HTTP streams don't complete until the stream times out. This PR changes the relevant tests to check the status using `async with` which seems to resolve the issue.

https://github.com/home-assistant/core/pull/78860

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
