### PR TITLE
Restore HomeKit Controller BLE GSN at startup

### DIFF
--- a/homeassistant/components/homekit_controller/button.py
+++ b/homeassistant/components/homekit_controller/button.py
@@ -84,7 +84,7 @@ async def async_setup_entry(
                 entity.old_unique_id, entity.unique_id, Platform.BUTTON
             )
 
-        async_add_entities(entities, True)
+        async_add_entities(entities)
         return True
 
     conn.add_char_factory(async_add_characteristic)

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -583,6 +583,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             accessories_state.config_num,
             accessories_state.accessories.serialize(),
             serialize_broadcast_key(accessories_state.broadcast_key),
+            accessories_state.state_num,
         )
 
         return self.async_create_entry(title=name, data=pairing_data)

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -185,8 +185,8 @@ class HKDevice:
         self.available = available
         async_dispatcher_send(self.hass, self.signal_state_updated)
 
-    async def _async_retry_populate_ble_accessory_state(self, event: Event) -> None:
-        """Try again to populate the BLE accessory state.
+    async def _async_populate_ble_accessory_state(self, event: Event) -> None:
+        """Populate the BLE accessory state without blocking startup.
 
         If the accessory was asleep at startup we need to retry
         since we continued on to allow startup to proceed.
@@ -221,19 +221,16 @@ class HKDevice:
         # so we only poll those chars but that is not possible
         # yet.
         attempts = None if self.hass.state == CoreState.running else 1
-        try:
-            await self.pairing.async_populate_accessories_state(
-                force_update=True, attempts=attempts
-            )
-        except AccessoryNotFoundError:
-            if transport != Transport.BLE or not pairing.accessories:
-                # BLE devices may sleep and we can't force a connection
-                raise
+        if transport == Transport.BLE and pairing.accessories:
             entry.async_on_unload(
                 self.hass.bus.async_listen(
                     EVENT_HOMEASSISTANT_STARTED,
-                    self._async_retry_populate_ble_accessory_state,
+                    self._async_populate_ble_accessory_state,
                 )
+            )
+        else:
+            await self.pairing.async_populate_accessories_state(
+                force_update=True, attempts=attempts
             )
 
         entry.async_on_unload(pairing.dispatcher_connect(self.process_new_events))

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -224,8 +224,8 @@ class HKDevice:
         if transport == Transport.BLE and pairing.accessories:
             # The GSN gets restored and a catch up poll will be
             # triggered via disconnected events automatically
-            # if we are out of sync. To be sure we are in sync
-            # if for some reason the BLE connection failed
+            # if we are out of sync. To be sure we are in sync;
+            # If for some reason the BLE connection failed
             # previously we force an update after startup
             # is complete.
             entry.async_on_unload(

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -217,7 +217,11 @@ class HKDevice:
         # so we only poll those chars but that is not possible
         # yet.
         attempts = None if self.hass.state == CoreState.running else 1
-        if transport == Transport.BLE and pairing.accessories:
+        if (
+            transport == Transport.BLE
+            and pairing.accessories
+            and pairing.accessories.has_aid(1)
+        ):
             # The GSN gets restored and a catch up poll will be
             # triggered via disconnected events automatically
             # if we are out of sync. To be sure we are in sync;

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -222,6 +222,11 @@ class HKDevice:
         # yet.
         attempts = None if self.hass.state == CoreState.running else 1
         if transport == Transport.BLE and pairing.accessories:
+            # The GSN gets restored and a catch up poll will be
+            # triggered via disconnected events automatically
+            # if we are out of sync. To be sure we are in sync
+            # we schedule a populate here but only after startup
+            # is complete.
             entry.async_on_unload(
                 self.hass.bus.async_listen(
                     EVENT_HOMEASSISTANT_STARTED,

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -225,8 +225,8 @@ class HKDevice:
             # The GSN gets restored and a catch up poll will be
             # triggered via disconnected events automatically
             # if we are out of sync. To be sure we are in sync
-            # we schedule a populate here but only after startup
-            # is complete.
+            # if for some reason the BLE connection failed or
+            # we missed the event we do a force update here.
             entry.async_on_unload(
                 self.hass.bus.async_listen(
                     EVENT_HOMEASSISTANT_STARTED,

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -225,8 +225,9 @@ class HKDevice:
             # The GSN gets restored and a catch up poll will be
             # triggered via disconnected events automatically
             # if we are out of sync. To be sure we are in sync
-            # if for some reason the BLE connection failed or
-            # we missed the event we do a force update here.
+            # if for some reason the BLE connection failed
+            # previously we force an update after startup
+            # is complete.
             entry.async_on_unload(
                 self.hass.bus.async_listen(
                     EVENT_HOMEASSISTANT_STARTED,

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==2.3.6"],
+  "requirements": ["aiohomekit==2.4.0"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."],
   "bluetooth": [{ "manufacturer_id": 76, "manufacturer_data_start": [6] }],
   "dependencies": ["bluetooth", "zeroconf"],

--- a/homeassistant/components/homekit_controller/number.py
+++ b/homeassistant/components/homekit_controller/number.py
@@ -78,7 +78,7 @@ async def async_setup_entry(
                 entity.old_unique_id, entity.unique_id, Platform.NUMBER
             )
 
-        async_add_entities(entities, True)
+        async_add_entities(entities)
         return True
 
     conn.add_char_factory(async_add_characteristic)

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -61,11 +61,15 @@ class EntityMapStorage:
         config_num: int,
         accessories: list[Any],
         broadcast_key: str | None = None,
+        state_num: int | None = None,
     ) -> Pairing:
         """Create a new pairing cache."""
         _LOGGER.debug("Creating or updating entity map for %s", homekit_id)
         data = Pairing(
-            config_num=config_num, accessories=accessories, broadcast_key=broadcast_key
+            config_num=config_num,
+            accessories=accessories,
+            broadcast_key=broadcast_key,
+            state_num=state_num,
         )
         self.storage_data[homekit_id] = data
         self._async_schedule_save()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -174,7 +174,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==2.3.6
+aiohomekit==2.4.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -158,7 +158,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==2.3.6
+aiohomekit==2.4.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We now restore the last know global state number for the BLE device at startup.  This allows us to know if we are out of sync and need to poll. It fixes Jc2k/aiohomekit#225 and the slow startup problem (as long as the device hasn't changed state between stop/start).

changelog: https://github.com/Jc2k/aiohomekit/compare/2.3.6...2.4.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
