### PR TITLE
Use attributes in vlc media player

### DIFF
--- a/homeassistant/components/vlc/media_player.py
+++ b/homeassistant/components/vlc/media_player.py
@@ -67,12 +67,7 @@ class VlcDevice(MediaPlayerEntity):
         """Initialize the vlc device."""
         self._instance = vlc.Instance(arguments)
         self._vlc = self._instance.media_player_new()
-        self._name = name
-        self._volume = None
-        self._muted = None
-        self._media_position_updated_at = None
-        self._media_position = None
-        self._media_duration = None
+        self._attr_name = name
 
     def update(self):
         """Get the latest details from the device."""
@@ -83,46 +78,16 @@ class VlcDevice(MediaPlayerEntity):
             self._attr_state = MediaPlayerState.PAUSED
         else:
             self._attr_state = MediaPlayerState.IDLE
-        self._media_duration = self._vlc.get_length() / 1000
-        position = self._vlc.get_position() * self._media_duration
-        if position != self._media_position:
-            self._media_position_updated_at = dt_util.utcnow()
-            self._media_position = position
+        self._attr_media_duration = self._vlc.get_length() / 1000
+        position = self._vlc.get_position() * self._attr_media_duration
+        if position != self._attr_media_position:
+            self._attr_media_position_updated_at = dt_util.utcnow()
+            self._attr_media_position = position
 
-        self._volume = self._vlc.audio_get_volume() / 100
-        self._muted = self._vlc.audio_get_mute() == 1
+        self._attr_volume_level = self._vlc.audio_get_volume() / 100
+        self._attr_is_volume_muted = self._vlc.audio_get_mute() == 1
 
         return True
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1)."""
-        return self._volume
-
-    @property
-    def is_volume_muted(self):
-        """Boolean if volume is currently muted."""
-        return self._muted
-
-    @property
-    def media_duration(self):
-        """Duration of current playing media in seconds."""
-        return self._media_duration
-
-    @property
-    def media_position(self):
-        """Position of current playing media in seconds."""
-        return self._media_position
-
-    @property
-    def media_position_updated_at(self):
-        """When was the position of the current playing media valid."""
-        return self._media_position_updated_at
 
     def media_seek(self, position: float) -> None:
         """Seek the media to a specific location."""
@@ -132,12 +97,12 @@ class VlcDevice(MediaPlayerEntity):
     def mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         self._vlc.audio_set_mute(mute)
-        self._muted = mute
+        self._attr_is_volume_muted = mute
 
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         self._vlc.audio_set_volume(int(volume * 100))
-        self._volume = volume
+        self._attr_volume_level = volume
 
     def media_play(self) -> None:
         """Send play command."""

--- a/homeassistant/components/vlc/media_player.py
+++ b/homeassistant/components/vlc/media_player.py
@@ -70,7 +70,6 @@ class VlcDevice(MediaPlayerEntity):
         self._name = name
         self._volume = None
         self._muted = None
-        self._state = None
         self._media_position_updated_at = None
         self._media_position = None
         self._media_duration = None
@@ -79,11 +78,11 @@ class VlcDevice(MediaPlayerEntity):
         """Get the latest details from the device."""
         status = self._vlc.get_state()
         if status == vlc.State.Playing:
-            self._state = MediaPlayerState.PLAYING
+            self._attr_state = MediaPlayerState.PLAYING
         elif status == vlc.State.Paused:
-            self._state = MediaPlayerState.PAUSED
+            self._attr_state = MediaPlayerState.PAUSED
         else:
-            self._state = MediaPlayerState.IDLE
+            self._attr_state = MediaPlayerState.IDLE
         self._media_duration = self._vlc.get_length() / 1000
         position = self._vlc.get_position() * self._media_duration
         if position != self._media_position:
@@ -99,11 +98,6 @@ class VlcDevice(MediaPlayerEntity):
     def name(self):
         """Return the name of the device."""
         return self._name
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
 
     @property
     def volume_level(self):
@@ -148,17 +142,17 @@ class VlcDevice(MediaPlayerEntity):
     def media_play(self) -> None:
         """Send play command."""
         self._vlc.play()
-        self._state = MediaPlayerState.PLAYING
+        self._attr_state = MediaPlayerState.PLAYING
 
     def media_pause(self) -> None:
         """Send pause command."""
         self._vlc.pause()
-        self._state = MediaPlayerState.PAUSED
+        self._attr_state = MediaPlayerState.PAUSED
 
     def media_stop(self) -> None:
         """Send stop command."""
         self._vlc.stop()
-        self._state = MediaPlayerState.IDLE
+        self._attr_state = MediaPlayerState.IDLE
 
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
@@ -186,7 +180,7 @@ class VlcDevice(MediaPlayerEntity):
             self._vlc.play()
 
         await self.hass.async_add_executor_job(play)
-        self._state = MediaPlayerState.PLAYING
+        self._attr_state = MediaPlayerState.PLAYING
 
     async def async_browse_media(
         self,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in vlc media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
