### PR TITLE
Use attributes in ue smart radio media player

### DIFF
--- a/homeassistant/components/ue_smart_radio/media_player.py
+++ b/homeassistant/components/ue_smart_radio/media_player.py
@@ -82,6 +82,7 @@ def setup_platform(
 class UERadioDevice(MediaPlayerEntity):
     """Representation of a Logitech UE Smart Radio device."""
 
+    _attr_icon = ICON
     _attr_media_content_type = MediaType.MUSIC
     _attr_supported_features = (
         MediaPlayerEntityFeature.PLAY
@@ -99,12 +100,9 @@ class UERadioDevice(MediaPlayerEntity):
         """Initialize the Logitech UE Smart Radio device."""
         self._session = session
         self._player_id = player_id
-        self._name = player_name
-        self._volume = 0
+        self._attr_name = player_name
+        self._attr_volume_level = 0
         self._last_volume = 0
-        self._media_title = None
-        self._media_artist = None
-        self._media_artwork_url = None
 
     def send_command(self, command):
         """Send command to radio."""
@@ -137,48 +135,18 @@ class UERadioDevice(MediaPlayerEntity):
 
         media_info = request["result"]["playlist_loop"][0]
 
-        self._volume = request["result"]["mixer volume"] / 100
-        self._media_artwork_url = media_info["artwork_url"]
-        self._media_title = media_info["title"]
+        self._attr_volume_level = request["result"]["mixer volume"] / 100
+        self._attr_media_image_url = media_info["artwork_url"]
+        self._attr_media_title = media_info["title"]
         if "artist" in media_info:
-            self._media_artist = media_info["artist"]
+            self._attr_media_artist = media_info["artist"]
         else:
-            self._media_artist = media_info.get("remote_title")
+            self._attr_media_artist = media_info.get("remote_title")
 
     @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def icon(self):
-        """Return the icon to use in the frontend, if any."""
-        return ICON
-
-    @property
-    def is_volume_muted(self):
+    def is_volume_muted(self) -> bool:
         """Boolean if volume is currently muted."""
-        return self._volume <= 0
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1)."""
-        return self._volume
-
-    @property
-    def media_image_url(self):
-        """Image URL of current playing media."""
-        return self._media_artwork_url
-
-    @property
-    def media_artist(self):
-        """Artist of current playing media, music track only."""
-        return self._media_artist
-
-    @property
-    def media_title(self):
-        """Title of current playing media."""
-        return self._media_title
+        return self.volume_level is not None and self.volume_level <= 0
 
     def turn_on(self) -> None:
         """Turn on specified media player or all."""
@@ -211,7 +179,7 @@ class UERadioDevice(MediaPlayerEntity):
     def mute_volume(self, mute: bool) -> None:
         """Send mute command."""
         if mute:
-            self._last_volume = self._volume
+            self._last_volume = self.volume_level
             self.send_command(["mixer", "volume", 0])
         else:
             self.send_command(["mixer", "volume", self._last_volume * 100])

--- a/homeassistant/components/ue_smart_radio/media_player.py
+++ b/homeassistant/components/ue_smart_radio/media_player.py
@@ -100,7 +100,6 @@ class UERadioDevice(MediaPlayerEntity):
         self._session = session
         self._player_id = player_id
         self._name = player_name
-        self._state = None
         self._volume = 0
         self._last_volume = 0
         self._media_title = None
@@ -128,13 +127,13 @@ class UERadioDevice(MediaPlayerEntity):
         )
 
         if request["error"] is not None:
-            self._state = None
+            self._attr_state = None
             return
 
         if request["result"]["power"] == 0:
-            self._state = MediaPlayerState.OFF
+            self._attr_state = MediaPlayerState.OFF
         else:
-            self._state = PLAYBACK_DICT[request["result"]["mode"]]
+            self._attr_state = PLAYBACK_DICT[request["result"]["mode"]]
 
         media_info = request["result"]["playlist_loop"][0]
 
@@ -150,11 +149,6 @@ class UERadioDevice(MediaPlayerEntity):
     def name(self):
         """Return the name of the device."""
         return self._name
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
 
     @property
     def icon(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in ue smart radio media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
