### PR TITLE
Extend matter websocket api

### DIFF
--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -87,7 +87,7 @@ async def websocket_commission(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "matter/commission_on_network",
-        vol.Required("pin"): str,
+        vol.Required("pin"): int,
     }
 )
 @websocket_api.async_response

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -92,15 +92,15 @@ async def websocket_commission(
 )
 @websocket_api.async_response
 @async_handle_failed_command
-@async_get_matter
+@async_get_matter_adapter
 async def websocket_commission_on_network(
     hass: HomeAssistant,
     connection: ActiveConnection,
     msg: dict[str, Any],
-    matter: Matter,
+    matter: MatterAdapter,
 ) -> None:
     """Commission a device already on the network."""
-    await matter.commission_on_network(msg["pin"])
+    await matter.matter_client.commission_on_network(msg["pin"])
     connection.send_result(msg[ID])
 
 
@@ -114,15 +114,15 @@ async def websocket_commission_on_network(
 )
 @websocket_api.async_response
 @async_handle_failed_command
-@async_get_matter
+@async_get_matter_adapter
 async def websocket_set_wifi_credentials(
     hass: HomeAssistant,
     connection: ActiveConnection,
     msg: dict[str, Any],
-    matter: Matter,
+    matter: MatterAdapter,
 ) -> None:
     """Set WiFi credentials for a device."""
-    await matter.client.driver.device_controller.set_wifi_credentials(
+    await matter.matter_client.set_wifi_credentials(
         ssid=msg["network_name"], credentials=msg["password"]
     )
     connection.send_result(msg[ID])

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -78,7 +78,7 @@ async def websocket_commission(
     msg: dict[str, Any],
     matter: MatterAdapter,
 ) -> None:
-    """Commission a device to the Matter network."""
+    """Add a device to the network and commission the device."""
     await matter.matter_client.commission_with_code(msg["code"])
     connection.send_result(msg[ID])
 

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -24,6 +24,7 @@ def async_register_api(hass: HomeAssistant) -> None:
     """Register all of our api endpoints."""
     websocket_api.async_register_command(hass, websocket_commission)
     websocket_api.async_register_command(hass, websocket_commission_on_network)
+    websocket_api.async_register_command(hass, websocket_set_thread_dataset)
     websocket_api.async_register_command(hass, websocket_set_wifi_credentials)
 
 
@@ -101,6 +102,29 @@ async def websocket_commission_on_network(
 ) -> None:
     """Commission a device already on the network."""
     await matter.matter_client.commission_on_network(msg["pin"])
+    connection.send_result(msg[ID])
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/set_thread",
+        vol.Required("thread_operation_dataset"): str,
+    }
+)
+@websocket_api.async_response
+@async_handle_failed_command
+@async_get_matter_adapter
+async def websocket_set_thread_dataset(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+) -> None:
+    """Set thread dataset."""
+    await matter.matter_client.set_thread_operational_dataset(
+        msg["thread_operation_dataset"]
+    )
     connection.send_result(msg[ID])
 
 

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -64,13 +64,13 @@ async def test_commission_on_network(
         {
             ID: 1,
             TYPE: "matter/commission_on_network",
-            "pin": "1234",
+            "pin": 1234,
         }
     )
     msg = await ws_client.receive_json()
 
     assert msg["success"]
-    matter_client.commission_on_network.assert_called_once_with("1234")
+    matter_client.commission_on_network.assert_called_once_with(1234)
 
     matter_client.commission_on_network.reset_mock()
     matter_client.commission_on_network.side_effect = FailedCommand(
@@ -81,14 +81,14 @@ async def test_commission_on_network(
         {
             ID: 2,
             TYPE: "matter/commission_on_network",
-            "pin": "1234",
+            "pin": 1234,
         }
     )
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
     assert msg["error"]["code"] == "test_code"
-    matter_client.commission_on_network.assert_called_once_with("1234")
+    matter_client.commission_on_network.assert_called_once_with(1234)
 
 
 async def test_set_wifi_credentials(

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -1,6 +1,6 @@
 """Test the api module."""
 from collections.abc import Awaitable, Callable
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from aiohttp import ClientWebSocketResponse
 from matter_server.client.exceptions import FailedCommand
@@ -49,3 +49,99 @@ async def test_commission(
     assert not msg["success"]
     assert msg["error"]["code"] == "test_code"
     matter_client.commission_with_code.assert_called_once_with("12345678")
+
+
+async def test_commission_on_network(
+    hass: HomeAssistant,
+    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    matter_client: MagicMock,
+    integration: MockConfigEntry,
+) -> None:
+    """Test the commission on network command."""
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/commission_on_network",
+            "pin": "1234",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    matter_client.commission_on_network.assert_called_once_with("1234")
+
+    matter_client.commission_on_network.reset_mock()
+    matter_client.commission_on_network.side_effect = FailedCommand(
+        "test_id", "test_code", "Failed to commission on network"
+    )
+
+    await ws_client.send_json(
+        {
+            ID: 2,
+            TYPE: "matter/commission_on_network",
+            "pin": "1234",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "test_code"
+    matter_client.commission_on_network.assert_called_once_with("1234")
+
+
+async def test_set_wifi_credentials(
+    hass: HomeAssistant,
+    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    matter_client: MagicMock,
+    integration: MockConfigEntry,
+) -> None:
+    """Test the set WiFi credentials command."""
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/set_wifi_credentials",
+            "network_name": "test_network",
+            "password": "test_password",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert (
+        matter_client.client.driver.device_controller.set_wifi_credentials.call_count
+        == 1
+    )
+    assert (
+        matter_client.client.driver.device_controller.set_wifi_credentials.call_args
+        == call(ssid="test_network", credentials="test_password")
+    )
+
+    matter_client.client.driver.device_controller.set_wifi_credentials.reset_mock()
+    matter_client.client.driver.device_controller.set_wifi_credentials.side_effect = (
+        FailedCommand("test_id", "test_code", "Failed to commission on network")
+    )
+
+    await ws_client.send_json(
+        {
+            ID: 2,
+            TYPE: "matter/set_wifi_credentials",
+            "network_name": "test_network",
+            "password": "test_password",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "test_code"
+    assert (
+        matter_client.client.driver.device_controller.set_wifi_credentials.call_count
+        == 1
+    )
+    assert (
+        matter_client.client.driver.device_controller.set_wifi_credentials.call_args
+        == call(ssid="test_network", credentials="test_password")
+    )

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -111,18 +111,14 @@ async def test_set_wifi_credentials(
     msg = await ws_client.receive_json()
 
     assert msg["success"]
-    assert (
-        matter_client.client.driver.device_controller.set_wifi_credentials.call_count
-        == 1
-    )
-    assert (
-        matter_client.client.driver.device_controller.set_wifi_credentials.call_args
-        == call(ssid="test_network", credentials="test_password")
+    assert matter_client.set_wifi_credentials.call_count == 1
+    assert matter_client.set_wifi_credentials.call_args == call(
+        ssid="test_network", credentials="test_password"
     )
 
-    matter_client.client.driver.device_controller.set_wifi_credentials.reset_mock()
-    matter_client.client.driver.device_controller.set_wifi_credentials.side_effect = (
-        FailedCommand("test_id", "test_code", "Failed to commission on network")
+    matter_client.set_wifi_credentials.reset_mock()
+    matter_client.set_wifi_credentials.side_effect = FailedCommand(
+        "test_id", "test_code", "Failed to commission on network"
     )
 
     await ws_client.send_json(
@@ -137,11 +133,7 @@ async def test_set_wifi_credentials(
 
     assert not msg["success"]
     assert msg["error"]["code"] == "test_code"
-    assert (
-        matter_client.client.driver.device_controller.set_wifi_credentials.call_count
-        == 1
-    )
-    assert (
-        matter_client.client.driver.device_controller.set_wifi_credentials.call_args
-        == call(ssid="test_network", credentials="test_password")
+    assert matter_client.set_wifi_credentials.call_count == 1
+    assert matter_client.set_wifi_credentials.call_args == call(
+        ssid="test_network", credentials="test_password"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add two commands that we need for the coming frontend integration panel.
- [x] Update the commands to use the new client API. I'll update the branch once the new API is merged and used in the target branch.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
