### PR TITLE
Populate suggested_area using the LIFX group name for each device

### DIFF
--- a/homeassistant/components/lifx/coordinator.py
+++ b/homeassistant/components/lifx/coordinator.py
@@ -173,6 +173,8 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator):
                 self.device.get_hostfirmware()
             if self.device.product is None:
                 self.device.get_version()
+            if self.device.group is None:
+                self.device.get_group()
 
             response = await async_execute_lifx(self.device.get_color)
 

--- a/homeassistant/components/lifx/entity.py
+++ b/homeassistant/components/lifx/entity.py
@@ -25,6 +25,7 @@ class LIFXEntity(CoordinatorEntity[LIFXUpdateCoordinator]):
             name=coordinator.label,
             model=products.product_map.get(self.bulb.product, "LIFX Bulb"),
             sw_version=self.bulb.host_firmware_version,
+            suggested_area=self.bulb.group,
         )
 
 
@@ -42,4 +43,5 @@ class LIFXSensorEntity(CoordinatorEntity[LIFXSensorUpdateCoordinator]):
             name=coordinator.parent.label,
             model=products.product_map.get(self.bulb.product, "LIFX Bulb"),
             sw_version=self.bulb.host_firmware_version,
+            suggested_area=self.bulb.group,
         )

--- a/homeassistant/components/lifx/strings.json
+++ b/homeassistant/components/lifx/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "{label} ({host}) {serial}",
+    "flow_title": "{label} ({group})",
     "step": {
       "user": {
         "description": "If you leave the host empty, discovery will be used to find devices.",
@@ -14,7 +14,7 @@
         }
       },
       "discovery_confirm": {
-        "description": "Do you want to setup {label} ({host}) {serial}?"
+        "description": "Do you want to setup {label} ({group})?"
       }
     },
     "error": {

--- a/homeassistant/components/lifx/translations/en.json
+++ b/homeassistant/components/lifx/translations/en.json
@@ -8,10 +8,10 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "{label} ({host}) {serial}",
+        "flow_title": "{label} ({group})",
         "step": {
             "discovery_confirm": {
-                "description": "Do you want to setup {label} ({host}) {serial}?"
+                "description": "Do you want to setup {label} ({group})?"
             },
             "pick_device": {
                 "data": {

--- a/tests/components/lifx/__init__.py
+++ b/tests/components/lifx/__init__.py
@@ -14,6 +14,7 @@ MODULE = "homeassistant.components.lifx"
 MODULE_CONFIG_FLOW = "homeassistant.components.lifx.config_flow"
 IP_ADDRESS = "127.0.0.1"
 LABEL = "My Bulb"
+GROUP = "My Group"
 SERIAL = "aa:bb:cc:dd:ee:cc"
 MAC_ADDRESS = "aa:bb:cc:dd:ee:cd"
 DEFAULT_ENTRY_TITLE = LABEL
@@ -81,6 +82,7 @@ def _mocked_bulb() -> Light:
     bulb = Light(asyncio.get_running_loop(), SERIAL, IP_ADDRESS)
     bulb.host_firmware_version = "3.00"
     bulb.label = LABEL
+    bulb.group = GROUP
     bulb.color = [1, 2, 3, 4]
     bulb.power_level = 0
     bulb.fire_and_forget = AsyncMock()
@@ -88,6 +90,7 @@ def _mocked_bulb() -> Light:
     bulb.try_sending = AsyncMock()
     bulb.set_infrared = MockLifxCommand(bulb)
     bulb.get_label = MockLifxCommand(bulb)
+    bulb.get_group = MockLifxCommand(bulb)
     bulb.get_color = MockLifxCommand(bulb)
     bulb.set_power = MockLifxCommand(bulb)
     bulb.set_color = MockLifxCommand(bulb)


### PR DESCRIPTION
## Proposed change

Add support for `suggested_area` to the LIFX integration using the label of the LIFX group to which the light belongs. Every LIFX device must belong to a group, so this will always contain a value. 

I was waiting for https://github.com/home-assistant/frontend/pull/14383 to get merged before submitting this feature, so that the suggested area is visible during config flow. 

I've also tweaked the config flow dialog titles to just be light name (label) and area (group) so that there's a clear connection from what was discovered to what Home Assistant suggested the user configure during the flow.

I checked the docs and I can't find any integration that documents this, except as part of YAML-based configuration, so I haven't updated the LIFX integration docs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
