### PR TITLE
Prevent use of deprecated units

### DIFF
--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
+from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
     LENGTH,
     LENGTH_CENTIMETERS,
     LENGTH_FEET,

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
+# pylint: disable-next=unused-import,hass-deprecated-import
+from homeassistant.const import (  # noqa: F401
     LENGTH,
     LENGTH_CENTIMETERS,
     LENGTH_FEET,

--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -1,7 +1,8 @@
 """Pressure util functions."""
 from __future__ import annotations
 
-from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
+# pylint: disable-next=unused-import,hass-deprecated-import
+from homeassistant.const import (  # noqa: F401
     PRESSURE,
     PRESSURE_BAR,
     PRESSURE_CBAR,

--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -1,7 +1,7 @@
 """Pressure util functions."""
 from __future__ import annotations
 
-from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
+from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
     PRESSURE,
     PRESSURE_BAR,
     PRESSURE_CBAR,

--- a/homeassistant/util/speed.py
+++ b/homeassistant/util/speed.py
@@ -1,7 +1,8 @@
 """Distance util functions."""
 from __future__ import annotations
 
-from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
+# pylint: disable-next=unused-import,hass-deprecated-import
+from homeassistant.const import (  # noqa: F401
     SPEED,
     SPEED_FEET_PER_SECOND,
     SPEED_INCHES_PER_DAY,

--- a/homeassistant/util/speed.py
+++ b/homeassistant/util/speed.py
@@ -1,7 +1,7 @@
 """Distance util functions."""
 from __future__ import annotations
 
-from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
+from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
     SPEED,
     SPEED_FEET_PER_SECOND,
     SPEED_INCHES_PER_DAY,

--- a/homeassistant/util/temperature.py
+++ b/homeassistant/util/temperature.py
@@ -1,5 +1,6 @@
 """Temperature util functions."""
-from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
+# pylint: disable-next=unused-import,hass-deprecated-import
+from homeassistant.const import (  # noqa: F401
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
     TEMP_KELVIN,

--- a/homeassistant/util/temperature.py
+++ b/homeassistant/util/temperature.py
@@ -1,5 +1,5 @@
 """Temperature util functions."""
-from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
+from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
     TEMP_KELVIN,

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -1,7 +1,8 @@
 """Volume conversion util functions."""
 from __future__ import annotations
 
-from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
+# pylint: disable-next=unused-import,hass-deprecated-import
+from homeassistant.const import (  # noqa: F401
     UNIT_NOT_RECOGNIZED_TEMPLATE,
     VOLUME,
     VOLUME_CUBIC_FEET,

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -1,7 +1,7 @@
 """Volume conversion util functions."""
 from __future__ import annotations
 
-from homeassistant.const import (  # pylint: disable=unused-import # noqa: F401
+from homeassistant.const import (  # pylint: disable=unused-import,hass-deprecated-import # noqa: F401
     UNIT_NOT_RECOGNIZED_TEMPLATE,
     VOLUME,
     VOLUME_CUBIC_FEET,

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -325,6 +325,10 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
         # ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
+            constant=re.compile(r"^TIME_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
             constant=re.compile(r"^VOLUME_(\w*)$"),
         ),
     ],

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -260,16 +260,52 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
     ],
     "homeassistant.const": [
         ObsoleteImportMatch(
-            reason="replaced by SensorDeviceClass enum",
+            reason="replaced by local constants",
+            constant=re.compile(r"^CONF_UNIT_SYSTEM_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by ***DeviceClass enum",
             constant=re.compile(r"^DEVICE_CLASS_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^ENERGY_(\w*)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by EntityCategory enum",
             constant=re.compile(r"^(ENTITY_CATEGORY_(\w*))|(ENTITY_CATEGORIES)$"),
         ),
         ObsoleteImportMatch(
-            reason="replaced by local constants",
-            constant=re.compile(r"^(CONF_UNIT_SYSTEM_(\w*))$"),
+            reason="replaced by unit enums",
+            constant=re.compile(r"^LENGTH_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^MASS_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^POWER_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^PRECIPITATION_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^PRESSURE_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^SPEED_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^TEMP_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^VOLUME_(\w*)$"),
         ),
     ],
     "homeassistant.core": [

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -264,6 +264,10 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
             constant=re.compile(r"^CONF_UNIT_SYSTEM_(\w*)$"),
         ),
         ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^DATA_RATE_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
             reason="replaced by ***DeviceClass enum",
             constant=re.compile(r"^DEVICE_CLASS_(\w*)$"),
         ),
@@ -274,6 +278,10 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
         ObsoleteImportMatch(
             reason="replaced by EntityCategory enum",
             constant=re.compile(r"^(ENTITY_CATEGORY_(\w*))|(ENTITY_CATEGORIES)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^IRRADIATION_(\w*)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
@@ -297,12 +305,16 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^SPEED_(\w*)$"),
+            constant=re.compile(r"^SOUND_PRESSURE_(\w*)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^TEMP_(\w*)$"),
+            constant=re.compile(r"^SPEED_(\w*)$"),
         ),
+        # ObsoleteImportMatch(
+        #    reason="replaced by unit enums",
+        #    constant=re.compile(r"^TEMP_(\w*)$"),
+        # ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
             constant=re.compile(r"^VOLUME_(\w*)$"),

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -273,6 +273,10 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
+            constant=re.compile(r"^ELECTRIC_(\w*)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
             constant=re.compile(r"^ENERGY_(\w*)$"),
         ),
         ObsoleteImportMatch(

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -265,7 +265,7 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^DATA_RATE_(\w*)$"),
+            constant=re.compile(r"^DATA_(\w*)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by ***DeviceClass enum",
@@ -278,6 +278,10 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
         ObsoleteImportMatch(
             reason="replaced by EntityCategory enum",
             constant=re.compile(r"^(ENTITY_CATEGORY_(\w*))|(ENTITY_CATEGORIES)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^FREQUENCY_(\w*)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -261,75 +261,75 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
     "homeassistant.const": [
         ObsoleteImportMatch(
             reason="replaced by local constants",
-            constant=re.compile(r"^CONF_UNIT_SYSTEM_(\w*)$"),
+            constant=re.compile(r"^CONF_UNIT_SYSTEM_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^DATA_(\w*)$"),
+            constant=re.compile(r"^DATA_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by ***DeviceClass enum",
-            constant=re.compile(r"^DEVICE_CLASS_(\w*)$"),
+            constant=re.compile(r"^DEVICE_CLASS_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^ELECTRIC_(\w*)$"),
+            constant=re.compile(r"^ELECTRIC_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^ENERGY_(\w*)$"),
+            constant=re.compile(r"^ENERGY_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by EntityCategory enum",
-            constant=re.compile(r"^(ENTITY_CATEGORY_(\w*))|(ENTITY_CATEGORIES)$"),
+            constant=re.compile(r"^(ENTITY_CATEGORY_(\w+))|(ENTITY_CATEGORIES)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^FREQUENCY_(\w*)$"),
+            constant=re.compile(r"^FREQUENCY_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^IRRADIATION_(\w*)$"),
+            constant=re.compile(r"^IRRADIATION_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^LENGTH_(\w*)$"),
+            constant=re.compile(r"^LENGTH_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^MASS_(\w*)$"),
+            constant=re.compile(r"^MASS_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^POWER_(\w*)$"),
+            constant=re.compile(r"^POWER_(?!VOLT_AMPERE_REACTIVE)(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^PRECIPITATION_(\w*)$"),
+            constant=re.compile(r"^PRECIPITATION_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^PRESSURE_(\w*)$"),
+            constant=re.compile(r"^PRESSURE_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^SOUND_PRESSURE_(\w*)$"),
+            constant=re.compile(r"^SOUND_PRESSURE_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^SPEED_(\w*)$"),
-        ),
-        # ObsoleteImportMatch(
-        #    reason="replaced by unit enums",
-        #    constant=re.compile(r"^TEMP_(\w*)$"),
-        # ),
-        ObsoleteImportMatch(
-            reason="replaced by unit enums",
-            constant=re.compile(r"^TIME_(\w*)$"),
+            constant=re.compile(r"^SPEED_(\w+)$"),
         ),
         ObsoleteImportMatch(
             reason="replaced by unit enums",
-            constant=re.compile(r"^VOLUME_(\w*)$"),
+            constant=re.compile(r"^TEMP_(\w+)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^TIME_(\w+)$"),
+        ),
+        ObsoleteImportMatch(
+            reason="replaced by unit enums",
+            constant=re.compile(r"^VOLUME_(\w+)$"),
         ),
     ],
     "homeassistant.core": [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust pylint plugin to prevent use of deprecated units.
~~Ignore units deprecated after 2022.12 beta~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
