### PR TITLE
Use attributes in yamaha media player

### DIFF
--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -193,13 +193,9 @@ class YamahaDevice(MediaPlayerEntity):
     def __init__(self, name, receiver, source_ignore, source_names, zone_names):
         """Initialize the Yamaha Receiver."""
         self.receiver = receiver
-        self._muted = False
-        self._volume = 0
+        self._attr_is_volume_muted = False
+        self._attr_volume_level = 0
         self._attr_state = MediaPlayerState.OFF
-        self._current_source = None
-        self._sound_mode = None
-        self._sound_mode_list = None
-        self._source_list = None
         self._source_ignore = source_ignore or []
         self._source_names = source_names or {}
         self._zone_names = zone_names or {}
@@ -228,25 +224,25 @@ class YamahaDevice(MediaPlayerEntity):
         else:
             self._attr_state = MediaPlayerState.OFF
 
-        self._muted = self.receiver.mute
-        self._volume = (self.receiver.volume / 100) + 1
+        self._attr_is_volume_muted = self.receiver.mute
+        self._attr_volume_level = (self.receiver.volume / 100) + 1
 
         if self.source_list is None:
             self.build_source_list()
 
         current_source = self.receiver.input
-        self._current_source = self._source_names.get(current_source, current_source)
+        self._attr_source = self._source_names.get(current_source, current_source)
         self._playback_support = self.receiver.get_playback_support()
         self._is_playback_supported = self.receiver.is_playback_supported(
-            self._current_source
+            self._attr_source
         )
         surround_programs = self.receiver.surround_programs()
         if surround_programs:
-            self._sound_mode = self.receiver.surround_program
-            self._sound_mode_list = surround_programs
+            self._attr_sound_mode = self.receiver.surround_program
+            self._attr_sound_mode_list = surround_programs
         else:
-            self._sound_mode = None
-            self._sound_mode_list = None
+            self._attr_sound_mode = None
+            self._attr_sound_mode_list = None
 
     def build_source_list(self):
         """Build the source list."""
@@ -254,7 +250,7 @@ class YamahaDevice(MediaPlayerEntity):
             alias: source for source, alias in self._source_names.items()
         }
 
-        self._source_list = sorted(
+        self._attr_source_list = sorted(
             self._source_names.get(source, source)
             for source in self.receiver.inputs()
             if source not in self._source_ignore
@@ -269,36 +265,6 @@ class YamahaDevice(MediaPlayerEntity):
             # Zone will be one of Main_Zone, Zone_2, Zone_3
             name += f" {zone_name.replace('_', ' ')}"
         return name
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1)."""
-        return self._volume
-
-    @property
-    def is_volume_muted(self):
-        """Boolean if volume is currently muted."""
-        return self._muted
-
-    @property
-    def source(self):
-        """Return the current input source."""
-        return self._current_source
-
-    @property
-    def sound_mode(self):
-        """Return the current sound mode."""
-        return self._sound_mode
-
-    @property
-    def sound_mode_list(self):
-        """Return the current sound mode."""
-        return self._sound_mode_list
-
-    @property
-    def source_list(self):
-        """List of available input sources."""
-        return self._source_list
 
     @property
     def zone_id(self):
@@ -342,7 +308,7 @@ class YamahaDevice(MediaPlayerEntity):
     def turn_on(self) -> None:
         """Turn the media player on."""
         self.receiver.on = True
-        self._volume = (self.receiver.volume / 100) + 1
+        self._attr_volume_level = (self.receiver.volume / 100) + 1
 
     def media_play(self) -> None:
         """Send play command."""

--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -195,7 +195,7 @@ class YamahaDevice(MediaPlayerEntity):
         self.receiver = receiver
         self._muted = False
         self._volume = 0
-        self._pwstate = MediaPlayerState.OFF
+        self._attr_state = MediaPlayerState.OFF
         self._current_source = None
         self._sound_mode = None
         self._sound_mode_list = None
@@ -220,13 +220,13 @@ class YamahaDevice(MediaPlayerEntity):
 
         if self.receiver.on:
             if self._play_status is None:
-                self._pwstate = MediaPlayerState.ON
+                self._attr_state = MediaPlayerState.ON
             elif self._play_status.playing:
-                self._pwstate = MediaPlayerState.PLAYING
+                self._attr_state = MediaPlayerState.PLAYING
             else:
-                self._pwstate = MediaPlayerState.IDLE
+                self._attr_state = MediaPlayerState.IDLE
         else:
-            self._pwstate = MediaPlayerState.OFF
+            self._attr_state = MediaPlayerState.OFF
 
         self._muted = self.receiver.mute
         self._volume = (self.receiver.volume / 100) + 1
@@ -269,11 +269,6 @@ class YamahaDevice(MediaPlayerEntity):
             # Zone will be one of Main_Zone, Zone_2, Zone_3
             name += f" {zone_name.replace('_', ' ')}"
         return name
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._pwstate
 
     @property
     def volume_level(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use _attr_state in yamaha media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
