### PR TITLE
Use OptionsFlowWithConfigEntry in braviatv

### DIFF
--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -245,22 +245,17 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return uuid, f"{NICKNAME_PREFIX} {uuid[:6]}"
 
 
-class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
+class BraviaTVOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
     """Config flow options for Bravia TV."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize Bravia TV options flow."""
-        self.config_entry = config_entry
-        self.ignored_sources = config_entry.options.get(CONF_IGNORED_SOURCES)
-        self.source_list: list[str] = []
+    source_list: list[str]
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
-        coordinator: BraviaTVCoordinator = self.hass.data[DOMAIN][
-            self.config_entry.entry_id
-        ]
+        coordinator: BraviaTVCoordinator
+        coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]
 
         try:
             await coordinator.async_update_sources()
@@ -283,7 +278,8 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema(
                 {
                     vol.Optional(
-                        CONF_IGNORED_SOURCES, default=self.ignored_sources
+                        CONF_IGNORED_SOURCES,
+                        default=self.options.get(CONF_IGNORED_SOURCES),
                     ): cv.multi_select(self.source_list)
                 }
             ),

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -21,6 +21,7 @@ from homeassistant.components.braviatv.const import (
 )
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import instance_id
 
 from tests.common import MockConfigEntry
@@ -381,7 +382,7 @@ async def test_create_entry_psk(hass):
         }
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -420,6 +421,43 @@ async def test_options_flow(hass):
 
         assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_IGNORED_SOURCES: ["HDMI 1", "HDMI 2"]}
+
+
+async def test_options_flow_error(hass: HomeAssistant) -> None:
+    """Test config flow options."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="very_unique_string",
+        data={
+            CONF_HOST: "bravia-host",
+            CONF_PIN: "1234",
+            CONF_MAC: "AA:BB:CC:DD:EE:FF",
+        },
+        title="TV-Model",
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch("pybravia.BraviaTV.connect"), patch(
+        "pybravia.BraviaTV.get_power_status",
+        return_value="active",
+    ), patch(
+        "pybravia.BraviaTV.get_external_status",
+        return_value=BRAVIA_SOURCES,
+    ), patch(
+        "pybravia.BraviaTV.send_rest_req",
+        return_value={},
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    with patch(
+        "pybravia.BraviaTV.send_rest_req",
+        side_effect=BraviaTVError,
+    ):
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["reason"] == "failed_update"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use OptionsFlowWithConfigEntry in braviatv

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
