### PR TITLE
Address late KNX flow tests review

### DIFF
--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -958,6 +958,7 @@ async def test_options_flow_connection_type(
     hass.data[DOMAIN] = Mock()  # GatewayScanner uses running XKNX() instance
     gateway = _gateway_descriptor("192.168.0.1", 3675)
 
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     menu_step = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
 
     with patch(
@@ -1025,7 +1026,6 @@ async def test_options_flow_secure_manual_to_keyfile(hass: HomeAssistant) -> Non
             CONF_KNX_LOCAL_IP: None,
         },
     )
-    mock_config_entry.add_to_hass(hass)
     gateway = _gateway_descriptor(
         "192.168.0.1",
         3675,
@@ -1033,6 +1033,8 @@ async def test_options_flow_secure_manual_to_keyfile(hass: HomeAssistant) -> Non
         requires_secure=True,
     )
 
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     menu_step = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
     with patch(
         "homeassistant.components.knx.config_flow.GatewayScanner"
@@ -1104,7 +1106,7 @@ async def test_options_communication_settings(
 ) -> None:
     """Test options flow changing communication settings."""
     mock_config_entry.add_to_hass(hass)
-
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     menu_step = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
 
     result = await hass.config_entries.options.async_configure(

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -48,7 +48,9 @@ from tests.common import MockConfigEntry
 @pytest.fixture(name="knx_setup", autouse=True)
 def knx_setup_fixture():
     """Mock KNX entry setup."""
-    with patch("homeassistant.components.knx.async_setup_entry", return_value=True):
+    with patch("homeassistant.components.knx.async_setup", return_value=True), patch(
+        "homeassistant.components.knx.async_setup_entry", return_value=True
+    ):
         yield
 
 

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -918,8 +918,8 @@ async def test_options_flow_connection_type(
             menu_step["flow_id"],
             {"next_step_id": "connection_type"},
         )
-        assert result.get("type") == FlowResultType.FORM
-        assert result.get("step_id") == "connection_type"
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "connection_type"
 
         result2 = await hass.config_entries.options.async_configure(
             result["flow_id"],
@@ -927,8 +927,8 @@ async def test_options_flow_connection_type(
                 CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
             },
         )
-        assert result2.get("type") == FlowResultType.FORM
-        assert result2.get("step_id") == "tunnel"
+        assert result2["type"] == FlowResultType.FORM
+        assert result2["step_id"] == "tunnel"
 
         result3 = await hass.config_entries.options.async_configure(
             result2["flow_id"],
@@ -937,8 +937,8 @@ async def test_options_flow_connection_type(
             },
         )
         await hass.async_block_till_done()
-        assert result3.get("type") == FlowResultType.CREATE_ENTRY
-        assert not result3.get("data")
+        assert result3["type"] == FlowResultType.CREATE_ENTRY
+        assert not result3["data"]
         assert mock_config_entry.data == {
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
             CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
@@ -994,8 +994,8 @@ async def test_options_flow_secure_manual_to_keyfile(
             menu_step["flow_id"],
             {"next_step_id": "connection_type"},
         )
-        assert result.get("type") == FlowResultType.FORM
-        assert result.get("step_id") == "connection_type"
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "connection_type"
 
         result2 = await hass.config_entries.options.async_configure(
             result["flow_id"],
@@ -1065,8 +1065,8 @@ async def test_options_communication_settings(
         menu_step["flow_id"],
         {"next_step_id": "communication_settings"},
     )
-    assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == "communication_settings"
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "communication_settings"
 
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -1076,7 +1076,7 @@ async def test_options_communication_settings(
         },
     )
     await hass.async_block_till_done()
-    assert result2.get("type") == FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert not result2.get("data")
     assert mock_config_entry.data == {
         **DEFAULT_ENTRY_DATA,

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the KNX config flow."""
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from xknx.exceptions.exception import InvalidSecureConfiguration
@@ -950,12 +950,12 @@ async def test_configure_secure_knxkeys_invalid_signature(hass: HomeAssistant):
         assert secure_knxkeys["errors"][CONF_KNX_KNXKEY_PASSWORD] == "invalid_signature"
 
 
+@patch("homeassistant.components.knx.async_setup_entry", AsyncMock(return_value=True))
 async def test_options_flow_connection_type(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test options flow changing interface."""
     mock_config_entry.add_to_hass(hass)
-    hass.data[DOMAIN] = Mock()  # GatewayScanner uses running XKNX() instance
     gateway = _gateway_descriptor("192.168.0.1", 3675)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -969,7 +969,6 @@ async def test_options_flow_connection_type(
             menu_step["flow_id"],
             {"next_step_id": "connection_type"},
         )
-
         assert result.get("type") == FlowResultType.FORM
         assert result.get("step_id") == "connection_type"
 
@@ -991,7 +990,6 @@ async def test_options_flow_connection_type(
         await hass.async_block_till_done()
         assert result3.get("type") == FlowResultType.CREATE_ENTRY
         assert not result3.get("data")
-
         assert mock_config_entry.data == {
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
             CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
@@ -1006,6 +1004,7 @@ async def test_options_flow_connection_type(
         }
 
 
+@patch("homeassistant.components.knx.async_setup_entry", AsyncMock(return_value=True))
 async def test_options_flow_secure_manual_to_keyfile(hass: HomeAssistant) -> None:
     """Test options flow changing secure credential source."""
     mock_config_entry = MockConfigEntry(
@@ -1082,6 +1081,7 @@ async def test_options_flow_secure_manual_to_keyfile(hass: HomeAssistant) -> Non
                 CONF_KNX_KNXKEY_PASSWORD: "password",
             },
         )
+        await hass.async_block_till_done()
     assert secure_knxkeys["type"] == FlowResultType.CREATE_ENTRY
     assert mock_config_entry.data == {
         **DEFAULT_ENTRY_DATA,
@@ -1101,6 +1101,7 @@ async def test_options_flow_secure_manual_to_keyfile(hass: HomeAssistant) -> Non
     }
 
 
+@patch("homeassistant.components.knx.async_setup_entry", AsyncMock(return_value=True))
 async def test_options_communication_settings(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -1123,11 +1124,9 @@ async def test_options_communication_settings(
             CONF_KNX_RATE_LIMIT: 40,
         },
     )
-
     await hass.async_block_till_done()
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
     assert not result2.get("data")
-
     assert mock_config_entry.data == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_AUTOMATIC,

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the KNX config flow."""
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 from xknx.exceptions.exception import InvalidSecureConfiguration
@@ -931,9 +931,9 @@ async def test_configure_secure_knxkeys_invalid_signature(hass: HomeAssistant):
         assert secure_knxkeys["errors"][CONF_KNX_KNXKEY_PASSWORD] == "invalid_signature"
 
 
-@patch("homeassistant.components.knx.async_setup_entry", AsyncMock(return_value=True))
+@patch("homeassistant.components.knx.async_setup_entry", return_value=True)
 async def test_options_flow_connection_type(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    setup_entry_mock, hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test options flow changing interface."""
     mock_config_entry.add_to_hass(hass)
@@ -985,8 +985,10 @@ async def test_options_flow_connection_type(
         }
 
 
-@patch("homeassistant.components.knx.async_setup_entry", AsyncMock(return_value=True))
-async def test_options_flow_secure_manual_to_keyfile(hass: HomeAssistant) -> None:
+@patch("homeassistant.components.knx.async_setup_entry", return_value=True)
+async def test_options_flow_secure_manual_to_keyfile(
+    setup_entry_mock, hass: HomeAssistant
+) -> None:
     """Test options flow changing secure credential source."""
     mock_config_entry = MockConfigEntry(
         title="KNX",
@@ -1082,9 +1084,9 @@ async def test_options_flow_secure_manual_to_keyfile(hass: HomeAssistant) -> Non
     }
 
 
-@patch("homeassistant.components.knx.async_setup_entry", AsyncMock(return_value=True))
+@patch("homeassistant.components.knx.async_setup_entry", return_value=True)
 async def test_options_communication_settings(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    setup_entry_mock, hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test options flow changing communication settings."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -46,7 +46,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="knx_setup", autouse=True)
-def knx_setup_fixture():
+def fixture_knx_setup():
     """Mock KNX entry setup."""
     with patch("homeassistant.components.knx.async_setup", return_value=True), patch(
         "homeassistant.components.knx.async_setup_entry", return_value=True

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -114,7 +114,6 @@ async def test_routing_setup(gateway_scanner_mock, hass: HomeAssistant) -> None:
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING,
         },
     )
-    await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "routing"
     assert result2["errors"] == {"base": "no_router_discovered"}
@@ -170,7 +169,6 @@ async def test_routing_setup_advanced(
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING,
         },
     )
-    await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "routing"
     assert result2["errors"] == {"base": "no_router_discovered"}
@@ -185,7 +183,6 @@ async def test_routing_setup_advanced(
             CONF_KNX_LOCAL_IP: "no_local_ip",
         },
     )
-    await hass.async_block_till_done()
     assert result_invalid_input["type"] == FlowResultType.FORM
     assert result_invalid_input["step_id"] == "routing"
     assert result_invalid_input["errors"] == {
@@ -244,7 +241,6 @@ async def test_routing_secure_manual_setup(
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING,
         },
     )
-    await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "routing"
     assert result2["errors"] == {"base": "no_router_discovered"}
@@ -335,7 +331,6 @@ async def test_routing_secure_keyfile(
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING,
         },
     )
-    await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "routing"
     assert result2["errors"] == {"base": "no_router_discovered"}
@@ -467,7 +462,6 @@ async def test_tunneling_setup_manual(
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
         },
     )
-    await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "manual_tunnel"
     assert result2["errors"] == {"base": "no_tunnel_discovered"}
@@ -512,7 +506,6 @@ async def test_tunneling_setup_for_local_ip(
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
         },
     )
-    await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "manual_tunnel"
     assert result2["errors"] == {"base": "no_tunnel_discovered"}
@@ -527,7 +520,6 @@ async def test_tunneling_setup_for_local_ip(
             CONF_KNX_LOCAL_IP: "192.168.1.112",
         },
     )
-    await hass.async_block_till_done()
     assert result_invalid_host["type"] == FlowResultType.FORM
     assert result_invalid_host["step_id"] == "manual_tunnel"
     assert result_invalid_host["errors"] == {
@@ -544,7 +536,6 @@ async def test_tunneling_setup_for_local_ip(
             CONF_KNX_LOCAL_IP: "asdf",
         },
     )
-    await hass.async_block_till_done()
     assert result_invalid_local["type"] == FlowResultType.FORM
     assert result_invalid_local["step_id"] == "manual_tunnel"
     assert result_invalid_local["errors"] == {
@@ -602,7 +593,6 @@ async def test_tunneling_setup_for_multiple_found_gateways(hass: HomeAssistant) 
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
         },
     )
-    await hass.async_block_till_done()
     assert tunnel_flow["type"] == FlowResultType.FORM
     assert tunnel_flow["step_id"] == "tunnel"
     assert not tunnel_flow["errors"]
@@ -660,7 +650,6 @@ async def test_manual_tunnel_step_with_found_gateway(
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
         },
     )
-    await hass.async_block_till_done()
     assert tunnel_flow["type"] == FlowResultType.FORM
     assert tunnel_flow["step_id"] == "tunnel"
     assert not tunnel_flow["errors"]
@@ -671,7 +660,6 @@ async def test_manual_tunnel_step_with_found_gateway(
             CONF_KNX_GATEWAY: OPTION_MANUAL_TUNNEL,
         },
     )
-    await hass.async_block_till_done()
     assert manual_tunnel_flow["type"] == FlowResultType.FORM
     assert manual_tunnel_flow["step_id"] == "manual_tunnel"
     assert not manual_tunnel_flow["errors"]
@@ -702,7 +690,6 @@ async def test_form_with_automatic_connection_handling(hass: HomeAssistant) -> N
             },
         )
         await hass.async_block_till_done()
-
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == CONF_KNX_AUTOMATIC.capitalize()
     assert result2["data"] == {
@@ -737,7 +724,6 @@ async def _get_menu_step(hass: HomeAssistant) -> FlowResult:
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
         },
     )
-    await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "tunnel"
     assert not result2["errors"]
@@ -746,7 +732,6 @@ async def _get_menu_step(hass: HomeAssistant) -> FlowResult:
         result2["flow_id"],
         {CONF_KNX_GATEWAY: str(gateway)},
     )
-    await hass.async_block_till_done()
     assert result3["type"] == FlowResultType.MENU
     assert result3["step_id"] == "secure_key_source"
     return result3
@@ -778,7 +763,6 @@ async def test_get_secure_menu_step_manual_tunnelling(
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
         },
     )
-    await hass.async_block_till_done()
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "tunnel"
     assert not result2["errors"]
@@ -798,7 +782,6 @@ async def test_get_secure_menu_step_manual_tunnelling(
             CONF_PORT: 3675,
         },
     )
-    await hass.async_block_till_done()
     assert result3["type"] == FlowResultType.MENU
     assert result3["step_id"] == "secure_key_source"
 
@@ -915,7 +898,6 @@ async def test_configure_secure_knxkeys_file_not_found(hass: HomeAssistant):
                 CONF_KNX_KNXKEY_PASSWORD: "password",
             },
         )
-        await hass.async_block_till_done()
         assert secure_knxkeys["type"] == FlowResultType.FORM
         assert secure_knxkeys["errors"]
         assert secure_knxkeys["errors"][CONF_KNX_KNXKEY_FILENAME] == "file_not_found"
@@ -944,7 +926,6 @@ async def test_configure_secure_knxkeys_invalid_signature(hass: HomeAssistant):
                 CONF_KNX_KNXKEY_PASSWORD: "password",
             },
         )
-        await hass.async_block_till_done()
         assert secure_knxkeys["type"] == FlowResultType.FORM
         assert secure_knxkeys["errors"]
         assert secure_knxkeys["errors"][CONF_KNX_KNXKEY_PASSWORD] == "invalid_signature"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Suggested changes in review of #82724
https://github.com/home-assistant/core/pull/82724/files#r1035524141

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #82724
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
