### PR TITLE
Parametrize Switcher button tests

### DIFF
--- a/tests/components/switcher_kis/test_button.py
+++ b/tests/components/switcher_kis/test_button.py
@@ -20,8 +20,15 @@ SWING_ON_EID = BASE_ENTITY_ID + "_vertical_swing_on"
 SWING_OFF_EID = BASE_ENTITY_ID + "_vertical_swing_off"
 
 
+@pytest.mark.parametrize(
+    "entity, state",
+    [
+        (ASSUME_ON_EID, DeviceState.ON),
+        (ASSUME_OFF_EID, DeviceState.OFF),
+    ],
+)
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_assume_button(hass: HomeAssistant, mock_bridge, mock_api):
+async def test_assume_button(hass: HomeAssistant, entity, state, mock_bridge, mock_api):
     """Test assume on/off button."""
     await init_integration(hass)
     assert mock_bridge
@@ -37,29 +44,24 @@ async def test_assume_button(hass: HomeAssistant, mock_bridge, mock_api):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
-            {ATTR_ENTITY_ID: ASSUME_ON_EID},
+            {ATTR_ENTITY_ID: entity},
             blocking=True,
         )
         assert mock_api.call_count == 2
-        mock_control_device.assert_called_once_with(
-            ANY, state=DeviceState.ON, update_state=True
-        )
-
-        mock_control_device.reset_mock()
-        await hass.services.async_call(
-            BUTTON_DOMAIN,
-            SERVICE_PRESS,
-            {ATTR_ENTITY_ID: ASSUME_OFF_EID},
-            blocking=True,
-        )
-        assert mock_api.call_count == 4
-        mock_control_device.assert_called_once_with(
-            ANY, state=DeviceState.OFF, update_state=True
-        )
+        mock_control_device.assert_called_once_with(ANY, state=state, update_state=True)
 
 
+@pytest.mark.parametrize(
+    "entity, swing",
+    [
+        (SWING_ON_EID, ThermostatSwing.ON),
+        (SWING_OFF_EID, ThermostatSwing.OFF),
+    ],
+)
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_swing_button(hass: HomeAssistant, mock_bridge, mock_api, monkeypatch):
+async def test_swing_button(
+    hass: HomeAssistant, entity, swing, mock_bridge, mock_api, monkeypatch
+):
     """Test vertical swing on/off button."""
     monkeypatch.setattr(DEVICE, "remote_id", "ELEC7022")
     await init_integration(hass)
@@ -76,21 +78,11 @@ async def test_swing_button(hass: HomeAssistant, mock_bridge, mock_api, monkeypa
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
-            {ATTR_ENTITY_ID: SWING_ON_EID},
+            {ATTR_ENTITY_ID: entity},
             blocking=True,
         )
         assert mock_api.call_count == 2
-        mock_control_device.assert_called_once_with(ANY, swing=ThermostatSwing.ON)
-
-        mock_control_device.reset_mock()
-        await hass.services.async_call(
-            BUTTON_DOMAIN,
-            SERVICE_PRESS,
-            {ATTR_ENTITY_ID: SWING_OFF_EID},
-            blocking=True,
-        )
-        assert mock_api.call_count == 4
-        mock_control_device.assert_called_once_with(ANY, swing=ThermostatSwing.OFF)
+        mock_control_device.assert_called_once_with(ANY, swing=swing)
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Address https://github.com/home-assistant/core/pull/81245#discussion_r1032946221

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
