### PR TITLE
Introduce unit enums for electric current and potential

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -535,7 +535,7 @@ ELECTRIC_CURRENT_AMPERE: Final = "A"
 
 
 # Electric_potential units
-class UnitOfElectricalPotential(StrEnum):
+class UnitOfElectricPotential(StrEnum):
     """Electric potential units."""
 
     MILLIVOLT = "mV"
@@ -543,9 +543,9 @@ class UnitOfElectricalPotential(StrEnum):
 
 
 ELECTRIC_POTENTIAL_MILLIVOLT: Final = "mV"
-"""Deprecated: please use UnitOfElectricalPotential.MILLIVOLT."""
+"""Deprecated: please use UnitOfElectricPotential.MILLIVOLT."""
 ELECTRIC_POTENTIAL_VOLT: Final = "V"
-"""Deprecated: please use UnitOfElectricalPotential.VOLT."""
+"""Deprecated: please use UnitOfElectricPotential.VOLT."""
 
 # Degree units
 DEGREE: Final = "°"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -533,9 +533,19 @@ ELECTRIC_CURRENT_MILLIAMPERE: Final = "mA"
 ELECTRIC_CURRENT_AMPERE: Final = "A"
 """Deprecated: please use UnitOfElectricCurrent.AMPERE."""
 
+
 # Electric_potential units
+class UnitOfElectricalPotential(StrEnum):
+    """Electric potential units."""
+
+    MILLIVOLT = "mV"
+    VOLT = "V"
+
+
 ELECTRIC_POTENTIAL_MILLIVOLT: Final = "mV"
+"""Deprecated: please use UnitOfElectricalPotential.MILLIVOLT."""
 ELECTRIC_POTENTIAL_VOLT: Final = "V"
+"""Deprecated: please use UnitOfElectricalPotential.VOLT."""
 
 # Degree units
 DEGREE: Final = "°"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -519,9 +519,19 @@ ENERGY_MEGA_WATT_HOUR: Final = "MWh"
 ENERGY_WATT_HOUR: Final = "Wh"
 """Deprecated: please use UnitOfEnergy.WATT_HOUR."""
 
+
 # Electric_current units
+class UnitOfElectricCurrent(StrEnum):
+    """Electric current units."""
+
+    MILLIAMPERE = "mA"
+    AMPERE = "A"
+
+
 ELECTRIC_CURRENT_MILLIAMPERE: Final = "mA"
+"""Deprecated: please use UnitOfElectricCurrent.MILLIAMPERE."""
 ELECTRIC_CURRENT_AMPERE: Final = "A"
+"""Deprecated: please use UnitOfElectricCurrent.AMPERE."""
 
 # Electric_potential units
 ELECTRIC_POTENTIAL_MILLIVOLT: Final = "mV"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
FOR DEVELOPPERS ONLY: as of Home Assistant Core 2023.1, the following unit constants are deprecated and replaced 
by a corresponding enum:

  - `UnitOfElectricCurrent` enumerator replaces `ELECTRIC_CURRENT_***` constants
  - `UnitOfElectricPotential` enumerator replaces `ELECTRIC_POTENTIAL_***` constants

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Introduce unit enums for electric current and potential

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1566

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
