### PR TITLE
Remove more useless manifest truthiness checks in hassfest

### DIFF
--- a/script/hassfest/codeowners.py
+++ b/script/hassfest/codeowners.py
@@ -49,10 +49,7 @@ def generate_and_validate(integrations: dict[str, Integration], config: Config) 
     for domain in sorted(integrations):
         integration = integrations[domain]
 
-        if (
-            not integration.manifest
-            or integration.manifest.get("integration_type") == "virtual"
-        ):
+        if integration.integration_type == "virtual":
             continue
 
         codeowners = integration.manifest["codeowners"]

--- a/script/hassfest/config_flow.py
+++ b/script/hassfest/config_flow.py
@@ -17,7 +17,7 @@ def _validate_integration(config: Config, integration: Integration) -> None:
     config_flow_file = integration.path / "config_flow.py"
 
     if not config_flow_file.is_file():
-        if (integration.manifest or {}).get("config_flow"):
+        if integration.manifest.get("config_flow"):
             integration.add_error(
                 "config_flow",
                 "Config flows need to be defined in the file config_flow.py",
@@ -149,7 +149,7 @@ def _generate_integrations(
     primary_domains = {
         domain
         for domain, integration in integrations.items()
-        if integration.manifest and domain not in brand_integration_domains
+        if domain not in brand_integration_domains
     }
     # Add all brands to the set
     primary_domains |= set(brands)

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -292,7 +292,7 @@ def validate_version(integration: Integration) -> None:
 
     Will be removed when the version key is no longer optional for custom integrations.
     """
-    if not (integration.manifest and integration.manifest.get("version")):
+    if not integration.manifest.get("version"):
         integration.add_error("manifest", "No 'version' key in the manifest file.")
         return
 


### PR DESCRIPTION
## Proposed change

Just a tiny additional cleanup.

Refs [#82091 comment](https://github.com/home-assistant/core/pull/82091#discussion_r1031019710)
Refs #82319 (followup)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
