### PR TITLE
Handle Twinkly devices without movies 

### DIFF
--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -31,3 +31,5 @@ HIDDEN_DEV_VALUES = (
 
 # Minimum version required to support effects
 MIN_EFFECT_VERSION = "2.7.1"
+
+TWINKLY_RETURN_CODE_OK = "1000"

--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -32,4 +32,5 @@ HIDDEN_DEV_VALUES = (
 # Minimum version required to support effects
 MIN_EFFECT_VERSION = "2.7.1"
 
-TWINKLY_RETURN_CODE_OK = "1000"
+TWINKLY_RETURN_CODE = "code"
+TWINKLY_RETURN_CODE_OK = 1000

--- a/homeassistant/components/twinkly/exceptions.py
+++ b/homeassistant/components/twinkly/exceptions.py
@@ -3,8 +3,3 @@
 
 class TwinklyError(ValueError):
     """Error from the API."""
-
-    def __init__(self, message: str, response=None) -> None:
-        """Initiate the exception."""
-        self.message = message
-        self.response = response

--- a/homeassistant/components/twinkly/exceptions.py
+++ b/homeassistant/components/twinkly/exceptions.py
@@ -1,0 +1,10 @@
+"""Exceptions for Twinkly."""
+
+
+class TwinklyError(ValueError):
+    """Error from the API."""
+
+    def __init__(self, message: str, response=None) -> None:
+        """Initiate the exception."""
+        self.message = message
+        self.response = response

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from aiohttp import ClientError
 from awesomeversion import AwesomeVersion
-from ttls.client import Twinkly
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -41,10 +40,9 @@ from .const import (
     DOMAIN,
     HIDDEN_DEV_VALUES,
     MIN_EFFECT_VERSION,
-    TWINKLY_RETURN_CODE,
-    TWINKLY_RETURN_CODE_OK,
 )
 from .exceptions import TwinklyError
+from .twinkly_wrapper import TwinklyWrapper
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,44 +76,13 @@ def twinkly_function(func):
     return twinkly_command
 
 
-class TwinklyWrapper(Twinkly):
-    """Wrap Twinkly to validate responses."""
-
-    def _valid_response(
-        self, response: dict[Any, Any], check_for: str | None = None
-    ) -> dict[Any, Any]:
-        """Validate twinkly-responses from the API."""
-        if (
-            response
-            and response.get(TWINKLY_RETURN_CODE) == TWINKLY_RETURN_CODE_OK
-            and (not check_for or check_for in response)
-        ):
-            _LOGGER.debug("Twinkly response: %s", response)
-            return response
-        raise TwinklyError(f"Invalid response from Twinkly: {response}")
-
-    async def get_saved_movies(self):
-        """Get saved movies."""
-        return self._valid_response(
-            await super().get_saved_movies(), check_for="movies"
-        )
-
-    async def get_current_movie(self):
-        """Get current active movie."""
-        return self._valid_response(await super().get_current_movie())
-
-    async def get_current_colour(self):
-        """Get current set color."""
-        return self._valid_response(await super().get_current_colour())
-
-
 class TwinklyLight(LightEntity):
     """Implementation of the light for the Twinkly service."""
 
     def __init__(
         self,
         conf: ConfigEntry,
-        client: Twinkly,
+        client: TwinklyWrapper,
         device_info,
     ) -> None:
         """Initialize a TwinklyLight entity."""

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -222,7 +222,6 @@ class TwinklyLight(LightEntity):
                 await self._client.set_mode("movie")
                 self._client.default_mode = "movie"
             self._attr_rgbw_color = kwargs[ATTR_RGBW_COLOR]
-
         if ATTR_RGB_COLOR in kwargs and kwargs[ATTR_RGB_COLOR] != self._attr_rgb_color:
 
             await self._client.interview()
@@ -305,9 +304,8 @@ class TwinklyLight(LightEntity):
                 await self.async_update_movies()
                 await self.async_update_current_movie()
                 await self.async_update_current_color()
-                _LOGGER.debug("Sett mode color: %s", self._movies)
                 if len(self._movies) == 0:
-                    self._client.default_mode = "color"
+                    self._client.default_mode = "effect"
 
             if not self._is_available:
                 _LOGGER.info("Twinkly '%s' is now available", self._client.host)
@@ -339,8 +337,7 @@ class TwinklyLight(LightEntity):
 
     async def async_update_current_color(self) -> None:
         """Update the current active color."""
-        # pylint: disable=protected-access
-        current_color = await self._client._get("led/color")
+        current_color = await self._client.get_current_colour()
         _LOGGER.debug("Current color: %s", current_color)
         if int(current_color.get("code")) == 1000:
             if self._attr_color_mode == ColorMode.RGBW:

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -304,6 +304,10 @@ class TwinklyLight(LightEntity):
             if LightEntityFeature.EFFECT & self.supported_features:
                 await self.async_update_movies()
                 await self.async_update_current_movie()
+                await self.async_update_current_color()
+                _LOGGER.debug("Sett mode color: %s", self._movies)
+                if len(self._movies) == 0:
+                    self._client.default_mode = "color"
 
             if not self._is_available:
                 _LOGGER.info("Twinkly '%s' is now available", self._client.host)
@@ -332,3 +336,23 @@ class TwinklyLight(LightEntity):
         _LOGGER.debug("Current movie: %s", current_movie)
         if current_movie and "id" in current_movie:
             self._current_movie = current_movie
+
+    async def async_update_current_color(self) -> None:
+        """Update the current active color."""
+        # pylint: disable=protected-access
+        current_color = await self._client._get("led/color")
+        _LOGGER.debug("Current color: %s", current_color)
+        if int(current_color.get("code")) == 1000:
+            if self._attr_color_mode == ColorMode.RGBW:
+                self._attr_rgbw_color = (
+                    current_color["red"],
+                    current_color["green"],
+                    current_color["blue"],
+                    0,
+                )
+            elif self._attr_color_mode == ColorMode.RGB:
+                self._attr_rgb_color = (
+                    current_color["red"],
+                    current_color["green"],
+                    current_color["blue"],
+                )

--- a/homeassistant/components/twinkly/manifest.json
+++ b/homeassistant/components/twinkly/manifest.json
@@ -2,7 +2,7 @@
   "domain": "twinkly",
   "name": "Twinkly",
   "documentation": "https://www.home-assistant.io/integrations/twinkly",
-  "requirements": ["ttls==1.5.1"],
+  "requirements": ["ttls==1.6.1"],
   "codeowners": ["@dr1rrb", "@Robbie1221"],
   "config_flow": true,
   "dhcp": [{ "hostname": "twinkly_*" }],

--- a/homeassistant/components/twinkly/twinkly_wrapper.py
+++ b/homeassistant/components/twinkly/twinkly_wrapper.py
@@ -1,0 +1,43 @@
+"""Simple wrapper for the Twinkly API."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ttls.client import Twinkly
+
+from .const import TWINKLY_RETURN_CODE, TWINKLY_RETURN_CODE_OK
+from .exceptions import TwinklyError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TwinklyWrapper(Twinkly):
+    """Wrap Twinkly to validate responses."""
+
+    def _valid_response(
+        self, response: dict[Any, Any], check_for: str | None = None
+    ) -> dict[Any, Any]:
+        """Validate twinkly-responses from the API."""
+        if (
+            response
+            and response.get(TWINKLY_RETURN_CODE) == TWINKLY_RETURN_CODE_OK
+            and (not check_for or check_for in response)
+        ):
+            _LOGGER.debug("Twinkly response: %s", response)
+            return response
+        raise TwinklyError(f"Invalid response from Twinkly: {response}")
+
+    async def get_saved_movies(self):
+        """Get saved movies."""
+        return self._valid_response(
+            await super().get_saved_movies(), check_for="movies"
+        )
+
+    async def get_current_movie(self):
+        """Get current active movie."""
+        return self._valid_response(await super().get_current_movie())
+
+    async def get_current_colour(self):
+        """Get current set color."""
+        return self._valid_response(await super().get_current_colour())

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2466,7 +2466,7 @@ tp-connected==0.0.4
 transmissionrpc==0.11
 
 # homeassistant.components.twinkly
-ttls==1.5.1
+ttls==1.6.1
 
 # homeassistant.components.tuya
 tuya-iot-py-sdk==0.6.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1703,7 +1703,7 @@ total_connect_client==2022.10
 transmissionrpc==0.11
 
 # homeassistant.components.twinkly
-ttls==1.5.1
+ttls==1.6.1
 
 # homeassistant.components.tuya
 tuya-iot-py-sdk==0.6.6

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -37,6 +37,7 @@ class ClientMock:
             "device_name": self.id,  # we make sure that entity id is different for each test
             "product_code": TEST_MODEL,
         }
+        self.mock_twinkly_error = False
 
     @property
     def host(self) -> str:
@@ -86,8 +87,9 @@ class ClientMock:
 
     async def set_static_colour(self, colour) -> None:
         """Set static color."""
-        self.color = colour
-        self.default_mode = "color"
+        if not self.mock_twinkly_error:
+            self.color = colour
+            self.default_mode = "color"
 
     async def set_cycle_colours(self, colour) -> None:
         """Set static color."""
@@ -123,8 +125,11 @@ class ClientMock:
 
     async def get_current_colour(self) -> dict:
         """Get current color."""
+        return_code = 1000
+        if self.mock_twinkly_error:
+            return_code = 500
         return {
-            "code": 1000,
+            "code": return_code,
             "red": int(self.color[0]),
             "green": int(self.color[1]),
             "blue": int(self.color[1]),

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -23,7 +23,8 @@ class ClientMock:
         self.brightness = {"mode": "enabled", "value": 10}
         self.color = (255, 255, 255)
         self.movies = {
-            "movies": [{"id": 1, "name": "Rainbow"}, {"id": 2, "name": "Flare"}]
+            "code": 1000,
+            "movies": [{"id": 1, "name": "Rainbow"}, {"id": 2, "name": "Flare"}],
         }
         self.current_movie = {}
         self.default_mode = "movie"
@@ -106,7 +107,7 @@ class ClientMock:
 
     async def set_current_movie(self, movie_id: int) -> dict:
         """Set current movie."""
-        self.current_movie = {"id": movie_id}
+        self.current_movie = {"code": 1000, "id": movie_id}
 
     async def set_mode(self, mode: str) -> None:
         """Set mode."""
@@ -118,7 +119,7 @@ class ClientMock:
 
     async def get_firmware_version(self) -> dict:
         """Get firmware version."""
-        return {"version": self.version}
+        return {"code": 1000, "version": self.version}
 
     async def get_current_colour(self) -> dict:
         """Get current color."""

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -21,7 +21,7 @@ class ClientMock:
         self.is_offline = False
         self.state = True
         self.brightness = {"mode": "enabled", "value": 10}
-        self.color = None
+        self.color = (255, 255, 255)
         self.movies = {
             "movies": [{"id": 1, "name": "Rainbow"}, {"id": 2, "name": "Flare"}]
         }
@@ -120,5 +120,11 @@ class ClientMock:
         """Get firmware version."""
         return {"version": self.version}
 
-    async def _get(self, url) -> dict:
-        return {"code": 1000, "red": 255, "green": 255, "blue": 255}
+    async def get_current_colour(self) -> dict:
+        """Get current color."""
+        return {
+            "code": 1000,
+            "red": int(self.color[0]),
+            "green": int(self.color[1]),
+            "blue": int(self.color[1]),
+        }

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -22,7 +22,9 @@ class ClientMock:
         self.state = True
         self.brightness = {"mode": "enabled", "value": 10}
         self.color = None
-        self.movies = [{"id": 1, "name": "Rainbow"}, {"id": 2, "name": "Flare"}]
+        self.movies = {
+            "movies": [{"id": 1, "name": "Rainbow"}, {"id": 2, "name": "Flare"}]
+        }
         self.current_movie = {}
         self.default_mode = "movie"
         self.mode = None
@@ -117,3 +119,6 @@ class ClientMock:
     async def get_firmware_version(self) -> dict:
         """Get firmware version."""
         return {"version": self.version}
+
+    async def _get(self, url) -> dict:
+        return {"code": 1000, "red": 255, "green": 255, "blue": 255}

--- a/tests/components/twinkly/test_config_flow.py
+++ b/tests/components/twinkly/test_config_flow.py
@@ -21,7 +21,8 @@ async def test_invalid_host(hass):
     client = ClientMock()
     client.is_offline = True
     with patch(
-        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+        "homeassistant.components.twinkly.config_flow.TwinklyWrapper",
+        return_value=client,
     ):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -43,7 +44,8 @@ async def test_success_flow(hass):
     """Test that an entity is created when the flow completes."""
     client = ClientMock()
     with patch(
-        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+        "homeassistant.components.twinkly.config_flow.TwinklyWrapper",
+        return_value=client,
     ), patch("homeassistant.components.twinkly.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -72,7 +74,8 @@ async def test_dhcp_can_confirm(hass):
     """Test DHCP discovery flow can confirm right away."""
     client = ClientMock()
     with patch(
-        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+        "homeassistant.components.twinkly.config_flow.TwinklyWrapper",
+        return_value=client,
     ):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN,
@@ -93,7 +96,8 @@ async def test_dhcp_success(hass):
     """Test DHCP discovery flow success."""
     client = ClientMock()
     with patch(
-        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+        "homeassistant.components.twinkly.config_flow.TwinklyWrapper",
+        return_value=client,
     ), patch("homeassistant.components.twinkly.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN,
@@ -138,7 +142,8 @@ async def test_dhcp_already_exists(hass):
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+        "homeassistant.components.twinkly.config_flow.TwinklyWrapper",
+        return_value=client,
     ):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN,

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -291,7 +291,7 @@ async def test_turn_on_without_movies(hass: HomeAssistant):
         LightEntityFeature.EFFECT
         & hass.states.get(entity.entity_id).attributes["supported_features"]
     )
-    assert client.default_mode == "color"
+    assert client.default_mode == "effect"
 
     await hass.services.async_call(
         "light",
@@ -303,7 +303,7 @@ async def test_turn_on_without_movies(hass: HomeAssistant):
     state = hass.states.get(entity.entity_id)
 
     assert state.state == "on"
-    assert state.attributes["rgb_color"] == (255, 255, 255)
+    assert client.default_mode == "effect"
 
 
 async def test_turn_off(hass: HomeAssistant):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If the user has not added any movies, he is currently not able to turn the Twinkly on from HA.
This fix assures that it can be turned on also without any movies set.

TTLS was updated to handle getting the current color set on the device.
https://github.com/jschlyter/ttls/releases

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #82874
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
