### PR TITLE
Support older twinkly devices without effects

### DIFF
--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -9,6 +9,7 @@ CONF_NAME = "name"
 
 # Strongly named HA attributes keys
 ATTR_HOST = "host"
+ATTR_VERSION = "version"
 
 # Keys of attributes read from the get_device_info
 DEV_ID = "uuid"
@@ -27,3 +28,6 @@ HIDDEN_DEV_VALUES = (
     "copyright",  # We should not display a copyright "LEDWORKS 2018" in the Home-Assistant UI
     "mac",  # Does not report the actual device mac address
 )
+
+# Minimum version required to support effects
+MIN_EFFECT_VERSION = "2.7.1"

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -318,6 +318,14 @@ class TwinklyLight(LightEntity):
                 if key not in HIDDEN_DEV_VALUES:
                     self._attributes[key] = value
 
+            if (
+                "max_movies" not in device_info
+                and LightEntityFeature.EFFECT in self.supported_features
+            ):
+                self._attr_supported_features = (
+                    self.supported_features & ~LightEntityFeature.EFFECT
+                )
+
             if LightEntityFeature.EFFECT in self.supported_features:
                 await self.async_update_movies()
                 await self.async_update_current_movie()

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -184,15 +184,31 @@ class TwinklyLight(LightEntity):
                     await self._client.interview()
                     if LightEntityFeature.EFFECT in self.supported_features:
                         # Static color only supports rgb
-                        await self._client.set_static_colour(
-                            (
-                                self._attr_rgbw_color[0],
-                                self._attr_rgbw_color[1],
-                                self._attr_rgbw_color[2],
+                        try:
+                            await self._client.set_static_colour(
+                                (
+                                    self._attr_rgbw_color[0],
+                                    self._attr_rgbw_color[1],
+                                    self._attr_rgbw_color[2],
+                                )
                             )
-                        )
-                        await self._client.set_mode("color")
-                        self._client.default_mode = "color"
+                            await self._client.set_mode("color")
+                            self._client.default_mode = "color"
+                        except ClientResponseError as error:
+                            if error.status == HTTPNotFound().status:
+                                self._attr_supported_features = (
+                                    self.supported_features & ~LightEntityFeature.EFFECT
+                                )
+                                await self._client.set_cycle_colours(
+                                    (
+                                        self._attr_rgbw_color[3],
+                                        self._attr_rgbw_color[0],
+                                        self._attr_rgbw_color[1],
+                                        self._attr_rgbw_color[2],
+                                    )
+                                )
+                            await self._client.set_mode("movie")
+                            self._client.default_mode = "movie"
                     else:
                         await self._client.set_cycle_colours(
                             (
@@ -213,9 +229,20 @@ class TwinklyLight(LightEntity):
 
                     await self._client.interview()
                     if LightEntityFeature.EFFECT in self.supported_features:
-                        await self._client.set_static_colour(self._attr_rgb_color)
-                        await self._client.set_mode("color")
-                        self._client.default_mode = "color"
+                        try:
+                            await self._client.set_static_colour(self._attr_rgb_color)
+                            await self._client.set_mode("color")
+                            self._client.default_mode = "color"
+                        except ClientResponseError as error:
+                            if error.status == HTTPNotFound().status:
+                                self._attr_supported_features = (
+                                    self.supported_features & ~LightEntityFeature.EFFECT
+                                )
+                                await self._client.set_cycle_colours(
+                                    self._attr_rgb_color
+                                )
+                                await self._client.set_mode("movie")
+                                self._client.default_mode = "movie"
                     else:
                         await self._client.set_cycle_colours(self._attr_rgb_color)
                         await self._client.set_mode("movie")

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -301,17 +301,6 @@ class TwinklyLight(LightEntity):
                 if key not in HIDDEN_DEV_VALUES:
                     self._attributes[key] = value
 
-            if ATTR_VERSION not in self._attributes:
-                firmware_version = await self._client.get_firmware_version()
-                self._attributes[ATTR_VERSION] = firmware_version[ATTR_VERSION]
-
-            if version.parse(self._attributes[ATTR_VERSION]) < version.parse(
-                MIN_EFFECT_VERSION
-            ):
-                self._attr_supported_features = (
-                    self.supported_features & ~LightEntityFeature.EFFECT
-                )
-
             if LightEntityFeature.EFFECT & self.supported_features:
                 await self.async_update_movies()
                 await self.async_update_current_movie()

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -343,7 +343,6 @@ class TwinklyLight(LightEntity):
                 self._attr_supported_features = (
                     self.supported_features & ~LightEntityFeature.EFFECT
                 )
-                print(f"Supported features: {self.supported_features}")
 
     async def async_update_current_movie(self) -> None:
         """Update the current active movie."""

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -207,8 +207,11 @@ class TwinklyLight(LightEntity):
                                         self._attr_rgbw_color[2],
                                     )
                                 )
-                            await self._client.set_mode("movie")
-                            self._client.default_mode = "movie"
+                                await self._client.set_mode("movie")
+                                self._client.default_mode = "movie"
+                            else:
+                                _LOGGER.warning("Unable to set rgbw-color")
+                                _LOGGER.warning(error)
                     else:
                         await self._client.set_cycle_colours(
                             (
@@ -243,6 +246,9 @@ class TwinklyLight(LightEntity):
                                 )
                                 await self._client.set_mode("movie")
                                 self._client.default_mode = "movie"
+                            else:
+                                _LOGGER.warning("Unable to set rgb-color")
+                                _LOGGER.warning(error)
                     else:
                         await self._client.set_cycle_colours(self._attr_rgb_color)
                         await self._client.set_mode("movie")
@@ -343,6 +349,9 @@ class TwinklyLight(LightEntity):
                 self._attr_supported_features = (
                     self.supported_features & ~LightEntityFeature.EFFECT
                 )
+            else:
+                _LOGGER.warning("Unable to get movies")
+                _LOGGER.warning(error)
 
     async def async_update_current_movie(self) -> None:
         """Update the current active movie."""
@@ -359,3 +368,6 @@ class TwinklyLight(LightEntity):
                 self._attr_supported_features = (
                     self.supported_features & ~LightEntityFeature.EFFECT
                 )
+            else:
+                _LOGGER.warning("Unable to get movies")
+                _LOGGER.warning(error)

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -33,7 +33,6 @@ class ClientMock:
             "uuid": self.id,
             "device_name": self.id,  # we make sure that entity id is different for each test
             "product_code": TEST_MODEL,
-            "max_movies": 100,
         }
 
     @property

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -2,9 +2,7 @@
 
 from uuid import uuid4
 
-from aiohttp import ClientResponseError, RequestInfo
 from aiohttp.client_exceptions import ClientConnectionError
-from aiohttp.web import HTTPNotFound
 
 from homeassistant.components.twinkly.const import DEV_NAME
 
@@ -26,7 +24,6 @@ class ClientMock:
         self.color = None
         self.movies = [{"id": 1, "name": "Rainbow"}, {"id": 2, "name": "Flare"}]
         self.current_movie = {}
-        self.mock_unsupported_effects = False
         self.default_mode = "movie"
         self.mode = None
         self.version = "2.8.10"
@@ -99,26 +96,10 @@ class ClientMock:
 
     async def get_saved_movies(self) -> dict:
         """Get saved movies."""
-        if self.mock_unsupported_effects:
-            raise ClientResponseError(
-                RequestInfo("url", "get", None),
-                None,
-                status=HTTPNotFound().status,
-                message="Not found",
-                headers=None,
-            )
         return self.movies
 
     async def get_current_movie(self) -> dict:
         """Get current movie."""
-        if self.mock_unsupported_effects:
-            raise ClientResponseError(
-                RequestInfo("url", "get", None),
-                None,
-                status=HTTPNotFound().status,
-                message="Not found",
-                headers=None,
-            )
         return self.current_movie
 
     async def set_current_movie(self, movie_id: int) -> dict:

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -29,6 +29,7 @@ class ClientMock:
         self.mock_unsupported_effects = False
         self.default_mode = "movie"
         self.mode = None
+        self.version = "2.8.10"
 
         self.id = str(uuid4())
         self.device_info = {
@@ -131,3 +132,7 @@ class ClientMock:
         else:
             await self.turn_on()
             self.mode = mode
+
+    async def get_firmware_version(self) -> dict:
+        """Get firmware version."""
+        return {"version": self.version}

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -57,6 +57,7 @@ class ClientMock:
         if self.is_offline:
             raise ClientConnectionError()
         self.state = True
+        self.mode = self.default_mode
 
     async def turn_off(self) -> None:
         """Set the mocked off state."""

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -35,6 +35,7 @@ class ClientMock:
             "uuid": self.id,
             "device_name": self.id,  # we make sure that entity id is different for each test
             "product_code": TEST_MODEL,
+            "max_movies": 100,
         }
 
     @property
@@ -126,7 +127,7 @@ class ClientMock:
     async def set_mode(self, mode: str) -> None:
         """Set mode."""
         if mode == "off":
-            self.turn_off()
+            await self.turn_off()
         else:
-            self.turn_on()
+            await self.turn_on()
             self.mode = mode

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -126,7 +126,7 @@ class ClientMock:
     async def set_mode(self, mode: str) -> None:
         """Set mode."""
         if mode == "off":
-            self.turn_off
+            self.turn_off()
         else:
-            self.turn_on
+            self.turn_on()
             self.mode = mode

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -2,7 +2,9 @@
 
 from uuid import uuid4
 
+from aiohttp import ClientResponseError, RequestInfo
 from aiohttp.client_exceptions import ClientConnectionError
+from aiohttp.web import HTTPNotFound
 
 from homeassistant.components.twinkly.const import DEV_NAME
 
@@ -24,7 +26,9 @@ class ClientMock:
         self.color = None
         self.movies = [{"id": 1, "name": "Rainbow"}, {"id": 2, "name": "Flare"}]
         self.current_movie = {}
+        self.mock_unsupported_effects = False
         self.default_mode = "movie"
+        self.mode = None
 
         self.id = str(uuid4())
         self.device_info = {
@@ -81,16 +85,38 @@ class ClientMock:
     async def set_static_colour(self, colour) -> None:
         """Set static color."""
         self.color = colour
+        self.default_mode = "color"
+
+    async def set_cycle_colours(self, colour) -> None:
+        """Set static color."""
+        self.color = colour
+        self.default_mode = "movie"
 
     async def interview(self) -> None:
         """Interview."""
 
     async def get_saved_movies(self) -> dict:
         """Get saved movies."""
+        if self.mock_unsupported_effects:
+            raise ClientResponseError(
+                RequestInfo("url", "get", None),
+                None,
+                status=HTTPNotFound().status,
+                message="Not found",
+                headers=None,
+            )
         return self.movies
 
     async def get_current_movie(self) -> dict:
         """Get current movie."""
+        if self.mock_unsupported_effects:
+            raise ClientResponseError(
+                RequestInfo("url", "get", None),
+                None,
+                status=HTTPNotFound().status,
+                message="Not found",
+                headers=None,
+            )
         return self.current_movie
 
     async def set_current_movie(self, movie_id: int) -> dict:
@@ -103,3 +129,4 @@ class ClientMock:
             self.turn_off
         else:
             self.turn_on
+            self.mode = mode

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -55,9 +55,8 @@ async def test_turn_on_off(hass: HomeAssistant):
     assert hass.states.get(entity.entity_id).state == "off"
 
     await hass.services.async_call(
-        "light", "turn_on", service_data={"entity_id": entity.entity_id}
+        "light", "turn_on", service_data={"entity_id": entity.entity_id}, blocking=True
     )
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 
@@ -78,8 +77,8 @@ async def test_turn_on_with_brightness(hass: HomeAssistant):
         "light",
         "turn_on",
         service_data={"entity_id": entity.entity_id, "brightness": 255},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 
@@ -90,8 +89,8 @@ async def test_turn_on_with_brightness(hass: HomeAssistant):
         "light",
         "turn_on",
         service_data={"entity_id": entity.entity_id, "brightness": 1},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 
@@ -112,8 +111,8 @@ async def test_turn_on_with_color_rgbw(hass: HomeAssistant):
         "light",
         "turn_on",
         service_data={"entity_id": entity.entity_id, "rgbw_color": (128, 64, 32, 0)},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 
@@ -136,8 +135,8 @@ async def test_turn_on_with_color_rgb(hass: HomeAssistant):
         "light",
         "turn_on",
         service_data={"entity_id": entity.entity_id, "rgb_color": (128, 64, 32)},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 
@@ -161,8 +160,8 @@ async def test_turn_on_with_effect(hass: HomeAssistant):
         "light",
         "turn_on",
         service_data={"entity_id": entity.entity_id, "effect": "1 Rainbow"},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 
@@ -177,26 +176,28 @@ async def test_turn_on_with_color_rgbw_and_missing_effect(hass: HomeAssistant):
     client.state = False
     client.device_info["led_profile"] = "RGBW"
     client.brightness = {"mode": "enabled", "value": 255}
+    client.version = "2.7.0"
     entity, _, _, _ = await _create_entries(hass, client)
 
     assert hass.states.get(entity.entity_id).state == "off"
     assert not client.current_movie
 
-    assert LightEntityFeature.EFFECT in entity.supported_features
-    client.mock_unsupported_effects = True
+    assert not LightEntityFeature.EFFECT & entity.supported_features
 
     # Turn off to force async_update
     await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": entity.entity_id}
+        "light",
+        "turn_off",
+        service_data={"entity_id": entity.entity_id},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
     await hass.services.async_call(
         "light",
         "turn_on",
         service_data={"entity_id": entity.entity_id, "rgbw_color": (128, 64, 32, 0)},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 
@@ -212,41 +213,6 @@ async def test_turn_on_with_color_rgb_and_missing_effect(hass: HomeAssistant):
     client.state = False
     client.device_info["led_profile"] = "RGB"
     client.brightness = {"mode": "enabled", "value": 255}
-    entity, _, _, _ = await _create_entries(hass, client)
-
-    assert hass.states.get(entity.entity_id).state == "off"
-    assert not client.current_movie
-    assert LightEntityFeature.EFFECT in entity.supported_features
-
-    client.mock_unsupported_effects = True
-
-    # Turn off to force async_update
-    await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": entity.entity_id}
-    )
-    await hass.async_block_till_done()
-
-    await hass.services.async_call(
-        "light",
-        "turn_on",
-        service_data={"entity_id": entity.entity_id, "rgb_color": (128, 64, 32)},
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity.entity_id)
-
-    assert state.state == "on"
-    assert client.color == (128, 64, 32)
-    assert client.mode == "movie"
-    assert client.default_mode == "movie"
-
-
-async def test_turn_on_with_color_rgb_and_missing_effect_2(hass: HomeAssistant):
-    """Test support of the light.turn_on service with rgb color and missing effect support."""
-    client = ClientMock()
-    client.state = False
-    client.device_info["led_profile"] = "RGB"
-    client.brightness = {"mode": "enabled", "value": 255}
     client.version = "2.7.0"
     entity, _, _, _ = await _create_entries(hass, client)
 
@@ -256,16 +222,15 @@ async def test_turn_on_with_color_rgb_and_missing_effect_2(hass: HomeAssistant):
 
     # Turn off to force async_update
     await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": entity.entity_id}
+        "light", "turn_off", service_data={"entity_id": entity.entity_id}, blocking=True
     )
-    await hass.async_block_till_done()
 
     await hass.services.async_call(
         "light",
         "turn_on",
         service_data={"entity_id": entity.entity_id, "rgb_color": (128, 64, 32)},
+        blocking=True,
     )
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 
@@ -282,9 +247,8 @@ async def test_turn_off(hass: HomeAssistant):
     assert hass.states.get(entity.entity_id).state == "on"
 
     await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": entity.entity_id}
+        "light", "turn_off", service_data={"entity_id": entity.entity_id}, blocking=True
     )
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 
@@ -303,9 +267,8 @@ async def test_update_name(hass: HomeAssistant):
 
     client.change_name("new_device_name")
     await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": entity.entity_id}
+        "light", "turn_off", service_data={"entity_id": entity.entity_id}, blocking=True
     )  # We call turn_off which will automatically cause an async_update
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
 

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -246,7 +246,7 @@ async def test_turn_on_with_color_rgb_and_missing_effect(hass: HomeAssistant):
 
 
 async def test_turn_on_with_effect_missing_effects(hass: HomeAssistant):
-    """Test support of the light.turn_on service with effects."""
+    """Test support of the light.turn_on service with effect set even if effects are not supported."""
     client = ClientMock()
     client.state = False
     client.device_info["led_profile"] = "RGB"

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -247,7 +247,7 @@ async def test_turn_on_with_color_rgb_and_missing_effect_2(hass: HomeAssistant):
     client.state = False
     client.device_info["led_profile"] = "RGB"
     client.brightness = {"mode": "enabled", "value": 255}
-    del client.device_info["max_movies"]
+    client.version = "2.7.0"
     entity, _, _, _ = await _create_entries(hass, client)
 
     assert hass.states.get(entity.entity_id).state == "off"

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -195,7 +195,6 @@ async def test_turn_on_with_color_rgbw_and_missing_effect(hass: HomeAssistant):
     entity, _, _, _ = await _create_entries(hass, client)
 
     assert hass.states.get(entity.entity_id).state == "off"
-    assert not client.current_movie
     assert (
         not LightEntityFeature.EFFECT
         & hass.states.get(entity.entity_id).attributes["supported_features"]
@@ -226,7 +225,6 @@ async def test_turn_on_with_color_rgb_and_missing_effect(hass: HomeAssistant):
     entity, _, _, _ = await _create_entries(hass, client)
 
     assert hass.states.get(entity.entity_id).state == "off"
-    assert not client.current_movie
     assert (
         not LightEntityFeature.EFFECT
         & hass.states.get(entity.entity_id).attributes["supported_features"]

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -106,6 +106,10 @@ async def test_turn_on_with_color_rgbw(hass: HomeAssistant):
     entity, _, _, _ = await _create_entries(hass, client)
 
     assert hass.states.get(entity.entity_id).state == "off"
+    assert (
+        LightEntityFeature.EFFECT
+        & hass.states.get(entity.entity_id).attributes["supported_features"]
+    )
 
     await hass.services.async_call(
         "light",
@@ -119,6 +123,7 @@ async def test_turn_on_with_color_rgbw(hass: HomeAssistant):
     assert state.state == "on"
     assert client.color == (128, 64, 32)
     assert client.default_mode == "color"
+    assert client.mode == "color"
 
 
 async def test_turn_on_with_color_rgb(hass: HomeAssistant):
@@ -130,6 +135,10 @@ async def test_turn_on_with_color_rgb(hass: HomeAssistant):
     entity, _, _, _ = await _create_entries(hass, client)
 
     assert hass.states.get(entity.entity_id).state == "off"
+    assert (
+        LightEntityFeature.EFFECT
+        & hass.states.get(entity.entity_id).attributes["supported_features"]
+    )
 
     await hass.services.async_call(
         "light",
@@ -143,6 +152,7 @@ async def test_turn_on_with_color_rgb(hass: HomeAssistant):
     assert state.state == "on"
     assert client.color == (128, 64, 32)
     assert client.default_mode == "color"
+    assert client.mode == "color"
 
 
 async def test_turn_on_with_effect(hass: HomeAssistant):
@@ -155,6 +165,10 @@ async def test_turn_on_with_effect(hass: HomeAssistant):
 
     assert hass.states.get(entity.entity_id).state == "off"
     assert not client.current_movie
+    assert (
+        LightEntityFeature.EFFECT
+        & hass.states.get(entity.entity_id).attributes["supported_features"]
+    )
 
     await hass.services.async_call(
         "light",
@@ -168,6 +182,7 @@ async def test_turn_on_with_effect(hass: HomeAssistant):
     assert state.state == "on"
     assert client.current_movie["id"] == 1
     assert client.default_mode == "movie"
+    assert client.mode == "movie"
 
 
 async def test_turn_on_with_color_rgbw_and_missing_effect(hass: HomeAssistant):
@@ -181,15 +196,9 @@ async def test_turn_on_with_color_rgbw_and_missing_effect(hass: HomeAssistant):
 
     assert hass.states.get(entity.entity_id).state == "off"
     assert not client.current_movie
-
-    assert not LightEntityFeature.EFFECT & entity.supported_features
-
-    # Turn off to force async_update
-    await hass.services.async_call(
-        "light",
-        "turn_off",
-        service_data={"entity_id": entity.entity_id},
-        blocking=True,
+    assert (
+        not LightEntityFeature.EFFECT
+        & hass.states.get(entity.entity_id).attributes["supported_features"]
     )
 
     await hass.services.async_call(
@@ -218,11 +227,9 @@ async def test_turn_on_with_color_rgb_and_missing_effect(hass: HomeAssistant):
 
     assert hass.states.get(entity.entity_id).state == "off"
     assert not client.current_movie
-    assert not LightEntityFeature.EFFECT & entity.supported_features
-
-    # Turn off to force async_update
-    await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": entity.entity_id}, blocking=True
+    assert (
+        not LightEntityFeature.EFFECT
+        & hass.states.get(entity.entity_id).attributes["supported_features"]
     )
 
     await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This should bring back support for older devices that was broken with the new effects functions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83076
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
