### PR TITLE
Initial Edilkamin stove integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -280,6 +280,9 @@ omit =
     homeassistant/components/ecowitt/entity.py
     homeassistant/components/ecowitt/sensor.py
     homeassistant/components/eddystone_temperature/sensor.py
+    homeassistant/components/edilkamin/__init__.py
+    homeassistant/components/edilkamin/climate.py
+    homeassistant/components/edilkamin/entity.py
     homeassistant/components/edimax/switch.py
     homeassistant/components/edl21/__init__.py
     homeassistant/components/edl21/sensor.py

--- a/.strict-typing
+++ b/.strict-typing
@@ -109,6 +109,7 @@ homeassistant.components.doorbird.*
 homeassistant.components.dormakaba_dkey.*
 homeassistant.components.dsmr.*
 homeassistant.components.dunehd.*
+homeassistant.components.edilkamin.*
 homeassistant.components.efergy.*
 homeassistant.components.electrasmart.*
 homeassistant.components.electric_kiwi.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -316,6 +316,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/ecovacs/ @OverloadUT @mib1185
 /homeassistant/components/ecowitt/ @pvizeli
 /tests/components/ecowitt/ @pvizeli
+/homeassistant/components/edilkamin/ @AndreMiras
+/tests/components/edilkamin/ @AndreMiras
 /homeassistant/components/efergy/ @tkdrob
 /tests/components/efergy/ @tkdrob
 /homeassistant/components/egardia/ @jeroenterheerdt

--- a/homeassistant/components/edilkamin/__init__.py
+++ b/homeassistant/components/edilkamin/__init__.py
@@ -1,0 +1,25 @@
+"""The edilkamin integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+PLATFORMS: list[Platform] = [Platform.CLIMATE]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up edilkamin from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = entry.data
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/homeassistant/components/edilkamin/climate.py
+++ b/homeassistant/components/edilkamin/climate.py
@@ -1,0 +1,32 @@
+"""The edilkamin integration."""
+from __future__ import annotations
+
+import edilkamin
+
+from homeassistant.components.bluetooth import async_discovered_service_info
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import EdilkaminEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the stove with config flow."""
+    username = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
+    ble_devices = tuple(
+        {"name": discovery_info.name, "address": discovery_info.address}
+        for discovery_info in async_discovered_service_info(hass, False)
+    )
+    mac_addresses = edilkamin.discover_devices_helper(ble_devices)
+    entities = [
+        EdilkaminEntity(username, password, mac_address)
+        for mac_address in mac_addresses
+    ]
+    async_add_entities(entities, True)

--- a/homeassistant/components/edilkamin/config_flow.py
+++ b/homeassistant/components/edilkamin/config_flow.py
@@ -1,0 +1,96 @@
+"""Config flow for edilkamin integration."""
+from __future__ import annotations
+
+from typing import Any, cast
+
+import edilkamin
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+import homeassistant.helpers.config_validation as cv
+
+from .const import DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    }
+)
+
+
+class EdilkaminHub:
+    """EdilkaminHub used for testing the authentication."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Create the Edilkamin hub using the HomeAssistant instance."""
+        self.hass = hass
+
+    async def authenticate(self, username: str, password: str) -> str:
+        """Authenticate with the host and return the token or raise an exception."""
+        try:
+            token = await self.hass.async_add_executor_job(
+                edilkamin.sign_in, username, password
+            )
+        except Exception as exception:
+            # we can't easily catch for the NotAuthorizedException directly since it
+            # was created dynamically with a factory
+            if exception.__class__.__name__ == "NotAuthorizedException":
+                raise InvalidAuth(exception) from exception
+            raise CannotConnect(exception) from exception
+        return cast(str, token)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> str:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+    hub = EdilkaminHub(hass)
+    username = data[CONF_USERNAME]
+    password = data[CONF_PASSWORD]
+    token = await hub.authenticate(username, password)
+    if not token:
+        raise InvalidAuth
+    return token
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for edilkamin."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initiated by the user."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+        errors = {}
+        try:
+            await validate_input(self.hass, user_input)
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        else:
+            data = user_input
+            return self.async_create_entry(title=user_input[CONF_USERNAME], data=data)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/edilkamin/const.py
+++ b/homeassistant/components/edilkamin/const.py
@@ -1,0 +1,5 @@
+"""Constants for the edilkamin integration."""
+import logging
+
+DOMAIN = "edilkamin"
+LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/edilkamin/entity.py
+++ b/homeassistant/components/edilkamin/entity.py
@@ -1,0 +1,80 @@
+"""Edilkamin integration entity."""
+from typing import Any, cast
+
+import edilkamin
+
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+
+from .const import LOGGER
+
+power_to_hvac = {
+    edilkamin.Power.OFF: HVACMode.OFF,
+    edilkamin.Power.ON: HVACMode.HEAT,
+}
+hvac_mode_to_power = {hvac: power for (power, hvac) in power_to_hvac.items()}
+
+
+class EdilkaminEntity(ClimateEntity):
+    """Representation of a stove."""
+
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        mac_address: str,
+    ) -> None:
+        """Create the Edilkamin entity.
+
+        Use:
+        - the username/password to login
+        - the MAC address that identifies the stove
+        """
+        self._attr_name = f"Stove ({mac_address})"
+        self._attr_unique_id = mac_address
+        self._username = username
+        self._password = password
+        self._mac_address = mac_address
+        self._device_info = None
+
+    def refresh_token(self) -> str:
+        """Login to refresh the token."""
+        return cast(str, edilkamin.sign_in(self._username, self._password))
+
+    def update(self) -> None:
+        """Get the latest data and update the relevant Entity attributes."""
+        token = self.refresh_token()
+        self._device_info = edilkamin.device_info(token, self._mac_address)
+        power = edilkamin.device_info_get_power(self._device_info)
+        self._attr_hvac_mode = power_to_hvac[power]
+        self._attr_target_temperature = edilkamin.device_info_get_target_temperature(
+            self._device_info
+        )
+        self._attr_current_temperature = (
+            edilkamin.device_info_get_environment_temperature(self._device_info)
+        )
+
+    def set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
+            return
+        token = self.refresh_token()
+        edilkamin.set_target_temperature(token, self._mac_address, temperature)
+
+    def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target hvac mode."""
+        LOGGER.debug("Setting async hvac mode: %s", hvac_mode)
+        if hvac_mode not in hvac_mode_to_power:
+            LOGGER.warning("Unsupported mode: %s", hvac_mode)
+            return
+        power = hvac_mode_to_power[hvac_mode]
+        token = self.refresh_token()
+        edilkamin.set_power(token, self._mac_address, power)

--- a/homeassistant/components/edilkamin/manifest.json
+++ b/homeassistant/components/edilkamin/manifest.json
@@ -1,0 +1,16 @@
+{
+  "domain": "edilkamin",
+  "name": "Edilkamin Stove",
+  "bluetooth": [
+    {
+      "local_name": "EDILKAMIN_*",
+      "connectable": false
+    }
+  ],
+  "codeowners": ["@AndreMiras"],
+  "config_flow": true,
+  "dependencies": ["bluetooth_adapters", "http"],
+  "documentation": "https://www.home-assistant.io/integrations/edilkamin",
+  "iot_class": "cloud_polling",
+  "requirements": ["edilkamin==1.3.0"]
+}

--- a/homeassistant/components/edilkamin/strings.json
+++ b/homeassistant/components/edilkamin/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -67,6 +67,11 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
         "service_uuid": "e7a60001-6639-429f-94fd-86de8ea26897",
     },
     {
+        "connectable": False,
+        "domain": "edilkamin",
+        "local_name": "EDILKAMIN_*",
+    },
+    {
         "domain": "eufylife_ble",
         "local_name": "eufy T9140",
     },

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -119,6 +119,7 @@ FLOWS = {
         "ecoforest",
         "econet",
         "ecowitt",
+        "edilkamin",
         "edl21",
         "efergy",
         "eight_sleep",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1351,6 +1351,12 @@
       "config_flow": false,
       "iot_class": "local_polling"
     },
+    "edilkamin": {
+      "name": "Edilkamin Stove",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "edimax": {
       "name": "Edimax",
       "integration_type": "hub",

--- a/mypy.ini
+++ b/mypy.ini
@@ -852,6 +852,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.edilkamin.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.efergy.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -718,6 +718,9 @@ ebusdpy==0.0.17
 # homeassistant.components.ecoal_boiler
 ecoaliface==0.4.0
 
+# homeassistant.components.edilkamin
+edilkamin==1.3.0
+
 # homeassistant.components.electric_kiwi
 electrickiwi-api==0.8.5
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -580,6 +580,9 @@ eagle100==0.1.1
 # homeassistant.components.easyenergy
 easyenergy==0.3.0
 
+# homeassistant.components.edilkamin
+edilkamin==1.3.0
+
 # homeassistant.components.electric_kiwi
 electrickiwi-api==0.8.5
 

--- a/tests/components/edilkamin/__init__.py
+++ b/tests/components/edilkamin/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the edilkamin integration."""

--- a/tests/components/edilkamin/conftest.py
+++ b/tests/components/edilkamin/conftest.py
@@ -1,0 +1,8 @@
+"""edilkamin session fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_bluetooth(enable_bluetooth):
+    """Auto mock bluetooth."""

--- a/tests/components/edilkamin/test_config_flow.py
+++ b/tests/components/edilkamin/test_config_flow.py
@@ -1,0 +1,106 @@
+"""Test the edilkamin config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.edilkamin.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+username = "user@email.com"
+password = "password"
+token = "the-token"
+
+
+class NotAuthorizedException(Exception):
+    """Cannot be imported as it's created dynamically within pycognito."""
+
+
+def patch_sign_in(return_value=None, side_effect=None):
+    """Patch the edilkamin.sign_in() function."""
+    return patch(
+        "homeassistant.components.edilkamin.config_flow.edilkamin.sign_in",
+        return_value=return_value,
+        side_effect=side_effect,
+    )
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+    with patch(
+        "homeassistant.components.edilkamin.config_flow.EdilkaminHub.authenticate",
+        return_value=token,
+    ), patch(
+        "homeassistant.components.edilkamin.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": username,
+                "password": password,
+            },
+        )
+        await hass.async_block_till_done()
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == username
+    assert result2["data"] == {
+        "username": username,
+        "password": password,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch_sign_in(side_effect=NotAuthorizedException):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": username,
+                "password": password,
+            },
+        )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_token_none(hass: HomeAssistant) -> None:
+    """Test we handle token=None."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch_sign_in():
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": username,
+                "password": password,
+            },
+        )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch_sign_in(side_effect=Exception):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": username,
+                "password": password,
+            },
+        )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
## Proposed change

This is a first iteration with a basic set of feature:
- turn on/off
- get/set target temperature
- get current temperature

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

The bluetooth is currently only used for device discovery. The device is then driven from a cloud based API.
It seems like alternatively the device can also be driven fully from bluetooth, but the underlying `edilkamin` Python library doesn't support it yet.


## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] https://github.com/home-assistant/home-assistant.io/pull/25072

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly. Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`. Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.