### PR TITLE
Bump lupupy to 0.2.1

### DIFF
--- a/homeassistant/components/lupusec/__init__.py
+++ b/homeassistant/components/lupusec/__init__.py
@@ -2,7 +2,6 @@
 import logging
 
 import lupupy
-from lupupy.exceptions import LupusecException
 import voluptuous as vol
 
 from homeassistant.components import persistent_notification

--- a/homeassistant/components/lupusec/__init__.py
+++ b/homeassistant/components/lupusec/__init__.py
@@ -2,6 +2,7 @@
 import logging
 
 import lupupy
+from lupupy.exceptions import LupusecException
 import voluptuous as vol
 
 from homeassistant.components import persistent_notification
@@ -55,7 +56,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     try:
         hass.data[DOMAIN] = LupusecSystem(username, password, ip_address, name)
-    except Exception as ex:
+    except LupusecException as ex:
         _LOGGER.error(ex)
 
         persistent_notification.create(

--- a/homeassistant/components/lupusec/__init__.py
+++ b/homeassistant/components/lupusec/__init__.py
@@ -55,7 +55,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     try:
         hass.data[DOMAIN] = LupusecSystem(username, password, ip_address, name)
-    except LupusecException as ex:
+    except Exception as ex:
         _LOGGER.error(ex)
 
         persistent_notification.create(

--- a/homeassistant/components/lupusec/manifest.json
+++ b/homeassistant/components/lupusec/manifest.json
@@ -2,7 +2,7 @@
   "domain": "lupusec",
   "name": "Lupus Electronics LUPUSEC",
   "documentation": "https://www.home-assistant.io/integrations/lupusec",
-  "requirements": ["lupupy==0.2.0"],
+  "requirements": ["lupupy==0.2.1"],
   "codeowners": ["@majuss"],
   "iot_class": "local_polling",
   "loggers": ["lupupy"]

--- a/homeassistant/components/lupusec/manifest.json
+++ b/homeassistant/components/lupusec/manifest.json
@@ -2,7 +2,7 @@
   "domain": "lupusec",
   "name": "Lupus Electronics LUPUSEC",
   "documentation": "https://www.home-assistant.io/integrations/lupusec",
-  "requirements": ["lupupy==0.1.9"],
+  "requirements": ["lupupy==0.2.0"],
   "codeowners": ["@majuss"],
   "iot_class": "local_polling",
   "loggers": ["lupupy"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1052,7 +1052,7 @@ london-tube-status==0.5
 luftdaten==0.7.4
 
 # homeassistant.components.lupusec
-lupupy==0.2.0
+lupupy==0.2.1
 
 # homeassistant.components.lw12wifi
 lw12==0.9.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1052,7 +1052,7 @@ london-tube-status==0.5
 luftdaten==0.7.4
 
 # homeassistant.components.lupusec
-lupupy==0.1.9
+lupupy==0.2.0
 
 # homeassistant.components.lw12wifi
 lw12==0.9.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
- lupupy changes: https://github.com/majuss/lupupy/compare/1a115f630de36ec02afc3d7ea59e2ac84bd2bb21...4dbd888581950b119c16a27045dc9c0d4a69455a
- bump lupupy to resolve issue: https://github.com/home-assistant/core/issues/81598
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/81598

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
