### PR TITLE
Twinkly preinstalled effects

### DIFF
--- a/homeassistant/components/twinkly/__init__.py
+++ b/homeassistant/components/twinkly/__init__.py
@@ -37,8 +37,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id][DATA_DEVICE_INFO] = device_info
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     return True
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
+    """Handle options update."""
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/twinkly/__init__.py
+++ b/homeassistant/components/twinkly/__init__.py
@@ -37,13 +37,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id][DATA_DEVICE_INFO] = device_info
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     return True
-
-
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
-    """Handle options update."""
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -23,6 +23,10 @@ DEV_PROFILE_RGBW = "RGBW"
 DATA_CLIENT = "client"
 DATA_DEVICE_INFO = "device_info"
 
+MODE_COLOR = "color"
+MODE_EFFECT = "effect"
+MODE_MOVIE = "movie"
+
 HIDDEN_DEV_VALUES = (
     "code",  # This is the internal status code of the API response
     "copyright",  # We should not display a copyright "LEDWORKS 2018" in the Home-Assistant UI

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -172,7 +172,7 @@ class TwinklyLight(LightEntity):
         effect_list = []
         _LOGGER.debug("Config: %s", self._conf)
         for i in range(self._effets_number):
-            effect_list.append(f"Effect {i + 1}")
+            effect_list.append(f"{ATTR_EFFECT.capitalize()} {i + 1}")
         for movie in self._movies:
             effect_list.append(f"{movie['id']} {movie['name']}")
         return effect_list
@@ -258,13 +258,23 @@ class TwinklyLight(LightEntity):
             and LightEntityFeature.EFFECT & self.supported_features
         ):
             movie_id = kwargs[ATTR_EFFECT].split(" ")[0]
-            if movie_id == "Effect":
+            if movie_id.lower() == ATTR_EFFECT:
                 effect_id = kwargs[ATTR_EFFECT].split(" ")[1]
                 await self.async_set_effect(int(effect_id) - 1)
-            elif "id" not in self._current_movie or int(movie_id) != int(
-                self._current_movie["id"]
+                self._client.default_mode = MODE_EFFECT
+                _LOGGER.debug("Setting effect mode %s", effect_id)
+            elif (
+                self._client.default_mode != MODE_MOVIE
+                or self._client.default_mode == MODE_MOVIE
+                and (
+                    "id" not in self._current_movie
+                    or int(movie_id) != int(self._current_movie["id"])
+                )
             ):
+
+                _LOGGER.debug("Setting move mode %s", movie_id)
                 await self.async_set_movie(int(movie_id))
+                self._client.default_mode = MODE_MOVIE
 
         if not self._is_on:
             await self._client.turn_on()

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -79,11 +79,11 @@ class TwinklyLight(LightEntity):
         if device_info.get(DEV_LED_PROFILE) == DEV_PROFILE_RGBW:
             self._attr_supported_color_modes = {ColorMode.RGBW}
             self._attr_color_mode = ColorMode.RGBW
-            self._attr_rgbw_color = (255, 255, 255, 0)
+            self._attr_rgbw_color = None
         elif device_info.get(DEV_LED_PROFILE) == DEV_PROFILE_RGB:
             self._attr_supported_color_modes = {ColorMode.RGB}
             self._attr_color_mode = ColorMode.RGB
-            self._attr_rgb_color = (255, 255, 255)
+            self._attr_rgb_color = None
         else:
             self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
             self._attr_color_mode = ColorMode.BRIGHTNESS
@@ -261,8 +261,8 @@ class TwinklyLight(LightEntity):
             if movie_id.lower() == ATTR_EFFECT:
                 effect_id = kwargs[ATTR_EFFECT].split(" ")[1]
                 await self.async_set_effect(int(effect_id) - 1)
+                await self._client.set_mode(MODE_EFFECT)
                 self._client.default_mode = MODE_EFFECT
-                _LOGGER.debug("Setting effect mode %s", effect_id)
             elif (
                 self._client.default_mode != MODE_MOVIE
                 or self._client.default_mode == MODE_MOVIE
@@ -272,9 +272,11 @@ class TwinklyLight(LightEntity):
                 )
             ):
 
-                _LOGGER.debug("Setting move mode %s", movie_id)
                 await self.async_set_movie(int(movie_id))
+                await self._client.set_mode(MODE_MOVIE)
                 self._client.default_mode = MODE_MOVIE
+            self._attr_rgb_color = None
+            self._attr_rgbw_color = None
 
         if not self._is_on:
             await self._client.turn_on()

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -353,15 +353,13 @@ class TwinklyLight(LightEntity):
 
     async def async_update_effects(self) -> None:
         """Update the number of effects."""
-        # pylint: disable=protected-access
-        effects = await self._client._get("led/effects")
+        effects = await self._client.get_predefined_effects()
         if "effects_number" in effects:
             self._effets_number = effects["effects_number"]
 
     async def async_update_current_effect(self) -> None:
         """Update current effect."""
-        # pylint: disable=protected-access
-        current_effect = await self._client._get("led/effects/current")
+        current_effect = await self._client.get_current_predefined_effect()
         _LOGGER.debug("Current effect: %s", current_effect)
         # Seems to have changed name sometime
         if "effect_id" in current_effect:
@@ -379,11 +377,6 @@ class TwinklyLight(LightEntity):
     async def async_set_effect(self, effect_id: int) -> None:
         """Set current effect."""
         await self._client.interview()
-        # await self._client.set_current_effect(int(effect_id))
-        # pylint: disable=protected-access
-        await self._client._post(
-            "led/effects/current",
-            json={"effect_id": int(effect_id)},
-        )
+        await self._client.set_current_predefined_effect(int(effect_id))
         await self._client.set_mode(MODE_EFFECT)
         self._client.default_mode = MODE_EFFECT

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -170,6 +170,7 @@ class TwinklyLight(LightEntity):
     def effect_list(self) -> list[str]:
         """Return the list of saved effects."""
         effect_list = []
+        _LOGGER.debug("Config: %s", self._conf)
         for i in range(self._effets_number):
             effect_list.append(f"Effect {i + 1}")
         for movie in self._movies:

--- a/homeassistant/components/twinkly/manifest.json
+++ b/homeassistant/components/twinkly/manifest.json
@@ -2,7 +2,7 @@
   "domain": "twinkly",
   "name": "Twinkly",
   "documentation": "https://www.home-assistant.io/integrations/twinkly",
-  "requirements": ["ttls==1.5.1"],
+  "requirements": ["ttls==1.6.1"],
   "codeowners": ["@dr1rrb", "@Robbie1221"],
   "config_flow": true,
   "dhcp": [{ "hostname": "twinkly_*" }],

--- a/homeassistant/components/twinkly/strings.json
+++ b/homeassistant/components/twinkly/strings.json
@@ -16,5 +16,14 @@
     "abort": {
       "device_exists": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "show_predefined_effects": "Show pre-defined effects"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/twinkly/translations/en.json
+++ b/homeassistant/components/twinkly/translations/en.json
@@ -16,5 +16,14 @@
                 }
             }
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "show_predefined_effects": "Show pre-defined effects"
+                }
+            }
+        }
     }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2466,7 +2466,7 @@ tp-connected==0.0.4
 transmissionrpc==0.11
 
 # homeassistant.components.twinkly
-ttls==1.5.1
+ttls==1.6.1
 
 # homeassistant.components.tuya
 tuya-iot-py-sdk==0.6.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1703,7 +1703,7 @@ total_connect_client==2022.10
 transmissionrpc==0.11
 
 # homeassistant.components.twinkly
-ttls==1.5.1
+ttls==1.6.1
 
 # homeassistant.components.tuya
 tuya-iot-py-sdk==0.6.6

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -105,7 +105,9 @@ class ClientMock:
 
     async def set_current_movie(self, movie_id: int) -> dict:
         """Set current movie."""
-        self.current_movie = {"id": movie_id}
+        for movie in self.movies:
+            if movie["id"] == movie_id:
+                self.current_movie = {"id": movie_id, "name": movie["name"]}
 
     async def set_mode(self, mode: str) -> None:
         """Set mode."""
@@ -134,4 +136,4 @@ class ClientMock:
     async def set_current_predefined_effect(self, effect_id: int) -> None:
         """Set current effect."""
         self.current_effect = {"effect_id": effect_id}
-        return self.get_current_predefined_effect()
+        return await self.get_current_predefined_effect()

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -123,27 +123,15 @@ class ClientMock:
         """Get current mode."""
         return {"mode": self.mode}
 
-    async def get_effects(self) -> dict:
+    async def get_predefined_effects(self) -> dict:
         """Get number of predefined effects."""
         return {"effects_number": 5}
 
-    async def get_current_effect(self) -> dict:
+    async def get_current_predefined_effect(self) -> dict:
         """Get current predefined effect."""
         return self.current_effect
 
-    async def set_current_effect(self, effect_id: int) -> None:
+    async def set_current_predefined_effect(self, effect_id: int) -> None:
         """Set current effect."""
         self.current_effect = {"effect_id": effect_id}
-        return self.get_current_effect()
-
-    async def _get(self, url: str) -> dict:
-        """Temp function to pass tests."""
-        if url == "led/effects":
-            return await self.get_effects()
-        if url == "led/effects/current":
-            return await self.get_current_effect()
-
-    async def _post(self, url: str, json=dict) -> dict:
-        """Temp function to pass tests."""
-        if url == "led/effects/current":
-            return await self.set_current_effect(effect_id=json.get("effect_id"))
+        return self.get_current_predefined_effect()

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -24,6 +24,7 @@ class ClientMock:
         self.color = None
         self.movies = [{"id": 1, "name": "Rainbow"}, {"id": 2, "name": "Flare"}]
         self.current_movie = {}
+        self.current_effect = {}
         self.default_mode = "movie"
         self.mode = None
         self.version = "2.8.10"
@@ -117,3 +118,32 @@ class ClientMock:
     async def get_firmware_version(self) -> dict:
         """Get firmware version."""
         return {"version": self.version}
+
+    async def get_mode(self) -> dict:
+        """Get current mode."""
+        return {"mode": self.mode}
+
+    async def get_effects(self) -> dict:
+        """Get number of predefined effects."""
+        return {"effects_number": 5}
+
+    async def get_current_effect(self) -> dict:
+        """Get current predefined effect."""
+        return self.current_effect
+
+    async def set_current_effect(self, effect_id: int) -> None:
+        """Set current effect."""
+        self.current_effect = {"effect_id": effect_id}
+        return self.get_current_effect()
+
+    async def _get(self, url: str) -> dict:
+        """Temp function to pass tests."""
+        if url == "led/effects":
+            return await self.get_effects()
+        if url == "led/effects/current":
+            return await self.get_current_effect()
+
+    async def _post(self, url: str, json=dict) -> dict:
+        """Temp function to pass tests."""
+        if url == "led/effects/current":
+            return await self.set_current_effect(effect_id=json.get("effect_id"))

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -173,6 +173,20 @@ async def test_turn_on_with_effect(hass: HomeAssistant):
     await hass.services.async_call(
         "light",
         "turn_on",
+        service_data={"entity_id": entity.entity_id, "effect": "Effect 3"},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity.entity_id)
+
+    assert state.state == "on"
+    assert client.current_effect["effect_id"] == 2
+    assert client.default_mode == "effect"
+    assert client.mode == "effect"
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
         service_data={"entity_id": entity.entity_id, "effect": "1 Rainbow"},
         blocking=True,
     )
@@ -259,6 +273,14 @@ async def test_turn_on_with_effect_missing_effects(hass: HomeAssistant):
     assert (
         not LightEntityFeature.EFFECT
         & hass.states.get(entity.entity_id).attributes["supported_features"]
+    )
+
+    # Turn on with color first to initiate values
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        service_data={"entity_id": entity.entity_id, "rgb_color": (128, 64, 32)},
+        blocking=True,
     )
 
     await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding an option to show and enable pre-defined effects on Twinkly devices.

This also fixes a problem where you could not re-select the previous effect if you switched between effect and color mode.

TTLS was updated to allow for this change: https://github.com/jschlyter/ttls/releases

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83489
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
