### PR TITLE
Use attributes in roon media player

### DIFF
--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -98,24 +98,19 @@ class RoonDevice(MediaPlayerEntity):
         """Initialize Roon device object."""
         self._remove_signal_status = None
         self._server = server
-        self._available = True
-        self._last_position_update = None
+        self._attr_available = True
         self._supports_standby = False
         self._attr_state = MediaPlayerState.IDLE
-        self._unique_id = None
         self._zone_id = None
         self._output_id = None
-        self._name = DEVICE_DEFAULT_NAME
-        self._media_title = None
-        self._media_album_name = None
-        self._media_artist = None
-        self._media_position = 0
-        self._media_duration = 0
-        self._is_volume_muted = False
-        self._volume_step = 0
-        self._shuffle = False
-        self._media_image_url = None
-        self._volume_level = 0
+        self._attr_name = DEVICE_DEFAULT_NAME
+        self._attr_media_position = 0
+        self._attr_media_duration = 0
+        self._attr_is_volume_muted = False
+        self._attr_volume_step = 0
+        self._attr_shuffle = False
+        self._attr_media_image_url = None
+        self._attr_volume_level = 0
         self.update_data(player_data)
 
     async def async_added_to_hass(self) -> None:
@@ -136,11 +131,6 @@ class RoonDevice(MediaPlayerEntity):
         self.async_write_ha_state()
 
     @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._available
-
-    @property
     def group_members(self):
         """Return the grouped players."""
 
@@ -153,7 +143,7 @@ class RoonDevice(MediaPlayerEntity):
         if self.player_data.get("source_controls"):
             dev_model = self.player_data["source_controls"][0].get("display_name")
         return DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)},
+            identifiers={(DOMAIN, self.unique_id)} if self.unique_id else set(),
             name=self.name,
             manufacturer="RoonLabs",
             model=dev_model,
@@ -166,14 +156,14 @@ class RoonDevice(MediaPlayerEntity):
             self.player_data = player_data
         if not self.player_data["is_available"]:
             # this player was removed
-            self._available = False
+            self._attr_available = False
             self._attr_state = MediaPlayerState.OFF
         else:
-            self._available = True
+            self._attr_available = True
             # determine player state
             self.update_state()
             if self.state == MediaPlayerState.PLAYING:
-                self._last_position_update = utcnow()
+                self._attr_media_position_updated_at = utcnow()
 
     @classmethod
     def _parse_volume(cls, player_data):
@@ -264,36 +254,24 @@ class RoonDevice(MediaPlayerEntity):
             else:
                 new_state = MediaPlayerState.IDLE
         self._attr_state = new_state
-        self._unique_id = self.player_data["dev_id"]
+        self._attr_unique_id = self.player_data["dev_id"]
         self._zone_id = self.player_data["zone_id"]
         self._output_id = self.player_data["output_id"]
-        self._shuffle = self.player_data["settings"]["shuffle"]
-        self._name = self.player_data["display_name"]
+        self._attr_shuffle = self.player_data["settings"]["shuffle"]
+        self._attr_name = self.player_data["display_name"]
 
         volume = RoonDevice._parse_volume(self.player_data)
-        self._is_volume_muted = volume["muted"]
-        self._volume_step = volume["step"]
-        self._is_volume_muted = volume["muted"]
-        self._volume_level = volume["level"]
+        self._attr_is_volume_muted = volume["muted"]
+        self._attr_volume_step = volume["step"]
+        self._attr_volume_level = volume["level"]
 
         now_playing = self._parse_now_playing(self.player_data)
-        self._media_title = now_playing["title"]
-        self._media_artist = now_playing["artist"]
-        self._media_album_name = now_playing["album"]
-        self._media_position = now_playing["position"]
-        self._media_duration = now_playing["duration"]
-        self._media_image_url = now_playing["image"]
-
-    @property
-    def media_position_updated_at(self):
-        """When was the position of the current playing media valid."""
-        # Returns value from homeassistant.util.dt.utcnow().
-        return self._last_position_update
-
-    @property
-    def unique_id(self):
-        """Return the id of this roon client."""
-        return self._unique_id
+        self._attr_media_title = now_playing["title"]
+        self._attr_media_artist = now_playing["artist"]
+        self._attr_media_album_name = now_playing["album"]
+        self._attr_media_position = now_playing["position"]
+        self._attr_media_duration = now_playing["duration"]
+        self._attr_media_image_url = now_playing["image"]
 
     @property
     def zone_id(self):
@@ -306,69 +284,14 @@ class RoonDevice(MediaPlayerEntity):
         return self._output_id
 
     @property
-    def name(self):
-        """Return device name."""
-        return self._name
-
-    @property
-    def media_title(self):
-        """Return title currently playing."""
-        return self._media_title
-
-    @property
-    def media_album_name(self):
-        """Album name of current playing media (Music track only)."""
-        return self._media_album_name
-
-    @property
-    def media_artist(self):
-        """Artist of current playing media (Music track only)."""
-        return self._media_artist
-
-    @property
-    def media_album_artist(self):
+    def media_album_artist(self) -> str | None:
         """Album artist of current playing media (Music track only)."""
-        return self._media_artist
-
-    @property
-    def media_image_url(self):
-        """Image url of current playing media."""
-        return self._media_image_url
-
-    @property
-    def media_position(self):
-        """Return position currently playing."""
-        return self._media_position
-
-    @property
-    def media_duration(self):
-        """Return total runtime length."""
-        return self._media_duration
-
-    @property
-    def volume_level(self):
-        """Return current volume level."""
-        return self._volume_level
-
-    @property
-    def is_volume_muted(self):
-        """Return mute state."""
-        return self._is_volume_muted
-
-    @property
-    def volume_step(self):
-        """.Return volume step size."""
-        return self._volume_step
+        return self.media_artist
 
     @property
     def supports_standby(self):
         """Return power state of source controls."""
         return self._supports_standby
-
-    @property
-    def shuffle(self):
-        """Boolean if shuffle is enabled."""
-        return self._shuffle
 
     def media_play(self) -> None:
         """Send play command to device."""
@@ -398,7 +321,7 @@ class RoonDevice(MediaPlayerEntity):
         """Send seek command to device."""
         self._server.roonapi.seek(self.output_id, position)
         # Seek doesn't cause an async update - so force one
-        self._media_position = position
+        self._attr_media_position = round(position)
         self.schedule_update_ha_state()
 
     def set_volume_level(self, volume: float) -> None:

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -101,7 +101,7 @@ class RoonDevice(MediaPlayerEntity):
         self._available = True
         self._last_position_update = None
         self._supports_standby = False
-        self._state = MediaPlayerState.IDLE
+        self._attr_state = MediaPlayerState.IDLE
         self._unique_id = None
         self._zone_id = None
         self._output_id = None
@@ -167,7 +167,7 @@ class RoonDevice(MediaPlayerEntity):
         if not self.player_data["is_available"]:
             # this player was removed
             self._available = False
-            self._state = MediaPlayerState.OFF
+            self._attr_state = MediaPlayerState.OFF
         else:
             self._available = True
             # determine player state
@@ -263,7 +263,7 @@ class RoonDevice(MediaPlayerEntity):
                 new_state = MediaPlayerState.PAUSED
             else:
                 new_state = MediaPlayerState.IDLE
-        self._state = new_state
+        self._attr_state = new_state
         self._unique_id = self.player_data["dev_id"]
         self._zone_id = self.player_data["zone_id"]
         self._output_id = self.player_data["output_id"]
@@ -364,11 +364,6 @@ class RoonDevice(MediaPlayerEntity):
     def supports_standby(self):
         """Return power state of source controls."""
         return self._supports_standby
-
-    @property
-    def state(self):
-        """Return current playstate of the device."""
-        return self._state
 
     @property
     def shuffle(self):

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -138,12 +138,14 @@ class RoonDevice(MediaPlayerEntity):
         return [self._server.entity_id(roon_name) for roon_name in roon_names]
 
     @property
-    def device_info(self) -> DeviceInfo:
+    def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
+        if self.unique_id is None:
+            return None
         if self.player_data.get("source_controls"):
             dev_model = self.player_data["source_controls"][0].get("display_name")
         return DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)} if self.unique_id else set(),
+            identifiers={(DOMAIN, self.unique_id)},
             name=self.name,
             manufacturer="RoonLabs",
             model=dev_model,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in roon media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
