### PR TITLE
Bump homematicip 1.0.11

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomematicIP Cloud",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homematicip_cloud",
-  "requirements": ["homematicip==1.0.7"],
+  "requirements": ["homematicip==1.0.11"],
   "codeowners": [],
   "quality_scale": "platinum",
   "iot_class": "cloud_push",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -890,7 +890,7 @@ home-assistant-frontend==20221108.0
 homeconnect==0.7.2
 
 # homeassistant.components.homematicip_cloud
-homematicip==1.0.7
+homematicip==1.0.11
 
 # homeassistant.components.home_plus_control
 homepluscontrol==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -670,7 +670,7 @@ home-assistant-frontend==20221108.0
 homeconnect==0.7.2
 
 # homeassistant.components.homematicip_cloud
-homematicip==1.0.7
+homematicip==1.0.11
 
 # homeassistant.components.home_plus_control
 homepluscontrol==0.0.5

--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -6830,6 +6830,55 @@
       "serializedGlobalTradeItemNumber": "3014F7110000000000000WGC",
       "type": "WALL_MOUNTED_GARAGE_DOOR_CONTROLLER",
       "updateState": "UP_TO_DATE"
+    },
+    "HUE00000-0000-0000-0000-000000000008": {
+      "connectionType": "EXTERNAL",
+      "deviceArchetype": "EXTERNAL",
+      "externalService": "HUE",
+      "firmwareVersion": "1.88.1",
+      "functionalChannels": {
+        "0": {
+          "channelId": "HUE00000-0000-0000-0000-000000000009",
+          "deviceId": "HUE00000-0000-0000-0000-000000000008",
+          "functionalChannelType": "EXTERNAL_BASE_CHANNEL",
+          "groupIndex": 0,
+          "groups": ["HUE00000-0000-0000-0000-000000000010"],
+          "index": 0,
+          "label": "",
+          "unreach": false
+        },
+        "1": {
+          "channelId": "HUE00000-0000-0000-0000-000000000011",
+          "channelRole": "UNIVERSAL_LIGHT_ACTUATOR",
+          "colorTemperature": 3165,
+          "deviceId": "HUE00000-0000-0000-0000-000000000008",
+          "dimLevel": 0.0,
+          "functionalChannelType": "EXTERNAL_UNIVERSAL_LIGHT_CHANNEL",
+          "groupIndex": 1,
+          "groups": ["HUE00000-0000-0000-0000-000000000012"],
+          "hue": null,
+          "index": 1,
+          "label": "",
+          "maximumColorTemperature": 6500,
+          "minimalColorTemperature": 2000,
+          "on": false,
+          "saturationLevel": null,
+          "supportedOptionalFeatures": {
+            "IFeatureLightGroupActuatorChannel": true,
+            "IOptionalFeatureColorTemperature": true,
+            "IOptionalFeatureDimmerState": true
+          }
+        }
+      },
+      "hasCustomLabel": false,
+      "homeId": "00000000-0000-0000-0000-000000000001",
+      "id": "HUE00000-0000-0000-0000-000000000008",
+      "label": "Hinten rechts",
+      "lastStatusUpdate": 1669539365772,
+      "modelType": "LTW013",
+      "permanentlyReachable": true,
+      "supported": true,
+      "type": "EXTERNAL"
     }
   },
   "groups": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Homematic introduced the support for adding hue devices to their environment. But this breaks the homematicip upstream library. Version 1.0.11 of homematicip fixes that.
Hue devices are not yet shown in home-assistant. The library just don't break.

Changelog: https://github.com/hahn-th/homematicip-rest-api/blob/1.0.11/CHANGELOG.md
Full diff between currently used version 1.0.7 and 1.0.11: https://github.com/hahn-th/homematicip-rest-api/compare/1.0.7...master


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #82737
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
