### PR TITLE
Raise an exception when an esp proxy gets empty services during connection so callers know to retry

### DIFF
--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -444,7 +444,7 @@ class ESPHomeClient(BaseBleakClient):
         if not esphome_services.services:
             # If we got no services, we must have disconnected
             # or something went wrong on the ESP32's BLE stack.
-            raise BleakError("Failed to services")
+            raise BleakError("Failed to get services from remote esp")
 
         self.services = services
         _LOGGER.debug(

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -321,7 +321,7 @@ class ESPHomeClient(BaseBleakClient):
         try:
             await self.get_services(dangerous_use_bleak_cache=dangerous_use_bleak_cache)
         except asyncio.CancelledError:
-            # On cancel we must still raise canceled error
+            # On cancel we must still raise cancelled error
             # to avoid blocking the cancellation even if the
             # disconnect call fails.
             with contextlib.suppress(Exception):


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the we lose the race from the previous connection attempt
and the connection actually was established on a previous attempt
just moments after we timed out in hass we will get empty
services. In this case we need to raise an exception and
disconnect so we can try again

fixes
```
Retrying setup: Characteristic None not found!
[12:51:01][W][bluetooth_proxy:217]: [0] [A3:02:00:00:03:B1] Connection already established
[12:51:01][E][bluetooth_proxy:110]: [0] [A3:02:00:00:03:B1] esp_ble_gattc_get_service error at offset=0, status=10
[12:51:01][E][bluetooth_proxy:110]: [0] [A3:02:00:00:03:B1] esp_ble_gattc_get_service error at offset=1, status=10
[12:51:01][E][bluetooth_proxy:110]: [0] [A3:02:00:00:03:B1] esp_ble_gattc_get_service error at offset=2, status=10
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
