### PR TITLE
Remove doubtful repairs issue from UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -12,10 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
-from homeassistant.helpers.issue_registry import IssueSeverity
-
-from .const import DOMAIN
+from homeassistant.helpers import entity_registry as er
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,23 +29,6 @@ async def async_migrate_data(
     _LOGGER.debug("Start Migrate: async_migrate_device_ids")
     await async_migrate_device_ids(hass, entry, protect)
     _LOGGER.debug("Completed Migrate: async_migrate_device_ids")
-
-    entity_registry = er.async_get(hass)
-    for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
-        if (
-            entity.domain == Platform.SENSOR
-            and entity.disabled_by is None
-            and "detected_object" in entity.unique_id
-        ):
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                "deprecate_smart_sensor",
-                is_fixable=False,
-                breaks_in_ha_version="2023.2.0",
-                severity=IssueSeverity.WARNING,
-                translation_key="deprecate_smart_sensor",
-            )
 
 
 async def async_get_bootstrap(protect: ProtectApiClient) -> Bootstrap:

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -75,10 +75,6 @@
     "ea_setup_failed": {
       "title": "Setup error using Early Access version",
       "description": "You are using v{version} of UniFi Protect which is an Early Access version. An unrecoverable error occurred while trying to load the integration. Please [downgrade to a stable version](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) of UniFi Protect to continue using the integration.\n\nError: {error}"
-    },
-    "deprecate_smart_sensor": {
-      "title": "Smart Detection Sensor Deprecated",
-      "description": "The unified \"Detected Object\" sensor for smart detections is now deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly."
     }
   },
   "entity": {

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -51,10 +51,6 @@
         }
     },
     "issues": {
-        "deprecate_smart_sensor": {
-            "description": "The unified \"Detected Object\" sensor for smart detections is now deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates or automations accordingly.",
-            "title": "Smart Detection Sensor Deprecated"
-        },
         "ea_setup_failed": {
             "description": "You are using v{version} of UniFi Protect which is an Early Access version. An unrecoverable error occurred while trying to load the integration. Please [downgrade to a stable version](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) of UniFi Protect to continue using the integration.\n\nError: {error}",
             "title": "Setup error using Early Access version"

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -6,7 +6,7 @@ from copy import copy
 from http import HTTPStatus
 from unittest.mock import Mock
 
-from pyunifiprotect.data import Camera, Version
+from pyunifiprotect.data import Version
 
 from homeassistant.components.repairs.issue_handler import (
     async_process_repairs_platforms,
@@ -16,9 +16,7 @@ from homeassistant.components.repairs.websocket_api import (
     RepairsFlowResourceView,
 )
 from homeassistant.components.unifiprotect.const import DOMAIN
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 
 from .utils import MockUFPFixture, init_entry
 
@@ -126,53 +124,3 @@ async def test_ea_warning_fix(
     data = await resp.json()
 
     assert data["type"] == "create_entry"
-
-
-async def test_deprecate_smart_default(
-    hass: HomeAssistant, ufp: MockUFPFixture, hass_ws_client, doorbell: Camera
-):
-    """Test Deprecate Sensor repair does not exist by default (new installs)."""
-
-    await init_entry(hass, ufp, [doorbell])
-
-    await async_process_repairs_platforms(hass)
-    ws_client = await hass_ws_client(hass)
-
-    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
-    msg = await ws_client.receive_json()
-
-    assert msg["success"]
-    issue = None
-    for i in msg["result"]["issues"]:
-        if i["issue_id"] == "deprecate_smart_sensor":
-            issue = i
-    assert issue is None
-
-
-async def test_deprecate_smart_active(
-    hass: HomeAssistant, ufp: MockUFPFixture, hass_ws_client, doorbell: Camera
-):
-    """Test Deprecate Sensor repair exists for existing installs."""
-
-    registry = er.async_get(hass)
-    registry.async_get_or_create(
-        Platform.SENSOR,
-        DOMAIN,
-        f"{doorbell.mac}_detected_object",
-        config_entry=ufp.entry,
-    )
-
-    await init_entry(hass, ufp, [doorbell])
-
-    await async_process_repairs_platforms(hass)
-    ws_client = await hass_ws_client(hass)
-
-    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
-    msg = await ws_client.receive_json()
-
-    assert msg["success"]
-    issue = None
-    for i in msg["result"]["issues"]:
-        if i["issue_id"] == "deprecate_smart_sensor":
-            issue = i
-    assert issue is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The unified "Detected Object" sensor for smart detections is now deprecated. It has been replaced with individual smart detection binary sensors for each smart detection type. Please update any templates, automations, or scripts accordingly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This removes a repair issue introduced in #82595, and reported in #83461 during beta.

The repair issue raised has two problems:

1. It doesn't tell the user what to do to resolve the issue. What they could do, is disable the sensor; However, the issue doesn't tell them that. This leaves the end-user with just one option: Ignore the issue. We do require that issues are resolvable by the end-user.

2. The issue triggers on fact the sensor is not disabled, which is the case for all installations prior to this one (this release disables it by default for the first time). That said, the repair is about adjusting templates & scripts. The detection doesn't match the message, resulting in repairs being raised that isn't relevant to the end-user.

Raised repair issues must be relevant and actionable for the end user. As both are questionable, as reasoned above, this PR removes the repairs issue. I'll be added it to the release notes as a breaking change instead (hence this PR is being marked as breaking change).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83461
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
