### PR TITLE
Add firmware update entity for Litter-Robot 4

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -1,7 +1,7 @@
 """The Litter-Robot integration."""
 from __future__ import annotations
 
-from pylitterbot import FeederRobot, LitterRobot, LitterRobot3, Robot
+from pylitterbot import FeederRobot, LitterRobot, LitterRobot3, LitterRobot4, Robot
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -19,6 +19,7 @@ PLATFORMS_BY_TYPE = {
     ),
     LitterRobot: (Platform.VACUUM,),
     LitterRobot3: (Platform.BUTTON,),
+    LitterRobot4: (Platform.UPDATE,),
     FeederRobot: (Platform.BUTTON,),
 }
 

--- a/homeassistant/components/litterrobot/update.py
+++ b/homeassistant/components/litterrobot/update.py
@@ -1,0 +1,107 @@
+"""Support for Litter-Robot updates."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from typing import Any
+
+from pylitterbot import LitterRobot4
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityDescription,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.start import async_at_start
+
+from .const import DOMAIN
+from .entity import LitterRobotEntity, LitterRobotHub
+
+FIRMWARE_UPDATE_ENTITY = UpdateEntityDescription(
+    key="firmware",
+    name="Firmware",
+    device_class=UpdateDeviceClass.FIRMWARE,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Litter-Robot update platform."""
+    hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
+    robots = hub.account.robots
+    entities = [
+        RobotUpdateEntity(robot=robot, hub=hub, description=FIRMWARE_UPDATE_ENTITY)
+        for robot in robots
+        if isinstance(robot, LitterRobot4)
+    ]
+    async_add_entities(entities)
+
+
+class RobotUpdateEntity(LitterRobotEntity[LitterRobot4], UpdateEntity):
+    """A class that describes robot update entities."""
+
+    _attr_supported_features = (
+        UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
+    )
+
+    def __init__(
+        self,
+        robot: LitterRobot4,
+        hub: LitterRobotHub,
+        description: UpdateEntityDescription,
+    ) -> None:
+        """Initialize a Litter-Robot update entity."""
+        super().__init__(robot, hub, description)
+        self._poll_unsub: Callable[[], None] | None = None
+        self._attr_installed_version = robot.firmware
+
+    @property
+    def in_progress(self) -> bool:
+        """Update installation progress."""
+        return self.robot.firmware_update_triggered
+
+    async def _async_update(self, _: HomeAssistant | datetime | None = None) -> None:
+        """Update the entity."""
+        self._poll_unsub = None
+
+        if await self.robot.has_firmware_update():
+            latest_version = await self.robot.get_latest_firmware()
+        else:
+            latest_version = self.installed_version
+
+        if self._attr_latest_version != self._attr_installed_version:
+            self._attr_latest_version = latest_version
+            self.async_write_ha_state()
+
+        self._poll_unsub = async_call_later(
+            self.hass, timedelta(days=1), self._async_update
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Set up a listener for the entity."""
+        await super().async_added_to_hass()
+        self.async_on_remove(async_at_start(self.hass, self._async_update))
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install an update."""
+        if await self.robot.has_firmware_update():
+            if not await self.robot.update_firmware():
+                message = f"Unable to start firmware update on {self.robot.name}"
+                raise HomeAssistantError(message)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Call when entity will be removed."""
+        if self._poll_unsub:
+            self._poll_unsub()
+            self._poll_unsub = None

--- a/homeassistant/components/litterrobot/update.py
+++ b/homeassistant/components/litterrobot/update.py
@@ -62,7 +62,11 @@ class RobotUpdateEntity(LitterRobotEntity[LitterRobot4], UpdateEntity):
         """Initialize a Litter-Robot update entity."""
         super().__init__(robot, hub, description)
         self._poll_unsub: Callable[[], None] | None = None
-        self._attr_installed_version = robot.firmware
+
+    @property
+    def installed_version(self) -> str:
+        """Version installed and in use."""
+        return self.robot.firmware
 
     @property
     def in_progress(self) -> bool:
@@ -78,7 +82,7 @@ class RobotUpdateEntity(LitterRobotEntity[LitterRobot4], UpdateEntity):
         else:
             latest_version = self.installed_version
 
-        if self._attr_latest_version != self._attr_installed_version:
+        if self._attr_latest_version != self.installed_version:
             self._attr_latest_version = latest_version
             self.async_write_ha_state()
 

--- a/tests/components/litterrobot/test_update.py
+++ b/tests/components/litterrobot/test_update.py
@@ -1,0 +1,81 @@
+"""Test the Litter-Robot update entity."""
+from unittest.mock import AsyncMock, MagicMock
+
+from pylitterbot import LitterRobot4
+import pytest
+
+from homeassistant.components.update import (
+    ATTR_INSTALLED_VERSION,
+    ATTR_LATEST_VERSION,
+    DOMAIN as PLATFORM_DOMAIN,
+    SERVICE_INSTALL,
+    UpdateDeviceClass,
+)
+from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .conftest import setup_integration
+
+ENTITY_ID = "update.test_firmware"
+OLD_FIRMWARE = "ESP: 1.1.50 / PIC: 10512.2560.2.53 / TOF: 4.0.65.4"
+NEW_FIRMWARE = "ESP: 1.1.51 / PIC: 10512.2560.2.53 / TOF: 4.0.65.4"
+
+
+async def test_robot_with_no_update(
+    hass: HomeAssistant, mock_account_with_litterrobot_4: MagicMock
+):
+    """Tests the update entity was set up."""
+    robot: LitterRobot4 = mock_account_with_litterrobot_4.robots[0]
+    robot.has_firmware_update = AsyncMock(return_value=False)
+
+    entry = await setup_integration(
+        hass, mock_account_with_litterrobot_4, PLATFORM_DOMAIN
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
+    assert state.attributes[ATTR_INSTALLED_VERSION] == OLD_FIRMWARE
+    assert state.attributes[ATTR_LATEST_VERSION] == OLD_FIRMWARE
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_robot_with_update(
+    hass: HomeAssistant, mock_account_with_litterrobot_4: MagicMock
+):
+    """Tests the update entity was set up."""
+    robot: LitterRobot4 = mock_account_with_litterrobot_4.robots[0]
+    robot.has_firmware_update = AsyncMock(return_value=True)
+    robot.get_latest_firmware = AsyncMock(return_value=NEW_FIRMWARE)
+
+    await setup_integration(hass, mock_account_with_litterrobot_4, PLATFORM_DOMAIN)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
+    assert state.attributes[ATTR_INSTALLED_VERSION] == OLD_FIRMWARE
+    assert state.attributes[ATTR_LATEST_VERSION] == NEW_FIRMWARE
+
+    robot.update_firmware = AsyncMock(return_value=False)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            PLATFORM_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+    assert robot.update_firmware.call_count == 1
+
+    robot.update_firmware = AsyncMock(return_value=True)
+    await hass.services.async_call(
+        PLATFORM_DOMAIN, SERVICE_INSTALL, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+    )
+    await hass.async_block_till_done()
+    assert robot.update_firmware.call_count == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the ability to update firmware from HA for Litter-Robot 4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25204

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
