### PR TITLE
Fix yale access bluetooth locks delaying startup when key changes

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -12,9 +12,9 @@ from yalexs.exceptions import AugustApiAIOHTTPError
 from yalexs.lock import Lock, LockDetail
 from yalexs.pubnub_activity import activities_from_pubnub_message
 from yalexs.pubnub_async import AugustPubNub, async_create_pubnub
+from yalexs_ble import YaleXSBLEDiscovery
 
-from homeassistant.components import yalexs_ble
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY, ConfigEntry
 from homeassistant.const import CONF_PASSWORD
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import (
@@ -22,7 +22,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, discovery_flow
 
 from .activity import ActivityStream
 from .const import DOMAIN, MIN_TIME_BETWEEN_DETAIL_UPDATES, PLATFORMS
@@ -38,6 +38,7 @@ API_CACHED_ATTRS = {
     "lock_status",
     "lock_status_datetime",
 }
+YALEXS_BLE_DOMAIN = "yalexs_ble"
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -100,9 +101,11 @@ def _async_trigger_ble_lock_discovery(
 ):
     """Update keys for the yalexs-ble integration if available."""
     for lock_detail in locks_with_offline_keys:
-        yalexs_ble.async_discovery(
+        discovery_flow.async_create_flow(
             hass,
-            yalexs_ble.YaleXSBLEDiscovery(
+            YALEXS_BLE_DOMAIN,
+            context={"source": SOURCE_INTEGRATION_DISCOVERY},
+            data=YaleXSBLEDiscovery(
                 {
                     "name": lock_detail.device_name,
                     "address": lock_detail.mac_address,

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.2.6"],
+  "requirements": ["yalexs==1.2.6", "yalexs_ble==1.10.0"],
   "codeowners": ["@bdraco"],
   "dhcp": [
     {
@@ -24,6 +24,5 @@
   ],
   "config_flow": true,
   "iot_class": "cloud_push",
-  "loggers": ["pubnub", "yalexs"],
-  "after_dependencies": ["yalexs_ble"]
+  "loggers": ["pubnub", "yalexs"]
 }

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -2,44 +2,21 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TypedDict
 
 import async_timeout
 from yalexs_ble import PushLock, local_name_is_unique
 
 from homeassistant.components import bluetooth
-from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import discovery_flow
 
 from .const import CONF_KEY, CONF_LOCAL_NAME, CONF_SLOT, DEVICE_TIMEOUT, DOMAIN
 from .models import YaleXSBLEData
 from .util import async_find_existing_service_info, bluetooth_callback_matcher
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.LOCK, Platform.SENSOR]
-
-
-class YaleXSBLEDiscovery(TypedDict):
-    """A validated discovery of a Yale XS BLE device."""
-
-    name: str
-    address: str
-    serial: str
-    key: str
-    slot: int
-
-
-@callback
-def async_discovery(hass: HomeAssistant, discovery: YaleXSBLEDiscovery) -> None:
-    """Update keys for the yalexs-ble integration if available."""
-    discovery_flow.async_create_flow(
-        hass,
-        DOMAIN,
-        context={"source": SOURCE_INTEGRATION_DISCOVERY},
-        data=discovery,
-    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/yalexs_ble/manifest.json
+++ b/homeassistant/components/yalexs_ble/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yale Access Bluetooth",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/yalexs_ble",
-  "requirements": ["yalexs-ble==1.9.8"],
+  "requirements": ["yalexs-ble==1.10.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@bdraco"],
   "bluetooth": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2603,10 +2603,13 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.3.9
 
 # homeassistant.components.yalexs_ble
-yalexs-ble==1.9.8
+yalexs-ble==1.10.0
 
 # homeassistant.components.august
 yalexs==1.2.6
+
+# homeassistant.components.august
+yalexs_ble==1.10.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1813,10 +1813,13 @@ xmltodict==0.13.0
 yalesmartalarmclient==0.3.9
 
 # homeassistant.components.yalexs_ble
-yalexs-ble==1.9.8
+yalexs-ble==1.10.0
 
 # homeassistant.components.august
 yalexs==1.2.6
+
+# homeassistant.components.august
+yalexs_ble==1.10.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -332,7 +332,7 @@ async def test_load_triggers_ble_discovery(hass):
     august_lock_without_key = await _mock_operative_august_lock_detail(hass)
 
     with patch(
-        "homeassistant.components.august.yalexs_ble.async_discovery"
+        "homeassistant.components.august.discovery_flow.async_create_flow"
     ) as mock_discovery:
         config_entry = await _create_august_with_devices(
             hass, [august_lock_with_key, august_lock_without_key]
@@ -341,7 +341,7 @@ async def test_load_triggers_ble_discovery(hass):
     assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(mock_discovery.mock_calls) == 1
-    assert mock_discovery.mock_calls[0][1][1] == {
+    assert mock_discovery.mock_calls[0].kwargs["data"] == {
         "name": "Front Door Lock",
         "address": None,
         "serial": "X2FSW05DGA",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This problem became obvious with the BLE proxies.

If the keys changed for the yale locks, the locks would be slow to setup. Because `august` had `yalexs_ble` as an after dep, it would be waiting with the new keys but not able to setup because it was waiting for the locks to setup which would be trying over and over until they failed because the key had changed out from under it.

This change moves some more code into the lib to avoid the dep and allows both to startup at the same time so the cloud service can feed the new keys in if needed without waiting for the lock to fail to setup

changelog: https://github.com/bdraco/yalexs-ble/compare/v1.9.8...v1.10.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
