### PR TITLE
Handle numeric versions in mqtt update

### DIFF
--- a/homeassistant/components/mqtt/update.py
+++ b/homeassistant/components/mqtt/update.py
@@ -175,11 +175,19 @@ class MqttUpdate(MqttEntity, UpdateEntity, RestoreEntity):
             json_payload = {}
             try:
                 json_payload = json_loads(payload)
-                _LOGGER.debug(
-                    "JSON payload detected after processing payload '%s' on topic %s",
-                    json_payload,
-                    msg.topic,
-                )
+                if isinstance(json_payload, dict):
+                    _LOGGER.debug(
+                        "JSON payload detected after processing payload '%s' on topic %s",
+                        json_payload,
+                        msg.topic,
+                    )
+                else:
+                    _LOGGER.debug(  # type:ignore[unreachable]
+                        "Non-dictionary JSON payload detected after processing payload '%s' on topic %s",
+                        payload,
+                        msg.topic,
+                    )
+                    json_payload = {"installed_version": payload}
             except JSON_DECODE_EXCEPTIONS:
                 _LOGGER.debug(
                     "No valid (JSON) payload detected after processing payload '%s' on topic %s",

--- a/homeassistant/components/mqtt/update.py
+++ b/homeassistant/components/mqtt/update.py
@@ -172,7 +172,7 @@ class MqttUpdate(MqttEntity, UpdateEntity, RestoreEntity):
                 )
                 return
 
-            json_payload = {}
+            json_payload: Any | dict = {}
             try:
                 json_payload = json_loads(payload)
                 if isinstance(json_payload, dict):
@@ -182,7 +182,7 @@ class MqttUpdate(MqttEntity, UpdateEntity, RestoreEntity):
                         msg.topic,
                     )
                 else:
-                    _LOGGER.debug(  # type:ignore[unreachable]
+                    _LOGGER.debug(
                         "Non-dictionary JSON payload detected after processing payload '%s' on topic %s",
                         payload,
                         msg.topic,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request adds a check to ensure that `json_payload` is a dictionary as well as tests that exercise the currently failing case.

#81131 added support for parsing additional information encoded as JSON from the update topic. In the case of a version that resolves as a string (such as "2.54.6") the JSON decoder fails to parse it and falls back to the pre-JSON behavior of treating the string as a version string. When the version resolves as a number (such as "2.08") the JSON decoder actually returns a float instead of failing to parse, which breaks the following handling.

The `# type:ignore[unreachable]` annotation was added because the static analyzer thinks that line can't be reached, while the coverage report of the unit tests I added prove that it is used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
