### PR TITLE
Add Twinkly diagnostics

### DIFF
--- a/homeassistant/components/twinkly/diagnostics.py
+++ b/homeassistant/components/twinkly/diagnostics.py
@@ -1,0 +1,43 @@
+"""Diagnostics support for Twinkly."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_IP_ADDRESS, CONF_MAC
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+TO_REDACT = [CONF_HOST, CONF_IP_ADDRESS, CONF_MAC]
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a Twinkly config entry."""
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    registry_devices = dr.async_entries_for_config_entry(
+        device_registry, entry.entry_id
+    )
+    registry_entities = er.async_entries_for_config_entry(
+        entity_registry, entry.entry_id
+    )
+    device = registry_devices.pop()
+    entity = registry_entities.pop()
+    state = hass.states.get(entity.entity_id)
+    attributes: dict[Any, Any] = {}
+    if state:
+        attributes = state.attributes
+
+    return {
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "sw_version": device.sw_version,
+            "attributes": async_redact_data(attributes, TO_REDACT),
+        },
+    }

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -22,6 +22,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MODEL
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -178,6 +179,13 @@ class TwinklyLight(LightEntity):
             ):
                 self._attr_supported_features = (
                     self.supported_features & ~LightEntityFeature.EFFECT
+                )
+
+            device_registry = dr.async_get(self.hass)
+            device_entry = device_registry.async_get_device({(DOMAIN, self._id)}, set())
+            if device_entry:
+                device_registry.async_update_device(
+                    device_entry.id, sw_version=self._software_version
                 )
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -20,9 +20,8 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_MODEL
+from homeassistant.const import ATTR_SW_VERSION, CONF_MODEL
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -56,6 +55,9 @@ async def async_setup_entry(
     client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
     device_info = hass.data[DOMAIN][config_entry.entry_id][DATA_DEVICE_INFO]
 
+    software_version = await client.get_firmware_version()
+    if ATTR_VERSION in software_version:
+        device_info[ATTR_SW_VERSION] = software_version[ATTR_VERSION]
     entity = TwinklyLight(config_entry, client, device_info)
 
     async_add_entities([entity], update_before_add=True)
@@ -100,7 +102,7 @@ class TwinklyLight(LightEntity):
         self._attributes: dict[Any, Any] = {}
         self._current_movie: dict[Any, Any] = {}
         self._movies: list[Any] = []
-        self._software_version = ""
+        self._software_version = device_info.get(ATTR_SW_VERSION)
         # We guess that most devices are "new" and support effects
         self._attr_supported_features = LightEntityFeature.EFFECT
 
@@ -170,23 +172,10 @@ class TwinklyLight(LightEntity):
 
     async def async_added_to_hass(self) -> None:
         """Device is added to hass."""
-        software_version = await self._client.get_firmware_version()
-        if ATTR_VERSION in software_version:
-            self._software_version = software_version[ATTR_VERSION]
-
-            if AwesomeVersion(self._software_version) < AwesomeVersion(
-                MIN_EFFECT_VERSION
-            ):
-                self._attr_supported_features = (
-                    self.supported_features & ~LightEntityFeature.EFFECT
-                )
-
-            device_registry = dr.async_get(self.hass)
-            device_entry = device_registry.async_get_device({(DOMAIN, self._id)}, set())
-            if device_entry:
-                device_registry.async_update_device(
-                    device_entry.id, sw_version=self._software_version
-                )
+        if AwesomeVersion(self._software_version) < AwesomeVersion(MIN_EFFECT_VERSION):
+            self._attr_supported_features = (
+                self.supported_features & ~LightEntityFeature.EFFECT
+            )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn device on."""

--- a/tests/components/twinkly/test_diagnostics.py
+++ b/tests/components/twinkly/test_diagnostics.py
@@ -15,5 +15,6 @@ async def test_diagnostics(hass: HomeAssistant, hass_client) -> None:
     diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert diag["entry"]["title"] == "Mock Title"
+    assert diag["entry"]["sw_version"] == "2.8.10"
     assert diag["entry"]["data"]["host"] == "**REDACTED**"
     assert "effect_list" in diag["entry"]["attributes"]

--- a/tests/components/twinkly/test_diagnostics.py
+++ b/tests/components/twinkly/test_diagnostics.py
@@ -1,0 +1,19 @@
+"""Tests for the diagnostics of the twinly component."""
+from homeassistant.core import HomeAssistant
+
+from . import ClientMock
+from .test_light import _create_entries
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_diagnostics(hass: HomeAssistant, hass_client) -> None:
+    """Test the diagnostics data."""
+    client = ClientMock()
+    _, _, _, config_entry = await _create_entries(hass, client)
+
+    diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+
+    assert diag["entry"]["title"] == "Mock Title"
+    assert diag["entry"]["data"]["host"] == "**REDACTED**"
+    assert "effect_list" in diag["entry"]["attributes"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics info to Twinkly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

Diagnostics output
```
{
  "home_assistant": {
    "installation_type": "Unsupported Third Party Container",
    "version": "2023.4.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.10.10",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Oslo",
    "os_name": "Linux",
    "os_version": "6.1.18-100.fc36.x86_64",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {

    "domain": "twinkly",
    "name": "Twinkly",
    "codeowners": [
      "@dr1rrb",
      "@Robbie1221"
    ],
    "config_flow": true,
    "dhcp": [
      {
        "hostname": "twinkly_*"
      }
    ],
    "documentation": "https://www.home-assistant.io/integrations/twinkly",
    "iot_class": "local_polling",
    "loggers": [
      "ttls"
    ],
    "requirements": [
      "ttls==1.5.1"
    ],
    "is_built_in": true  
  },
  "data": {
    "entry": {
      "title": "Twinkly Leon",
      "data": {
        "host": "**REDACTED**",
        "id": "9A586984-C950-4C78-A233-0DDD7009AF56",
        "name": "Twinkly Leon",
        "model": "TWFL200STW"
      },
      "sw_version": "2.8.15",
      "attributes": {
        "effect_list": [
          "0 Rainbow",
          "1 Snow",
          "2 Beat",
          "3 Snake"
        ],
        "supported_color_modes": [
          "rgb"
        ],
        "icon": "mdi:string-lights",
        "friendly_name": "Twinkly Leon",
        "supported_features": 4
      }
    }
  }
}
```



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
