### PR TITLE
Use _attr in pjlink media player

### DIFF
--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -79,18 +79,17 @@ class PjLinkDevice(MediaPlayerEntity):
         """Iinitialize the PJLink device."""
         self._host = host
         self._port = port
-        self._name = name
+        self._attr_name = name
         self._password = password
         self._encoding = encoding
-        self._muted = False
+        self._attr_is_volume_muted = False
         self._attr_state = MediaPlayerState.OFF
-        self._current_source = None
         with self.projector() as projector:
-            if not self._name:
-                self._name = projector.get_name()
+            if not self._attr_name:
+                self._attr_name = projector.get_name()
             inputs = projector.get_inputs()
         self._source_name_mapping = {format_input_source(*x): x for x in inputs}
-        self._source_list = sorted(self._source_name_mapping.keys())
+        self._attr_source_list = sorted(self._source_name_mapping.keys())
 
     def projector(self):
         """Create PJLink Projector instance."""
@@ -109,46 +108,26 @@ class PjLinkDevice(MediaPlayerEntity):
                 pwstate = projector.get_power()
                 if pwstate in ("on", "warm-up"):
                     self._attr_state = MediaPlayerState.ON
-                    self._muted = projector.get_mute()[1]
-                    self._current_source = format_input_source(*projector.get_input())
+                    self._attr_is_volume_muted = projector.get_mute()[1]
+                    self._attr_source = format_input_source(*projector.get_input())
                 else:
                     self._attr_state = MediaPlayerState.OFF
-                    self._muted = False
-                    self._current_source = None
+                    self._attr_is_volume_muted = False
+                    self._attr_source = None
             except KeyError as err:
                 if str(err) == "'OK'":
                     self._attr_state = MediaPlayerState.OFF
-                    self._muted = False
-                    self._current_source = None
+                    self._attr_is_volume_muted = False
+                    self._attr_source = None
                 else:
                     raise
             except ProjectorError as err:
                 if str(err) == "unavailable time":
                     self._attr_state = MediaPlayerState.OFF
-                    self._muted = False
-                    self._current_source = None
+                    self._attr_is_volume_muted = False
+                    self._attr_source = None
                 else:
                     raise
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def is_volume_muted(self):
-        """Return boolean indicating mute status."""
-        return self._muted
-
-    @property
-    def source(self):
-        """Return current input source."""
-        return self._current_source
-
-    @property
-    def source_list(self):
-        """Return all available input sources."""
-        return self._source_list
 
     def turn_off(self) -> None:
         """Turn projector off."""

--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -83,7 +83,7 @@ class PjLinkDevice(MediaPlayerEntity):
         self._password = password
         self._encoding = encoding
         self._muted = False
-        self._pwstate = MediaPlayerState.OFF
+        self._attr_state = MediaPlayerState.OFF
         self._current_source = None
         with self.projector() as projector:
             if not self._name:
@@ -108,23 +108,23 @@ class PjLinkDevice(MediaPlayerEntity):
             try:
                 pwstate = projector.get_power()
                 if pwstate in ("on", "warm-up"):
-                    self._pwstate = MediaPlayerState.ON
+                    self._attr_state = MediaPlayerState.ON
                     self._muted = projector.get_mute()[1]
                     self._current_source = format_input_source(*projector.get_input())
                 else:
-                    self._pwstate = MediaPlayerState.OFF
+                    self._attr_state = MediaPlayerState.OFF
                     self._muted = False
                     self._current_source = None
             except KeyError as err:
                 if str(err) == "'OK'":
-                    self._pwstate = MediaPlayerState.OFF
+                    self._attr_state = MediaPlayerState.OFF
                     self._muted = False
                     self._current_source = None
                 else:
                     raise
             except ProjectorError as err:
                 if str(err) == "unavailable time":
-                    self._pwstate = MediaPlayerState.OFF
+                    self._attr_state = MediaPlayerState.OFF
                     self._muted = False
                     self._current_source = None
                 else:
@@ -134,11 +134,6 @@ class PjLinkDevice(MediaPlayerEntity):
     def name(self):
         """Return the name of the device."""
         return self._name
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._pwstate
 
     @property
     def is_volume_muted(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in pjlink media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
