### PR TITLE
Add new method async_finish_flow to FlowHandler

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -104,7 +104,10 @@ class AuthManagerFlowManager(data_entry_flow.FlowManager):
         """Return a user as result of login flow."""
         flow = cast(LoginFlow, flow)
 
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] not in (
+            data_entry_flow.FlowResultType.CREATE_ENTRY,
+            data_entry_flow.FlowResultType.FINISH_FLOW,
+        ):
             return result
 
         # we got final result

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -52,7 +52,8 @@ flow for details.
 
 Progress the flow. Most flows will be 1 page, but could optionally add extra
 login challenges, like TFA. Once the flow has finished, the returned step will
-have type FlowResultType.CREATE_ENTRY and "result" key will contain an authorization code.
+have type FlowResultType.CREATE_ENTRY or FlowResultType.FINISH_FLOW and "result"
+key will contain an authorization code.
 The authorization code associated with an authorized user by default, it will
 associate with an credential if "type" set to "link_user" in
 "/auth/login_flow"
@@ -156,7 +157,10 @@ def _prepare_result_json(
     result: data_entry_flow.FlowResult,
 ) -> data_entry_flow.FlowResult:
     """Convert result to JSON."""
-    if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
+    if result["type"] in (
+        data_entry_flow.FlowResultType.CREATE_ENTRY,
+        data_entry_flow.FlowResultType.FINISH_FLOW,
+    ):
         data = result.copy()
         data.pop("result")
         data.pop("data")
@@ -196,7 +200,10 @@ class LoginFlowBaseView(HomeAssistantView):
         result: data_entry_flow.FlowResult,
     ) -> web.Response:
         """Convert the flow result to a response."""
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] not in (
+            data_entry_flow.FlowResultType.CREATE_ENTRY,
+            data_entry_flow.FlowResultType.FINISH_FLOW,
+        ):
             # @log_invalid_auth does not work here since it returns HTTP 200.
             # We need to manually log failed login attempts.
             if (

--- a/homeassistant/components/auth/mfa_setup_flow.py
+++ b/homeassistant/components/auth/mfa_setup_flow.py
@@ -145,7 +145,10 @@ def _prepare_result_json(
     result: data_entry_flow.FlowResult,
 ) -> data_entry_flow.FlowResult:
     """Convert result to JSON."""
-    if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
+    if result["type"] not in (
+        data_entry_flow.FlowResultType.CREATE_ENTRY,
+        data_entry_flow.FlowResultType.FINISH_FLOW,
+    ):
         data = result.copy()
         return data
 

--- a/homeassistant/components/auth/mfa_setup_flow.py
+++ b/homeassistant/components/auth/mfa_setup_flow.py
@@ -145,7 +145,7 @@ def _prepare_result_json(
     result: data_entry_flow.FlowResult,
 ) -> data_entry_flow.FlowResult:
     """Convert result to JSON."""
-    if result["type"] not in (
+    if result["type"] in (
         data_entry_flow.FlowResultType.CREATE_ENTRY,
         data_entry_flow.FlowResultType.FINISH_FLOW,
     ):

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -117,7 +117,10 @@ class ConfigManagerEntryResourceReloadView(HomeAssistantView):
 
 def _prepare_config_flow_result_json(result, prepare_result_json):
     """Convert result to JSON."""
-    if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+    if result["type"] not in (
+        data_entry_flow.FlowResultType.CREATE_ENTRY,
+        data_entry_flow.FlowResultType.FINISH_FLOW,
+    ):
         return prepare_result_json(result)
 
     data = result.copy()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -761,7 +761,10 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
         if not self._async_has_other_discovery_flows(flow.flow_id):
             persistent_notification.async_dismiss(self.hass, DISCOVERY_NOTIFICATION_ID)
 
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] not in (
+            data_entry_flow.FlowResultType.CREATE_ENTRY,
+            data_entry_flow.FlowResultType.FINISH_FLOW,
+        ):
             return result
 
         # Check if config entry exists with unique ID. Unload it.
@@ -1674,7 +1677,10 @@ class OptionsFlowManager(data_entry_flow.FlowManager):
         """
         flow = cast(OptionsFlow, flow)
 
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] not in (
+            data_entry_flow.FlowResultType.CREATE_ENTRY,
+            data_entry_flow.FlowResultType.FINISH_FLOW,
+        ):
             return result
 
         entry = self.hass.config_entries.async_get_entry(flow.handler)

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -26,7 +26,7 @@ class _BaseFlowManagerView(HomeAssistantView):
         self, result: data_entry_flow.FlowResult
     ) -> data_entry_flow.FlowResult:
         """Convert result to JSON."""
-        if result["type"] not in (
+        if result["type"] in (
             data_entry_flow.FlowResultType.CREATE_ENTRY,
             data_entry_flow.FlowResultType.FINISH_FLOW,
         ):

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -26,7 +26,10 @@ class _BaseFlowManagerView(HomeAssistantView):
         self, result: data_entry_flow.FlowResult
     ) -> data_entry_flow.FlowResult:
         """Convert result to JSON."""
-        if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] not in (
+            data_entry_flow.FlowResultType.CREATE_ENTRY,
+            data_entry_flow.FlowResultType.FINISH_FLOW,
+        ):
             data = result.copy()
             data.pop("result")
             data.pop("data")

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -398,7 +398,7 @@ class SchemaOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
         data: Mapping[str, Any],
         **kwargs: Any,
     ) -> FlowResult:
-        """Finish config flow and create a config entry."""
+        """Finish options flow."""
         if self._async_options_flow_finished:
             self._async_options_flow_finished(self.hass, data)
         return super().async_create_entry(data=data, **kwargs)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new method `async_finish_flow` to `FlowHandler` and deprecate the existing method `async_create_entry`.

The background for the change is that while `async_create_entry` makes sense for `ConfigFlow`, it doesn't make sense as the final method for any other classes implementing or extending `FlowHandler` which do not end in creating a config entry.

In follow-up PRs:
- Adjust non config data flows derived from `FlowHandler` to call `async_finish_flow` instead of  `async_create_entry`
- Adjust `ConfigFlow.async_create_entry` to call `super().async_finish_flow`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
