### PR TITLE
Add ability to edit sensors in scrape config flow

### DIFF
--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -175,7 +175,7 @@ async def get_edit_sensor_suggested_values(
 async def validate_sensor_edit(
     handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
 ) -> dict[str, Any]:
-    """Validate sensor input."""
+    """Update edited sensor."""
     user_input[CONF_INDEX] = int(user_input[CONF_INDEX])
 
     # Standard behavior is to merge the result with the options.

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -145,13 +145,13 @@ async def validate_sensor_setup(
 async def validate_select_sensor(
     handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
 ) -> dict[str, Any]:
-    """Store selected sensor index for editing."""
+    """Store sensor index in flow state."""
     handler.flow_state["_idx"] = int(user_input[CONF_INDEX])
     return {}
 
 
 async def get_select_sensor_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
-    """Return schema for sensor selection."""
+    """Return schema for selecting a sensor."""
     return vol.Schema(
         {
             vol.Required(CONF_INDEX): vol.In(

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -145,13 +145,13 @@ async def validate_sensor_setup(
 async def validate_select_sensor(
     handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
 ) -> dict[str, Any]:
-    """Validate sensor input."""
+    """Store selected sensor index for editing."""
     handler.flow_state["_idx"] = int(user_input[CONF_INDEX])
     return {}
 
 
 async def get_select_sensor_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
-    """Return schema for sensor removal."""
+    """Return schema for sensor selection."""
     return vol.Schema(
         {
             vol.Required(CONF_INDEX): vol.In(

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -87,7 +87,6 @@ RESOURCE_SETUP = {
 }
 
 SENSOR_SETUP = {
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
     vol.Required(CONF_SELECT): TextSelector(),
     vol.Optional(CONF_INDEX, default=0): NumberSelector(
         NumberSelectorConfig(min=0, step=1, mode=NumberSelectorMode.BOX)
@@ -143,6 +142,49 @@ async def validate_sensor_setup(
     return {}
 
 
+async def validate_select_sensor(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate sensor input."""
+    handler.flow_state["_idx"] = int(user_input[CONF_INDEX])
+    return {}
+
+
+async def get_select_sensor_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
+    """Return schema for sensor removal."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_INDEX): vol.In(
+                {
+                    str(index): config[CONF_NAME]
+                    for index, config in enumerate(handler.options[SENSOR_DOMAIN])
+                },
+            )
+        }
+    )
+
+
+async def get_edit_sensor_suggested_values(
+    handler: SchemaCommonFlowHandler,
+) -> dict[str, Any]:
+    """Return suggested values for sensor editing."""
+    idx: int = handler.flow_state["_idx"]
+    return handler.options[SENSOR_DOMAIN][idx]
+
+
+async def validate_sensor_edit(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate sensor input."""
+    user_input[CONF_INDEX] = int(user_input[CONF_INDEX])
+
+    # Standard behavior is to merge the result with the options.
+    # In this case, we want to add a sub-item so we update the options directly.
+    idx: int = handler.flow_state["_idx"]
+    handler.options[SENSOR_DOMAIN][idx].update(user_input)
+    return {}
+
+
 async def get_remove_sensor_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
     """Return schema for sensor removal."""
     return vol.Schema(
@@ -180,7 +222,13 @@ async def validate_remove_sensor(
 
 
 DATA_SCHEMA_RESOURCE = vol.Schema(RESOURCE_SETUP)
-DATA_SCHEMA_SENSOR = vol.Schema(SENSOR_SETUP)
+DATA_SCHEMA_EDIT_SENSOR = vol.Schema(SENSOR_SETUP)
+DATA_SCHEMA_SENSOR = vol.Schema(
+    {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
+        **SENSOR_SETUP,
+    }
+)
 
 CONFIG_FLOW = {
     "user": SchemaFlowFormStep(
@@ -194,7 +242,9 @@ CONFIG_FLOW = {
     ),
 }
 OPTIONS_FLOW = {
-    "init": SchemaFlowMenuStep(["resource", "add_sensor", "remove_sensor"]),
+    "init": SchemaFlowMenuStep(
+        ["resource", "add_sensor", "select_edit_sensor", "remove_sensor"]
+    ),
     "resource": SchemaFlowFormStep(
         DATA_SCHEMA_RESOURCE,
         validate_user_input=validate_rest_setup,
@@ -203,6 +253,17 @@ OPTIONS_FLOW = {
         DATA_SCHEMA_SENSOR,
         suggested_values=None,
         validate_user_input=validate_sensor_setup,
+    ),
+    "select_edit_sensor": SchemaFlowFormStep(
+        get_select_sensor_schema,
+        suggested_values=None,
+        validate_user_input=validate_select_sensor,
+        next_step="edit_sensor",
+    ),
+    "edit_sensor": SchemaFlowFormStep(
+        DATA_SCHEMA_EDIT_SENSOR,
+        suggested_values=get_edit_sensor_suggested_values,
+        validate_user_input=validate_sensor_edit,
     ),
     "remove_sensor": SchemaFlowFormStep(
         get_remove_sensor_schema,

--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -54,11 +54,33 @@
       "init": {
         "menu_options": {
           "add_sensor": "Add sensor",
+          "select_edit_sensor": "Configure sensor",
           "remove_sensor": "Remove sensor",
           "resource": "Configure resource"
         }
       },
       "add_sensor": {
+        "data": {
+          "name": "[%key:component::scrape::config::step::sensor::data::name%]",
+          "attribute": "[%key:component::scrape::config::step::sensor::data::attribute%]",
+          "index": "[%key:component::scrape::config::step::sensor::data::index%]",
+          "select": "[%key:component::scrape::config::step::sensor::data::select%]",
+          "value_template": "[%key:component::scrape::config::step::sensor::data::value_template%]",
+          "device_class": "[%key:component::scrape::config::step::sensor::data::device_class%]",
+          "state_class": "[%key:component::scrape::config::step::sensor::data::state_class%]",
+          "unit_of_measurement": "[%key:component::scrape::config::step::sensor::data::unit_of_measurement%]"
+        },
+        "data_description": {
+          "select": "[%key:component::scrape::config::step::sensor::data_description::select%]",
+          "attribute": "[%key:component::scrape::config::step::sensor::data_description::attribute%]",
+          "index": "[%key:component::scrape::config::step::sensor::data_description::index%]",
+          "value_template": "[%key:component::scrape::config::step::sensor::data_description::value_template%]",
+          "device_class": "[%key:component::scrape::config::step::sensor::data_description::device_class%]",
+          "state_class": "[%key:component::scrape::config::step::sensor::data_description::state_class%]",
+          "unit_of_measurement": "[%key:component::scrape::config::step::sensor::data_description::unit_of_measurement%]"
+        }
+      },
+      "edit_sensor": {
         "data": {
           "name": "[%key:component::scrape::config::step::sensor::data::name%]",
           "attribute": "[%key:component::scrape::config::step::sensor::data::attribute%]",

--- a/homeassistant/components/scrape/translations/en.json
+++ b/homeassistant/components/scrape/translations/en.json
@@ -78,26 +78,31 @@
                     "value_template": "Defines a template to get the state of the sensor"
                 }
             },
-            "init": {
+            "edit_sensor": {
                 "data": {
-                    "authentication": "Select authentication method",
-                    "headers": "Headers",
-                    "method": "Method",
-                    "password": "Password",
-                    "resource": "Resource",
-                    "timeout": "Timeout",
-                    "username": "Username",
-                    "verify_ssl": "Verify SSL certificate"
+                    "attribute": "Attribute",
+                    "device_class": "Device Class",
+                    "index": "Index",
+                    "name": "Name",
+                    "select": "Select",
+                    "state_class": "State Class",
+                    "unit_of_measurement": "Unit of Measurement",
+                    "value_template": "Value Template"
                 },
                 "data_description": {
-                    "authentication": "Type of the HTTP authentication. Either basic or digest",
-                    "headers": "Headers to use for the web request",
-                    "resource": "The URL to the website that contains the value",
-                    "timeout": "Timeout for connection to website",
-                    "verify_ssl": "Enables/disables verification of SSL/TLS certificate, for example if it is self-signed"
-                },
+                    "attribute": "Get value of an attribute on the selected tag",
+                    "device_class": "The type/class of the sensor to set the icon in the frontend",
+                    "index": "Defines which of the elements returned by the CSS selector to use",
+                    "select": "Defines what tag to search for. Check Beautifulsoup CSS selectors for details",
+                    "state_class": "The state_class of the sensor",
+                    "unit_of_measurement": "Choose temperature measurement or create your own",
+                    "value_template": "Defines a template to get the state of the sensor"
+                }
+            },
+            "init": {
                 "menu_options": {
                     "add_sensor": "Add sensor",
+                    "select_edit_sensor": "Configure sensor",
                     "remove_sensor": "Remove sensor",
                     "resource": "Configure resource"
                 }

--- a/tests/components/scrape/test_config_flow.py
+++ b/tests/components/scrape/test_config_flow.py
@@ -340,3 +340,69 @@ async def test_options_add_remove_sensor_flow(
     # Check the state of the new entity
     state = hass.states.get("sensor.template")
     assert state.state == "Trying to get"
+
+
+async def test_options_edit_sensor_flow(
+    hass: HomeAssistant, loaded_entry: MockConfigEntry
+) -> None:
+    """Test options flow to edit a sensor."""
+
+    state = hass.states.get("sensor.current_version")
+    assert state.state == "Current Version: 2021.12.10"
+
+    result = await hass.config_entries.options.async_init(loaded_entry.entry_id)
+
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"next_step_id": "select_edit_sensor"},
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "select_edit_sensor"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"index": "0"},
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "edit_sensor"
+
+    mocker = MockRestData("test_scrape_sensor2")
+    with patch("homeassistant.components.rest.RestData", return_value=mocker):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_SELECT: "template",
+                CONF_INDEX: 0.0,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_RESOURCE: "https://www.home-assistant.io",
+        CONF_METHOD: "GET",
+        CONF_VERIFY_SSL: True,
+        CONF_TIMEOUT: 10,
+        "sensor": [
+            {
+                CONF_NAME: "Current version",
+                CONF_SELECT: "template",
+                CONF_INDEX: 0,
+                CONF_UNIQUE_ID: "3699ef88-69e6-11ed-a1eb-0242ac120002",
+            },
+        ],
+    }
+
+    await hass.async_block_till_done()
+
+    # Check the entity was updated
+    assert len(hass.states.async_all()) == 1
+
+    # Check the state of the entity has changed as expected
+    state = hass.states.get("sensor.current_version")
+    assert state.state == "Trying to get"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add ability to edit sensors in scrape config flow

~~Needs #82967 and #82962~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
