### PR TITLE
Validate state class and unit of measurement for non-numeric sensors

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -758,7 +758,6 @@ class SensorEntity(Entity):
         # should not have a state class or unit of measurement
         if device_class in {
             SensorDeviceClass.DATE,
-            SensorDeviceClass.DURATION,
             SensorDeviceClass.ENUM,
             SensorDeviceClass.TIMESTAMP,
         }:

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -243,7 +243,6 @@ async def test_setup_timestamp(
                 "method": "GET",
                 "value_template": "{{ value_json.key }}",
                 "device_class": SensorDeviceClass.TIMESTAMP,
-                "state_class": SensorStateClass.MEASUREMENT,
             }
         },
     )
@@ -255,7 +254,6 @@ async def test_setup_timestamp(
     state = hass.states.get("sensor.rest_sensor")
     assert state.state == "2021-11-11T11:39:00+00:00"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TIMESTAMP
-    assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.MEASUREMENT
     assert "sensor.rest_sensor rendered invalid timestamp" not in caplog.text
     assert "sensor.rest_sensor rendered timestamp without timezone" not in caplog.text
 

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1018,18 +1018,28 @@ async def test_invalid_enumeration_entity_without_device_class(
     ) in caplog.text
 
 
-async def test_invalid_enumeration_with_state_class(
+@pytest.mark.parametrize(
+    "device_class",
+    {
+        SensorDeviceClass.DATE,
+        SensorDeviceClass.DURATION,
+        SensorDeviceClass.ENUM,
+        SensorDeviceClass.TIMESTAMP,
+    },
+)
+async def test_non_numeric_device_class_with_state_class(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     enable_custom_integrations: None,
+    device_class: SensorDeviceClass,
 ):
-    """Test warning on numeric entities that provide an enum."""
+    """Test error on numeric entities that provide an state class."""
     platform = getattr(hass.components, "test.sensor")
     platform.init(empty=True)
     platform.ENTITIES["0"] = platform.MockSensor(
         name="Test",
-        native_value=42,
-        device_class=SensorDeviceClass.ENUM,
+        native_value=None,
+        device_class=device_class,
         state_class=SensorStateClass.MEASUREMENT,
         options=["option1", "option2"],
     )
@@ -1038,23 +1048,33 @@ async def test_invalid_enumeration_with_state_class(
     await hass.async_block_till_done()
 
     assert (
-        "Sensor sensor.test has an state_class and thus indicating "
-        "it has a numeric value; however, it has the enum device class"
+        "Sensor sensor.test has a state class and thus indicating it has a numeric "
+        f"value; however, it has the non-numeric device class: {device_class}"
     ) in caplog.text
 
 
-async def test_invalid_enumeration_with_unit_of_measurement(
+@pytest.mark.parametrize(
+    "device_class",
+    {
+        SensorDeviceClass.DATE,
+        SensorDeviceClass.DURATION,
+        SensorDeviceClass.ENUM,
+        SensorDeviceClass.TIMESTAMP,
+    },
+)
+async def test_non_numeric_device_class_with_unit_of_measurement(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     enable_custom_integrations: None,
+    device_class: SensorDeviceClass,
 ):
-    """Test warning on numeric entities that provide an enum."""
+    """Test error on numeric entities that provide an unit of measurement."""
     platform = getattr(hass.components, "test.sensor")
     platform.init(empty=True)
     platform.ENTITIES["0"] = platform.MockSensor(
         name="Test",
-        native_value=42,
-        device_class=SensorDeviceClass.ENUM,
+        native_value=None,
+        device_class=device_class,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         options=["option1", "option2"],
     )
@@ -1063,6 +1083,6 @@ async def test_invalid_enumeration_with_unit_of_measurement(
     await hass.async_block_till_done()
 
     assert (
-        "Sensor sensor.test has an unit of measurement and thus indicating "
-        "it has a numeric value; however, it has the enum device class"
+        "Sensor sensor.test has a unit of measurement and thus indicating it has "
+        f"a numeric value; however, it has the non-numeric device class: {device_class}"
     ) in caplog.text

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1022,7 +1022,6 @@ async def test_invalid_enumeration_entity_without_device_class(
     "device_class",
     {
         SensorDeviceClass.DATE,
-        SensorDeviceClass.DURATION,
         SensorDeviceClass.ENUM,
         SensorDeviceClass.TIMESTAMP,
     },
@@ -1057,7 +1056,6 @@ async def test_non_numeric_device_class_with_state_class(
     "device_class",
     {
         SensorDeviceClass.DATE,
-        SensorDeviceClass.DURATION,
         SensorDeviceClass.ENUM,
         SensorDeviceClass.TIMESTAMP,
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds additional state validation to the `sensor` entities.
When an entity has a device class defined, for which we know the value will be non-numeric, we'll ensure there is no `state_class` or `unit_of_measurement` set (as those only apply to numeric values).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
