### PR TITLE
Tighten validation on calendar create event websocket

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -1,10 +1,11 @@
 """Support for Google Calendar event device sensors."""
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 import dataclasses
 import datetime
 from http import HTTPStatus
+from itertools import groupby
 import logging
 import re
 from typing import Any, cast, final
@@ -365,17 +366,49 @@ class CalendarListView(http.HomeAssistantView):
         return self.json(sorted(calendar_list, key=lambda x: cast(str, x["name"])))
 
 
+def _has_same_type(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Verify that all values are of the same type."""
+
+    def validate(obj: dict[str, Any]) -> dict[str, Any]:
+        """Test that all keys in the dict have values of the same type."""
+        uniq_values = groupby([type(obj[k]) for k in keys])
+        if len(list(uniq_values)) > 1:
+            raise vol.Invalid(f"Expected all values to be the same type: {keys}")
+        return obj
+
+    return validate
+
+
+def _is_sorted(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Verify that the specified values are sequential."""
+
+    def validate(obj: dict[str, Any]) -> dict[str, Any]:
+        """Test that all keys in the dict are in order."""
+        values = [obj[k] for k in keys]
+        if values != sorted(values):
+            raise vol.Invalid(f"Values were not in order: {values}")
+        return obj
+
+    return validate
+
+
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "calendar/event/create",
         vol.Required("entity_id"): cv.entity_id,
-        vol.Required(CONF_EVENT): {
-            vol.Required(EVENT_START): vol.Any(cv.date, cv.datetime),
-            vol.Required(EVENT_END): vol.Any(cv.date, cv.datetime),
-            vol.Required(EVENT_SUMMARY): cv.string,
-            vol.Optional(EVENT_DESCRIPTION): cv.string,
-            vol.Optional(EVENT_RRULE): _validate_rrule,
-        },
+        CONF_EVENT: vol.Schema(
+            vol.All(
+                {
+                    vol.Required(EVENT_START): vol.Any(cv.date, cv.datetime),
+                    vol.Required(EVENT_END): vol.Any(cv.date, cv.datetime),
+                    vol.Required(EVENT_SUMMARY): cv.string,
+                    vol.Optional(EVENT_DESCRIPTION): cv.string,
+                    vol.Optional(EVENT_RRULE): _validate_rrule,
+                },
+                _has_same_type(EVENT_START, EVENT_END),
+                _is_sorted(EVENT_START, EVENT_END),
+            )
+        ),
     }
 )
 @websocket_api.async_response

--- a/tests/components/local_calendar/test_calendar.py
+++ b/tests/components/local_calendar/test_calendar.py
@@ -682,3 +682,26 @@ async def test_invalid_recurrence_rule(
     assert "error" in result
     assert "code" in result.get("error")
     assert result["error"]["code"] == "invalid_format"
+
+
+async def test_invalid_date_formats(
+    ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
+):
+    """Exercises a validation error within rfc5545 parsing in ical."""
+    client = await ws_client()
+    result = await client.cmd(
+        "create",
+        {
+            "entity_id": TEST_ENTITY,
+            "event": {
+                "summary": "Bastille Day Party",
+                # Can't mix offset aware and floating dates
+                "dtstart": "1997-07-15T04:00:00+08:00",
+                "dtend": "1997-07-14T17:00:00",
+            },
+        },
+    )
+    assert not result.get("success")
+    assert "error" in result
+    assert "code" in result.get("error")
+    assert result["error"]["code"] == "invalid_format"

--- a/tests/components/local_calendar/test_calendar.py
+++ b/tests/components/local_calendar/test_calendar.py
@@ -612,3 +612,73 @@ async def test_all_day_iter_order(
 
     events = await get_events("2022-10-06T00:00:00Z", "2022-10-09T00:00:00Z")
     assert [event["summary"] for event in events] == event_order
+
+
+async def test_start_end_types(
+    ws_client: ClientFixture,
+    setup_integration: None,
+):
+    """Test a start and end with different date and date time types."""
+    client = await ws_client()
+    result = await client.cmd(
+        "create",
+        {
+            "entity_id": TEST_ENTITY,
+            "event": {
+                "summary": "Bastille Day Party",
+                "dtstart": "1997-07-15",
+                "dtend": "1997-07-14T17:00:00+00:00",
+            },
+        },
+    )
+    assert not result.get("success")
+    assert "error" in result
+    assert "code" in result.get("error")
+    assert result["error"]["code"] == "invalid_format"
+
+
+async def test_end_before_start(
+    ws_client: ClientFixture,
+    setup_integration: None,
+):
+    """Test an event with a start/end date time."""
+    client = await ws_client()
+    result = await client.cmd(
+        "create",
+        {
+            "entity_id": TEST_ENTITY,
+            "event": {
+                "summary": "Bastille Day Party",
+                "dtstart": "1997-07-15T04:00:00+00:00",
+                "dtend": "1997-07-14T17:00:00+00:00",
+            },
+        },
+    )
+    assert not result.get("success")
+    assert "error" in result
+    assert "code" in result.get("error")
+    assert result["error"]["code"] == "invalid_format"
+
+
+async def test_invalid_recurrence_rule(
+    ws_client: ClientFixture,
+    setup_integration: None,
+):
+    """Test an event with a recurrence rule."""
+    client = await ws_client()
+    result = await client.cmd(
+        "create",
+        {
+            "entity_id": TEST_ENTITY,
+            "event": {
+                "summary": "Monday meeting",
+                "dtstart": "2022-08-29T09:00:00",
+                "dtend": "2022-08-29T10:00:00",
+                "rrule": "FREQ=invalid;'",
+            },
+        },
+    )
+    assert not result.get("success")
+    assert "error" in result
+    assert "code" in result.get("error")
+    assert result["error"]["code"] == "invalid_format"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tighten validation on calendar create event websocket to be fail more loudly when out of order dates/times are specified. This would be defense in depth for things like the issue fixed in https://github.com/home-assistant/frontend/pull/14545
Debug information can also help give more clear error messages for #83401

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #83413
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
