### PR TITLE
Enable Shelly firmware update by default

### DIFF
--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -79,7 +79,7 @@ REST_UPDATES: Final = {
         beta=False,
         device_class=UpdateDeviceClass.FIRMWARE,
         entity_category=EntityCategory.CONFIG,
-        entity_registry_enabled_default=False,
+        entity_registry_enabled_default=True,
     ),
     "fwupdate_beta": RestUpdateDescription(
         name="Beta Firmware Update",
@@ -101,7 +101,7 @@ RPC_UPDATES: Final = {
         beta=False,
         device_class=UpdateDeviceClass.FIRMWARE,
         entity_category=EntityCategory.CONFIG,
-        entity_registry_enabled_default=False,
+        entity_registry_enabled_default=True,
     ),
     "fwupdate_beta": RpcUpdateDescription(
         name="Beta Firmware Update",

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -51,7 +51,6 @@ async def test_remove_legacy_entities(
         DOMAIN,
         unique_id,
         suggested_object_id=f"test_name_{object_id}",
-        disabled_by=None,
     )
 
     assert entity_registry.async_get(entity_id) is not None
@@ -69,7 +68,6 @@ async def test_block_update(hass: HomeAssistant, mock_block_device, monkeypatch)
         DOMAIN,
         f"{MOCK_MAC}-fwupdate",
         suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
     )
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
@@ -113,7 +111,6 @@ async def test_block_beta_update(hass: HomeAssistant, mock_block_device, monkeyp
         DOMAIN,
         f"{MOCK_MAC}-fwupdate_beta",
         suggested_object_id="test_name_beta_firmware_update",
-        disabled_by=None,
     )
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
@@ -169,7 +166,6 @@ async def test_block_update_connection_error(
         DOMAIN,
         f"{MOCK_MAC}-fwupdate",
         suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
     )
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
@@ -200,7 +196,6 @@ async def test_block_update_auth_error(
         DOMAIN,
         f"{MOCK_MAC}-fwupdate",
         suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
     )
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
@@ -242,7 +237,6 @@ async def test_rpc_update(hass: HomeAssistant, mock_rpc_device, monkeypatch):
         DOMAIN,
         f"{MOCK_MAC}-sys-fwupdate",
         suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
     )
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
     monkeypatch.setitem(
@@ -292,7 +286,6 @@ async def test_rpc_beta_update(hass: HomeAssistant, mock_rpc_device, monkeypatch
         DOMAIN,
         f"{MOCK_MAC}-sys-fwupdate_beta",
         suggested_object_id="test_name_beta_firmware_update",
-        disabled_by=None,
     )
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
     monkeypatch.setitem(
@@ -368,7 +361,6 @@ async def test_rpc_update__errors(
         DOMAIN,
         f"{MOCK_MAC}-sys-fwupdate",
         suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
     )
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
     monkeypatch.setitem(
@@ -404,7 +396,6 @@ async def test_rpc_update_auth_error(
         DOMAIN,
         f"{MOCK_MAC}-sys-fwupdate",
         suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
     )
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
     monkeypatch.setitem(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Shelly firmware update entity should be enabled by default, as documented [here](https://www.home-assistant.io/integrations/shelly/#ota-update). Only the beta entity should be disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
