### PR TITLE
KNX Config/OptionsFlow: Test connection to manually configured tunnel

### DIFF
--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -205,8 +205,11 @@ class KNXCommonFlow(ABC, FlowHandler):
             return await self.async_step_manual_tunnel()
 
         errors: dict = {}
-        tunnel_options = [str(tunnel) for tunnel in self._found_tunnels]
-        tunnel_options.append(OPTION_MANUAL_TUNNEL)
+        tunnel_options = {
+            str(tunnel): f"{tunnel}{' 🔐' if tunnel.tunnelling_requires_secure else ''}"
+            for tunnel in self._found_tunnels
+        }
+        tunnel_options |= {OPTION_MANUAL_TUNNEL: OPTION_MANUAL_TUNNEL}
         fields = {vol.Required(CONF_KNX_GATEWAY): vol.In(tunnel_options)}
 
         return self.async_show_form(

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -7,9 +7,10 @@ from typing import Any, Final
 
 import voluptuous as vol
 from xknx import XKNX
-from xknx.exceptions.exception import InvalidSecureConfiguration
+from xknx.exceptions.exception import CommunicationError, InvalidSecureConfiguration
 from xknx.io import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from xknx.io.gateway_scanner import GatewayDescriptor, GatewayScanner
+from xknx.io.self_description import request_description
 from xknx.secure import load_keyring
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
@@ -230,17 +231,38 @@ class KNXCommonFlow(ABC, FlowHandler):
                 except vol.Invalid:
                     errors[CONF_KNX_LOCAL_IP] = "invalid_ip_address"
 
+            selected_tunnelling_type = user_input[CONF_KNX_TUNNELING_TYPE]
             if not errors:
-                connection_type = user_input[CONF_KNX_TUNNELING_TYPE]
+                try:
+                    self._selected_tunnel = await request_description(
+                        gateway_ip=_host,
+                        gateway_port=user_input[CONF_PORT],
+                        local_ip=_local_ip,
+                        route_back=user_input[CONF_KNX_ROUTE_BACK],
+                    )
+                except CommunicationError:
+                    errors["base"] = "cannot_connect"
+                else:
+                    if self._selected_tunnel.tunnelling_requires_secure and not (
+                        selected_tunnelling_type == CONF_KNX_TUNNELING_TCP_SECURE
+                    ):
+                        errors[CONF_KNX_TUNNELING_TYPE] = "unsupported_tunnel_type"
+                    elif (
+                        selected_tunnelling_type == CONF_KNX_TUNNELING_TCP
+                        and not self._selected_tunnel.supports_tunnelling_tcp
+                    ):
+                        errors[CONF_KNX_TUNNELING_TYPE] = "unsupported_tunnel_type"
+
+            if not errors:
                 self.new_entry_data = KNXConfigEntryData(
+                    connection_type=selected_tunnelling_type,
                     host=_host,
                     port=user_input[CONF_PORT],
                     route_back=user_input[CONF_KNX_ROUTE_BACK],
                     local_ip=_local_ip,
-                    connection_type=connection_type,
                 )
 
-                if connection_type == CONF_KNX_TUNNELING_TCP_SECURE:
+                if selected_tunnelling_type == CONF_KNX_TUNNELING_TCP_SECURE:
                     return self.async_show_menu(
                         step_id="secure_key_source",
                         menu_options=["secure_knxkeys", "secure_routing_manual"],
@@ -299,7 +321,7 @@ class KNXCommonFlow(ABC, FlowHandler):
         if self.show_advanced_options:
             fields[vol.Optional(CONF_KNX_LOCAL_IP)] = _IP_SELECTOR
 
-        if not self._found_tunnels:
+        if not self._found_tunnels and not errors.get("base"):
             errors["base"] = "no_tunnel_discovered"
         return self.async_show_form(
             step_id="manual_tunnel", data_schema=vol.Schema(fields), errors=errors

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -243,7 +243,7 @@ class KNXCommonFlow(ABC, FlowHandler):
                 except CommunicationError:
                     errors["base"] = "cannot_connect"
                 else:
-                    if self._selected_tunnel.tunnelling_requires_secure and not (
+                    if bool(self._selected_tunnel.tunnelling_requires_secure) is not (
                         selected_tunnelling_type == CONF_KNX_TUNNELING_TCP_SECURE
                     ):
                         errors[CONF_KNX_TUNNELING_TYPE] = "unsupported_tunnel_type"

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -99,7 +99,8 @@
       "invalid_signature": "The password to decrypt the `.knxkeys` file is wrong.",
       "file_not_found": "The specified `.knxkeys` file was not found in the path config/.storage/knx/",
       "no_router_discovered": "No KNXnet/IP router was discovered on the network.",
-      "no_tunnel_discovered": "Could not find a KNX tunneling server on your network."
+      "no_tunnel_discovered": "Could not find a KNX tunneling server on your network.",
+      "unsupported_tunnel_type": "Selected tunnelling type not supported by gateway."
     }
   },
   "options": {
@@ -214,7 +215,8 @@
       "invalid_signature": "[%key:component::knx::config::error::invalid_signature%]",
       "file_not_found": "[%key:component::knx::config::error::file_not_found%]",
       "no_router_discovered": "[%key:component::knx::config::error::no_router_discovered%]",
-      "no_tunnel_discovered": "[%key:component::knx::config::error::no_tunnel_discovered%]"
+      "no_tunnel_discovered": "[%key:component::knx::config::error::no_tunnel_discovered%]",
+      "unsupported_tunnel_type": "[%key:component::knx::config::error::unsupported_tunnel_type%]"
     }
   }
 }

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -2,7 +2,7 @@
 from unittest.mock import patch
 
 import pytest
-from xknx.exceptions.exception import InvalidSecureConfiguration
+from xknx.exceptions.exception import CommunicationError, InvalidSecureConfiguration
 from xknx.io import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from xknx.io.gateway_scanner import GatewayDescriptor
 
@@ -441,7 +441,11 @@ async def test_routing_secure_keyfile(
     return_value=GatewayScannerMock(),
 )
 async def test_tunneling_setup_manual(
-    gateway_scanner_mock, hass: HomeAssistant, knx_setup, user_input, config_entry_data
+    _gateway_scanner_mock,
+    hass: HomeAssistant,
+    knx_setup,
+    user_input,
+    config_entry_data,
 ) -> None:
     """Test tunneling if no gateway was found found (or `manual` option was chosen)."""
     result = await hass.config_entries.flow.async_init(
@@ -460,11 +464,21 @@ async def test_tunneling_setup_manual(
     assert result2["step_id"] == "manual_tunnel"
     assert result2["errors"] == {"base": "no_tunnel_discovered"}
 
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
-        user_input,
-    )
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.knx.config_flow.request_description",
+        return_value=_gateway_descriptor(
+            user_input[CONF_HOST],
+            user_input[CONF_PORT],
+            supports_tunnelling_tcp=(
+                user_input[CONF_KNX_TUNNELING_TYPE] == CONF_KNX_TUNNELING_TCP
+            ),
+        ),
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            user_input,
+        )
+        await hass.async_block_till_done()
     assert result3["type"] == FlowResultType.CREATE_ENTRY
     assert result3["title"] == "Tunneling @ 192.168.0.1"
     assert result3["data"] == config_entry_data
@@ -475,8 +489,124 @@ async def test_tunneling_setup_manual(
     "homeassistant.components.knx.config_flow.GatewayScanner",
     return_value=GatewayScannerMock(),
 )
+async def test_tunneling_setup_manual_request_description_error(
+    _gateway_scanner_mock,
+    hass: HomeAssistant,
+) -> None:
+    """Test tunneling if no gateway was found found (or `manual` option was chosen)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
+        },
+    )
+    assert result["step_id"] == "manual_tunnel"
+    assert result["errors"] == {"base": "no_tunnel_discovered"}
+
+    # TCP configured but not supported by gateway
+    with patch(
+        "homeassistant.components.knx.config_flow.request_description",
+        return_value=_gateway_descriptor(
+            "192.168.0.1",
+            3671,
+            supports_tunnelling_tcp=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING_TCP,
+                CONF_HOST: "192.168.0.1",
+                CONF_PORT: 3671,
+            },
+        )
+        assert result["step_id"] == "manual_tunnel"
+        assert result["errors"] == {
+            "base": "no_tunnel_discovered",
+            "tunneling_type": "unsupported_tunnel_type",
+        }
+    # TCP configured but Secure required by gateway
+    with patch(
+        "homeassistant.components.knx.config_flow.request_description",
+        return_value=_gateway_descriptor(
+            "192.168.0.1",
+            3671,
+            supports_tunnelling_tcp=True,
+            requires_secure=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING_TCP,
+                CONF_HOST: "192.168.0.1",
+                CONF_PORT: 3671,
+            },
+        )
+        assert result["step_id"] == "manual_tunnel"
+        assert result["errors"] == {
+            "base": "no_tunnel_discovered",
+            "tunneling_type": "unsupported_tunnel_type",
+        }
+    # No connection to gateway
+    with patch(
+        "homeassistant.components.knx.config_flow.request_description",
+        side_effect=CommunicationError(""),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING_TCP,
+                CONF_HOST: "192.168.0.1",
+                CONF_PORT: 3671,
+            },
+        )
+        assert result["step_id"] == "manual_tunnel"
+        assert result["errors"] == {"base": "cannot_connect"}
+    # OK configuration
+    with patch(
+        "homeassistant.components.knx.config_flow.request_description",
+        return_value=_gateway_descriptor(
+            "192.168.0.1",
+            3671,
+            supports_tunnelling_tcp=True,
+        ),
+    ), patch(
+        "homeassistant.components.knx.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING_TCP,
+                CONF_HOST: "192.168.0.1",
+                CONF_PORT: 3671,
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == "Tunneling @ 192.168.0.1"
+        assert result["data"] == {
+            **DEFAULT_ENTRY_DATA,
+            CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP,
+            CONF_HOST: "192.168.0.1",
+            CONF_PORT: 3671,
+        }
+        assert len(mock_setup_entry.mock_calls) == 1
+
+
+@patch(
+    "homeassistant.components.knx.config_flow.GatewayScanner",
+    return_value=GatewayScannerMock(),
+)
+@patch(
+    "homeassistant.components.knx.config_flow.request_description",
+    return_value=_gateway_descriptor("192.168.0.2", 3675),
+)
 async def test_tunneling_setup_for_local_ip(
-    gateway_scanner_mock, hass: HomeAssistant, knx_setup
+    _request_description_mock, _gateway_scanner_mock, hass: HomeAssistant, knx_setup
 ) -> None:
     """Test tunneling if only one gateway is found."""
     result = await hass.config_entries.flow.async_init(
@@ -715,7 +845,12 @@ async def _get_menu_step(hass: HomeAssistant) -> FlowResult:
     return result3
 
 
+@patch(
+    "homeassistant.components.knx.config_flow.request_description",
+    return_value=_gateway_descriptor("192.168.0.1", 3675),
+)
 async def test_get_secure_menu_step_manual_tunnelling(
+    _request_description_mock,
     hass: HomeAssistant,
 ):
     """Test flow reaches secure_tunnellinn menu step from manual tunnelling configuration."""

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -551,6 +551,29 @@ async def test_tunneling_setup_manual_request_description_error(
             "base": "no_tunnel_discovered",
             "tunneling_type": "unsupported_tunnel_type",
         }
+    # Secure configured but not enabled on gateway
+    with patch(
+        "homeassistant.components.knx.config_flow.request_description",
+        return_value=_gateway_descriptor(
+            "192.168.0.1",
+            3671,
+            supports_tunnelling_tcp=True,
+            requires_secure=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KNX_TUNNELING_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
+                CONF_HOST: "192.168.0.1",
+                CONF_PORT: 3671,
+            },
+        )
+        assert result["step_id"] == "manual_tunnel"
+        assert result["errors"] == {
+            "base": "no_tunnel_discovered",
+            "tunneling_type": "unsupported_tunnel_type",
+        }
     # No connection to gateway
     with patch(
         "homeassistant.components.knx.config_flow.request_description",
@@ -847,7 +870,12 @@ async def _get_menu_step(hass: HomeAssistant) -> FlowResult:
 
 @patch(
     "homeassistant.components.knx.config_flow.request_description",
-    return_value=_gateway_descriptor("192.168.0.1", 3675),
+    return_value=_gateway_descriptor(
+        "192.168.0.1",
+        3675,
+        supports_tunnelling_tcp=True,
+        requires_secure=True,
+    ),
 )
 async def test_get_secure_menu_step_manual_tunnelling(
     _request_description_mock,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Actually test the connection a user sets up manually in the flow to avoid non-working configurations.
- Mark secure tunnels in the dropdown list with a `🔐` because its cute 😃

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
