### PR TITLE
Migrate WLED translations

### DIFF
--- a/homeassistant/components/wled/const.py
+++ b/homeassistant/components/wled/const.py
@@ -1,7 +1,6 @@
 """Constants for the WLED integration."""
 from datetime import timedelta
 import logging
-from typing import Final
 
 # Integration domain
 DOMAIN = "wled"
@@ -24,6 +23,3 @@ ATTR_SOFTWARE_VERSION = "sw_version"
 ATTR_SPEED = "speed"
 ATTR_TARGET_BRIGHTNESS = "target_brightness"
 ATTR_UDP_PORT = "udp_port"
-
-# Device classes
-DEVICE_CLASS_WLED_LIVE_OVERRIDE: Final = "wled__live_override"

--- a/homeassistant/components/wled/select.py
+++ b/homeassistant/components/wled/select.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DEVICE_CLASS_WLED_LIVE_OVERRIDE, DOMAIN
+from .const import DOMAIN
 from .coordinator import WLEDDataUpdateCoordinator
 from .helpers import wled_exception_handler
 from .models import WLEDEntity
@@ -48,10 +48,10 @@ async def async_setup_entry(
 class WLEDLiveOverrideSelect(WLEDEntity, SelectEntity):
     """Defined a WLED Live Override select."""
 
-    _attr_device_class = DEVICE_CLASS_WLED_LIVE_OVERRIDE
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:theater"
     _attr_name = "Live override"
+    _attr_translation_key = "live_override"
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator) -> None:
         """Initialize WLED ."""

--- a/homeassistant/components/wled/strings.json
+++ b/homeassistant/components/wled/strings.json
@@ -30,5 +30,16 @@
         }
       }
     }
+  },
+  "entity": {
+    "select": {
+      "live_override": {
+        "state": {
+          "0": "[%key:common::state::off%]",
+          "1": "[%key:common::state::on%]",
+          "2": "Until device restarts"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/wled/strings.select.json
+++ b/homeassistant/components/wled/strings.select.json
@@ -1,9 +1,0 @@
-{
-  "state": {
-    "wled__live_override": {
-      "0": "[%key:common::state::off%]",
-      "1": "[%key:common::state::on%]",
-      "2": "Until device restarts"
-    }
-  }
-}

--- a/homeassistant/components/wled/translations/en.json
+++ b/homeassistant/components/wled/translations/en.json
@@ -22,6 +22,17 @@
             }
         }
     },
+    "entity": {
+        "select": {
+            "live_override": {
+                "state": {
+                    "0": "Off",
+                    "1": "On",
+                    "2": "Until device restarts"
+                }
+            }
+        }
+    },
     "options": {
         "step": {
             "init": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the entity state translations of WLED to the new format.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
