### PR TITLE
Fix zwave_js_value_updated event

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -717,7 +717,7 @@ class NodeEvents:
 
         raw_value = value_ = value.value
         if value.metadata.states:
-            value_ = value.metadata.states.get(str(value), value_)
+            value_ = value.metadata.states.get(str(value_), value_)
 
         self.hass.bus.async_fire(
             ZWAVE_JS_VALUE_UPDATED_EVENT,

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -235,7 +235,6 @@ async def test_value_updated(hass, vision_security_zl7432, integration, client):
     """Test value updated events."""
     node = vision_security_zl7432
     # Add states to the value we are updating to ensure the translation happens
-    # assert node.values.keys() == []
     node.values["7-37-1-currentValue"].metadata.data["states"] = {"1": "on", "0": "off"}
     events = async_capture_events(hass, "zwave_js_value_updated")
 

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -234,6 +234,9 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
 async def test_value_updated(hass, vision_security_zl7432, integration, client):
     """Test value updated events."""
     node = vision_security_zl7432
+    # Add states to the value we are updating to ensure the translation happens
+    # assert node.values.keys() == []
+    node.values["7-37-1-currentValue"].metadata.data["states"] = {"1": "on", "0": "off"}
     events = async_capture_events(hass, "zwave_js_value_updated")
 
     event = Event(
@@ -266,7 +269,7 @@ async def test_value_updated(hass, vision_security_zl7432, integration, client):
     assert events[0].data["endpoint"] == 1
     assert events[0].data["property_name"] == "currentValue"
     assert events[0].data["property"] == "currentValue"
-    assert events[0].data["value"] == 1
+    assert events[0].data["value"] == "on"
     assert events[0].data["value_raw"] == 1
 
     # Try a value updated event on a value we aren't watching to make sure


### PR DESCRIPTION
## Proposed change
While adding test coverage I realized there was a bug in the logic to convert the new value to its friendly representation.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
