### PR TITLE
Use _attr in onkyo media player

### DIFF
--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -252,27 +252,25 @@ class OnkyoDevice(MediaPlayerEntity):
     ):
         """Initialize the Onkyo Receiver."""
         self._receiver = receiver
-        self._muted = False
-        self._volume = 0
+        self._attr_is_volume_muted = False
+        self._attr_volume_level = 0
         self._attr_state = MediaPlayerState.OFF
         if name:
             # not discovered
-            self._name = name
-            self._unique_id = None
+            self._attr_name = name
         else:
             # discovered
-            self._unique_id = (
+            self._attr_unique_id = (
                 f"{receiver.info['model_name']}_{receiver.info['identifier']}"
             )
-            self._name = self._unique_id
+            self._attr_name = self._attr_unique_id
 
         self._max_volume = max_volume
         self._receiver_max_volume = receiver_max_volume
-        self._current_source = None
-        self._source_list = list(sources.values())
+        self._attr_source_list = list(sources.values())
         self._source_mapping = sources
         self._reverse_mapping = {value: key for key, value in sources.items()}
-        self._attributes = {}
+        self._attr_extra_state_attributes = {}
         self._hdmi_out_supported = True
         self._audio_info_supported = True
         self._video_info_supported = True
@@ -284,9 +282,9 @@ class OnkyoDevice(MediaPlayerEntity):
         except (ValueError, OSError, AttributeError, AssertionError):
             if self._receiver.command_socket:
                 self._receiver.command_socket = None
-                _LOGGER.debug("Resetting connection to %s", self._name)
+                _LOGGER.debug("Resetting connection to %s", self.name)
             else:
-                _LOGGER.info("%s is disconnected. Attempting to reconnect", self._name)
+                _LOGGER.info("%s is disconnected. Attempting to reconnect", self.name)
             return False
         _LOGGER.debug("Result for %s: %s", command, result)
         return result
@@ -301,10 +299,10 @@ class OnkyoDevice(MediaPlayerEntity):
             self._attr_state = MediaPlayerState.ON
         else:
             self._attr_state = MediaPlayerState.OFF
-            self._attributes.pop(ATTR_AUDIO_INFORMATION, None)
-            self._attributes.pop(ATTR_VIDEO_INFORMATION, None)
-            self._attributes.pop(ATTR_PRESET, None)
-            self._attributes.pop(ATTR_VIDEO_OUT, None)
+            self._attr_extra_state_attributes.pop(ATTR_AUDIO_INFORMATION, None)
+            self._attr_extra_state_attributes.pop(ATTR_VIDEO_INFORMATION, None)
+            self._attr_extra_state_attributes.pop(ATTR_PRESET, None)
+            self._attr_extra_state_attributes.pop(ATTR_VIDEO_OUT, None)
             return
 
         volume_raw = self.command("volume query")
@@ -331,61 +329,26 @@ class OnkyoDevice(MediaPlayerEntity):
 
         for source in sources:
             if source in self._source_mapping:
-                self._current_source = self._source_mapping[source]
+                self._attr_source = self._source_mapping[source]
                 break
-            self._current_source = "_".join(sources)
+            self._attr_source = "_".join(sources)
 
-        if preset_raw and self._current_source.lower() == "radio":
-            self._attributes[ATTR_PRESET] = preset_raw[1]
-        elif ATTR_PRESET in self._attributes:
-            del self._attributes[ATTR_PRESET]
+        if preset_raw and self.source and self.source.lower() == "radio":
+            self._attr_extra_state_attributes[ATTR_PRESET] = preset_raw[1]
+        elif ATTR_PRESET in self._attr_extra_state_attributes:
+            del self._attr_extra_state_attributes[ATTR_PRESET]
 
-        self._muted = bool(mute_raw[1] == "on")
+        self._attr_is_volume_muted = bool(mute_raw[1] == "on")
         #       AMP_VOL/MAX_RECEIVER_VOL*(MAX_VOL/100)
-        self._volume = volume_raw[1] / (
+        self._attr_volume_level = volume_raw[1] / (
             self._receiver_max_volume * self._max_volume / 100
         )
 
         if not hdmi_out_raw:
             return
-        self._attributes[ATTR_VIDEO_OUT] = ",".join(hdmi_out_raw[1])
+        self._attr_extra_state_attributes[ATTR_VIDEO_OUT] = ",".join(hdmi_out_raw[1])
         if hdmi_out_raw[1] == "N/A":
             self._hdmi_out_supported = False
-
-    @property
-    def unique_id(self):
-        """Return unique ID for this device."""
-        return self._unique_id
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def volume_level(self):
-        """Return the volume level of the media player (0..1)."""
-        return self._volume
-
-    @property
-    def is_volume_muted(self):
-        """Return boolean indicating mute status."""
-        return self._muted
-
-    @property
-    def source(self):
-        """Return the current input source of the device."""
-        return self._current_source
-
-    @property
-    def source_list(self):
-        """List of available input sources."""
-        return self._source_list
-
-    @property
-    def extra_state_attributes(self):
-        """Return device specific state attributes."""
-        return self._attributes
 
     def turn_off(self) -> None:
         """Turn the media player off."""
@@ -426,13 +389,13 @@ class OnkyoDevice(MediaPlayerEntity):
 
     def select_source(self, source: str) -> None:
         """Set the input source."""
-        if source in self._source_list:
+        if self.source_list and source in self.source_list:
             source = self._reverse_mapping[source]
         self.command(f"input-selector {source}")
 
     def play_media(self, media_type: str, media_id: str, **kwargs: Any) -> None:
         """Play radio station by preset number."""
-        source = self._reverse_mapping[self._current_source]
+        source = self._reverse_mapping[self._attr_source]
         if media_type.lower() == "radio" and source in DEFAULT_PLAYABLE_SOURCES:
             self.command(f"preset {media_id}")
 
@@ -455,9 +418,9 @@ class OnkyoDevice(MediaPlayerEntity):
                 "output_channels": _tuple_get(values, 5),
                 "output_frequency": _tuple_get(values, 6),
             }
-            self._attributes[ATTR_AUDIO_INFORMATION] = info
+            self._attr_extra_state_attributes[ATTR_AUDIO_INFORMATION] = info
         else:
-            self._attributes.pop(ATTR_AUDIO_INFORMATION, None)
+            self._attr_extra_state_attributes.pop(ATTR_AUDIO_INFORMATION, None)
 
     def _parse_video_information(self, video_information_raw):
         values = _parse_onkyo_payload(video_information_raw)
@@ -475,9 +438,9 @@ class OnkyoDevice(MediaPlayerEntity):
                 "output_color_depth": _tuple_get(values, 7),
                 "picture_mode": _tuple_get(values, 8),
             }
-            self._attributes[ATTR_VIDEO_INFORMATION] = info
+            self._attr_extra_state_attributes[ATTR_VIDEO_INFORMATION] = info
         else:
-            self._attributes.pop(ATTR_VIDEO_INFORMATION, None)
+            self._attr_extra_state_attributes.pop(ATTR_VIDEO_INFORMATION, None)
 
 
 class OnkyoDeviceZone(OnkyoDevice):
@@ -533,17 +496,17 @@ class OnkyoDeviceZone(OnkyoDevice):
 
         for source in current_source_tuples[1]:
             if source in self._source_mapping:
-                self._current_source = self._source_mapping[source]
+                self._attr_source = self._source_mapping[source]
                 break
-            self._current_source = "_".join(current_source_tuples[1])
-        self._muted = bool(mute_raw[1] == "on")
-        if preset_raw and self._current_source.lower() == "radio":
-            self._attributes[ATTR_PRESET] = preset_raw[1]
-        elif ATTR_PRESET in self._attributes:
-            del self._attributes[ATTR_PRESET]
+            self._attr_source = "_".join(current_source_tuples[1])
+        self._attr_is_volume_muted = bool(mute_raw[1] == "on")
+        if preset_raw and self.source and self.source.lower() == "radio":
+            self._attr_extra_state_attributes[ATTR_PRESET] = preset_raw[1]
+        elif ATTR_PRESET in self._attr_extra_state_attributes:
+            del self._attr_extra_state_attributes[ATTR_PRESET]
         if self._supports_volume:
             # AMP_VOL/MAX_RECEIVER_VOL*(MAX_VOL/100)
-            self._volume = (
+            self._attr_volume_level = (
                 volume_raw[1] / self._receiver_max_volume * (self._max_volume / 100)
             )
 
@@ -593,6 +556,6 @@ class OnkyoDeviceZone(OnkyoDevice):
 
     def select_source(self, source: str) -> None:
         """Set the input source."""
-        if source in self._source_list:
+        if self.source_list and source in self.source_list:
             source = self._reverse_mapping[source]
         self.command(f"zone{self._zone}.selector={source}")

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -254,7 +254,7 @@ class OnkyoDevice(MediaPlayerEntity):
         self._receiver = receiver
         self._muted = False
         self._volume = 0
-        self._pwstate = MediaPlayerState.OFF
+        self._attr_state = MediaPlayerState.OFF
         if name:
             # not discovered
             self._name = name
@@ -298,9 +298,9 @@ class OnkyoDevice(MediaPlayerEntity):
         if not status:
             return
         if status[1] == "on":
-            self._pwstate = MediaPlayerState.ON
+            self._attr_state = MediaPlayerState.ON
         else:
-            self._pwstate = MediaPlayerState.OFF
+            self._attr_state = MediaPlayerState.OFF
             self._attributes.pop(ATTR_AUDIO_INFORMATION, None)
             self._attributes.pop(ATTR_VIDEO_INFORMATION, None)
             self._attributes.pop(ATTR_PRESET, None)
@@ -361,11 +361,6 @@ class OnkyoDevice(MediaPlayerEntity):
     def name(self):
         """Return the name of the device."""
         return self._name
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._pwstate
 
     @property
     def volume_level(self):
@@ -509,9 +504,9 @@ class OnkyoDeviceZone(OnkyoDevice):
         if not status:
             return
         if status[1] == "on":
-            self._pwstate = MediaPlayerState.ON
+            self._attr_state = MediaPlayerState.ON
         else:
-            self._pwstate = MediaPlayerState.OFF
+            self._attr_state = MediaPlayerState.OFF
             return
 
         volume_raw = self.command(f"zone{self._zone}.volume=query")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in onkyo media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
