### PR TITLE
Add ability to send custom keys to Samsung TV

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -49,7 +49,7 @@ from .const import (
     UPNP_SVC_RENDERING_CONTROL,
 )
 
-PLATFORMS = [Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE]
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -6,6 +6,7 @@ import asyncio
 from asyncio.exceptions import TimeoutError as AsyncioTimeoutError
 from collections.abc import Callable, Iterable, Mapping
 import contextlib
+from datetime import datetime, timedelta
 from typing import Any, Generic, TypeVar, cast
 
 from samsungctl import Remote
@@ -43,8 +44,10 @@ from homeassistant.const import (
     CONF_TOKEN,
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import entity_component
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_DESCRIPTION,
@@ -65,6 +68,13 @@ from .const import (
     VALUE_CONF_ID,
     VALUE_CONF_NAME,
     WEBSOCKET_PORTS,
+)
+
+# Since the TV will take a few seconds to go to sleep
+# and actually be seen as off, we need to wait just a bit
+# more than the next scan interval
+SCAN_INTERVAL_PLUS_OFF_TIME = entity_component.DEFAULT_SCAN_INTERVAL + timedelta(
+    seconds=5
 )
 
 KEY_PRESS_TIMEOUT = 1.2
@@ -161,6 +171,10 @@ class SamsungTVBridge(ABC):
         self._update_config_entry: Callable[[Mapping[str, Any]], None] | None = None
         self._app_list_callback: Callable[[dict[str, str]], None] | None = None
 
+        # Mark the end of a shutdown command (need to wait 15 seconds before
+        # sending the next command to avoid turning the TV back ON).
+        self._end_of_power_off: datetime | None = None
+
     def register_reauth_callback(self, func: CALLBACK_TYPE) -> None:
         """Register a callback function."""
         self._reauth_callback = func
@@ -203,8 +217,17 @@ class SamsungTVBridge(ABC):
     async def async_send_keys(self, keys: list[str]) -> None:
         """Send a list of keys to the tv."""
 
+    @property
+    def power_off_in_progress(self) -> bool:
+        """Return if power off has been recently requested."""
+        return (
+            self._end_of_power_off is not None
+            and self._end_of_power_off > dt_util.utcnow()
+        )
+
     async def async_power_off(self) -> None:
         """Send power off command to remote and close."""
+        self._end_of_power_off = dt_util.utcnow() + SCAN_INTERVAL_PLUS_OFF_TIME
         await self._async_send_power_off()
         # Force closing of remote session to provide instant UI feedback
         await self.async_close_remote()

--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -1,0 +1,32 @@
+"""Base SamsungTV Entity."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_MAC, CONF_MODEL, CONF_NAME
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import DeviceInfo, Entity
+
+from .bridge import SamsungTVBridge
+from .const import CONF_MANUFACTURER, DOMAIN
+
+
+class SamsungTVEntity(Entity):
+    """Defines a base SamsungTV entity."""
+
+    def __init__(self, *, bridge: SamsungTVBridge, config_entry: ConfigEntry) -> None:
+        """Initialize the SamsungTV entity."""
+        self._bridge = bridge
+        self._mac = config_entry.data.get(CONF_MAC)
+        self._attr_name = config_entry.data.get(CONF_NAME)
+        self._attr_unique_id = config_entry.unique_id
+        self._attr_device_info = DeviceInfo(
+            name=self.name,
+            manufacturer=config_entry.data.get(CONF_MANUFACTURER),
+            model=config_entry.data.get(CONF_MODEL),
+        )
+        if self.unique_id:
+            self._attr_device_info["identifiers"] = {(DOMAIN, self.unique_id)}
+        if self._mac:
+            self._attr_device_info["connections"] = {
+                (dr.CONNECTION_NETWORK_MAC, self._mac)
+            }

--- a/homeassistant/components/samsungtv/remote.py
+++ b/homeassistant/components/samsungtv/remote.py
@@ -35,9 +35,7 @@ class SamsungTVRemote(SamsungTVEntity, RemoteEntity):
         See https://github.com/jaruba/ha-samsungtv-tizen/blob/master/Key_codes.md
         """
         if self._bridge.power_off_in_progress:
-            LOGGER.info(
-                "TV is powering off, not sending command: %s", ",".join(command)
-            )
+            LOGGER.info("TV is powering off, not sending keys: %s", command)
             return
 
         num_repeats = kwargs[ATTR_NUM_REPEATS]

--- a/homeassistant/components/samsungtv/remote.py
+++ b/homeassistant/components/samsungtv/remote.py
@@ -1,0 +1,47 @@
+"""Support for the SamsungTV remote."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, LOGGER
+from .entity import SamsungTVEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the Samsung TV from a config entry."""
+    bridge = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([SamsungTVRemote(bridge=bridge, config_entry=entry)], True)
+
+
+class SamsungTVRemote(SamsungTVEntity, RemoteEntity):
+    """Device that sends commands to a SamsungTV."""
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        await self._bridge.async_power_off()
+
+    async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
+        """Send a command to a device.
+
+        Supported keys vary between models.
+        See https://github.com/jaruba/ha-samsungtv-tizen/blob/master/Key_codes.md
+        """
+        if self._bridge.power_off_in_progress:
+            LOGGER.info(
+                "TV is powering off, not sending command: %s", ",".join(command)
+            )
+            return
+
+        num_repeats = kwargs[ATTR_NUM_REPEATS]
+        command_list = list(command)
+
+        for _ in range(num_repeats):
+            await self._bridge.async_send_keys(command_list)

--- a/tests/components/samsungtv/test_remote.py
+++ b/tests/components/samsungtv/test_remote.py
@@ -1,7 +1,8 @@
 """The tests for the SamsungTV remote platform."""
-from unittest.mock import patch
+from unittest.mock import Mock
 
 import pytest
+from samsungtvws.encrypted.remote import SamsungTVEncryptedCommand
 
 from homeassistant.components.remote import (
     ATTR_COMMAND,
@@ -18,12 +19,14 @@ from .test_media_player import MOCK_ENTRYDATA_ENCRYPTED_WS
 ENTITY_ID = f"{REMOTE_DOMAIN}.fake"
 
 
+@pytest.mark.usefixtures("remoteencws", "rest_api")
 async def test_setup(hass: HomeAssistant) -> None:
     """Test setup with basic config."""
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
     assert hass.states.get(ENTITY_ID)
 
 
+@pytest.mark.usefixtures("remoteencws", "rest_api")
 async def test_unique_id(hass: HomeAssistant) -> None:
     """Test unique id."""
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
@@ -34,29 +37,57 @@ async def test_unique_id(hass: HomeAssistant) -> None:
     assert main.unique_id == "any"
 
 
-@pytest.mark.usefixtures("rest_api")
-async def test_main_services(hass: HomeAssistant) -> None:
-    """Test the different services."""
+@pytest.mark.usefixtures("remoteencws", "rest_api")
+async def test_main_services(
+    hass: HomeAssistant, remoteencws: Mock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test for turn_off."""
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
 
-    with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVEncryptedBridge.async_power_off"
-    ) as remote_mock:
-        await hass.services.async_call(
-            REMOTE_DOMAIN,
-            SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: ENTITY_ID},
-            blocking=True,
-        )
-        remote_mock.assert_called_once()
+    remoteencws.send_commands.reset_mock()
 
-    with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVEncryptedBridge.async_send_keys"
-    ) as remote_mock:
-        await hass.services.async_call(
-            REMOTE_DOMAIN,
-            SERVICE_SEND_COMMAND,
-            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["dash"]},
-            blocking=True,
-        )
-        remote_mock.assert_called_once_with(["dash"])
+    assert await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    # key called
+    assert remoteencws.send_commands.call_count == 1
+    commands = remoteencws.send_commands.call_args_list[0].args[0]
+    assert len(commands) == 2
+    assert isinstance(command := commands[0], SamsungTVEncryptedCommand)
+    assert command.body["param3"] == "KEY_POWEROFF"
+    assert isinstance(command := commands[1], SamsungTVEncryptedCommand)
+    assert command.body["param3"] == "KEY_POWER"
+
+    # commands not sent : power off in progress
+    remoteencws.send_commands.reset_mock()
+    assert await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["dash"]},
+        blocking=True,
+    )
+    assert "TV is powering off, not sending keys: ['dash']" in caplog.text
+    remoteencws.send_commands.assert_not_called()
+
+
+@pytest.mark.usefixtures("remoteencws", "rest_api")
+async def test_send_command_service(hass: HomeAssistant, remoteencws: Mock) -> None:
+    """Test the send command."""
+    await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
+
+    assert await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["dash"]},
+        blocking=True,
+    )
+
+    assert remoteencws.send_commands.call_count == 1
+    commands = remoteencws.send_commands.call_args_list[0].args[0]
+    assert len(commands) == 1
+    assert isinstance(command := commands[0], SamsungTVEncryptedCommand)
+    assert command.body["param3"] == "dash"

--- a/tests/components/samsungtv/test_remote.py
+++ b/tests/components/samsungtv/test_remote.py
@@ -1,0 +1,62 @@
+"""The tests for the SamsungTV remote platform."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.remote import (
+    ATTR_COMMAND,
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_SEND_COMMAND,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_samsungtv_entry
+from .test_media_player import MOCK_ENTRYDATA_ENCRYPTED_WS
+
+ENTITY_ID = f"{REMOTE_DOMAIN}.fake"
+
+
+async def test_setup(hass: HomeAssistant) -> None:
+    """Test setup with basic config."""
+    await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
+    assert hass.states.get(ENTITY_ID)
+
+
+async def test_unique_id(hass: HomeAssistant) -> None:
+    """Test unique id."""
+    await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
+
+    entity_registry = er.async_get(hass)
+
+    main = entity_registry.async_get(ENTITY_ID)
+    assert main.unique_id == "any"
+
+
+@pytest.mark.usefixtures("rest_api")
+async def test_main_services(hass: HomeAssistant) -> None:
+    """Test the different services."""
+    await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
+
+    with patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVEncryptedBridge.async_power_off"
+    ) as remote_mock:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+        remote_mock.assert_called_once()
+
+    with patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVEncryptedBridge.async_send_keys"
+    ) as remote_mock:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["dash"]},
+            blocking=True,
+        )
+        remote_mock.assert_called_once_with(["dash"])


### PR DESCRIPTION
## Proposed change

Add a Remote entity to the samsungtv component to support sending custom keys directly via the remote. 

This enables more complex interactions with the older not-so-smart Samsung TVs. E.g., the picture can be turned off to make the TV a music player by driving the remote control directly with a remote control command such as `KEY_MENU, KEY_RIGHT, KEY_UP, KEY_UP, KEY_ENTER`.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25618

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
