### PR TITLE
Use _attr in nad media player

### DIFF
--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -81,20 +81,18 @@ def setup_platform(
 class NAD(MediaPlayerEntity):
     """Representation of a NAD Receiver."""
 
+    _attr_icon = "mdi:speaker-multiple"
     _attr_supported_features = SUPPORT_NAD
 
     def __init__(self, config):
         """Initialize the NAD Receiver device."""
         self.config = config
         self._instantiate_nad_receiver()
+        self._attr_name = self.config[CONF_NAME]
         self._min_volume = config[CONF_MIN_VOLUME]
         self._max_volume = config[CONF_MAX_VOLUME]
         self._source_dict = config[CONF_SOURCE_DICT]
         self._reverse_mapping = {value: key for key, value in self._source_dict.items()}
-
-        self._volume = None
-        self._mute = None
-        self._source = None
 
     def _instantiate_nad_receiver(self) -> NADReceiver:
         if self.config[CONF_TYPE] == "RS232":
@@ -103,26 +101,6 @@ class NAD(MediaPlayerEntity):
             host = self.config.get(CONF_HOST)
             port = self.config[CONF_PORT]
             self._nad_receiver = NADReceiverTelnet(host, port)
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self.config[CONF_NAME]
-
-    @property
-    def icon(self):
-        """Return the icon for the device."""
-        return "mdi:speaker-multiple"
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1)."""
-        return self._volume
-
-    @property
-    def is_volume_muted(self):
-        """Boolean if volume is currently muted."""
-        return self._mute
 
     def turn_off(self) -> None:
         """Turn the media player off."""
@@ -156,11 +134,6 @@ class NAD(MediaPlayerEntity):
         self._nad_receiver.main_source("=", self._reverse_mapping.get(source))
 
     @property
-    def source(self):
-        """Name of the current input source."""
-        return self._source
-
-    @property
     def source_list(self):
         """List of available input sources."""
         return sorted(self._reverse_mapping)
@@ -183,12 +156,16 @@ class NAD(MediaPlayerEntity):
         )
 
         if self.state == MediaPlayerState.ON:
-            self._mute = self._nad_receiver.main_mute("?") == "On"
+            self._attr_is_volume_muted = self._nad_receiver.main_mute("?") == "On"
             volume = self._nad_receiver.main_volume("?")
             # Some receivers cannot report the volume, e.g. C 356BEE,
             # instead they only support stepping the volume up or down
-            self._volume = self.calc_volume(volume) if volume is not None else None
-            self._source = self._source_dict.get(self._nad_receiver.main_source("?"))
+            self._attr_volume_level = (
+                self.calc_volume(volume) if volume is not None else None
+            )
+            self._attr_source = self._source_dict.get(
+                self._nad_receiver.main_source("?")
+            )
 
     def calc_volume(self, decibel):
         """
@@ -218,31 +195,13 @@ class NADtcp(MediaPlayerEntity):
 
     def __init__(self, config):
         """Initialize the amplifier."""
-        self._name = config[CONF_NAME]
+        self._attr_name = config[CONF_NAME]
         self._nad_receiver = NADReceiverTCP(config.get(CONF_HOST))
         self._min_vol = (config[CONF_MIN_VOLUME] + 90) * 2  # from dB to nad vol (0-200)
         self._max_vol = (config[CONF_MAX_VOLUME] + 90) * 2  # from dB to nad vol (0-200)
         self._volume_step = config[CONF_VOLUME_STEP]
-        self._mute = None
         self._nad_volume = None
-        self._volume = None
-        self._source = None
         self._source_list = self._nad_receiver.available_sources()
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1)."""
-        return self._volume
-
-    @property
-    def is_volume_muted(self):
-        """Boolean if volume is currently muted."""
-        return self._mute
 
     def turn_off(self) -> None:
         """Turn the media player off."""
@@ -279,11 +238,6 @@ class NADtcp(MediaPlayerEntity):
         self._nad_receiver.select_source(source)
 
     @property
-    def source(self):
-        """Name of the current input source."""
-        return self._source
-
-    @property
     def source_list(self):
         """List of available input sources."""
         return self._nad_receiver.available_sources()
@@ -304,14 +258,14 @@ class NADtcp(MediaPlayerEntity):
             self._attr_state = MediaPlayerState.OFF
 
         # Update current volume
-        self._volume = self.nad_vol_to_internal_vol(nad_status["volume"])
+        self._attr_volume_level = self.nad_vol_to_internal_vol(nad_status["volume"])
         self._nad_volume = nad_status["volume"]
 
         # Update muted state
-        self._mute = nad_status["muted"]
+        self._attr_is_volume_muted = nad_status["muted"]
 
         # Update current source
-        self._source = nad_status["source"]
+        self._attr_source = nad_status["source"]
 
     def nad_vol_to_internal_vol(self, nad_volume):
         """Convert nad volume range (0-200) to internal volume range.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in nad media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
