### PR TITLE
Use _attr_state in russound met media player

### DIFF
--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -87,7 +87,6 @@ class RussoundRNETDevice(MediaPlayerEntity):
         self._sources = sources
         self._zone_id = zone_id
 
-        self._state = None
         self._volume = None
         self._source = None
 
@@ -101,9 +100,9 @@ class RussoundRNETDevice(MediaPlayerEntity):
         if ret is not None:
             _LOGGER.debug("Updating status for zone %s", self._zone_id)
             if ret[0] == 0:
-                self._state = MediaPlayerState.OFF
+                self._attr_state = MediaPlayerState.OFF
             else:
-                self._state = MediaPlayerState.ON
+                self._attr_state = MediaPlayerState.ON
             self._volume = ret[2] * 2 / 100.0
             # Returns 0 based index for source.
             index = ret[1]
@@ -122,11 +121,6 @@ class RussoundRNETDevice(MediaPlayerEntity):
     def name(self):
         """Return the name of the zone."""
         return self._name
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
 
     @property
     def source(self):

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -82,13 +82,10 @@ class RussoundRNETDevice(MediaPlayerEntity):
 
     def __init__(self, hass, russ, sources, zone_id, extra):
         """Initialise the Russound RNET device."""
-        self._name = extra["name"]
+        self._attr_name = extra["name"]
         self._russ = russ
-        self._sources = sources
+        self._attr_source_list = sources
         self._zone_id = zone_id
-
-        self._volume = None
-        self._source = None
 
     def update(self) -> None:
         """Retrieve latest state."""
@@ -103,38 +100,17 @@ class RussoundRNETDevice(MediaPlayerEntity):
                 self._attr_state = MediaPlayerState.OFF
             else:
                 self._attr_state = MediaPlayerState.ON
-            self._volume = ret[2] * 2 / 100.0
+            self._attr_volume_level = ret[2] * 2 / 100.0
             # Returns 0 based index for source.
             index = ret[1]
             # Possibility exists that user has defined list of all sources.
             # If a source is set externally that is beyond the defined list then
             # an exception will be thrown.
             # In this case return and unknown source (None)
-            try:
-                self._source = self._sources[index]
-            except IndexError:
-                self._source = None
+            if self.source_list and 0 <= index < len(self.source_list):
+                self._attr_source = self.source_list[index]
         else:
             _LOGGER.error("Could not update status for zone %s", self._zone_id)
-
-    @property
-    def name(self):
-        """Return the name of the zone."""
-        return self._name
-
-    @property
-    def source(self):
-        """Get the currently selected source."""
-        return self._source
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1).
-
-        Value is returned based on a range (0..100).
-        Therefore float divide by 100 to get to the required range.
-        """
-        return self._volume
 
     def set_volume_level(self, volume: float) -> None:
         """Set volume level.  Volume has a range (0..1).
@@ -158,12 +134,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
 
     def select_source(self, source: str) -> None:
         """Set the input source."""
-        if source in self._sources:
-            index = self._sources.index(source)
+        if self.source_list and source in self.source_list:
+            index = self.source_list.index(source)
             # 0 based value for source
             self._russ.set_source("1", self._zone_id, index)
-
-    @property
-    def source_list(self):
-        """Return a list of available input sources."""
-        return self._sources


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in russound met media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
