### PR TITLE
Bump growattServer to 1.3.0

### DIFF
--- a/homeassistant/components/growatt_server/manifest.json
+++ b/homeassistant/components/growatt_server/manifest.json
@@ -3,7 +3,7 @@
   "name": "Growatt",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/growatt_server/",
-  "requirements": ["growattServer==1.2.4"],
+  "requirements": ["growattServer==1.3.0"],
   "codeowners": ["@indykoning", "@muppet3000", "@JasperPlant"],
   "iot_class": "cloud_polling",
   "loggers": ["growattServer"]

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -80,11 +80,11 @@ async def async_setup_entry(
         config[CONF_URL] = url
         hass.config_entries.async_update_entry(config_entry, data=config)
 
-    # Initialise the library with a random user id each time it is started, also extend the library's default identifier to include 'home-assistant'
+    # Initialise the library with a random user id each time it is started,
+    # also extend the library's default identifier to include 'home-assistant'
     api = growattServer.GrowattApi(
         add_random_user_id=True,
-        agent_identifier=growattServer.GrowattApi.agent_identifier
-        + " - home-assistant",
+        agent_identifier=f"{growattServer.GrowattApi.agent_identifier} - home-assistant",
     )
     api.server_url = url
 

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -80,7 +80,12 @@ async def async_setup_entry(
         config[CONF_URL] = url
         hass.config_entries.async_update_entry(config_entry, data=config)
 
-    api = growattServer.GrowattApi()
+    # Initialise the library with a random user id each time it is started, also extend the library's default identifier to include 'home-assistant'
+    api = growattServer.GrowattApi(
+        add_random_user_id=True,
+        agent_identifier=growattServer.GrowattApi.agent_identifier
+        + " - home-assistant",
+    )
     api.server_url = url
 
     devices, plant_id = await hass.async_add_executor_job(get_device_list, api, config)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -817,7 +817,7 @@ greenwavereality==0.5.1
 gridnet==4.0.0
 
 # homeassistant.components.growatt_server
-growattServer==1.2.4
+growattServer==1.3.0
 
 # homeassistant.components.google_sheets
 gspread==5.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -612,7 +612,7 @@ greeneye_monitor==3.0.3
 gridnet==4.0.0
 
 # homeassistant.components.growatt_server
-growattServer==1.2.4
+growattServer==1.3.0
 
 # homeassistant.components.google_sheets
 gspread==5.5.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps the GrowattServer upstream library dependency to 1.3.0 to make use of the new randomised user ID feature as well as identifying the source of requests as Home Assistant using the library.

Release for upstream library: https://github.com/indykoning/PyPi_GrowattServer/releases/tag/1.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81951 
- This PR is related to issue: #81951
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
