### PR TITLE
Refactor support for integrations to drop custom unit conversion

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -490,7 +490,8 @@ class SensorEntity(Entity):
         needed without breaking existing sensors. Only works for sensors which are in
         the entity registry.
 
-        This can be removed once core integrations have dropped custom unit conversion.
+        This can be removed once core integrations have dropped unneeded custom unit
+        conversion.
         """
         super().add_to_platform_start(hass, platform, parallel_updates)
 
@@ -509,7 +510,7 @@ class SensorEntity(Entity):
 
         # If the sensor has 'unit_of_measuremeny' in its sensor options, the user has
         # overridden the unit.
-        # If the sensor has 'sensor.private' in its entity options, it was added after
+        # If the sensor has 'sensor.private' in its entity options, it was added before
         # automatic unit conversion was implemented.
         registry_unit = registry_entry.unit_of_measurement
         if (

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -484,10 +484,18 @@ class SensorEntity(Entity):
         platform: EntityPlatform,
         parallel_updates: asyncio.Semaphore | None,
     ) -> None:
-        """Start adding an entity to a platform."""
+        """Start adding an entity to a platform.
+
+        Allows integrations to remove legacy custom unit conversion which is no longer
+        needed without breaking existing sensors. Only works for sensors which are in
+        the entity registry.
+
+        This can be removed once core integrations have dropped custom unit conversion.
+        """
         super().add_to_platform_start(hass, platform, parallel_updates)
 
-        if self.unique_id is None:
+        # Bail out if the sensor doesn't have a unique_id or a device class
+        if self.unique_id is None or self.device_class is None:
             return
         registry = er.async_get(self.hass)
         if not (
@@ -499,24 +507,36 @@ class SensorEntity(Entity):
         registry_entry = registry.async_get(entity_id)
         assert registry_entry
 
-        # Store unit override according to automatic unit conversion rules if:
-        # - no unit override is stored in the entity registry
-        # - units have changed
-        # - the unit stored in the registry matches automatic unit conversion rules
-        # This allows integrations to drop custom unit conversion and rely on automatic
-        # conversion.
+        # If the sensor has 'unit_of_measuremeny' in its sensor options, the user has
+        # overridden the unit.
+        # If the sensor has 'sensor.private' in its entity options, it was added after
+        # automatic unit conversion was implemented.
         registry_unit = registry_entry.unit_of_measurement
         if (
-            DOMAIN not in registry_entry.options
-            and f"{DOMAIN}.private" not in registry_entry.options
-            and self.unit_of_measurement != registry_unit
-            and (suggested_unit := self._get_initial_suggested_unit()) == registry_unit
-        ):
-            registry.async_update_entity_options(
-                entity_id,
-                f"{DOMAIN}.private",
-                {"suggested_unit_of_measurement": suggested_unit},
+            (
+                (sensor_options := registry_entry.options.get(DOMAIN))
+                and CONF_UNIT_OF_MEASUREMENT in sensor_options
             )
+            or f"{DOMAIN}.private" in registry_entry.options
+            or self.unit_of_measurement == registry_unit
+        ):
+            return
+
+        # Make sure we can convert the units
+        if (
+            (unit_converter := UNIT_CONVERTERS.get(self.device_class)) is None
+            or registry_unit not in unit_converter.VALID_UNITS
+            or self.unit_of_measurement not in unit_converter.VALID_UNITS
+        ):
+            return
+
+        # Set suggested_unit_of_measurement to the old unit to enable automatic
+        # conversion
+        registry.async_update_entity_options(
+            entity_id,
+            f"{DOMAIN}.private",
+            {"suggested_unit_of_measurement": registry_unit},
+        )
 
     async def async_internal_added_to_hass(self) -> None:
         """Call when the sensor entity is added to hass."""
@@ -572,8 +592,12 @@ class SensorEntity(Entity):
 
         return None
 
-    def _get_initial_suggested_unit(self) -> str | None:
-        """Return initial suggested unit of measurement."""
+    def get_initial_entity_options(self) -> er.EntityOptionsType | None:
+        """Return initial entity options.
+
+        These will be stored in the entity registry the first time the entity is seen,
+        and then never updated.
+        """
         # Unit suggested by the integration
         suggested_unit_of_measurement = self.suggested_unit_of_measurement
 
@@ -583,15 +607,6 @@ class SensorEntity(Entity):
                 self.device_class, self.native_unit_of_measurement
             )
 
-        return suggested_unit_of_measurement
-
-    def get_initial_entity_options(self) -> er.EntityOptionsType | None:
-        """Return initial entity options.
-
-        These will be stored in the entity registry the first time the entity is seen,
-        and then never updated.
-        """
-        suggested_unit_of_measurement = self._get_initial_suggested_unit()
         if suggested_unit_of_measurement is None:
             return None
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -508,9 +508,9 @@ class SensorEntity(Entity):
         registry_entry = registry.async_get(entity_id)
         assert registry_entry
 
-        # If the sensor has 'unit_of_measuremeny' in its sensor options, the user has
+        # If the sensor has 'unit_of_measurement' in its sensor options, the user has
         # overridden the unit.
-        # If the sensor has 'sensor.private' in its entity options, it was added before
+        # If the sensor has 'sensor.private' in its entity options, it was added after
         # automatic unit conversion was implemented.
         registry_unit = registry_entry.unit_of_measurement
         if (

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -889,6 +889,14 @@ async def test_unit_conversion_priority_suggested_unit_change(
             621,
             SensorDeviceClass.DISTANCE,
         ),
+        (
+            US_CUSTOMARY_SYSTEM,
+            LENGTH_METERS,
+            LENGTH_MILES,
+            1000000,
+            621.371,
+            SensorDeviceClass.DISTANCE,
+        ),
     ],
 )
 async def test_unit_conversion_priority_legacy_conversion_removed(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow integrations to drop custom unit conversion and rely on automatic rules without causing a breaking change

This works by updating the entity registry entity options if:
 - The entity is in the entity registry
 - The entity does not have any initial entity options, meaning it was added before support for automatic conversion was implemented
 - The user has not overridden the unit
 - Units have changed, i.e., the `unit_of_measurement` in the entity registry does not match the sensor's `unit_of_measurement`
 - The sensors `unit_of_measurement` can be converted to the `unit_of_measurement` stored in the entity registry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
