### PR TITLE
Bump pykoplenti to 1.0.0

### DIFF
--- a/homeassistant/components/kostal_plenticore/__init__.py
+++ b/homeassistant/components/kostal_plenticore/__init__.py
@@ -1,7 +1,7 @@
 """The Kostal Plenticore Solar Inverter integration."""
 import logging
 
-from kostal.plenticore import PlenticoreApiException
+from pykoplenti import ApiException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -39,7 +39,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         plenticore = hass.data[DOMAIN].pop(entry.entry_id)
         try:
             await plenticore.async_unload()
-        except PlenticoreApiException as err:
+        except ApiException as err:
             _LOGGER.error("Error logging out from inverter: %s", err)
 
     return unload_ok

--- a/homeassistant/components/kostal_plenticore/config_flow.py
+++ b/homeassistant/components/kostal_plenticore/config_flow.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 
 from aiohttp.client_exceptions import ClientError
-from kostal.plenticore import PlenticoreApiClient, PlenticoreAuthenticationException
+from pykoplenti import ApiClient, AuthenticationException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -30,7 +30,7 @@ async def test_connection(hass: HomeAssistant, data) -> str:
     """
 
     session = async_get_clientsession(hass)
-    async with PlenticoreApiClient(session, data["host"]) as client:
+    async with ApiClient(session, data["host"]) as client:
         await client.login(data["password"])
         values = await client.get_setting_values("scb:network", "Hostname")
 
@@ -52,7 +52,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 hostname = await test_connection(self.hass, user_input)
-            except PlenticoreAuthenticationException as ex:
+            except AuthenticationException as ex:
                 errors[CONF_PASSWORD] = "invalid_auth"
                 _LOGGER.error("Error response: %s", ex)
             except (ClientError, asyncio.TimeoutError):

--- a/homeassistant/components/kostal_plenticore/helper.py
+++ b/homeassistant/components/kostal_plenticore/helper.py
@@ -9,11 +9,7 @@ import logging
 from typing import Any, TypeVar, cast
 
 from aiohttp.client_exceptions import ClientError
-from kostal.plenticore import (
-    PlenticoreApiClient,
-    PlenticoreApiException,
-    PlenticoreAuthenticationException,
-)
+from pykoplenti import ApiClient, ApiException, AuthenticationException
 
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
@@ -48,18 +44,16 @@ class Plenticore:
         return self.config_entry.data[CONF_HOST]
 
     @property
-    def client(self) -> PlenticoreApiClient:
+    def client(self) -> ApiClient:
         """Return the Plenticore API client."""
         return self._client
 
     async def async_setup(self) -> bool:
         """Set up Plenticore API client."""
-        self._client = PlenticoreApiClient(
-            async_get_clientsession(self.hass), host=self.host
-        )
+        self._client = ApiClient(async_get_clientsession(self.hass), host=self.host)
         try:
             await self._client.login(self.config_entry.data[CONF_PASSWORD])
-        except PlenticoreAuthenticationException as err:
+        except AuthenticationException as err:
             _LOGGER.error(
                 "Authentication exception connecting to %s: %s", self.host, err
             )
@@ -135,7 +129,7 @@ class DataUpdateCoordinatorMixin:
 
         try:
             return await client.get_setting_values(module_id, data_id)
-        except PlenticoreApiException:
+        except ApiException:
             return None
 
     async def async_write_data(self, module_id: str, value: dict[str, str]) -> bool:
@@ -149,7 +143,7 @@ class DataUpdateCoordinatorMixin:
 
         try:
             await client.set_setting_values(module_id, value)
-        except PlenticoreApiException:
+        except ApiException:
             return False
         else:
             return True

--- a/homeassistant/components/kostal_plenticore/manifest.json
+++ b/homeassistant/components/kostal_plenticore/manifest.json
@@ -3,7 +3,7 @@
   "name": "Kostal Plenticore Solar Inverter",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/kostal_plenticore",
-  "requirements": ["kostal_plenticore==0.2.0"],
+  "requirements": ["pykoplenti==1.0.0"],
   "codeowners": ["@stegm"],
   "iot_class": "local_polling",
   "loggers": ["kostal"]

--- a/homeassistant/components/kostal_plenticore/number.py
+++ b/homeassistant/components/kostal_plenticore/number.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
-from kostal.plenticore import SettingsData
+from pykoplenti import SettingsData
 
 from homeassistant.components.number import (
     NumberDeviceClass,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1018,7 +1018,7 @@ kiwiki-client==0.1.1
 konnected==1.2.0
 
 # homeassistant.components.kostal_plenticore
-kostal_plenticore==0.2.0
+pykoplenti==1.0.0
 
 # homeassistant.components.kraken
 krakenex==2.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1017,9 +1017,6 @@ kiwiki-client==0.1.1
 # homeassistant.components.konnected
 konnected==1.2.0
 
-# homeassistant.components.kostal_plenticore
-pykoplenti==1.0.0
-
 # homeassistant.components.kraken
 krakenex==2.1.0
 
@@ -1712,6 +1709,9 @@ pykmtronic==0.3.0
 
 # homeassistant.components.kodi
 pykodi==0.2.7
+
+# homeassistant.components.kostal_plenticore
+pykoplenti==1.0.0
 
 # homeassistant.components.kraken
 pykrakenapi==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -764,9 +764,6 @@ kegtron-ble==0.4.0
 # homeassistant.components.konnected
 konnected==1.2.0
 
-# homeassistant.components.kostal_plenticore
-kostal_plenticore==0.2.0
-
 # homeassistant.components.kraken
 krakenex==2.1.0
 
@@ -1228,6 +1225,9 @@ pykmtronic==0.3.0
 
 # homeassistant.components.kodi
 pykodi==0.2.7
+
+# homeassistant.components.kostal_plenticore
+pykoplenti==1.0.0
 
 # homeassistant.components.kraken
 pykrakenapi==0.1.8

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from kostal.plenticore import MeData, VersionData
+from pykoplenti import MeData, VersionData
 import pytest
 
 from homeassistant.components.kostal_plenticore.helper import Plenticore

--- a/tests/components/kostal_plenticore/test_config_flow.py
+++ b/tests/components/kostal_plenticore/test_config_flow.py
@@ -2,7 +2,7 @@
 import asyncio
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
-from kostal.plenticore import PlenticoreAuthenticationException
+from pykoplenti import AuthenticationException
 
 from homeassistant import config_entries
 from homeassistant.components.kostal_plenticore.const import DOMAIN
@@ -75,7 +75,7 @@ async def test_form_invalid_auth(hass):
         # mock of the context manager instance
         mock_api_ctx = MagicMock()
         mock_api_ctx.login = AsyncMock(
-            side_effect=PlenticoreAuthenticationException(404, "invalid user"),
+            side_effect=AuthenticationException(404, "invalid user"),
         )
 
         # mock of the return instance of PlenticoreApiClient

--- a/tests/components/kostal_plenticore/test_config_flow.py
+++ b/tests/components/kostal_plenticore/test_config_flow.py
@@ -20,7 +20,7 @@ async def test_formx(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.kostal_plenticore.config_flow.PlenticoreApiClient"
+        "homeassistant.components.kostal_plenticore.config_flow.ApiClient"
     ) as mock_api_class, patch(
         "homeassistant.components.kostal_plenticore.async_setup_entry",
         return_value=True,
@@ -32,7 +32,7 @@ async def test_formx(hass):
             return_value={"scb:network": {"Hostname": "scb"}}
         )
 
-        # mock of the return instance of PlenticoreApiClient
+        # mock of the return instance of ApiClient
         mock_api = MagicMock()
         mock_api.__aenter__.return_value = mock_api_ctx
         mock_api.__aexit__ = AsyncMock()
@@ -70,7 +70,7 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-        "homeassistant.components.kostal_plenticore.config_flow.PlenticoreApiClient"
+        "homeassistant.components.kostal_plenticore.config_flow.ApiClient"
     ) as mock_api_class:
         # mock of the context manager instance
         mock_api_ctx = MagicMock()
@@ -78,7 +78,7 @@ async def test_form_invalid_auth(hass):
             side_effect=AuthenticationException(404, "invalid user"),
         )
 
-        # mock of the return instance of PlenticoreApiClient
+        # mock of the return instance of ApiClient
         mock_api = MagicMock()
         mock_api.__aenter__.return_value = mock_api_ctx
         mock_api.__aexit__.return_value = None
@@ -104,7 +104,7 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.kostal_plenticore.config_flow.PlenticoreApiClient"
+        "homeassistant.components.kostal_plenticore.config_flow.ApiClient"
     ) as mock_api_class:
         # mock of the context manager instance
         mock_api_ctx = MagicMock()
@@ -112,7 +112,7 @@ async def test_form_cannot_connect(hass):
             side_effect=asyncio.TimeoutError(),
         )
 
-        # mock of the return instance of PlenticoreApiClient
+        # mock of the return instance of ApiClient
         mock_api = MagicMock()
         mock_api.__aenter__.return_value = mock_api_ctx
         mock_api.__aexit__.return_value = None
@@ -138,7 +138,7 @@ async def test_form_unexpected_error(hass):
     )
 
     with patch(
-        "homeassistant.components.kostal_plenticore.config_flow.PlenticoreApiClient"
+        "homeassistant.components.kostal_plenticore.config_flow.ApiClient"
     ) as mock_api_class:
         # mock of the context manager instance
         mock_api_ctx = MagicMock()
@@ -146,7 +146,7 @@ async def test_form_unexpected_error(hass):
             side_effect=Exception(),
         )
 
-        # mock of the return instance of PlenticoreApiClient
+        # mock of the return instance of ApiClient
         mock_api = MagicMock()
         mock_api.__aenter__.return_value = mock_api_ctx
         mock_api.__aexit__.return_value = None

--- a/tests/components/kostal_plenticore/test_diagnostics.py
+++ b/tests/components/kostal_plenticore/test_diagnostics.py
@@ -1,6 +1,6 @@
 """Test Kostal Plenticore diagnostics."""
 from aiohttp import ClientSession
-from kostal.plenticore import SettingsData
+from pykoplenti import SettingsData
 
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.components.kostal_plenticore.helper import Plenticore

--- a/tests/components/kostal_plenticore/test_diagnostics.py
+++ b/tests/components/kostal_plenticore/test_diagnostics.py
@@ -57,7 +57,7 @@ async def test_entry_diagnostics(
         },
         "client": {
             "version": "Version(api_version=0.2.0, hostname=scb, name=PUCK RESTful API, sw_version=01.16.05025)",
-            "me": "Me(locked=False, active=True, authenticated=True, permissions=[] anonymous=False role=USER)",
+            "me": "Me(locked=False, active=True, authenticated=True, permissions=[], anonymous=False, role=USER)",
             "available_process_data": {"devices:local": ["HomeGrid_P", "HomePv_P"]},
             "available_settings_data": {
                 "devices:local": [

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 from datetime import timedelta
 from unittest.mock import patch
 
-from kostal.plenticore import PlenticoreApiClient, SettingsData
+from pykoplenti import ApiClient, SettingsData
 import pytest
 
 from homeassistant.components.number import (
@@ -23,17 +23,17 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture
-def mock_plenticore_client() -> Generator[PlenticoreApiClient, None, None]:
-    """Return a patched PlenticoreApiClient."""
+def mock_plenticore_client() -> Generator[ApiClient, None, None]:
+    """Return a patched ApiClient."""
     with patch(
-        "homeassistant.components.kostal_plenticore.helper.PlenticoreApiClient",
+        "homeassistant.components.kostal_plenticore.helper.ApiClient",
         autospec=True,
     ) as plenticore_client_class:
         yield plenticore_client_class.return_value
 
 
 @pytest.fixture
-def mock_get_setting_values(mock_plenticore_client: PlenticoreApiClient) -> list:
+def mock_get_setting_values(mock_plenticore_client: ApiClient) -> list:
     """Add a setting value to the given Plenticore client.
 
     Returns a list with setting values which can be extended by test cases.
@@ -88,7 +88,7 @@ def mock_get_setting_values(mock_plenticore_client: PlenticoreApiClient) -> list
 async def test_setup_all_entries(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_plenticore_client: PlenticoreApiClient,
+    mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
 ):
@@ -107,7 +107,7 @@ async def test_setup_all_entries(
 async def test_setup_no_entries(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_plenticore_client: PlenticoreApiClient,
+    mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
 ):
@@ -128,7 +128,7 @@ async def test_setup_no_entries(
 async def test_number_has_value(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_plenticore_client: PlenticoreApiClient,
+    mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
 ):
@@ -153,7 +153,7 @@ async def test_number_has_value(
 async def test_number_is_unavailable(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_plenticore_client: PlenticoreApiClient,
+    mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
 ):
@@ -174,7 +174,7 @@ async def test_number_is_unavailable(
 async def test_set_value(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_plenticore_client: PlenticoreApiClient,
+    mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
 ):

--- a/tests/components/kostal_plenticore/test_select.py
+++ b/tests/components/kostal_plenticore/test_select.py
@@ -1,5 +1,5 @@
 """Test the Kostal Plenticore Solar Inverter select platform."""
-from kostal.plenticore import SettingsData
+from pykoplenti import SettingsData
 
 from homeassistant.components.kostal_plenticore.helper import Plenticore
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Update the Kostal Plenticore integration and replace kostal-plenticore (0.2.0) library with the newer and maintained pykoplenti (1.0.0) library.
- Basically this is just renamed 1.0 release of the old kostal-plenticore lib.
- Comparison: https://github.com/stegm/pykoplenti/compare/v0.2.0...v1.0.0

The idea of this is that the old kostal-plenticore is not maintained as it's replaced by the pykoplenti (It seems that the old lib, new lib, and this integration is actually created by the same DEV). Kostal has released many updates to their inverter during 2022 and I think, it would be wise to update the HA integration to use the latest library version for the integration. Even though there currently are no breaking changes introduced in any of the Kostal Inverter updates, if such a thing would happen, we could then hopefully manage that in HA with just dependency update without code changes. 

- ~~Added Finnish localizations for Kostal integration.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
