### PR TITLE
Use _attr_state in mediaroom media player

### DIFF
--- a/homeassistant/components/mediaroom/media_player.py
+++ b/homeassistant/components/mediaroom/media_player.py
@@ -142,7 +142,7 @@ class MediaroomDevice(MediaPlayerEntity):
             State.UNKNOWN: None,
         }
 
-        self._state = state_map[mediaroom_state]
+        self._attr_state = state_map[mediaroom_state]
 
     def __init__(self, host, device_id, optimistic=False, timeout=DEFAULT_TIMEOUT):
         """Initialize the device."""
@@ -154,7 +154,7 @@ class MediaroomDevice(MediaPlayerEntity):
         )
         self._channel = None
         self._optimistic = optimistic
-        self._state = (
+        self._attr_state = (
             MediaPlayerState.PLAYING if optimistic else MediaPlayerState.STANDBY
         )
         self._name = f"Mediaroom {device_id if device_id else host}"
@@ -179,7 +179,7 @@ class MediaroomDevice(MediaPlayerEntity):
             if not stb_state:
                 return
             self.set_state(stb_state)
-            _LOGGER.debug("STB(%s) is [%s]", self.host, self._state)
+            _LOGGER.debug("STB(%s) is [%s]", self.host, self.state)
             self._available = True
             self.async_write_ha_state()
 
@@ -215,7 +215,7 @@ class MediaroomDevice(MediaPlayerEntity):
         try:
             await self.stb.send_cmd(command)
             if self._optimistic:
-                self._state = MediaPlayerState.PLAYING
+                self._attr_state = MediaPlayerState.PLAYING
             self._available = True
         except PyMediaroomError:
             self._available = False
@@ -232,11 +232,6 @@ class MediaroomDevice(MediaPlayerEntity):
         return self._name
 
     @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
-
-    @property
     def media_channel(self):
         """Channel currently playing."""
         return self._channel
@@ -247,7 +242,7 @@ class MediaroomDevice(MediaPlayerEntity):
         try:
             self.set_state(await self.stb.turn_on())
             if self._optimistic:
-                self._state = MediaPlayerState.PLAYING
+                self._attr_state = MediaPlayerState.PLAYING
             self._available = True
         except PyMediaroomError:
             self._available = False
@@ -259,7 +254,7 @@ class MediaroomDevice(MediaPlayerEntity):
         try:
             self.set_state(await self.stb.turn_off())
             if self._optimistic:
-                self._state = MediaPlayerState.STANDBY
+                self._attr_state = MediaPlayerState.STANDBY
             self._available = True
         except PyMediaroomError:
             self._available = False
@@ -272,7 +267,7 @@ class MediaroomDevice(MediaPlayerEntity):
             _LOGGER.debug("media_play()")
             await self.stb.send_cmd("PlayPause")
             if self._optimistic:
-                self._state = MediaPlayerState.PLAYING
+                self._attr_state = MediaPlayerState.PLAYING
             self._available = True
         except PyMediaroomError:
             self._available = False
@@ -284,7 +279,7 @@ class MediaroomDevice(MediaPlayerEntity):
         try:
             await self.stb.send_cmd("PlayPause")
             if self._optimistic:
-                self._state = MediaPlayerState.PAUSED
+                self._attr_state = MediaPlayerState.PAUSED
             self._available = True
         except PyMediaroomError:
             self._available = False
@@ -296,7 +291,7 @@ class MediaroomDevice(MediaPlayerEntity):
         try:
             await self.stb.send_cmd("Stop")
             if self._optimistic:
-                self._state = MediaPlayerState.PAUSED
+                self._attr_state = MediaPlayerState.PAUSED
             self._available = True
         except PyMediaroomError:
             self._available = False
@@ -308,7 +303,7 @@ class MediaroomDevice(MediaPlayerEntity):
         try:
             await self.stb.send_cmd("ProgDown")
             if self._optimistic:
-                self._state = MediaPlayerState.PLAYING
+                self._attr_state = MediaPlayerState.PLAYING
             self._available = True
         except PyMediaroomError:
             self._available = False
@@ -320,7 +315,7 @@ class MediaroomDevice(MediaPlayerEntity):
         try:
             await self.stb.send_cmd("ProgUp")
             if self._optimistic:
-                self._state = MediaPlayerState.PLAYING
+                self._attr_state = MediaPlayerState.PLAYING
             self._available = True
         except PyMediaroomError:
             self._available = False


### PR DESCRIPTION
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in mediaroom media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
