### PR TITLE
Add current sound mode or source to list in LG soundbar

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -673,7 +673,6 @@ omit =
     homeassistant/components/led_ble/light.py
     homeassistant/components/lg_netcast/media_player.py
     homeassistant/components/lg_soundbar/__init__.py
-    homeassistant/components/lg_soundbar/media_player.py
     homeassistant/components/lidarr/__init__.py
     homeassistant/components/lidarr/coordinator.py
     homeassistant/components/lidarr/sensor.py

--- a/tests/components/lg_soundbar/__init__.py
+++ b/tests/components/lg_soundbar/__init__.py
@@ -1,1 +1,213 @@
 """Tests for the lg_soundbar component."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import DEFAULT, MagicMock
+
+from homeassistant.components.lg_soundbar.const import DEFAULT_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+MOCK_CONFIG = {CONF_HOST: "127.0.0.1", CONF_PORT: DEFAULT_PORT}
+MOCK_ENTITY_ID = "mock_entity_id"
+MOCK_MP_ENTITY_ID = "media_player.lg_soundbar_" + MOCK_ENTITY_ID
+MOCK_TEMESCAL_EQUALISERS = [
+    "Standard",
+    "Bass",
+    "Flat",
+    "Boost",
+    "Treble and Bass",
+    "User",
+    "Music",
+    "Cinema",
+    "Night",
+    "News",
+    "Voice",
+    "ia_sound",
+    "Adaptive Sound Control",
+    "Movie",
+    "Bass Blast",
+    "Dolby Atmos",
+    "DTS Virtual X",
+    "Bass Boost Plus",
+    "DTS X",
+    "AI Sound Pro",
+    "Clear Voice",
+    "Sports",
+    "Game",
+]
+MOCK_TEMESCAL_FUNCTIONS = [
+    "Wi-Fi",
+    "Bluetooth",
+    "Portable",
+    "Aux",
+    "Optical",
+    "CP",
+    "HDMI",
+    "ARC",
+    "Spotify",
+    "Optical2",
+    "HDMI2",
+    "HDMI3",
+    "LG TV",
+    "Mic",
+    "Chromecast",
+    "Optical/HDMI ARC",
+    "LG Optical",
+    "FM",
+    "USB",
+    "USB2",
+    "E-ARC",
+]
+
+TEMESCAL_ATTR_UUID = "s_uuid"
+TEMESCAL_ATTR_USERNAME = "s_user_name"
+
+TEMESCAL_EQ_VIEW_INFO = "EQ_VIEW_INFO"
+TEMESCAL_FUNC_VIEW_INFO = "FUNC_VIEW_INFO"
+TEMESCAL_MAC_INFO_DEV = "MAC_INFO_DEV"
+TEMESCAL_PRODUCT_INFO = "PRODUCT_INFO"
+TEMESCAL_SETTING_VIEW_INFO = "SETTING_VIEW_INFO"
+TEMESCAL_SPK_LIST_VIEW_INFO = "SPK_LIST_VIEW_INFO"
+
+TEMESCAL_RESPONSES = {
+    TEMESCAL_EQ_VIEW_INFO: {
+        "i_curr_eq": 19,
+        "i_bass": 5,
+        "i_treble": 10,
+        "ai_eq_list": [19, 0, 6, 7, 20, 21, 22, 14, 5, 15, 23, 24, 25],
+        "merdian_eq_list": [6],
+    },
+    TEMESCAL_FUNC_VIEW_INFO: {
+        "b_connect": True,
+        "i_curr_func": 15,
+        "s_bt_name": "d",
+        "s_spk_bt_name": "bt name",
+        "ai_func_list": [0, 1, 15, 6, 19],
+    },
+    TEMESCAL_PRODUCT_INFO: {
+        "i_network_type": 1,
+        "i_model_no": 0,
+        "i_model_type": 0,
+        "s_model_name": "S90QY",
+        "s_product_id": "P017",
+        "s_product_name": "WiFi Speaker",
+        "s_uuid": MOCK_ENTITY_ID,
+        "b_admin_mode": False,
+    },
+    TEMESCAL_SETTING_VIEW_INFO: {
+        "b_drc": True,
+        "b_auto_vol": True,
+        "b_auto_power": True,
+        "b_tv_remote": True,
+        "b_night_time": False,
+        "b_rear": True,
+        "b_enable_imax": True,
+        "b_support_diag": True,
+        "b_neuralx": True,
+        "b_enable_dialog": False,
+        "b_set_device_name": True,
+        "b_support_avsmrm": True,
+        "b_avsmrm_status": False,
+        "b_soundbarmode": False,
+        "b_wow_connect": False,
+        "b_nighttime_enable": True,
+        "i_av_sync": 0,
+        "i_woofer_level": 12,
+        "i_woofer_min": -15,
+        "i_woofer_max": 6,
+        "i_rear_level": 9,
+        "i_rear_min": -6,
+        "i_rear_max": 6,
+        "i_top_level": 8,
+        "i_top_min": -6,
+        "i_top_max": 6,
+        "i_center_level": 12,
+        "i_center_min": -6,
+        "i_center_max": 6,
+        "i_side_level": 8,
+        "i_side_min": -6,
+        "i_side_max": 6,
+        "i_dialog_level": 0,
+        "i_dialog_min": 0,
+        "i_dialog_max": 6,
+        "i_curr_eq": 19,
+        "i_calibration_status": 3,
+        "s_user_name": "LG sound bar",
+        "s_ipv4_addr": "127.0.0.1",
+        "s_ipv6_addr": "",
+    },
+    TEMESCAL_SPK_LIST_VIEW_INFO: {
+        "i_vol": 10,
+        "i_vol_min": 0,
+        "i_vol_max": 40,
+        "i_curr_func": 15,
+        "b_mute": False,
+        "b_support_avsmrm": True,
+        "b_avsmrm_status": False,
+        "b_spotify_connect": False,
+        "b_func_pictogram": True,
+        "b_soundbarmode": False,
+        "b_wow_connect": False,
+        "i_calibration_status": 3,
+        "i_year": 22,
+        "i_model_option": 1,
+        "i_color_option": 0,
+        "b_update": False,
+        "b_powerstatus": False,
+        "b_display_volume_text": True,
+        "s_user_name": "LG sound bar",
+        "s_audio_source": "NO SIGNAL",
+    },
+}
+
+
+def _msg_to_temescal_func(msg: str, mock: MagicMock) -> MagicMock:
+    """Map LG soundbar API messages to the mocked function that responds to the message."""
+    return {
+        TEMESCAL_EQ_VIEW_INFO: mock.get_eq,
+        TEMESCAL_FUNC_VIEW_INFO: mock.get_func,
+        TEMESCAL_MAC_INFO_DEV: mock.get_mac_info,
+        TEMESCAL_PRODUCT_INFO: mock.get_product_info,
+        TEMESCAL_SETTING_VIEW_INFO: mock.get_settings,
+        TEMESCAL_SPK_LIST_VIEW_INFO: mock.get_info,
+    }.get(msg)
+
+
+def setup_mock_temescal(
+    hass: HomeAssistant,
+    mock_temescal: MagicMock,
+    msg_dicts: dict[str, dict[str, Any]] = None,
+):
+    """Set up a mock of the temescal object to craft our expected responses."""
+    tmock = mock_temescal.temescal
+    instance = tmock.return_value
+
+    def create_temescal_response(msg: str, data: dict | None = None) -> dict[str, Any]:
+        response: dict[str, Any] = {"msg": msg}
+        if data is not None:
+            response["data"] = data
+        return response
+
+    def temescal_side_effect(
+        addr: str, port: int, callback: Callable[[dict[str, Any]], None]
+    ):
+        def _hass_add_job(
+            func: MagicMock,
+            msg: str,
+            response: dict[str, Any],
+        ):
+            func.side_effect = lambda: hass.add_job(
+                callback, create_temescal_response(msg=msg, data=response)
+            )
+
+        for key in msg_dicts.keys():
+            func = _msg_to_temescal_func(key, instance)
+            if func is not None:
+                _hass_add_job(func, key, msg_dicts[key])
+        return DEFAULT
+
+    mock_temescal.equalisers = MOCK_TEMESCAL_EQUALISERS
+    mock_temescal.functions = MOCK_TEMESCAL_FUNCTIONS
+    tmock.side_effect = temescal_side_effect

--- a/tests/components/lg_soundbar/test_media_player.py
+++ b/tests/components/lg_soundbar/test_media_player.py
@@ -1,0 +1,276 @@
+"""Tests for the lg_soundbar Media Player platform."""
+from __future__ import annotations
+
+import socket
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.lg_soundbar.const import DOMAIN
+from homeassistant.components.media_player import (
+    ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
+    ATTR_SOUND_MODE,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_SELECT_SOUND_MODE,
+    SERVICE_SELECT_SOURCE,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
+    SERVICE_VOLUME_UP,
+)
+from homeassistant.core import HomeAssistant
+
+from . import (
+    MOCK_CONFIG,
+    MOCK_ENTITY_ID,
+    MOCK_MP_ENTITY_ID,
+    TEMESCAL_RESPONSES,
+    setup_mock_temescal,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def _setup_lg_soundbar(
+    hass: HomeAssistant, responses: dict[str, Any] | None = None
+) -> MagicMock:
+    with patch(
+        "homeassistant.components.lg_soundbar.config_flow.QUEUE_TIMEOUT",
+        new=0.1,
+    ), patch(
+        "homeassistant.components.lg_soundbar.config_flow.temescal"
+    ) as mock_temescal_config, patch(
+        "homeassistant.components.lg_soundbar.media_player.temescal",
+    ) as mock_temescal_mp:
+        dicts = TEMESCAL_RESPONSES if responses is None else responses
+        setup_mock_temescal(
+            hass,
+            mock_temescal_config,
+            msg_dicts=dicts,
+        )
+        setup_mock_temescal(
+            hass,
+            mock_temescal_mp,
+            msg_dicts=dicts,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN, data=MOCK_CONFIG, entry_id=MOCK_ENTITY_ID
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    return mock_temescal_mp
+
+
+async def _call_mp_service(
+    hass: HomeAssistant, name: str, data: dict[str, Any]
+) -> None:
+    return await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN, name, service_data=data, blocking=True
+    )
+
+
+async def test_cannot_connect(hass: HomeAssistant) -> None:
+    """Test connection error."""
+    with patch(
+        "homeassistant.components.lg_soundbar.media_player.temescal",
+    ) as mock_temescal:
+        mock_temescal.temescal.side_effect = socket.timeout
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert hass.states.get(MOCK_MP_ENTITY_ID) is None
+
+
+async def test_mute_volume(hass: HomeAssistant) -> None:
+    """Test mute functionality."""
+    mock_temescal = await _setup_lg_soundbar(hass)
+    mock_temescal_instance = mock_temescal.temescal.return_value
+
+    await _call_mp_service(
+        hass,
+        SERVICE_VOLUME_SET,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.5},
+    )
+    await _call_mp_service(
+        hass,
+        SERVICE_VOLUME_MUTE,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: False},
+    )
+    mock_temescal_instance.set_mute.assert_called_with(False)
+
+    await _call_mp_service(
+        hass,
+        SERVICE_VOLUME_MUTE,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: True},
+    )
+    mock_temescal_instance.set_mute.assert_called_with(True)
+
+
+async def test_volume_level(hass: HomeAssistant) -> None:
+    """Test set volume level functionality."""
+    mock_temescal = await _setup_lg_soundbar(hass)
+    mock_temescal_instance = mock_temescal.temescal.return_value
+
+    await _call_mp_service(
+        hass,
+        SERVICE_VOLUME_SET,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.0},
+    )
+    mock_temescal_instance.set_volume.assert_called_with(0)
+
+    await _call_mp_service(hass, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID})
+    # mock response i_vol is 10, so 10 + (0.1 * i_vol_max(40)) = 14
+    mock_temescal_instance.set_volume.assert_called_with(14)
+
+    await _call_mp_service(
+        hass,
+        SERVICE_VOLUME_SET,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.5},
+    )
+    # 0.5 * i_vol_max(40) = 20
+    mock_temescal_instance.set_volume.assert_called_with(20)
+
+    await _call_mp_service(
+        hass, SERVICE_VOLUME_DOWN, {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID}
+    )
+    # i_vol(10) - (0.1 * i_vol_max(40)) = 6
+    mock_temescal_instance.set_volume.assert_called_with(6)
+
+
+async def test_volume_level_max_is_zero(hass: HomeAssistant) -> None:
+    """Test set volume level functionality when max volume is 0."""
+    responses = TEMESCAL_RESPONSES.copy()
+    responses["SPK_LIST_VIEW_INFO"]["i_vol_max"] = 0
+
+    mock_temescal = await _setup_lg_soundbar(hass, responses)
+    mock_temescal_instance = mock_temescal.temescal.return_value
+
+    await _call_mp_service(
+        hass,
+        SERVICE_VOLUME_SET,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.0},
+    )
+    mock_temescal_instance.set_volume.assert_called_with(0)
+
+    await _call_mp_service(hass, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID})
+    mock_temescal_instance.set_volume.assert_called_with(0)
+
+
+async def test_select_source(hass: HomeAssistant) -> None:
+    """Test select source functionality."""
+    mock_temescal = await _setup_lg_soundbar(hass)
+    mock_temescal_instance = mock_temescal.temescal.return_value
+
+    assert (
+        hass.states.get(MOCK_MP_ENTITY_ID).attributes[ATTR_INPUT_SOURCE]
+        == "Optical/HDMI ARC"
+    )
+    assert await _call_mp_service(
+        hass,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_INPUT_SOURCE: "Wi-Fi"},
+    )
+    mock_temescal_instance.set_func.assert_called_with(0)
+
+    assert await _call_mp_service(
+        hass,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_INPUT_SOURCE: "HDMI"},
+    )
+    mock_temescal_instance.set_func.assert_called_with(6)
+
+
+async def test_select_source_invalid_source(hass: HomeAssistant) -> None:
+    """Test select source functionality when selecting an invalid source."""
+    mock_temescal = await _setup_lg_soundbar(hass)
+    mock_temescal_instance = mock_temescal.temescal.return_value
+
+    assert await _call_mp_service(
+        hass,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_INPUT_SOURCE: "non-existent"},
+    )
+    mock_temescal_instance.set_func.assert_not_called()
+
+
+async def test_source_list_unlisted_source(hass: HomeAssistant) -> None:
+    """Test display of source when soundbar returns an item not in the available source list."""
+    responses = TEMESCAL_RESPONSES.copy()
+    responses["FUNC_VIEW_INFO"]["i_curr_func"] = 20
+    responses["SPK_LIST_VIEW_INFO"]["i_curr_func"] = 20
+
+    assert await _setup_lg_soundbar(hass, responses)
+    assert hass.states.get(MOCK_MP_ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "E-ARC"
+
+
+async def test_invalid_source_selected(hass: HomeAssistant) -> None:
+    """Test source functionality when an invalid source is reported by the sound bar."""
+    responses = TEMESCAL_RESPONSES.copy()
+    responses["FUNC_VIEW_INFO"]["i_curr_func"] = -1
+    responses["SPK_LIST_VIEW_INFO"]["i_curr_func"] = -1
+
+    assert await _setup_lg_soundbar(hass, responses)
+    assert ATTR_INPUT_SOURCE not in hass.states.get(MOCK_MP_ENTITY_ID).attributes
+
+
+async def test_select_sound_mode(hass: HomeAssistant) -> None:
+    """Test select sound mode functionality."""
+    mock_temescal = await _setup_lg_soundbar(hass)
+    mock_temescal_instance = mock_temescal.temescal.return_value
+
+    assert (
+        hass.states.get(MOCK_MP_ENTITY_ID).attributes[ATTR_SOUND_MODE] == "AI Sound Pro"
+    )
+    assert await _call_mp_service(
+        hass,
+        SERVICE_SELECT_SOUND_MODE,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_SOUND_MODE: "Standard"},
+    )
+    mock_temescal_instance.set_eq.assert_called_with(0)
+
+    assert await _call_mp_service(
+        hass,
+        SERVICE_SELECT_SOUND_MODE,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_SOUND_MODE: "Music"},
+    )
+    mock_temescal_instance.set_eq.assert_called_with(6)
+
+
+async def test_select_sound_mode_invalid_mode(hass: HomeAssistant) -> None:
+    """Test select sound mode functionality when selecting an invalid mode."""
+    mock_temescal = await _setup_lg_soundbar(hass)
+    mock_temescal_instance = mock_temescal.temescal.return_value
+
+    assert await _call_mp_service(
+        hass,
+        SERVICE_SELECT_SOUND_MODE,
+        {ATTR_ENTITY_ID: MOCK_MP_ENTITY_ID, ATTR_SOUND_MODE: "non-existent"},
+    )
+    mock_temescal_instance.set_eq.assert_not_called()
+
+
+async def test_sound_mode_list_unlisted_mode(hass: HomeAssistant) -> None:
+    """Test display of sound mode when soundbar returns an item not in the available sound mode list."""
+    responses = TEMESCAL_RESPONSES.copy()
+    responses["EQ_VIEW_INFO"]["i_curr_eq"] = 1
+    responses["SETTING_VIEW_INFO"]["i_curr_eq"] = 1
+
+    assert await _setup_lg_soundbar(hass, responses)
+    assert hass.states.get(MOCK_MP_ENTITY_ID).attributes[ATTR_SOUND_MODE] == "Bass"
+
+
+async def test_invalid_sound_mode_selected(hass: HomeAssistant) -> None:
+    """Test sound mode functionality when an invalid sound mode is reported by the sound bar."""
+    responses = TEMESCAL_RESPONSES.copy()
+    responses["EQ_VIEW_INFO"]["i_curr_eq"] = -1
+    responses["SETTING_VIEW_INFO"]["i_curr_eq"] = -1
+
+    assert await _setup_lg_soundbar(hass, responses)
+    assert ATTR_SOUND_MODE not in hass.states.get(MOCK_MP_ENTITY_ID).attributes


### PR DESCRIPTION
* Prevent the current source or sound mode from displaying a blank item if the soundbar API returns an item that's not present in the list of supported sources or sound modes (e.g. selecting "Optical/HDMI ARC" source then returns "E-ARC" as the current source)
* Added lg_soundbar media_player tests and refactored existing tests

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some LG sound bars may display a function that is not returned by the list of available functions in the API (e.g. S90QY soundbar will display the function as "E-ARC" after selecting the "Optical/HDMI ARC" function), which results in a blank entry in the HA "Source" field. This change adds the unlisted source to the source list so that it has something to display in the field.

It also applies the same logic to the sound modes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
