### PR TITLE
Fix missing services with esp32 proxies

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -7,7 +7,7 @@
   "quality_scale": "internal",
   "requirements": [
     "bleak==0.19.2",
-    "bleak-retry-connector==2.8.9",
+    "bleak-retry-connector==2.9.0",
     "bluetooth-adapters==0.11.0",
     "bluetooth-auto-recovery==0.5.4",
     "bluetooth-data-tools==0.3.0",

--- a/homeassistant/components/bluetooth/wrappers.py
+++ b/homeassistant/components/bluetooth/wrappers.py
@@ -12,7 +12,7 @@ from bleak import BleakClient, BleakError
 from bleak.backends.client import BaseBleakClient, get_platform_client_backend_type
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementDataCallback, BaseBleakScanner
-from bleak_retry_connector import NO_RSSI_VALUE, ble_device_description
+from bleak_retry_connector import NO_RSSI_VALUE, ble_device_description, clear_cache
 
 from homeassistant.core import CALLBACK_TYPE, callback as hass_callback
 from homeassistant.helpers.frame import report
@@ -168,6 +168,12 @@ class HaBleakClientWrapper(BleakClient):
     def is_connected(self) -> bool:
         """Return True if the client is connected to a device."""
         return self._backend is not None and self._backend.is_connected
+
+    async def clear_cache(self) -> bool:
+        """Clear the GATT cache."""
+        if self._backend is not None and hasattr(self._backend, "clear_cache"):
+            return await self._backend.clear_cache()  # type: ignore[no-any-return]
+        return await clear_cache(self.__address)
 
     def set_disconnected_callback(
         self,

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -449,6 +449,11 @@ class ESPHomeClient(BaseBleakClient):
             raise BleakError(f"Characteristic {char_specifier} was not found!")
         return characteristic
 
+    async def clear_cache(self) -> None:
+        """Clear the GATT cache."""
+        self.entry_data.clear_gatt_services_cache(self._address_as_int)
+        self.entry_data.clear_gatt_mtu_cache(self._address_as_int)
+
     @verify_connected
     @api_error_as_bleak_error
     async def read_gatt_char(

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -119,6 +119,10 @@ class RuntimeEntryData:
         """Set the BleakGATTServiceCollection for the given address."""
         self._gatt_services_cache[address] = services
 
+    def clear_gatt_services_cache(self, address: int) -> None:
+        """Clear the BleakGATTServiceCollection for the given address."""
+        self._gatt_services_cache.pop(address, None)
+
     def get_gatt_mtu_cache(self, address: int) -> int | None:
         """Get the mtu cache for the given address."""
         return self._gatt_mtu_cache.get(address)
@@ -126,6 +130,10 @@ class RuntimeEntryData:
     def set_gatt_mtu_cache(self, address: int, mtu: int) -> None:
         """Set the mtu cache for the given address."""
         self._gatt_mtu_cache[address] = mtu
+
+    def clear_gatt_mtu_cache(self, address: int) -> None:
+        """Clear the mtu cache for the given address."""
+        self._gatt_mtu_cache.pop(address, None)
 
     @callback
     def async_update_ble_connection_limits(self, free: int, limit: int) -> None:

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -10,7 +10,7 @@ atomicwrites-homeassistant==1.4.1
 attrs==21.2.0
 awesomeversion==22.9.0
 bcrypt==3.1.7
-bleak-retry-connector==2.8.9
+bleak-retry-connector==2.9.0
 bleak==0.19.2
 bluetooth-adapters==0.11.0
 bluetooth-auto-recovery==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -422,7 +422,7 @@ bimmer_connected==0.10.4
 bizkaibus==0.1.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.8.9
+bleak-retry-connector==2.9.0
 
 # homeassistant.components.bluetooth
 bleak==0.19.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -346,7 +346,7 @@ bellows==0.34.5
 bimmer_connected==0.10.4
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.8.9
+bleak-retry-connector==2.9.0
 
 # homeassistant.components.bluetooth
 bleak==0.19.2

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -219,3 +219,7 @@ class MockBleakClient(BleakClient):
     async def get_services(self, *args, **kwargs):
         """Mock get_services."""
         return []
+
+    async def clear_cache(self, *args, **kwargs):
+        """Mock clear_cache."""
+        return True

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -45,6 +45,7 @@ async def test_wrapped_bleak_client_raises_device_missing(hass, enable_bluetooth
         await client.connect()
     assert client.is_connected is False
     await client.disconnect()
+    assert await client.clear_cache() is False
 
 
 async def test_wrapped_bleak_client_set_disconnected_callback_before_connected(
@@ -166,6 +167,62 @@ async def test_ble_device_with_proxy_client_out_of_connections(
     assert client.is_connected is False
     client.set_disconnected_callback(lambda client: None)
     await client.disconnect()
+
+
+async def test_ble_device_with_proxy_clear_cache(hass, enable_bluetooth, one_adapter):
+    """Test we can clear cache on the proxy."""
+    manager = _get_manager()
+
+    switchbot_proxy_device_with_connection_slot = BLEDevice(
+        "44:44:33:11:23:45",
+        "wohand",
+        {
+            "connector": HaBluetoothConnector(
+                MockBleakClient, "mock_bleak_client", lambda: True
+            ),
+            "path": "/org/bluez/hci0/dev_44_44_33_11_23_45",
+        },
+        rssi=-30,
+    )
+    switchbot_adv = generate_advertisement_data(
+        local_name="wohand", service_uuids=[], manufacturer_data={1: b"\x01"}
+    )
+
+    class FakeScanner(BaseHaScanner):
+        @property
+        def discovered_devices_and_advertisement_data(
+            self,
+        ) -> dict[str, tuple[BLEDevice, AdvertisementData]]:
+            """Return a list of discovered devices."""
+            return {
+                switchbot_proxy_device_with_connection_slot.address: (
+                    switchbot_proxy_device_with_connection_slot,
+                    switchbot_adv,
+                )
+            }
+
+        async def async_get_device_by_address(self, address: str) -> BLEDevice | None:
+            """Return a list of discovered devices."""
+            if address == switchbot_proxy_device_with_connection_slot.address:
+                return switchbot_adv
+            return None
+
+    scanner = FakeScanner(hass, "esp32", "esp32")
+    cancel = manager.async_register_scanner(scanner, True)
+    inject_advertisement_with_source(
+        hass, switchbot_proxy_device_with_connection_slot, switchbot_adv, "esp32"
+    )
+
+    assert manager.async_discovered_devices(True) == [
+        switchbot_proxy_device_with_connection_slot
+    ]
+
+    client = HaBleakClientWrapper(switchbot_proxy_device_with_connection_slot)
+    await client.connect()
+    assert client.is_connected is True
+    assert await client.clear_cache() is True
+    await client.disconnect()
+    cancel()
 
 
 async def test_ble_device_with_proxy_client_out_of_connections_uses_best_available(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


We need to be able to clear the gatt services cache when we detect service resolution went wrong on the esp32. Since we cannot fix the BLE stack on the ESP32, we need to clear the cache and try again.

changelog: https://github.com/Bluetooth-Devices/bleak-retry-connector/compare/v2.8.9...v2.9.0

Part of fixing (each lib will need to clear the cache when it detects this issue -- they already detect the issue):
```
aiohomekit.controller.ble.bleak.BleakServiceMissing: VOCOlinc-VS1-1857C6: Service 00000055-0000-1000-8000-0026BB765291 not found, available services: [00001800-0000-1000-8000-00805f9b34fb, 00001801-0000-1000-8000-00805f9b34fb, 0000003e-0000-1000-8000-0026bb765291, 000000a2-0000-1000-8000-0026bb765291, 00001530-1212-efde-1523-785feabcd123, 00000080-0000-1000-8000-0026bb765291]
switchbot.devices.device.CharacteristicMissingError: cba20003-224d-11e6-9fb8-0002a5d5c51b
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
