### PR TITLE
Use attributes in ps4 media player

### DIFF
--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -85,9 +85,7 @@ class PS4Device(MediaPlayerEntity):
         self._region = region
         self._creds = creds
         self._media_image = None
-        self._source = None
         self._games = {}
-        self._source_list = []
         self._retry = 0
         self._disconnected = False
 
@@ -201,7 +199,7 @@ class PS4Device(MediaPlayerEntity):
             # If locked get attributes from file.
             if store.get(ATTR_LOCKED):
                 self._attr_media_title = store.get(ATTR_MEDIA_TITLE)
-                self._source = self._attr_media_title
+                self._attr_source = self._attr_media_title
                 self._media_image = store.get(ATTR_MEDIA_IMAGE_URL)
                 self._attr_media_content_type = store.get(ATTR_MEDIA_CONTENT_TYPE)
                 return True
@@ -268,7 +266,7 @@ class PS4Device(MediaPlayerEntity):
 
         finally:
             self._attr_media_title = app_name or name
-            self._source = self._attr_media_title
+            self._attr_source = self._attr_media_title
             self._media_image = art or None
             self._attr_media_content_type = media_type
 
@@ -297,12 +295,12 @@ class PS4Device(MediaPlayerEntity):
 
         self.get_source_list()
 
-    def get_source_list(self):
+    def get_source_list(self) -> None:
         """Parse data entry and update source list."""
         games = []
         for data in self._games.values():
             games.append(data[ATTR_MEDIA_TITLE])
-        self._source_list = sorted(games)
+        self._attr_source_list = sorted(games)
 
     def add_games(self, title_id, app_name, image, g_type, is_locked=False):
         """Add games to list."""
@@ -384,16 +382,6 @@ class PS4Device(MediaPlayerEntity):
         if self.media_content_id is None:
             return MEDIA_IMAGE_DEFAULT
         return self._media_image
-
-    @property
-    def source(self):
-        """Return the current input source."""
-        return self._source
-
-    @property
-    def source_list(self):
-        """List of available input sources."""
-        return self._source_list
 
     async def async_turn_off(self) -> None:
         """Turn off media player."""

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -83,7 +83,6 @@ class PS4Device(MediaPlayerEntity):
         self._name = name
         self._region = region
         self._creds = creds
-        self._state = None
         self._media_content_id = None
         self._media_title = None
         self._media_image = None
@@ -172,7 +171,7 @@ class PS4Device(MediaPlayerEntity):
                 name = status.get("running-app-name")
 
                 if title_id and name is not None:
-                    self._state = MediaPlayerState.PLAYING
+                    self._attr_state = MediaPlayerState.PLAYING
 
                     if self._media_content_id != title_id:
                         self._media_content_id = title_id
@@ -186,10 +185,10 @@ class PS4Device(MediaPlayerEntity):
                         # Get data from PS Store.
                         asyncio.ensure_future(self.async_get_title_data(title_id, name))
                 else:
-                    if self._state != MediaPlayerState.IDLE:
+                    if self.state != MediaPlayerState.IDLE:
                         self.idle()
             else:
-                if self._state != MediaPlayerState.STANDBY:
+                if self.state != MediaPlayerState.STANDBY:
                     self.state_standby()
 
         elif self._retry > DEFAULT_RETRIES:
@@ -214,17 +213,17 @@ class PS4Device(MediaPlayerEntity):
     def idle(self):
         """Set states for state idle."""
         self.reset_title()
-        self._state = MediaPlayerState.IDLE
+        self._attr_state = MediaPlayerState.IDLE
 
     def state_standby(self):
         """Set states for state standby."""
         self.reset_title()
-        self._state = MediaPlayerState.STANDBY
+        self._attr_state = MediaPlayerState.STANDBY
 
     def state_unknown(self):
         """Set states for state unknown."""
         self.reset_title()
-        self._state = None
+        self._attr_state = None
         if self._disconnected is False:
             _LOGGER.warning("PS4 could not be reached")
         self._disconnected = True
@@ -377,7 +376,7 @@ class PS4Device(MediaPlayerEntity):
     def entity_picture(self):
         """Return picture."""
         if (
-            self._state == MediaPlayerState.PLAYING
+            self.state == MediaPlayerState.PLAYING
             and self._media_content_id is not None
             and (image_hash := self.media_image_hash) is not None
         ):
@@ -391,11 +390,6 @@ class PS4Device(MediaPlayerEntity):
     def name(self):
         """Return the name of the device."""
         return self._name
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
 
     @property
     def icon(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in ps4 media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
