### PR TITLE
Bump subarulink to v0.7.0

### DIFF
--- a/homeassistant/components/subaru/manifest.json
+++ b/homeassistant/components/subaru/manifest.json
@@ -3,7 +3,7 @@
   "name": "Subaru",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/subaru",
-  "requirements": ["subarulink==0.7.0rc1"],
+  "requirements": ["subarulink==0.7.0"],
   "codeowners": ["@G-Two"],
   "iot_class": "cloud_polling",
   "loggers": ["stdiomask", "subarulink"]

--- a/homeassistant/components/subaru/manifest.json
+++ b/homeassistant/components/subaru/manifest.json
@@ -3,7 +3,7 @@
   "name": "Subaru",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/subaru",
-  "requirements": ["subarulink==0.6.1"],
+  "requirements": ["subarulink==0.7.0rc1"],
   "codeowners": ["@G-Two"],
   "iot_class": "cloud_polling",
   "loggers": ["stdiomask", "subarulink"]

--- a/homeassistant/components/subaru/sensor.py
+++ b/homeassistant/components/subaru/sensor.py
@@ -14,12 +14,10 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ELECTRIC_POTENTIAL_VOLT,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
     PERCENTAGE,
     PRESSURE_HPA,
-    TEMP_CELSIUS,
     VOLUME_GALLONS,
     VOLUME_LITERS,
 )
@@ -115,20 +113,6 @@ API_GEN_2_SENSORS = [
         device_class=SensorDeviceClass.PRESSURE,
         name="Tire pressure RR",
         native_unit_of_measurement=PRESSURE_HPA,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    SensorEntityDescription(
-        key=sc.EXTERNAL_TEMP,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        name="External temp",
-        native_unit_of_measurement=TEMP_CELSIUS,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    SensorEntityDescription(
-        key=sc.BATTERY_VOLTAGE,
-        device_class=SensorDeviceClass.VOLTAGE,
-        name="12V battery voltage",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
 ]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2373,7 +2373,7 @@ streamlabswater==1.0.1
 stringcase==1.2.0
 
 # homeassistant.components.subaru
-subarulink==0.6.1
+subarulink==0.7.0rc1
 
 # homeassistant.components.solarlog
 sunwatcher==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2373,7 +2373,7 @@ streamlabswater==1.0.1
 stringcase==1.2.0
 
 # homeassistant.components.subaru
-subarulink==0.7.0rc1
+subarulink==0.7.0
 
 # homeassistant.components.solarlog
 sunwatcher==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1652,7 +1652,7 @@ stookalert==0.1.4
 stringcase==1.2.0
 
 # homeassistant.components.subaru
-subarulink==0.7.0rc1
+subarulink==0.7.0
 
 # homeassistant.components.solarlog
 sunwatcher==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1652,7 +1652,7 @@ stookalert==0.1.4
 stringcase==1.2.0
 
 # homeassistant.components.subaru
-subarulink==0.6.1
+subarulink==0.7.0rc1
 
 # homeassistant.components.solarlog
 sunwatcher==0.2.1

--- a/tests/components/subaru/api_responses.py
+++ b/tests/components/subaru/api_responses.py
@@ -53,7 +53,6 @@ MOCK_DATETIME = datetime.fromtimestamp(1595560000, timezone.utc)
 VEHICLE_STATUS_EV = {
     "status": {
         "AVG_FUEL_CONSUMPTION": 2.3,
-        "BATTERY_VOLTAGE": 12.0,
         "DISTANCE_TO_EMPTY_FUEL": 707,
         "DOOR_BOOT_LOCK_STATUS": "UNKNOWN",
         "DOOR_BOOT_POSITION": "CLOSED",
@@ -75,7 +74,6 @@ VEHICLE_STATUS_EV = {
         "EV_STATE_OF_CHARGE_MODE": "EV_MODE",
         "EV_STATE_OF_CHARGE_PERCENT": 20,
         "EV_TIME_TO_FULLY_CHARGED_UTC": MOCK_DATETIME,
-        "EXT_EXTERNAL_TEMP": 21.5,
         "ODOMETER": 1234,
         "POSITION_HEADING_DEGREE": 150,
         "POSITION_SPEED_KMPH": "0",
@@ -103,7 +101,7 @@ VEHICLE_STATUS_EV = {
         "TYRE_PRESSURE_FRONT_LEFT": 0,
         "TYRE_PRESSURE_FRONT_RIGHT": 2550,
         "TYRE_PRESSURE_REAR_LEFT": 2450,
-        "TYRE_PRESSURE_REAR_RIGHT": 2350,
+        "TYRE_PRESSURE_REAR_RIGHT": None,
         "TYRE_STATUS_FRONT_LEFT": "UNKNOWN",
         "TYRE_STATUS_FRONT_RIGHT": "UNKNOWN",
         "TYRE_STATUS_REAR_LEFT": "UNKNOWN",
@@ -115,9 +113,9 @@ VEHICLE_STATUS_EV = {
         "WINDOW_REAR_LEFT_STATUS": "UNKNOWN",
         "WINDOW_REAR_RIGHT_STATUS": "UNKNOWN",
         "WINDOW_SUNROOF_STATUS": "UNKNOWN",
-        "heading": 170,
-        "latitude": 40.0,
-        "longitude": -100.0,
+        "HEADING": 170,
+        "LATITUDE": 40.0,
+        "LONGITUDE": -100.0,
     }
 }
 
@@ -125,7 +123,6 @@ VEHICLE_STATUS_EV = {
 VEHICLE_STATUS_G2 = {
     "status": {
         "AVG_FUEL_CONSUMPTION": 2.3,
-        "BATTERY_VOLTAGE": 12.0,
         "DISTANCE_TO_EMPTY_FUEL": 707,
         "DOOR_BOOT_LOCK_STATUS": "UNKNOWN",
         "DOOR_BOOT_POSITION": "CLOSED",
@@ -139,7 +136,6 @@ VEHICLE_STATUS_G2 = {
         "DOOR_REAR_LEFT_POSITION": "CLOSED",
         "DOOR_REAR_RIGHT_LOCK_STATUS": "UNKNOWN",
         "DOOR_REAR_RIGHT_POSITION": "CLOSED",
-        "EXT_EXTERNAL_TEMP": None,
         "ODOMETER": 1234,
         "POSITION_HEADING_DEGREE": 150,
         "POSITION_SPEED_KMPH": "0",
@@ -167,7 +163,7 @@ VEHICLE_STATUS_G2 = {
         "TYRE_PRESSURE_FRONT_LEFT": 2550,
         "TYRE_PRESSURE_FRONT_RIGHT": 2550,
         "TYRE_PRESSURE_REAR_LEFT": 2450,
-        "TYRE_PRESSURE_REAR_RIGHT": 2350,
+        "TYRE_PRESSURE_REAR_RIGHT": None,
         "TYRE_STATUS_FRONT_LEFT": "UNKNOWN",
         "TYRE_STATUS_FRONT_RIGHT": "UNKNOWN",
         "TYRE_STATUS_REAR_LEFT": "UNKNOWN",
@@ -179,15 +175,14 @@ VEHICLE_STATUS_G2 = {
         "WINDOW_REAR_LEFT_STATUS": "UNKNOWN",
         "WINDOW_REAR_RIGHT_STATUS": "UNKNOWN",
         "WINDOW_SUNROOF_STATUS": "UNKNOWN",
-        "heading": 170,
-        "latitude": 40.0,
-        "longitude": -100.0,
+        "HEADING": 170,
+        "LATITUDE": 40.0,
+        "LONGITUDE": -100.0,
     }
 }
 
 EXPECTED_STATE_EV_IMPERIAL = {
     "AVG_FUEL_CONSUMPTION": "102.3",
-    "BATTERY_VOLTAGE": "12.0",
     "DISTANCE_TO_EMPTY_FUEL": "439.3",
     "EV_CHARGER_STATE_TYPE": "CHARGING",
     "EV_CHARGE_SETTING_AMPERE_TYPE": "MAXIMUM",
@@ -197,7 +192,6 @@ EXPECTED_STATE_EV_IMPERIAL = {
     "EV_STATE_OF_CHARGE_MODE": "EV_MODE",
     "EV_STATE_OF_CHARGE_PERCENT": "20",
     "EV_TIME_TO_FULLY_CHARGED_UTC": "2020-07-24T03:06:40+00:00",
-    "EXT_EXTERNAL_TEMP": "70.7",
     "ODOMETER": "766.8",
     "POSITION_HEADING_DEGREE": "150",
     "POSITION_SPEED_KMPH": "0",
@@ -207,16 +201,15 @@ EXPECTED_STATE_EV_IMPERIAL = {
     "TYRE_PRESSURE_FRONT_LEFT": "0.0",
     "TYRE_PRESSURE_FRONT_RIGHT": "37.0",
     "TYRE_PRESSURE_REAR_LEFT": "35.5",
-    "TYRE_PRESSURE_REAR_RIGHT": "34.1",
+    "TYRE_PRESSURE_REAR_RIGHT": "unknown",
     "VEHICLE_STATE_TYPE": "IGNITION_OFF",
-    "heading": 170,
-    "latitude": 40.0,
-    "longitude": -100.0,
+    "HEADING": 170,
+    "LATITUDE": 40.0,
+    "LONGITUDE": -100.0,
 }
 
 EXPECTED_STATE_EV_METRIC = {
     "AVG_FUEL_CONSUMPTION": "2.3",
-    "BATTERY_VOLTAGE": "12.0",
     "DISTANCE_TO_EMPTY_FUEL": "707",
     "EV_CHARGER_STATE_TYPE": "CHARGING",
     "EV_CHARGE_SETTING_AMPERE_TYPE": "MAXIMUM",
@@ -226,7 +219,6 @@ EXPECTED_STATE_EV_METRIC = {
     "EV_STATE_OF_CHARGE_MODE": "EV_MODE",
     "EV_STATE_OF_CHARGE_PERCENT": "20",
     "EV_TIME_TO_FULLY_CHARGED_UTC": "2020-07-24T03:06:40+00:00",
-    "EXT_EXTERNAL_TEMP": "21.5",
     "ODOMETER": "1234",
     "POSITION_HEADING_DEGREE": "150",
     "POSITION_SPEED_KMPH": "0",
@@ -236,17 +228,16 @@ EXPECTED_STATE_EV_METRIC = {
     "TYRE_PRESSURE_FRONT_LEFT": "0",
     "TYRE_PRESSURE_FRONT_RIGHT": "2550",
     "TYRE_PRESSURE_REAR_LEFT": "2450",
-    "TYRE_PRESSURE_REAR_RIGHT": "2350",
+    "TYRE_PRESSURE_REAR_RIGHT": "unknown",
     "VEHICLE_STATE_TYPE": "IGNITION_OFF",
-    "heading": 170,
-    "latitude": 40.0,
-    "longitude": -100.0,
+    "HEADING": 170,
+    "LATITUDE": 40.0,
+    "LONGITUDE": -100.0,
 }
 
 
 EXPECTED_STATE_EV_UNAVAILABLE = {
     "AVG_FUEL_CONSUMPTION": "unavailable",
-    "BATTERY_VOLTAGE": "unavailable",
     "DISTANCE_TO_EMPTY_FUEL": "unavailable",
     "EV_CHARGER_STATE_TYPE": "unavailable",
     "EV_CHARGE_SETTING_AMPERE_TYPE": "unavailable",
@@ -256,7 +247,6 @@ EXPECTED_STATE_EV_UNAVAILABLE = {
     "EV_STATE_OF_CHARGE_MODE": "unavailable",
     "EV_STATE_OF_CHARGE_PERCENT": "unavailable",
     "EV_TIME_TO_FULLY_CHARGED_UTC": "unavailable",
-    "EXT_EXTERNAL_TEMP": "unavailable",
     "ODOMETER": "unavailable",
     "POSITION_HEADING_DEGREE": "unavailable",
     "POSITION_SPEED_KMPH": "unavailable",
@@ -268,7 +258,7 @@ EXPECTED_STATE_EV_UNAVAILABLE = {
     "TYRE_PRESSURE_REAR_LEFT": "unavailable",
     "TYRE_PRESSURE_REAR_RIGHT": "unavailable",
     "VEHICLE_STATE_TYPE": "unavailable",
-    "heading": "unavailable",
-    "latitude": "unavailable",
-    "longitude": "unavailable",
+    "HEADING": "unavailable",
+    "LATITUDE": "unavailable",
+    "LONGITUDE": "unavailable",
 }

--- a/tests/components/subaru/fixtures/diagnostics_config_entry.json
+++ b/tests/components/subaru/fixtures/diagnostics_config_entry.json
@@ -6,12 +6,13 @@
     "pin": "**REDACTED**",
     "device_id": "**REDACTED**"
   },
-  "options": { "update_enabled": true },
+  "options": {
+    "update_enabled": true
+  },
   "data": [
     {
       "status": {
         "AVG_FUEL_CONSUMPTION": 2.3,
-        "BATTERY_VOLTAGE": 12.0,
         "DISTANCE_TO_EMPTY_FUEL": 707,
         "DOOR_BOOT_LOCK_STATUS": "UNKNOWN",
         "DOOR_BOOT_POSITION": "CLOSED",
@@ -33,7 +34,6 @@
         "EV_STATE_OF_CHARGE_MODE": "EV_MODE",
         "EV_STATE_OF_CHARGE_PERCENT": 20,
         "EV_TIME_TO_FULLY_CHARGED_UTC": "2020-07-24T03:06:40+00:00",
-        "EXT_EXTERNAL_TEMP": 21.5,
         "ODOMETER": "**REDACTED**",
         "POSITION_HEADING_DEGREE": 150,
         "POSITION_SPEED_KMPH": "0",
@@ -61,7 +61,7 @@
         "TYRE_PRESSURE_FRONT_LEFT": 0,
         "TYRE_PRESSURE_FRONT_RIGHT": 2550,
         "TYRE_PRESSURE_REAR_LEFT": 2450,
-        "TYRE_PRESSURE_REAR_RIGHT": 2350,
+        "TYRE_PRESSURE_REAR_RIGHT": null,
         "TYRE_STATUS_FRONT_LEFT": "UNKNOWN",
         "TYRE_STATUS_FRONT_RIGHT": "UNKNOWN",
         "TYRE_STATUS_REAR_LEFT": "UNKNOWN",
@@ -73,9 +73,9 @@
         "WINDOW_REAR_LEFT_STATUS": "UNKNOWN",
         "WINDOW_REAR_RIGHT_STATUS": "UNKNOWN",
         "WINDOW_SUNROOF_STATUS": "UNKNOWN",
-        "heading": 170,
-        "latitude": "**REDACTED**",
-        "longitude": "**REDACTED**"
+        "HEADING": 170,
+        "LATITUDE": "**REDACTED**",
+        "LONGITUDE": "**REDACTED**"
       }
     }
   ]

--- a/tests/components/subaru/fixtures/diagnostics_device.json
+++ b/tests/components/subaru/fixtures/diagnostics_device.json
@@ -6,11 +6,12 @@
     "pin": "**REDACTED**",
     "device_id": "**REDACTED**"
   },
-  "options": { "update_enabled": true },
+  "options": {
+    "update_enabled": true
+  },
   "data": {
     "status": {
       "AVG_FUEL_CONSUMPTION": 2.3,
-      "BATTERY_VOLTAGE": 12.0,
       "DISTANCE_TO_EMPTY_FUEL": 707,
       "DOOR_BOOT_LOCK_STATUS": "UNKNOWN",
       "DOOR_BOOT_POSITION": "CLOSED",
@@ -32,7 +33,6 @@
       "EV_STATE_OF_CHARGE_MODE": "EV_MODE",
       "EV_STATE_OF_CHARGE_PERCENT": 20,
       "EV_TIME_TO_FULLY_CHARGED_UTC": "2020-07-24T03:06:40+00:00",
-      "EXT_EXTERNAL_TEMP": 21.5,
       "ODOMETER": "**REDACTED**",
       "POSITION_HEADING_DEGREE": 150,
       "POSITION_SPEED_KMPH": "0",
@@ -60,7 +60,7 @@
       "TYRE_PRESSURE_FRONT_LEFT": 0,
       "TYRE_PRESSURE_FRONT_RIGHT": 2550,
       "TYRE_PRESSURE_REAR_LEFT": 2450,
-      "TYRE_PRESSURE_REAR_RIGHT": 2350,
+      "TYRE_PRESSURE_REAR_RIGHT": null,
       "TYRE_STATUS_FRONT_LEFT": "UNKNOWN",
       "TYRE_STATUS_FRONT_RIGHT": "UNKNOWN",
       "TYRE_STATUS_REAR_LEFT": "UNKNOWN",
@@ -72,9 +72,9 @@
       "WINDOW_REAR_LEFT_STATUS": "UNKNOWN",
       "WINDOW_REAR_RIGHT_STATUS": "UNKNOWN",
       "WINDOW_SUNROOF_STATUS": "UNKNOWN",
-      "heading": 170,
-      "latitude": "**REDACTED**",
-      "longitude": "**REDACTED**"
+      "HEADING": 170,
+      "LATITUDE": "**REDACTED**",
+      "LONGITUDE": "**REDACTED**"
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Subaru API has changed and no longer returns values required by two sensors:
- External temp
- 12V battery voltage

This change removes these two sensors from the Subaru integration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Subaru has discontinued support for their API version "g2v21" causing HTTP 404 errors for all users of this integration.

This change is a dependency upgrade for subarulink to v0.7.0 ([changelog](https://github.com/G-Two/subarulink/releases)) which will allow this integration to begin using the "g2v24" version of the Subaru API (which is now the only supported version).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83187 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
