### PR TITLE
Fix manual.alarm_control_panel RestoreEntity bugs

### DIFF
--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -358,7 +358,10 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
         self._state = state
         self._state_ts = dt_util.utcnow()
         self.async_schedule_update_ha_state()
+        self._async_set_state_update_events()
 
+    def _async_set_state_update_events(self) -> None:
+        state = self._state
         if state == STATE_ALARM_TRIGGERED:
             pending_time = self._pending_time(state)
             async_track_point_in_time(
@@ -418,14 +421,14 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
         if state := await self.async_get_last_state():
-            if (
-                state.state in (STATE_ALARM_PENDING, STATE_ALARM_ARMING)
-                and hasattr(state, "attributes")
-                and state.attributes[ATTR_PREVIOUS_STATE]
-            ):
-                # If in arming or pending state, we return to the ATTR_PREVIOUS_STATE
-                self._state = state.attributes[ATTR_PREVIOUS_STATE]
-                self._state_ts = dt_util.utcnow()
+            self._state_ts = state.last_updated
+            if hasattr(state, "attributes") and ATTR_NEXT_STATE in state.attributes:
+                # If in arming or pending state we record the transition,
+                # not the current state
+                self._state = state.attributes[ATTR_NEXT_STATE]
             else:
                 self._state = state.state
-                self._state_ts = state.last_updated
+
+            if hasattr(state, "attributes") and ATTR_PREVIOUS_STATE in state.attributes:
+                self._previous_state = state.attributes[ATTR_PREVIOUS_STATE]
+                self._async_set_state_update_events()

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -403,6 +403,10 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
                 ATTR_PREVIOUS_STATE: self._previous_state,
                 ATTR_NEXT_STATE: self._state,
             }
+        if self.state == STATE_ALARM_TRIGGERED:
+            return {
+                ATTR_PREVIOUS_STATE: self._previous_state,
+            }
         return {}
 
     @callback

--- a/tests/components/manual/test_alarm_control_panel.py
+++ b/tests/components/manual/test_alarm_control_panel.py
@@ -354,7 +354,9 @@ async def test_trigger_no_pending(hass):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
 
 async def test_trigger_with_delay(hass):
@@ -398,6 +400,7 @@ async def test_trigger_with_delay(hass):
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -490,6 +493,7 @@ async def test_trigger_with_pending(hass):
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
     assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
@@ -546,6 +550,7 @@ async def test_trigger_with_unused_specific_delay(hass):
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -591,6 +596,7 @@ async def test_trigger_with_specific_delay(hass):
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -647,6 +653,7 @@ async def test_trigger_with_pending_and_delay(hass):
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -704,6 +711,7 @@ async def test_trigger_with_pending_and_specific_delay(hass):
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -739,7 +747,9 @@ async def test_trigger_with_specific_pending(hass):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -775,7 +785,9 @@ async def test_trigger_with_disarm_after_trigger(hass):
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -839,7 +851,9 @@ async def test_trigger_with_unused_zero_specific_trigger_time(hass):
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -875,7 +889,9 @@ async def test_trigger_with_specific_trigger_time(hass):
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -916,7 +932,9 @@ async def test_trigger_with_no_disarm_after_trigger(hass):
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -957,7 +975,9 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(hass):
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -971,7 +991,9 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(hass):
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -1060,7 +1082,9 @@ async def test_disarm_during_trigger_with_invalid_code(hass):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
 
 async def test_disarm_with_template_code(hass):
@@ -1159,6 +1183,7 @@ async def test_arm_away_after_disabled_disarmed(hass):
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

The RestoreEntity implementation for the manual alarm control panel does not correctly restore timers. After this pull request, it restores the full state of the integration instead.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
