### PR TITLE
Remove deprecated GCM API from html5

### DIFF
--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -60,9 +60,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional("gcm_sender_id"): vol.All(cv.string, gcm_api_deprecated),
         vol.Optional("gcm_api_key"): cv.string,
-        vol.Optional(ATTR_VAPID_PUB_KEY): cv.string,
-        vol.Optional(ATTR_VAPID_PRV_KEY): cv.string,
-        vol.Optional(ATTR_VAPID_EMAIL): cv.string,
+        vol.Required(ATTR_VAPID_PUB_KEY): cv.string,
+        vol.Required(ATTR_VAPID_PRV_KEY): cv.string,
+        vol.Required(ATTR_VAPID_EMAIL): cv.string,
     }
 )
 

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -170,9 +170,9 @@ def get_service(hass, config, discovery_info=None):
     if registrations is None:
         return None
 
-    vapid_pub_key = config.get(ATTR_VAPID_PUB_KEY)
-    vapid_prv_key = config.get(ATTR_VAPID_PRV_KEY)
-    vapid_email = config.get(ATTR_VAPID_EMAIL)
+    vapid_pub_key = config[ATTR_VAPID_PUB_KEY]
+    vapid_prv_key = config[ATTR_VAPID_PRV_KEY]
+    vapid_email = config[ATTR_VAPID_EMAIL]
 
     def websocket_appkey(hass, connection, msg):
         connection.send_message(websocket_api.result_message(msg["id"], vapid_pub_key))

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -12,6 +12,7 @@ from homeassistant.setup import async_setup_component
 CONFIG_FILE = "file.conf"
 
 VAPID_CONF = {
+    "platform": "html5",
     "vapid_pub_key": "BJMA2gDZEkHaXRhf1fhY_"
     + "QbKbhVIHlSJXI0bFyo0eJXnUPOjdgycCAbj-2bMKMKNKs"
     + "_rM8JoSnyKGCXAY2dbONI",
@@ -70,7 +71,7 @@ async def mock_client(hass, hass_client, registrations=None):
     with patch(
         "homeassistant.components.html5.notify._load_config", return_value=registrations
     ):
-        await async_setup_component(hass, "notify", {"notify": {"platform": "html5"}})
+        await async_setup_component(hass, "notify", {"notify": VAPID_CONF})
         await hass.async_block_till_done()
 
     return await hass_client()
@@ -99,7 +100,7 @@ class TestHtml5Notify:
 
         m = mock_open(read_data=json.dumps(data))
         with patch("homeassistant.util.json.open", m, create=True):
-            service = html5.get_service(hass, {"gcm_sender_id": "100"})
+            service = html5.get_service(hass, VAPID_CONF)
 
         assert service is not None
 
@@ -111,7 +112,7 @@ class TestHtml5Notify:
         assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_1["subscription"]
 
         # Call to send
-        payload = json.loads(mock_wp.mock_calls[3][1][0])
+        payload = json.loads(mock_wp.mock_calls[3][2]["data"])
 
         assert payload["dismiss"] is True
         assert payload["tag"] == "test"
@@ -126,7 +127,7 @@ class TestHtml5Notify:
 
         m = mock_open(read_data=json.dumps(data))
         with patch("homeassistant.util.json.open", m, create=True):
-            service = html5.get_service(hass, {"gcm_sender_id": "100"})
+            service = html5.get_service(hass, VAPID_CONF)
 
         assert service is not None
 
@@ -140,38 +141,10 @@ class TestHtml5Notify:
         assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_1["subscription"]
 
         # Call to send
-        payload = json.loads(mock_wp.mock_calls[3][1][0])
+        payload = json.loads(mock_wp.mock_calls[3][2]["data"])
 
         assert payload["body"] == "Hello"
         assert payload["icon"] == "beer.png"
-
-    @patch("homeassistant.components.html5.notify.WebPusher")
-    def test_gcm_key_include(self, mock_wp):
-        """Test if the gcm_key is only included for GCM endpoints."""
-        hass = MagicMock()
-        mock_wp().send().status_code = 201
-
-        data = {"chrome": SUBSCRIPTION_1, "firefox": SUBSCRIPTION_2}
-
-        m = mock_open(read_data=json.dumps(data))
-        with patch("homeassistant.util.json.open", m, create=True):
-            service = html5.get_service(
-                hass, {"gcm_sender_id": "100", "gcm_api_key": "Y6i0JdZ0mj9LOaSI"}
-            )
-
-        assert service is not None
-
-        service.send_message("Hello", target=["chrome", "firefox"])
-
-        assert len(mock_wp.mock_calls) == 6
-
-        # WebPusher constructor
-        assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_1["subscription"]
-        assert mock_wp.mock_calls[4][1][0] == SUBSCRIPTION_2["subscription"]
-
-        # Get the keys passed to the WebPusher's send method
-        assert mock_wp.mock_calls[3][2]["gcm_key"] is not None
-        assert mock_wp.mock_calls[5][2]["gcm_key"] is None
 
     @patch("homeassistant.components.html5.notify.WebPusher")
     def test_fcm_key_include(self, mock_wp):
@@ -264,14 +237,6 @@ class TestHtml5Notify:
 
         # Get the keys passed to the WebPusher's send method
         assert mock_wp.mock_calls[3][2]["headers"]["priority"] == "normal"
-
-
-def test_create_vapid_withoutvapid():
-    """Test creating empty vapid."""
-    resp = html5.create_vapid_headers(
-        vapid_email=None, vapid_private_key=None, subscription_info=None, timestamp=None
-    )
-    assert resp is None
 
 
 async def test_registering_new_device_view(hass, hass_client):
@@ -479,7 +444,7 @@ async def test_callback_view_with_jwt(hass, hass_client):
     assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_1["subscription"]
 
     # Call to send
-    push_payload = json.loads(mock_wp.mock_calls[3][1][0])
+    push_payload = json.loads(mock_wp.mock_calls[3][2]["data"])
 
     assert push_payload["body"] == "Hello"
     assert push_payload["icon"] == "beer.png"

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -86,7 +86,7 @@ class TestHtml5Notify:
 
         m = mock_open()
         with patch("homeassistant.util.json.open", m, create=True):
-            service = html5.get_service(hass, {})
+            service = html5.get_service(hass, VAPID_CONF)
 
         assert service is not None
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Google Cloud Messaging (GCM) is deprecated since 2018 and stopped working in 2019: https://developers.google.com/cloud-messaging. This PR removes GCM support from the html5 integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25143

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
