### PR TITLE
Replace NINA corona filter with regex

### DIFF
--- a/homeassistant/components/nina/__init__.py
+++ b/homeassistant/components/nina/__init__.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_HEADLINE_FILTER,
     CONF_REGIONS,
     DOMAIN,
+    NO_MATCH_REGEX,
     SCAN_INTERVAL,
 )
 
@@ -32,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     regions: dict[str, str] = entry.data[CONF_REGIONS]
 
     if CONF_HEADLINE_FILTER not in entry.data:
-        filter_regex = "/(?!)/"
+        filter_regex = NO_MATCH_REGEX
 
         if entry.data[CONF_FILTER_CORONA]:
             filter_regex = ".*corona.*"

--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -18,12 +18,13 @@ from homeassistant.helpers.entity_registry import (
 
 from .const import (
     _LOGGER,
-    CONF_FILTER_CORONA,
+    CONF_HEADLINE_FILTER,
     CONF_MESSAGE_SLOTS,
     CONF_REGIONS,
     CONST_REGION_MAPPING,
     CONST_REGIONS,
     DOMAIN,
+    NO_MATCH_REGEX,
 )
 
 
@@ -125,6 +126,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if group_input := user_input.get(group):
                     user_input[CONF_REGIONS] += group_input
 
+            if not user_input[CONF_HEADLINE_FILTER]:
+                user_input[CONF_HEADLINE_FILTER] = NO_MATCH_REGEX
+
             if user_input[CONF_REGIONS]:
                 return self.async_create_entry(
                     title="NINA",
@@ -144,7 +148,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_MESSAGE_SLOTS, default=5): vol.All(
                         int, vol.Range(min=1, max=20)
                     ),
-                    vol.Required(CONF_FILTER_CORONA, default=True): cv.boolean,
+                    vol.Optional(CONF_HEADLINE_FILTER, default=""): cv.string,
                 }
             ),
             errors=errors,
@@ -255,10 +259,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_MESSAGE_SLOTS,
                         default=self.data[CONF_MESSAGE_SLOTS],
                     ): vol.All(int, vol.Range(min=1, max=20)),
-                    vol.Required(
-                        CONF_FILTER_CORONA,
-                        default=self.data[CONF_FILTER_CORONA],
-                    ): cv.boolean,
+                    vol.Optional(
+                        CONF_HEADLINE_FILTER,
+                        default=self.data[CONF_HEADLINE_FILTER],
+                    ): cv.string,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/nina/const.py
+++ b/homeassistant/components/nina/const.py
@@ -11,9 +11,11 @@ SCAN_INTERVAL: timedelta = timedelta(minutes=5)
 
 DOMAIN: str = "nina"
 
+NO_MATCH_REGEX: str = "/(?!)/"
+
 CONF_REGIONS: str = "regions"
 CONF_MESSAGE_SLOTS: str = "slots"
-CONF_FILTER_CORONA: str = "corona_filter"
+CONF_FILTER_CORONA: str = "corona_filter"  # deprecated
 CONF_HEADLINE_FILTER: str = "headline_filter"
 
 ATTR_HEADLINE: str = "headline"

--- a/homeassistant/components/nina/const.py
+++ b/homeassistant/components/nina/const.py
@@ -14,6 +14,7 @@ DOMAIN: str = "nina"
 CONF_REGIONS: str = "regions"
 CONF_MESSAGE_SLOTS: str = "slots"
 CONF_FILTER_CORONA: str = "corona_filter"
+CONF_HEADLINE_FILTER: str = "headline_filter"
 
 ATTR_HEADLINE: str = "headline"
 ATTR_DESCRIPTION: str = "description"

--- a/homeassistant/components/nina/strings.json
+++ b/homeassistant/components/nina/strings.json
@@ -11,7 +11,7 @@
           "_r_to_u": "City/county (R-U)",
           "_v_to_z": "City/county (V-Z)",
           "slots": "Maximum warnings per city/county",
-          "corona_filter": "Remove Corona Warnings"
+          "headline_filter": "Blacklist regex to filter warning headlines"
         }
       }
     },
@@ -36,7 +36,7 @@
           "_r_to_u": "City/county (R-U)",
           "_v_to_z": "City/county (V-Z)",
           "slots": "Maximum warnings per city/county",
-          "corona_filter": "Remove Corona Warnings"
+          "headline_filter": "Blacklist regex to filter warning headlines"
         }
       }
     },

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -10,7 +10,7 @@ from pynina import ApiError
 
 from homeassistant import data_entry_flow
 from homeassistant.components.nina.const import (
-    CONF_FILTER_CORONA,
+    CONF_HEADLINE_FILTER,
     CONF_MESSAGE_SLOTS,
     CONF_REGIONS,
     CONST_REGION_A_TO_D,
@@ -37,7 +37,7 @@ DUMMY_DATA: dict[str, Any] = {
     CONST_REGION_M_TO_Q: ["071380000000_0", "071380000000_1"],
     CONST_REGION_R_TO_U: ["072320000000_0", "072320000000_1"],
     CONST_REGION_V_TO_Z: ["081270000000_0", "081270000000_1"],
-    CONF_FILTER_CORONA: True,
+    CONF_HEADLINE_FILTER: ".*corona.*",
 }
 
 DUMMY_RESPONSE_REGIONS: dict[str, Any] = json.loads(
@@ -113,7 +113,7 @@ async def test_step_user_no_selection(hass: HomeAssistant) -> None:
         wraps=mocked_request_function,
     ):
         result: dict[str, Any] = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data={}
+            DOMAIN, context={"source": SOURCE_USER}, data={CONF_HEADLINE_FILTER: ""}
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -145,7 +145,7 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         title="NINA",
         data={
-            CONF_FILTER_CORONA: deepcopy(DUMMY_DATA[CONF_FILTER_CORONA]),
+            CONF_HEADLINE_FILTER: deepcopy(DUMMY_DATA[CONF_HEADLINE_FILTER]),
             CONF_MESSAGE_SLOTS: deepcopy(DUMMY_DATA[CONF_MESSAGE_SLOTS]),
             CONST_REGION_A_TO_D: deepcopy(DUMMY_DATA[CONST_REGION_A_TO_D]),
             CONF_REGIONS: {"095760000000": "Aach"},
@@ -183,7 +183,7 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
         assert result["data"] is None
 
         assert dict(config_entry.data) == {
-            CONF_FILTER_CORONA: deepcopy(DUMMY_DATA[CONF_FILTER_CORONA]),
+            CONF_HEADLINE_FILTER: deepcopy(DUMMY_DATA[CONF_HEADLINE_FILTER]),
             CONF_MESSAGE_SLOTS: deepcopy(DUMMY_DATA[CONF_MESSAGE_SLOTS]),
             CONST_REGION_A_TO_D: ["072350000000_1"],
             CONST_REGION_E_TO_H: [],
@@ -229,6 +229,7 @@ async def test_options_flow_with_no_selection(hass: HomeAssistant) -> None:
                 CONST_REGION_M_TO_Q: [],
                 CONST_REGION_R_TO_U: [],
                 CONST_REGION_V_TO_Z: [],
+                CONF_HEADLINE_FILTER: "",
             },
         )
 

--- a/tests/components/nina/test_init.py
+++ b/tests/components/nina/test_init.py
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry
 
 ENTRY_DATA: dict[str, Any] = {
     "slots": 5,
-    "corona_filter": True,
+    "headline_filter": ".*corona.*",
     "regions": {"083350000000": "Aach, Stadt"},
 }
 
@@ -35,6 +35,27 @@ async def init_integration(hass) -> MockConfigEntry:
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         return entry
+
+
+async def test_config_migration(hass: HomeAssistant) -> None:
+    """Test the migration to a new configuration layout."""
+
+    old_entry_data: dict[str, Any] = {
+        "slots": 5,
+        "corona_filter": True,
+        "regions": {"083350000000": "Aach, Stadt"},
+    }
+
+    old_conf_entry: MockConfigEntry = MockConfigEntry(
+        domain=DOMAIN, title="NINA", data=old_entry_data
+    )
+
+    old_conf_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(old_conf_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert dict(old_conf_entry.data) == ENTRY_DATA
 
 
 async def test_config_entry_not_ready(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR replaces the corona filter with the possibility to define your own regex to filter the warnings.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83587 and fixes #87473
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
