### PR TITLE
Use new device class in meteo_france

### DIFF
--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -1,13 +1,6 @@
 """Meteo-France component constants."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntityDescription,
-    SensorStateClass,
-)
 from homeassistant.components.weather import (
     ATTR_CONDITION_CLEAR_NIGHT,
     ATTR_CONDITION_CLOUDY,
@@ -25,15 +18,7 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_WINDY,
     ATTR_CONDITION_WINDY_VARIANT,
 )
-from homeassistant.const import (
-    LENGTH_MILLIMETERS,
-    PERCENTAGE,
-    PRESSURE_HPA,
-    SPEED_KILOMETERS_PER_HOUR,
-    TEMP_CELSIUS,
-    UV_INDEX,
-    Platform,
-)
+from homeassistant.const import Platform
 
 DOMAIN = "meteo_france"
 PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
@@ -52,135 +37,6 @@ FORECAST_MODE = [FORECAST_MODE_HOURLY, FORECAST_MODE_DAILY]
 
 ATTR_NEXT_RAIN_1_HOUR_FORECAST = "1_hour_forecast"
 ATTR_NEXT_RAIN_DT_REF = "forecast_time_ref"
-
-
-@dataclass
-class MeteoFranceRequiredKeysMixin:
-    """Mixin for required keys."""
-
-    data_path: str
-
-
-@dataclass
-class MeteoFranceSensorEntityDescription(
-    SensorEntityDescription, MeteoFranceRequiredKeysMixin
-):
-    """Describes Meteo-France sensor entity."""
-
-
-SENSOR_TYPES: tuple[MeteoFranceSensorEntityDescription, ...] = (
-    MeteoFranceSensorEntityDescription(
-        key="pressure",
-        name="Pressure",
-        native_unit_of_measurement=PRESSURE_HPA,
-        device_class=SensorDeviceClass.PRESSURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_registry_enabled_default=False,
-        data_path="current_forecast:sea_level",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="wind_gust",
-        name="Wind gust",
-        native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:weather-windy-variant",
-        entity_registry_enabled_default=False,
-        data_path="current_forecast:wind:gust",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="wind_speed",
-        name="Wind speed",
-        native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:weather-windy",
-        entity_registry_enabled_default=False,
-        data_path="current_forecast:wind:speed",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="temperature",
-        name="Temperature",
-        native_unit_of_measurement=TEMP_CELSIUS,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_registry_enabled_default=False,
-        data_path="current_forecast:T:value",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="uv",
-        name="UV",
-        native_unit_of_measurement=UV_INDEX,
-        icon="mdi:sunglasses",
-        data_path="today_forecast:uv",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="precipitation",
-        name="Daily precipitation",
-        native_unit_of_measurement=LENGTH_MILLIMETERS,
-        icon="mdi:cup-water",
-        data_path="today_forecast:precipitation:24h",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="cloud",
-        name="Cloud cover",
-        native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-partly-cloudy",
-        data_path="current_forecast:clouds",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="original_condition",
-        name="Original condition",
-        entity_registry_enabled_default=False,
-        data_path="current_forecast:weather:desc",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="daily_original_condition",
-        name="Daily original condition",
-        entity_registry_enabled_default=False,
-        data_path="today_forecast:weather12H:desc",
-    ),
-)
-
-SENSOR_TYPES_RAIN: tuple[MeteoFranceSensorEntityDescription, ...] = (
-    MeteoFranceSensorEntityDescription(
-        key="next_rain",
-        name="Next rain",
-        device_class=SensorDeviceClass.TIMESTAMP,
-        data_path="",
-    ),
-)
-
-SENSOR_TYPES_ALERT: tuple[MeteoFranceSensorEntityDescription, ...] = (
-    MeteoFranceSensorEntityDescription(
-        key="weather_alert",
-        name="Weather alert",
-        icon="mdi:weather-cloudy-alert",
-        data_path="",
-    ),
-)
-
-SENSOR_TYPES_PROBABILITY: tuple[MeteoFranceSensorEntityDescription, ...] = (
-    MeteoFranceSensorEntityDescription(
-        key="rain_chance",
-        name="Rain chance",
-        native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-rainy",
-        data_path="probability_forecast:rain:3h",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="snow_chance",
-        name="Snow chance",
-        native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-snowy",
-        data_path="probability_forecast:snow:3h",
-    ),
-    MeteoFranceSensorEntityDescription(
-        key="freeze_chance",
-        name="Freeze chance",
-        native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:snowflake",
-        data_path="probability_forecast:freezing",
-    ),
-)
 
 
 CONDITION_CLASSES: dict[str, list[str]] = {

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -1,13 +1,28 @@
 """Support for Meteo-France raining forecast sensor."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from meteofrance_api.helpers import (
     get_warning_text_status_from_indice_color,
     readeable_phenomenoms_dict,
 )
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    PERCENTAGE,
+    UV_INDEX,
+    UnitOfPrecipitationDepth,
+    UnitOfPressure,
+    UnitOfSpeed,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
@@ -28,11 +43,138 @@ from .const import (
     DOMAIN,
     MANUFACTURER,
     MODEL,
-    SENSOR_TYPES,
-    SENSOR_TYPES_ALERT,
-    SENSOR_TYPES_PROBABILITY,
-    SENSOR_TYPES_RAIN,
-    MeteoFranceSensorEntityDescription,
+)
+
+
+@dataclass
+class MeteoFranceRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    data_path: str
+
+
+@dataclass
+class MeteoFranceSensorEntityDescription(
+    SensorEntityDescription, MeteoFranceRequiredKeysMixin
+):
+    """Describes Meteo-France sensor entity."""
+
+
+SENSOR_TYPES: tuple[MeteoFranceSensorEntityDescription, ...] = (
+    MeteoFranceSensorEntityDescription(
+        key="pressure",
+        name="Pressure",
+        native_unit_of_measurement=UnitOfPressure.HPA,
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        data_path="current_forecast:sea_level",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="wind_gust",
+        name="Wind gust",
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        device_class=SensorDeviceClass.WIND_SPEED,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:weather-windy-variant",
+        entity_registry_enabled_default=False,
+        data_path="current_forecast:wind:gust",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="wind_speed",
+        name="Wind speed",
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        device_class=SensorDeviceClass.WIND_SPEED,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:weather-windy",
+        entity_registry_enabled_default=False,
+        data_path="current_forecast:wind:speed",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="temperature",
+        name="Temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        data_path="current_forecast:T:value",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="uv",
+        name="UV",
+        native_unit_of_measurement=UV_INDEX,
+        icon="mdi:sunglasses",
+        data_path="today_forecast:uv",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="precipitation",
+        name="Daily precipitation",
+        native_unit_of_measurement=UnitOfPrecipitationDepth.MILLIMETERS,
+        device_class=SensorDeviceClass.PRECIPITATION,
+        icon="mdi:cup-water",
+        data_path="today_forecast:precipitation:24h",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="cloud",
+        name="Cloud cover",
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:weather-partly-cloudy",
+        data_path="current_forecast:clouds",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="original_condition",
+        name="Original condition",
+        entity_registry_enabled_default=False,
+        data_path="current_forecast:weather:desc",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="daily_original_condition",
+        name="Daily original condition",
+        entity_registry_enabled_default=False,
+        data_path="today_forecast:weather12H:desc",
+    ),
+)
+
+SENSOR_TYPES_RAIN: tuple[MeteoFranceSensorEntityDescription, ...] = (
+    MeteoFranceSensorEntityDescription(
+        key="next_rain",
+        name="Next rain",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        data_path="",
+    ),
+)
+
+SENSOR_TYPES_ALERT: tuple[MeteoFranceSensorEntityDescription, ...] = (
+    MeteoFranceSensorEntityDescription(
+        key="weather_alert",
+        name="Weather alert",
+        icon="mdi:weather-cloudy-alert",
+        data_path="",
+    ),
+)
+
+SENSOR_TYPES_PROBABILITY: tuple[MeteoFranceSensorEntityDescription, ...] = (
+    MeteoFranceSensorEntityDescription(
+        key="rain_chance",
+        name="Rain chance",
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:weather-rainy",
+        data_path="probability_forecast:rain:3h",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="snow_chance",
+        name="Snow chance",
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:weather-snowy",
+        data_path="probability_forecast:snow:3h",
+    ),
+    MeteoFranceSensorEntityDescription(
+        key="freeze_chance",
+        name="Freeze chance",
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:snowflake",
+        data_path="probability_forecast:freezing",
+    ),
 )
 
 

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -86,7 +86,6 @@ SENSOR_TYPES: tuple[MeteoFranceSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
         device_class=SensorDeviceClass.WIND_SPEED,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:weather-windy",
         entity_registry_enabled_default=False,
         data_path="current_forecast:wind:speed",
     ),

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -111,7 +111,6 @@ SENSOR_TYPES: tuple[MeteoFranceSensorEntityDescription, ...] = (
         name="Daily precipitation",
         native_unit_of_measurement=UnitOfPrecipitationDepth.MILLIMETERS,
         device_class=SensorDeviceClass.PRECIPITATION,
-        icon="mdi:cup-water",
         data_path="today_forecast:precipitation:24h",
     ),
     MeteoFranceSensorEntityDescription(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use PRECIPITATION and WIND_SPEED device class in meteo_france
Also move entity descriptions out of const into sensor.py, and use new enum units

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
