### PR TITLE
Remove unused device class from Renault select

### DIFF
--- a/homeassistant/components/renault/const.py
+++ b/homeassistant/components/renault/const.py
@@ -18,4 +18,3 @@ PLATFORMS = [
 
 DEVICE_CLASS_PLUG_STATE = "renault__plug_state"
 DEVICE_CLASS_CHARGE_STATE = "renault__charge_state"
-DEVICE_CLASS_CHARGE_MODE = "renault__charge_mode"

--- a/homeassistant/components/renault/const.py
+++ b/homeassistant/components/renault/const.py
@@ -15,6 +15,3 @@ PLATFORMS = [
     Platform.SELECT,
     Platform.SENSOR,
 ]
-
-DEVICE_CLASS_PLUG_STATE = "renault__plug_state"
-DEVICE_CLASS_CHARGE_STATE = "renault__charge_state"

--- a/homeassistant/components/renault/select.py
+++ b/homeassistant/components/renault/select.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import DEVICE_CLASS_CHARGE_MODE, DOMAIN
+from .const import DOMAIN
 from .renault_entities import RenaultDataEntity, RenaultDataEntityDescription
 from .renault_hub import RenaultHub
 
@@ -90,7 +90,6 @@ SENSOR_TYPES: tuple[RenaultSelectEntityDescription, ...] = (
         key="charge_mode",
         coordinator="charge_mode",
         data_key="chargeMode",
-        device_class=DEVICE_CLASS_CHARGE_MODE,
         icon_lambda=_get_charge_mode_icon,
         name="Charge mode",
         options=["always", "always_charging", "schedule_mode"],

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -36,7 +36,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util.dt import as_utc, parse_datetime
 
-from .const import DEVICE_CLASS_CHARGE_STATE, DEVICE_CLASS_PLUG_STATE, DOMAIN
+from .const import DOMAIN
 from .renault_coordinator import T
 from .renault_entities import RenaultDataEntity, RenaultDataEntityDescription
 from .renault_hub import RenaultHub
@@ -171,7 +171,6 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
         key="charge_state",
         coordinator="battery",
         data_key="chargingStatus",
-        device_class=DEVICE_CLASS_CHARGE_STATE,
         entity_class=RenaultSensor[KamereonVehicleBatteryStatusData],
         icon_lambda=_get_charge_state_icon,
         name="Charge state",
@@ -219,7 +218,6 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
         key="plug_state",
         coordinator="battery",
         data_key="plugStatus",
-        device_class=DEVICE_CLASS_PLUG_STATE,
         entity_class=RenaultSensor[KamereonVehicleBatteryStatusData],
         icon_lambda=_get_plug_state_icon,
         name="Plug state",

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -3,8 +3,6 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.renault.const import (
     CONF_KAMEREON_ACCOUNT_ID,
     CONF_LOCALE,
-    DEVICE_CLASS_CHARGE_STATE,
-    DEVICE_CLASS_PLUG_STATE,
     DOMAIN,
 )
 from homeassistant.components.select import ATTR_OPTIONS
@@ -169,7 +167,6 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
             {
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_STATE,
                 ATTR_ENTITY_ID: "sensor.reg_number_charge_state",
                 ATTR_ICON: "mdi:flash",
                 ATTR_STATE: "charge_in_progress",
@@ -222,7 +219,6 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_hvac_last_activity",
             },
             {
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_PLUG_STATE,
                 ATTR_ENTITY_ID: "sensor.reg_number_plug_state",
                 ATTR_ICON: "mdi:power-plug",
                 ATTR_STATE: "plugged",
@@ -387,7 +383,6 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
             {
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_STATE,
                 ATTR_ENTITY_ID: "sensor.reg_number_charge_state",
                 ATTR_ICON: "mdi:flash-off",
                 ATTR_STATE: "charge_error",
@@ -440,7 +435,6 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_hvac_last_activity",
             },
             {
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_PLUG_STATE,
                 ATTR_ENTITY_ID: "sensor.reg_number_plug_state",
                 ATTR_ICON: "mdi:power-plug-off",
                 ATTR_STATE: "unplugged",
@@ -605,7 +599,6 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
             {
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_STATE,
                 ATTR_ENTITY_ID: "sensor.reg_number_charge_state",
                 ATTR_ICON: "mdi:flash",
                 ATTR_STATE: "charge_in_progress",
@@ -655,7 +648,6 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_PLUG_STATE,
                 ATTR_ENTITY_ID: "sensor.reg_number_plug_state",
                 ATTR_ICON: "mdi:power-plug",
                 ATTR_STATE: "plugged",

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -3,7 +3,6 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.renault.const import (
     CONF_KAMEREON_ACCOUNT_ID,
     CONF_LOCALE,
-    DEVICE_CLASS_CHARGE_MODE,
     DEVICE_CLASS_CHARGE_STATE,
     DEVICE_CLASS_PLUG_STATE,
     DOMAIN,
@@ -121,7 +120,6 @@ MOCK_VEHICLES = {
         Platform.DEVICE_TRACKER: [],
         Platform.SELECT: [
             {
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_MODE,
                 ATTR_ENTITY_ID: "select.reg_number_charge_mode",
                 ATTR_ICON: "mdi:calendar-remove",
                 ATTR_OPTIONS: ["always", "always_charging", "schedule_mode"],
@@ -340,7 +338,6 @@ MOCK_VEHICLES = {
         ],
         Platform.SELECT: [
             {
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_MODE,
                 ATTR_ENTITY_ID: "select.reg_number_charge_mode",
                 ATTR_ICON: "mdi:calendar-clock",
                 ATTR_OPTIONS: ["always", "always_charging", "schedule_mode"],
@@ -559,7 +556,6 @@ MOCK_VEHICLES = {
         ],
         Platform.SELECT: [
             {
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_MODE,
                 ATTR_ENTITY_ID: "select.reg_number_charge_mode",
                 ATTR_ICON: "mdi:calendar-remove",
                 ATTR_OPTIONS: ["always", "always_charging", "schedule_mode"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes a custom device class showing up in Renault select entities.
No translations are using this device class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
