### PR TITLE
Frontier Silicone component: Play station from list of presets

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from afsapi import (
     AFSAPI,
@@ -232,6 +233,20 @@ class AFSAPIDevice(MediaPlayerEntity):
         """Turn off the device."""
         await self.fs_device.set_power(False)
 
+    # preset control
+    async def async_play_media(
+        self, media_type: MediaType | str, media_id: str, **kwargs: Any
+    ) -> None:
+        """Play a media from the preset."""
+        preset_list = await self.fs_device.get_presets()
+        if media_id.isdigit() and int(media_id) in (p.key for p in preset_list):
+            # Preset found
+            await self.fs_device.select_preset(media_id)
+        else:
+            # Station not found in preset list.
+            _LOGGER.warning("Unable to find preset with id %s", media_id)
+
+    # media control
     async def async_media_play(self) -> None:
         """Send play command."""
         await self.fs_device.play()

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -237,14 +237,20 @@ class AFSAPIDevice(MediaPlayerEntity):
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
-        """Play a media from the preset."""
-        preset_list = await self.fs_device.get_presets()
-        if media_id.isdigit() and int(media_id) in (p.key for p in preset_list):
-            # Preset found
-            await self.fs_device.select_preset(media_id)
+        """Play a media from the list of presets."""
+        if media_type == MediaType.CHANNEL:
+            preset_list = await self.fs_device.get_presets()
+            if media_id.isdigit() and int(media_id) in (p.key for p in preset_list):
+                # Preset found
+                await self.fs_device.select_preset(media_id)
+            else:
+                # Station not found in preset list.
+                _LOGGER.warning("Unable to find preset with id %s", media_id)
         else:
-            # Station not found in preset list.
-            _LOGGER.warning("Unable to find preset with id %s", media_id)
+            _LOGGER.warning(
+                "Media Type %s not Implemented. Use media type 'channel' to select a preset",
+                media_type,
+            )
 
     # media control
     async def async_media_play(self) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the option to change the radio station by selection the desired station from the list of presets. A user can now call 

```
service: media_player.play_media
data:
  media_content_type: channel
  media_content_id: "1"
target:
  entity_id: media_player.bathroom_radio
```

where `media_content_id` is the _slot_ in the preset list. My radio (Hama IR50) has 30 of these slots.

![image](https://user-images.githubusercontent.com/2639206/204377347-95c852c7-b163-4004-9410-320efe42b1ff.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
