### PR TITLE
Fix restored temperature values in Shelly climate platform

### DIFF
--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -163,7 +163,7 @@ class BlockSleepingClimate(
         if self.block is not None:
             return cast(float, self.block.targetTemp)
         # The restored value can be in Fahrenheit so we have to convert it to Celsius
-        # because we use this unit in integration.
+        # because we use this unit internally in integration.
         target_temp = self.last_state_attributes.get("temperature")
         if self.hass.config.units is US_CUSTOMARY_SYSTEM and target_temp:
             return TemperatureConverter.convert(
@@ -179,7 +179,7 @@ class BlockSleepingClimate(
         if self.block is not None:
             return cast(float, self.block.temp)
         # The restored value can be in Fahrenheit so we have to convert it to Celsius
-        # because we use this unit in integration.
+        # because we use this unit internally in integration.
         current_temp = self.last_state_attributes.get("current_temperature")
         if self.hass.config.units is US_CUSTOMARY_SYSTEM and current_temp:
             return TemperatureConverter.convert(

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -24,7 +24,8 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util.unit_system import METRIC_SYSTEM
+from homeassistant.util.unit_conversion import TemperatureConverter
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .const import LOGGER, SHTRV_01_TEMPERATURE_SETTINGS
 from .coordinator import ShellyBlockCoordinator, get_entry_data
@@ -127,10 +128,10 @@ class BlockSleepingClimate(
         self.last_state: State | None = None
         self.last_state_attributes: Mapping[str, Any]
         self._preset_modes: list[str] = []
-        if coordinator.hass.config.units is METRIC_SYSTEM:
-            self._last_target_temp = 20.0
-        else:
+        if coordinator.hass.config.units is US_CUSTOMARY_SYSTEM:
             self._last_target_temp = 68.0
+        else:
+            self._last_target_temp = 20.0
 
         if self.block is not None and self.device_block is not None:
             self._unique_id = f"{self.coordinator.mac}-{self.block.description}"
@@ -161,14 +162,32 @@ class BlockSleepingClimate(
         """Set target temperature."""
         if self.block is not None:
             return cast(float, self.block.targetTemp)
-        return self.last_state_attributes.get("temperature")
+        # The restored value can be in Fahrenheit so we have to convert it to Celsius
+        # because we use this unit in integration.
+        target_temp = self.last_state_attributes.get("temperature")
+        if self.hass.config.units is US_CUSTOMARY_SYSTEM and target_temp:
+            return TemperatureConverter.convert(
+                cast(float, target_temp),
+                UnitOfTemperature.FAHRENHEIT,
+                UnitOfTemperature.CELSIUS,
+            )
+        return target_temp
 
     @property
     def current_temperature(self) -> float | None:
         """Return current temperature."""
         if self.block is not None:
             return cast(float, self.block.temp)
-        return self.last_state_attributes.get("current_temperature")
+        # The restored value can be in Fahrenheit so we have to convert it to Celsius
+        # because we use this unit in integration.
+        current_temp = self.last_state_attributes.get("current_temperature")
+        if self.hass.config.units is US_CUSTOMARY_SYSTEM and current_temp:
+            return TemperatureConverter.convert(
+                cast(float, current_temp),
+                UnitOfTemperature.FAHRENHEIT,
+                UnitOfTemperature.CELSIUS,
+            )
+        return current_temp
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import LOGGER, SHTRV_01_TEMPERATURE_SETTINGS
 from .coordinator import ShellyBlockCoordinator, get_entry_data
@@ -126,7 +127,10 @@ class BlockSleepingClimate(
         self.last_state: State | None = None
         self.last_state_attributes: Mapping[str, Any]
         self._preset_modes: list[str] = []
-        self._last_target_temp = 20.0
+        if coordinator.hass.config.units is METRIC_SYSTEM:
+            self._last_target_temp = 20.0
+        else:
+            self._last_target_temp = 68.0
 
         if self.block is not None and self.device_block is not None:
             self._unique_id = f"{self.coordinator.mac}-{self.block.description}"

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -129,9 +129,13 @@ class BlockSleepingClimate(
         self.last_state_attributes: Mapping[str, Any]
         self._preset_modes: list[str] = []
         if coordinator.hass.config.units is US_CUSTOMARY_SYSTEM:
-            self._last_target_temp = 68.0
+            self._last_target_temp = TemperatureConverter.convert(
+                SHTRV_01_TEMPERATURE_SETTINGS["default"],
+                UnitOfTemperature.CELSIUS,
+                UnitOfTemperature.FAHRENHEIT,
+            )
         else:
-            self._last_target_temp = 20.0
+            self._last_target_temp = SHTRV_01_TEMPERATURE_SETTINGS["default"]
 
         if self.block is not None and self.device_block is not None:
             self._unique_id = f"{self.coordinator.mac}-{self.block.description}"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -147,6 +147,7 @@ SHTRV_01_TEMPERATURE_SETTINGS: Final = {
     "min": 4,
     "max": 31,
     "step": 0.5,
+    "default": 20.0,
 }
 
 # Kelvin value for colorTemp

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -21,6 +21,7 @@ from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNAVAILABLE
 from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import init_integration, register_device, register_entity
 
@@ -210,6 +211,53 @@ async def test_block_restored_climate(hass, mock_block_device, device_reg, monke
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == HVACMode.OFF
+
+
+async def test_block_restored_climate_us_customery(
+    hass, mock_block_device, device_reg, monkeypatch
+):
+    """Test block restored climate with US CUSTOMATY unit system."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    monkeypatch.delattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "targetTemp")
+    monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "valveError", 0)
+    entry = await init_integration(hass, 1, sleep_period=1000, skip_setup=True)
+    register_device(device_reg, entry)
+    entity_id = register_entity(
+        hass,
+        CLIMATE_DOMAIN,
+        "test_name",
+        "sensor_0",
+        entry,
+    )
+    attrs = {"current_temperature": 67, "temperature": 68}
+    mock_restore_cache(hass, [State(entity_id, HVACMode.HEAT, attributes=attrs)])
+
+    monkeypatch.setattr(mock_block_device, "initialized", False)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == HVACMode.HEAT
+    assert hass.states.get(entity_id).attributes.get("temperature") == 68
+    assert hass.states.get(entity_id).attributes.get("current_temperature") == 67
+
+    # Partial update, should not change state
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == HVACMode.HEAT
+    assert hass.states.get(entity_id).attributes.get("temperature") == 68
+    assert hass.states.get(entity_id).attributes.get("current_temperature") == 67
+
+    # Make device online
+    monkeypatch.setattr(mock_block_device, "initialized", True)
+    monkeypatch.setattr(mock_block_device.blocks[SENSOR_BLOCK_ID], "targetTemp", 19.7)
+    monkeypatch.setattr(mock_block_device.blocks[SENSOR_BLOCK_ID], "temp", 18.2)
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == HVACMode.HEAT
+    assert hass.states.get(entity_id).attributes.get("temperature") == 67
+    assert hass.states.get(entity_id).attributes.get("current_temperature") == 65
 
 
 async def test_block_restored_climate_unavailable(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, if the US customary system is used, when HA starts, the temperature values in F are restored from the registry and unnecessarily converted to F. This causes the temperature values to be very high after HA starts.
With this change, the values restored from the registry are converted to C so that high values do not appear.

Also, the default value of `last_target_temp` is now dependent on the unit system used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #82572
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
