### PR TITLE
Add matter config entry add-on management

### DIFF
--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -37,7 +37,7 @@ from .device_platform import DEVICE_PLATFORM
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Matter from a config entry."""
     if use_addon := entry.data.get(CONF_USE_ADDON):
-        await async_ensure_addon_running(hass, entry)
+        await _async_ensure_addon_running(hass, entry)
 
     matter = Matter(MatterAdapter(hass, entry))
     try:
@@ -302,7 +302,7 @@ def _async_init_services(hass: HomeAssistant) -> None:
     )
 
 
-async def async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Ensure that Matter Server add-on is installed and running."""
     addon_manager = _get_addon_manager(hass)
     try:

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -6,36 +6,66 @@ from pathlib import Path
 from typing import cast
 
 import async_timeout
-from matter_server.client.exceptions import CannotConnect, FailedCommand
+from matter_server.client.exceptions import (
+    CannotConnect,
+    FailedCommand,
+    InvalidServerVersion,
+)
 from matter_server.client.matter import Matter
 import voluptuous as vol
 
+from homeassistant.components.hassio import AddonError, AddonManager, AddonState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 from homeassistant.helpers.service import async_register_admin_service
 
 from .adapter import MatterAdapter, get_matter_store
+from .addon import get_addon_manager
 from .api import async_register_api
-from .const import DOMAIN
+from .const import CONF_INTEGRATION_CREATED_ADDON, CONF_USE_ADDON, DOMAIN, LOGGER
 from .device_platform import DEVICE_PLATFORM
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Matter from a config entry."""
+    if use_addon := entry.data.get(CONF_USE_ADDON):
+        await async_ensure_addon_running(hass, entry)
+
     matter = Matter(MatterAdapter(hass, entry))
     try:
         await matter.connect()
     except CannotConnect as err:
         raise ConfigEntryNotReady("Failed to connect to matter server") from err
+    except InvalidServerVersion as err:
+        if use_addon:
+            addon_manager = _get_addon_manager(hass)
+            addon_manager.async_schedule_update_addon(catch_error=True)
+        else:
+            async_create_issue(
+                hass,
+                DOMAIN,
+                "invalid_server_version",
+                is_fixable=False,
+                severity=IssueSeverity.ERROR,
+                translation_key="invalid_server_version",
+            )
+        raise ConfigEntryNotReady(f"Invalid server version: {err}") from err
 
     except Exception as err:
         matter.adapter.logger.exception("Failed to connect to matter server")
         raise ConfigEntryNotReady(
             "Unknown error connecting to the Matter server"
         ) from err
+    else:
+        async_delete_issue(hass, DOMAIN, "invalid_server_version")
 
     async def on_hass_stop(event: Event) -> None:
         """Handle incoming stop event from Home Assistant."""
@@ -73,6 +103,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         matter: Matter = hass.data[DOMAIN].pop(entry.entry_id)
         await matter.disconnect()
 
+    if entry.data.get(CONF_USE_ADDON) and entry.disabled_by:
+        addon_manager: AddonManager = get_addon_manager(hass)
+        LOGGER.debug("Stopping Matter Server add-on")
+        try:
+            await addon_manager.async_stop_addon()
+        except AddonError as err:
+            LOGGER.error("Failed to stop the Matter Server add-on: %s", err)
+            return False
+
     return unload_ok
 
 
@@ -81,6 +120,25 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     # Remove storage file.
     storage_path = get_matter_store(hass, entry).path
     await hass.async_add_executor_job(Path(storage_path).unlink)
+
+    if not entry.data.get(CONF_INTEGRATION_CREATED_ADDON):
+        return
+
+    addon_manager: AddonManager = get_addon_manager(hass)
+    try:
+        await addon_manager.async_stop_addon()
+    except AddonError as err:
+        LOGGER.error(err)
+        return
+    try:
+        await addon_manager.async_create_backup()
+    except AddonError as err:
+        LOGGER.error(err)
+        return
+    try:
+        await addon_manager.async_uninstall_addon()
+    except AddonError as err:
+        LOGGER.error(err)
 
 
 async def async_remove_config_entry_device(
@@ -242,3 +300,34 @@ def _async_init_services(hass: HomeAssistant) -> None:
         open_commissioning_window,
         vol.Schema({"device_id": str}),
     )
+
+
+async def async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Ensure that Matter Server add-on is installed and running."""
+    addon_manager = _get_addon_manager(hass)
+    try:
+        addon_info = await addon_manager.async_get_addon_info()
+    except AddonError as err:
+        raise ConfigEntryNotReady(err) from err
+
+    addon_state = addon_info.state
+
+    if addon_state == AddonState.NOT_INSTALLED:
+        addon_manager.async_schedule_install_setup_addon(
+            addon_info.options,
+            catch_error=True,
+        )
+        raise ConfigEntryNotReady
+
+    if addon_state == AddonState.NOT_RUNNING:
+        addon_manager.async_schedule_start_addon(catch_error=True)
+        raise ConfigEntryNotReady
+
+
+@callback
+def _get_addon_manager(hass: HomeAssistant) -> AddonManager:
+    """Ensure that Matter Server add-on is updated and running."""
+    addon_manager: AddonManager = get_addon_manager(hass)
+    if addon_manager.task_in_progress():
+        raise ConfigEntryNotReady
+    return addon_manager

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -326,7 +326,10 @@ async def _async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) -
 
 @callback
 def _get_addon_manager(hass: HomeAssistant) -> AddonManager:
-    """Ensure that Matter Server add-on is updated and running."""
+    """Ensure that Matter Server add-on is updated and running.
+
+    May only be used as part of async_setup_entry above.
+    """
     addon_manager: AddonManager = get_addon_manager(hass)
     if addon_manager.task_in_progress():
         raise ConfigEntryNotReady

--- a/tests/components/matter/conftest.py
+++ b/tests/components/matter/conftest.py
@@ -53,6 +53,15 @@ async def integration_fixture(
     return entry
 
 
+@pytest.fixture(name="create_backup")
+def create_backup_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock Supervisor create backup of add-on."""
+    with patch(
+        "homeassistant.components.hassio.addon_manager.async_create_backup"
+    ) as create_backup:
+        yield create_backup
+
+
 @pytest.fixture(name="addon_store_info")
 def addon_store_info_fixture() -> Generator[AsyncMock, None, None]:
     """Mock Supervisor add-on store info."""
@@ -124,11 +133,25 @@ def addon_running_fixture(
 
 
 @pytest.fixture(name="install_addon")
-def install_addon_fixture() -> Generator[AsyncMock, None, None]:
+def install_addon_fixture(
+    addon_store_info: AsyncMock, addon_info: AsyncMock
+) -> Generator[AsyncMock, None, None]:
     """Mock install add-on."""
+
+    async def install_addon_side_effect(hass: HomeAssistant, slug: str) -> None:
+        """Mock install add-on."""
+        addon_store_info.return_value = {
+            "installed": "1.0.0",
+            "state": "stopped",
+            "version": "1.0.0",
+        }
+        addon_info.return_value["state"] = "stopped"
+        addon_info.return_value["version"] = "1.0.0"
+
     with patch(
         "homeassistant.components.hassio.addon_manager.async_install_addon"
     ) as install_addon:
+        install_addon.side_effect = install_addon_side_effect
         yield install_addon
 
 
@@ -139,3 +162,30 @@ def start_addon_fixture() -> Generator[AsyncMock, None, None]:
         "homeassistant.components.hassio.addon_manager.async_start_addon"
     ) as start_addon:
         yield start_addon
+
+
+@pytest.fixture(name="stop_addon")
+def stop_addon_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock stop add-on."""
+    with patch(
+        "homeassistant.components.hassio.addon_manager.async_stop_addon"
+    ) as stop_addon:
+        yield stop_addon
+
+
+@pytest.fixture(name="uninstall_addon")
+def uninstall_addon_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock uninstall add-on."""
+    with patch(
+        "homeassistant.components.hassio.addon_manager.async_uninstall_addon"
+    ) as uninstall_addon:
+        yield uninstall_addon
+
+
+@pytest.fixture(name="update_addon")
+def update_addon_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock update add-on."""
+    with patch(
+        "homeassistant.components.hassio.addon_manager.async_update_addon"
+    ) as update_addon:
+        yield update_addon

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -1,0 +1,406 @@
+"""Test the Matter integration init."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+from matter_server.client.exceptions import InvalidServerVersion
+import pytest
+
+from homeassistant.components.hassio import HassioAPIError
+from homeassistant.components.matter.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="mock_pathlib", autouse=True)
+def mock_pathlib_fixture() -> Generator[MagicMock, None, None]:
+    """Mock pathlib."""
+    with patch("homeassistant.components.matter.Path") as mock_path:
+        yield mock_path
+
+
+async def test_raise_addon_task_in_progress(
+    hass: HomeAssistant,
+    addon_not_installed: AsyncMock,
+    install_addon: AsyncMock,
+    start_addon: AsyncMock,
+) -> None:
+    """Test raise ConfigEntryNotReady if an add-on task is in progress."""
+    install_event = asyncio.Event()
+
+    install_addon_original_side_effect = install_addon.side_effect
+
+    async def install_addon_side_effect(hass: HomeAssistant, slug: str) -> None:
+        """Mock install add-on."""
+        await install_event.wait()
+        await install_addon_original_side_effect(hass, slug)
+
+    install_addon.side_effect = install_addon_side_effect
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Matter",
+        data={
+            "url": "ws://host1:5581/chip_ws",
+            "use_addon": True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await asyncio.sleep(0.05)
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert install_addon.call_count == 1
+    assert start_addon.call_count == 0
+
+    # Check that we only call install add-on once if a task is in progress.
+    await hass.config_entries.async_reload(entry.entry_id)
+    await asyncio.sleep(0.05)
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert install_addon.call_count == 1
+    assert start_addon.call_count == 0
+
+    install_event.set()
+    await hass.async_block_till_done()
+
+    assert install_addon.call_count == 1
+    assert start_addon.call_count == 1
+
+
+async def test_start_addon(
+    hass: HomeAssistant,
+    addon_installed: AsyncMock,
+    addon_info: AsyncMock,
+    install_addon: AsyncMock,
+    start_addon: AsyncMock,
+) -> None:
+    """Test start the Matter Server add-on during entry setup."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Matter",
+        data={
+            "url": "ws://host1:5581/chip_ws",
+            "use_addon": True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert addon_info.call_count == 1
+    assert install_addon.call_count == 0
+    assert start_addon.call_count == 1
+    assert start_addon.call_args == call(hass, "core_matter_server")
+
+
+async def test_install_addon(
+    hass: HomeAssistant,
+    addon_not_installed: AsyncMock,
+    addon_store_info: AsyncMock,
+    install_addon: AsyncMock,
+    start_addon: AsyncMock,
+) -> None:
+    """Test install and start the Matter add-on during entry setup."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Matter",
+        data={
+            "url": "ws://host1:5581/chip_ws",
+            "use_addon": True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert addon_store_info.call_count == 2
+    assert install_addon.call_count == 1
+    assert install_addon.call_args == call(hass, "core_matter_server")
+    assert start_addon.call_count == 1
+    assert start_addon.call_args == call(hass, "core_matter_server")
+
+
+async def test_addon_info_failure(
+    hass: HomeAssistant,
+    addon_installed: AsyncMock,
+    addon_info: AsyncMock,
+    install_addon: AsyncMock,
+    start_addon: AsyncMock,
+) -> None:
+    """Test failure to get add-on info for Matter add-on during entry setup."""
+    addon_info.side_effect = HassioAPIError("Boom")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Matter",
+        data={
+            "url": "ws://host1:5581/chip_ws",
+            "use_addon": True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert addon_info.call_count == 1
+    assert install_addon.call_count == 0
+    assert start_addon.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "addon_version, update_available, update_calls, backup_calls, "
+    "update_addon_side_effect, create_backup_side_effect",
+    [
+        ("1.0.0", True, 1, 1, None, None),
+        ("1.0.0", False, 0, 0, None, None),
+        ("1.0.0", True, 1, 1, HassioAPIError("Boom"), None),
+        ("1.0.0", True, 0, 1, None, HassioAPIError("Boom")),
+    ],
+)
+async def test_update_addon(
+    hass: HomeAssistant,
+    addon_installed: AsyncMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+    install_addon: AsyncMock,
+    start_addon: AsyncMock,
+    create_backup: AsyncMock,
+    update_addon: AsyncMock,
+    matter_client: MagicMock,
+    addon_version: str,
+    update_available: bool,
+    update_calls: int,
+    backup_calls: int,
+    update_addon_side_effect: Exception | None,
+    create_backup_side_effect: Exception | None,
+):
+    """Test update the Matter add-on during entry setup."""
+    addon_info.return_value["version"] = addon_version
+    addon_info.return_value["update_available"] = update_available
+    create_backup.side_effect = create_backup_side_effect
+    update_addon.side_effect = update_addon_side_effect
+    matter_client.connect.side_effect = InvalidServerVersion("Invalid version")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Matter",
+        data={
+            "url": "ws://host1:5581/chip_ws",
+            "use_addon": True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert create_backup.call_count == backup_calls
+    assert update_addon.call_count == update_calls
+
+
+async def test_issue_registry_invalid_version(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Test issue registry for invalid version."""
+    original_connect_side_effect = matter_client.connect.side_effect
+    matter_client.connect.side_effect = InvalidServerVersion("Invalid version")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Matter",
+        data={
+            "url": "ws://host1:5581/chip_ws",
+            "use_addon": False,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_reg = ir.async_get(hass)
+    entry_state = entry.state
+    assert entry_state is ConfigEntryState.SETUP_RETRY
+    assert issue_reg.async_get_issue(DOMAIN, "invalid_server_version")
+
+    matter_client.connect.side_effect = original_connect_side_effect
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert not issue_reg.async_get_issue(DOMAIN, "invalid_server_version")
+
+
+@pytest.mark.parametrize(
+    "stop_addon_side_effect, entry_state",
+    [
+        (None, ConfigEntryState.NOT_LOADED),
+        (HassioAPIError("Boom"), ConfigEntryState.LOADED),
+    ],
+)
+async def test_stop_addon(
+    hass,
+    matter_client: MagicMock,
+    addon_installed: AsyncMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+    stop_addon: AsyncMock,
+    stop_addon_side_effect: Exception | None,
+    entry_state: ConfigEntryState,
+):
+    """Test stop the Matter add-on on entry unload if entry is disabled."""
+    stop_addon.side_effect = stop_addon_side_effect
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Matter",
+        data={
+            "url": "ws://host1:5581/chip_ws",
+            "use_addon": True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert addon_info.call_count == 1
+    addon_info.reset_mock()
+
+    await hass.config_entries.async_set_disabled_by(
+        entry.entry_id, ConfigEntryDisabler.USER
+    )
+    await hass.async_block_till_done()
+
+    assert entry.state == entry_state
+    assert stop_addon.call_count == 1
+    assert stop_addon.call_args == call(hass, "core_matter_server")
+
+
+async def test_remove_entry(
+    hass: HomeAssistant,
+    addon_installed: AsyncMock,
+    stop_addon: AsyncMock,
+    create_backup: AsyncMock,
+    uninstall_addon: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test remove the config entry."""
+    # test successful remove without created add-on
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Matter",
+        data={"integration_created_addon": False},
+    )
+    entry.add_to_hass(hass)
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+    await hass.config_entries.async_remove(entry.entry_id)
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 0
+
+    # test successful remove with created add-on
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Matter",
+        data={"integration_created_addon": True},
+    )
+    entry.add_to_hass(hass)
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+    await hass.config_entries.async_remove(entry.entry_id)
+
+    assert stop_addon.call_count == 1
+    assert stop_addon.call_args == call(hass, "core_matter_server")
+    assert create_backup.call_count == 1
+    assert create_backup.call_args == call(
+        hass,
+        {"name": "addon_core_matter_server_1.0.0", "addons": ["core_matter_server"]},
+        partial=True,
+    )
+    assert uninstall_addon.call_count == 1
+    assert uninstall_addon.call_args == call(hass, "core_matter_server")
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 0
+    stop_addon.reset_mock()
+    create_backup.reset_mock()
+    uninstall_addon.reset_mock()
+
+    # test add-on stop failure
+    entry.add_to_hass(hass)
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    stop_addon.side_effect = HassioAPIError()
+
+    await hass.config_entries.async_remove(entry.entry_id)
+
+    assert stop_addon.call_count == 1
+    assert stop_addon.call_args == call(hass, "core_matter_server")
+    assert create_backup.call_count == 0
+    assert uninstall_addon.call_count == 0
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 0
+    assert "Failed to stop the Matter Server add-on" in caplog.text
+    stop_addon.side_effect = None
+    stop_addon.reset_mock()
+    create_backup.reset_mock()
+    uninstall_addon.reset_mock()
+
+    # test create backup failure
+    entry.add_to_hass(hass)
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    create_backup.side_effect = HassioAPIError()
+
+    await hass.config_entries.async_remove(entry.entry_id)
+
+    assert stop_addon.call_count == 1
+    assert stop_addon.call_args == call(hass, "core_matter_server")
+    assert create_backup.call_count == 1
+    assert create_backup.call_args == call(
+        hass,
+        {"name": "addon_core_matter_server_1.0.0", "addons": ["core_matter_server"]},
+        partial=True,
+    )
+    assert uninstall_addon.call_count == 0
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 0
+    assert "Failed to create a backup of the Matter Server add-on" in caplog.text
+    create_backup.side_effect = None
+    stop_addon.reset_mock()
+    create_backup.reset_mock()
+    uninstall_addon.reset_mock()
+
+    # test add-on uninstall failure
+    entry.add_to_hass(hass)
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    uninstall_addon.side_effect = HassioAPIError()
+
+    await hass.config_entries.async_remove(entry.entry_id)
+
+    assert stop_addon.call_count == 1
+    assert stop_addon.call_args == call(hass, "core_matter_server")
+    assert create_backup.call_count == 1
+    assert create_backup.call_args == call(
+        hass,
+        {"name": "addon_core_matter_server_1.0.0", "addons": ["core_matter_server"]},
+        partial=True,
+    )
+    assert uninstall_addon.call_count == 1
+    assert uninstall_addon.call_args == call(hass, "core_matter_server")
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 0
+    assert "Failed to uninstall the Matter Server add-on" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Manage the Matter Server add-on when setting up the matter config entry.
- Make sure the add-on is installed and running.
- Update the add-on if needed.
- Stop the add-on if the config entry is disabled.
- Uninstall the add-on if the config entry is removed and the config entry installed the add-on in the config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
