### PR TITLE
2022.12.1

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -9,7 +9,7 @@
     "bleak==0.19.2",
     "bleak-retry-connector==2.10.1",
     "bluetooth-adapters==0.12.0",
-    "bluetooth-auto-recovery==0.5.4",
+    "bluetooth-auto-recovery==0.5.5",
     "bluetooth-data-tools==0.3.0",
     "dbus-fast==1.75.0"
   ],

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -2,7 +2,7 @@
   "domain": "frontend",
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
-  "requirements": ["home-assistant-frontend==20221207.0"],
+  "requirements": ["home-assistant-frontend==20221208.0"],
   "dependencies": [
     "api",
     "auth",

--- a/homeassistant/components/hikvision/manifest.json
+++ b/homeassistant/components/hikvision/manifest.json
@@ -2,7 +2,7 @@
   "domain": "hikvision",
   "name": "Hikvision",
   "documentation": "https://www.home-assistant.io/integrations/hikvision",
-  "requirements": ["pyhik==0.3.1"],
+  "requirements": ["pyhik==0.3.2"],
   "codeowners": ["@mezz64"],
   "iot_class": "local_push",
   "loggers": ["pyhik"]

--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -236,7 +236,16 @@ class OptionsFlowHandler(BaseMultiPanFlow, config_entries.OptionsFlow):
         if not is_hassio(self.hass):
             return self.async_abort(reason="not_hassio")
 
-        return await self.async_step_on_supervisor()
+        return self.async_abort(
+            reason="disabled_due_to_bug",
+            description_placeholders={
+                "url": "https://developers.home-assistant.io/blog/2022/12/08/multi-pan-rollback"
+            },
+        )
+
+        # pylint: disable=unreachable
+
+        return await self.async_step_on_supervisor()  # type: ignore[unreachable]
 
     async def async_step_on_supervisor(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -245,7 +245,7 @@ class OptionsFlowHandler(BaseMultiPanFlow, config_entries.OptionsFlow):
 
         # pylint: disable=unreachable
 
-        return await self.async_step_on_supervisor()  # type: ignore[unreachable]
+        return await self.async_step_on_supervisor()
 
     async def async_step_on_supervisor(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -32,7 +32,8 @@
         "addon_set_config_failed": "Failed to set Silicon Labs Multiprotocol configuration.",
         "addon_start_failed": "Failed to start the Silicon Labs Multiprotocol add-on.",
         "not_hassio": "The hardware options can only be configured on HassOS installations.",
-        "zha_migration_failed": "The ZHA migration did not succeed."
+        "zha_migration_failed": "The ZHA migration did not succeed.",
+        "disabled_due_to_bug": "The hardware options are temporarily disabled while we fix a bug. [Learn more]({url})"
       },
       "progress": {
         "install_addon": "Please wait while the Silicon Labs Multiprotocol add-on installation finishes. This can take several minutes.",

--- a/homeassistant/components/homeassistant_hardware/translations/en.json
+++ b/homeassistant/components/homeassistant_hardware/translations/en.json
@@ -6,6 +6,7 @@
                 "addon_install_failed": "Failed to install the Silicon Labs Multiprotocol add-on.",
                 "addon_set_config_failed": "Failed to set Silicon Labs Multiprotocol configuration.",
                 "addon_start_failed": "Failed to start the Silicon Labs Multiprotocol add-on.",
+                "disabled_due_to_bug": "The hardware options are temporarily disabled while we fix a bug. [Learn more]({url})",
                 "not_hassio": "The hardware options can only be configured on HassOS installations.",
                 "zha_migration_failed": "The ZHA migration did not succeed."
             },

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -31,7 +31,8 @@
       "addon_set_config_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::addon_set_config_failed%]",
       "addon_start_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::addon_start_failed%]",
       "not_hassio": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::not_hassio%]",
-      "zha_migration_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::zha_migration_failed%]"
+      "zha_migration_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::zha_migration_failed%]",
+      "disabled_due_to_bug": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::disabled_due_to_bug%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",

--- a/homeassistant/components/homeassistant_sky_connect/translations/en.json
+++ b/homeassistant/components/homeassistant_sky_connect/translations/en.json
@@ -5,6 +5,7 @@
             "addon_install_failed": "Failed to install the Silicon Labs Multiprotocol add-on.",
             "addon_set_config_failed": "Failed to set Silicon Labs Multiprotocol configuration.",
             "addon_start_failed": "Failed to start the Silicon Labs Multiprotocol add-on.",
+            "disabled_due_to_bug": "The hardware options are temporarily disabled while we fix a bug. [Learn more]({url})",
             "not_hassio": "The hardware options can only be configured on HassOS installations.",
             "zha_migration_failed": "The ZHA migration did not succeed."
         },

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -31,7 +31,8 @@
       "addon_set_config_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::addon_set_config_failed%]",
       "addon_start_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::addon_start_failed%]",
       "not_hassio": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::not_hassio%]",
-      "zha_migration_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::zha_migration_failed%]"
+      "zha_migration_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::zha_migration_failed%]",
+      "disabled_due_to_bug": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::disabled_due_to_bug%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",

--- a/homeassistant/components/homeassistant_yellow/translations/en.json
+++ b/homeassistant/components/homeassistant_yellow/translations/en.json
@@ -5,6 +5,7 @@
             "addon_install_failed": "Failed to install the Silicon Labs Multiprotocol add-on.",
             "addon_set_config_failed": "Failed to set Silicon Labs Multiprotocol configuration.",
             "addon_start_failed": "Failed to start the Silicon Labs Multiprotocol add-on.",
+            "disabled_due_to_bug": "The hardware options are temporarily disabled while we fix a bug. [Learn more]({url})",
             "not_hassio": "The hardware options can only be configured on HassOS installations.",
             "zha_migration_failed": "The ZHA migration did not succeed."
         },

--- a/homeassistant/components/intellifire/manifest.json
+++ b/homeassistant/components/intellifire/manifest.json
@@ -3,7 +3,7 @@
   "name": "IntelliFire",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/intellifire",
-  "requirements": ["intellifire4py==2.2.1"],
+  "requirements": ["intellifire4py==2.2.2"],
   "codeowners": ["@jeeftor"],
   "iot_class": "local_polling",
   "loggers": ["intellifire4py"],

--- a/homeassistant/components/local_calendar/manifest.json
+++ b/homeassistant/components/local_calendar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Local Calendar",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/local_calendar",
-  "requirements": ["ical==4.2.1"],
+  "requirements": ["ical==4.2.2"],
   "codeowners": ["@allenporter"],
   "iot_class": "local_polling",
   "loggers": ["ical"]

--- a/homeassistant/components/matter/manifest.json
+++ b/homeassistant/components/matter/manifest.json
@@ -3,7 +3,7 @@
   "name": "Matter (BETA)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/matter",
-  "requirements": ["python-matter-server==1.0.6"],
+  "requirements": ["python-matter-server==1.0.7"],
   "dependencies": ["websocket_api"],
   "codeowners": ["@MartinHjelmare", "@marcelveldt"],
   "iot_class": "local_push"

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1,8 +1,11 @@
 """Support for MQTT message handling."""
+# pylint: disable=deprecated-typing-alias
+#   In Python 3.9.0 and 3.9.1 collections.abc.Callable
+#   can't be used inside typing.Union or typing.Optional
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Coroutine, Iterable
+from collections.abc import Coroutine, Iterable
 from functools import lru_cache, partial, wraps
 import inspect
 from itertools import groupby
@@ -10,7 +13,7 @@ import logging
 from operator import attrgetter
 import ssl
 import time
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Union, cast
 import uuid
 
 import attr

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -101,6 +101,8 @@ class PhilipsTVMediaPlayer(
 
     async def async_added_to_hass(self) -> None:
         """Handle being added to hass."""
+        await super().async_added_to_hass()
+
         if (entry := self.registry_entry) and entry.device_id:
             self.async_on_remove(
                 self._turn_on.async_register(

--- a/homeassistant/components/sensirion_ble/manifest.json
+++ b/homeassistant/components/sensirion_ble/manifest.json
@@ -5,9 +5,11 @@
   "documentation": "https://www.home-assistant.io/integrations/sensirion_ble",
   "bluetooth": [
     {
+      "connectable": false,
       "manufacturer_id": 1749
     },
     {
+      "connectable": false,
       "local_name": "MyCO2*"
     }
   ],

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==2022.11.2"],
+  "requirements": ["simplisafe-python==2022.12.0"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",
   "dhcp": [

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,7 @@ from .backports.enum import StrEnum
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 12
-PATCH_VERSION: Final = "0"
+PATCH_VERSION: Final = "1"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -273,10 +273,12 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
         "local_name": "Ruuvi *",
     },
     {
+        "connectable": False,
         "domain": "sensirion_ble",
         "manufacturer_id": 1749,
     },
     {
+        "connectable": False,
         "domain": "sensirion_ble",
         "local_name": "MyCO2*",
     },

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,7 @@ bcrypt==3.1.7
 bleak-retry-connector==2.10.1
 bleak==0.19.2
 bluetooth-adapters==0.12.0
-bluetooth-auto-recovery==0.5.4
+bluetooth-auto-recovery==0.5.5
 bluetooth-data-tools==0.3.0
 certifi>=2021.5.30
 ciso8601==2.2.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -22,7 +22,7 @@ dbus-fast==1.75.0
 fnvhash==0.1.0
 hass-nabucasa==0.61.0
 home-assistant-bluetooth==1.8.1
-home-assistant-frontend==20221207.0
+home-assistant-frontend==20221208.0
 httpx==0.23.1
 ifaddr==0.1.7
 janus==1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2022.12.0"
+version     = "2022.12.1"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2291,7 +2291,7 @@ simplehound==0.3
 simplepush==2.1.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==2022.11.2
+simplisafe-python==2022.12.0
 
 # homeassistant.components.sisyphus
 sisyphus-control==3.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2030,7 +2030,7 @@ python-kasa==0.5.0
 # python-lirc==1.2.3
 
 # homeassistant.components.matter
-python-matter-server==1.0.6
+python-matter-server==1.0.7
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -450,7 +450,7 @@ bluemaestro-ble==0.2.0
 bluetooth-adapters==0.12.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==0.5.4
+bluetooth-auto-recovery==0.5.5
 
 # homeassistant.components.bluetooth
 # homeassistant.components.led_ble

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1627,7 +1627,7 @@ pyhaversion==22.8.0
 pyheos==0.7.2
 
 # homeassistant.components.hikvision
-pyhik==0.3.1
+pyhik==0.3.2
 
 # homeassistant.components.hive
 pyhiveapi==0.5.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -956,7 +956,7 @@ inkbird-ble==0.5.5
 insteon-frontend-home-assistant==0.2.0
 
 # homeassistant.components.intellifire
-intellifire4py==2.2.1
+intellifire4py==2.2.2
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -926,7 +926,7 @@ ibm-watson==5.2.2
 ibmiotf==0.3.4
 
 # homeassistant.components.local_calendar
-ical==4.2.1
+ical==4.2.2
 
 # homeassistant.components.ping
 icmplib==3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -884,7 +884,7 @@ hole==0.7.0
 holidays==0.17.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20221207.0
+home-assistant-frontend==20221208.0
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1588,7 +1588,7 @@ simplehound==0.3
 simplepush==2.1.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==2022.11.2
+simplisafe-python==2022.12.0
 
 # homeassistant.components.slack
 slackclient==2.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1417,7 +1417,7 @@ python-juicenet==1.1.0
 python-kasa==0.5.0
 
 # homeassistant.components.matter
-python-matter-server==1.0.6
+python-matter-server==1.0.7
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -712,7 +712,7 @@ inkbird-ble==0.5.5
 insteon-frontend-home-assistant==0.2.0
 
 # homeassistant.components.intellifire
-intellifire4py==2.2.1
+intellifire4py==2.2.2
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -664,7 +664,7 @@ hole==0.7.0
 holidays==0.17.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20221207.0
+home-assistant-frontend==20221208.0
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -364,7 +364,7 @@ bluemaestro-ble==0.2.0
 bluetooth-adapters==0.12.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==0.5.4
+bluetooth-auto-recovery==0.5.5
 
 # homeassistant.components.bluetooth
 # homeassistant.components.led_ble

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -691,7 +691,7 @@ iaqualink==0.5.0
 ibeacon_ble==1.0.1
 
 # homeassistant.components.local_calendar
-ical==4.2.1
+ical==4.2.2
 
 # homeassistant.components.ping
 icmplib==3.0

--- a/script/pip_check
+++ b/script/pip_check
@@ -2,8 +2,8 @@
 PIP_CACHE=$1
 
 # Number of existing dependency conflicts
-# Update if a PR resolve one!
-DEPENDENCY_CONFLICTS=3
+# Update if a PR resolves one!
+DEPENDENCY_CONFLICTS=4
 
 PIP_CHECK=$(pip check --cache-dir=$PIP_CACHE)
 LINE_COUNT=$(echo "$PIP_CHECK" | wc -l)

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -20,6 +20,9 @@ from tests.common import MockConfigEntry, MockModule, mock_integration, mock_pla
 TEST_DOMAIN = "test"
 
 
+pytest.skip(reason="Temporarily disabled", allow_module_level=True)
+
+
 class TestConfigFlow(ConfigFlow, domain=TEST_DOMAIN):
     """Handle a config flow for the silabs multiprotocol add-on."""
 

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -2,6 +2,8 @@
 import copy
 from unittest.mock import Mock, patch
 
+import pytest
+
 from homeassistant.components import homeassistant_sky_connect, usb
 from homeassistant.components.homeassistant_sky_connect.const import DOMAIN
 from homeassistant.components.zha.core.const import (
@@ -150,6 +152,7 @@ async def test_config_flow_update_device(hass: HomeAssistant) -> None:
     assert len(mock_unload_entry.mock_calls) == 1
 
 
+@pytest.mark.skip(reason="Temporarily disabled")
 async def test_option_flow_install_multi_pan_addon(
     hass: HomeAssistant,
     addon_store_info,
@@ -240,6 +243,7 @@ def mock_detect_radio_type(radio_type=RadioType.ezsp, ret=True):
     return detect
 
 
+@pytest.mark.skip(reason="Temporarily disabled")
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaRadioManager.detect_radio_type",
     mock_detect_radio_type(),

--- a/tests/components/homeassistant_yellow/test_config_flow.py
+++ b/tests/components/homeassistant_yellow/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the Home Assistant Yellow config flow."""
 from unittest.mock import Mock, patch
 
+import pytest
+
 from homeassistant.components.homeassistant_yellow.const import DOMAIN
 from homeassistant.components.zha.core.const import DOMAIN as ZHA_DOMAIN
 from homeassistant.core import HomeAssistant
@@ -59,6 +61,7 @@ async def test_config_flow_single_entry(hass: HomeAssistant) -> None:
     mock_setup_entry.assert_not_called()
 
 
+@pytest.mark.skip(reason="Temporarily disabled")
 async def test_option_flow_install_multi_pan_addon(
     hass: HomeAssistant,
     addon_store_info,
@@ -127,6 +130,7 @@ async def test_option_flow_install_multi_pan_addon(
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.skip(reason="Temporarily disabled")
 async def test_option_flow_install_multi_pan_addon_zha(
     hass: HomeAssistant,
     addon_store_info,


### PR DESCRIPTION
- Set connectable as false for sensirion_ble ([@chkuendig] - [#83481]) ([sensirion_ble docs])
- Make sure super async_added_to_hass is called ([@elupus] - [#83493]) ([philips_js docs])
- Bump `simplisafe-python` to 2022.12.0 ([@bachya] - [#83497]) ([simplisafe docs])
- Bump python-matter-server to 1.0.7 ([@marcelveldt] - [#83507]) ([matter docs])
- Bump pyhik to 0.3.2 ([@mezz64] - [#83517]) ([hikvision docs])
- Bump ical to 4.2.2 ([@allenporter] - [#83520]) ([local_calendar docs])
- Fix issue with Callable, Union, and Python 3.9 [mqtt] ([@cdce8p] - [#83547]) ([mqtt docs])
- Update frontend to 20221208.0 ([@bramkragten] - [#83551]) ([frontend docs])
- Improve local calendar input validation error handling ([@allenporter] - [#83563]) ([local_calendar docs])
- Bump pip_check conflicts +1 ([@frenck] - [#83536])
- Bump intellifire4py to 2.2.2 ([@jeeftor] - [#83589]) ([intellifire docs])
- Bump bluetooth-auto-recovery to 0.5.5 ([@bdraco] - [#83597]) ([bluetooth docs])
- Disable multi-pan ([@balloob] - [#83603]) ([homeassistant_yellow docs]) ([homeassistant_sky_connect docs]) ([homeassistant_hardware docs])

[#83481]: https://github.com/home-assistant/core/pull/83481
[#83482]: https://github.com/home-assistant/core/pull/83482
[#83493]: https://github.com/home-assistant/core/pull/83493
[#83497]: https://github.com/home-assistant/core/pull/83497
[#83507]: https://github.com/home-assistant/core/pull/83507
[#83517]: https://github.com/home-assistant/core/pull/83517
[#83520]: https://github.com/home-assistant/core/pull/83520
[#83536]: https://github.com/home-assistant/core/pull/83536
[#83547]: https://github.com/home-assistant/core/pull/83547
[#83551]: https://github.com/home-assistant/core/pull/83551
[#83563]: https://github.com/home-assistant/core/pull/83563
[#83589]: https://github.com/home-assistant/core/pull/83589
[#83597]: https://github.com/home-assistant/core/pull/83597
[#83603]: https://github.com/home-assistant/core/pull/83603
[@allenporter]: https://github.com/allenporter
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@bramkragten]: https://github.com/bramkragten
[@cdce8p]: https://github.com/cdce8p
[@chkuendig]: https://github.com/chkuendig
[@elupus]: https://github.com/elupus
[@frenck]: https://github.com/frenck
[@jeeftor]: https://github.com/jeeftor
[@marcelveldt]: https://github.com/marcelveldt
[@mezz64]: https://github.com/mezz64
[abode docs]: https://www.home-assistant.io/integrations/abode/
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/
[bluetooth docs]: https://www.home-assistant.io/integrations/bluetooth/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[hikvision docs]: https://www.home-assistant.io/integrations/hikvision/
[homeassistant_hardware docs]: https://www.home-assistant.io/integrations/homeassistant_hardware/
[homeassistant_sky_connect docs]: https://www.home-assistant.io/integrations/homeassistant_sky_connect/
[homeassistant_yellow docs]: https://www.home-assistant.io/integrations/homeassistant_yellow/
[intellifire docs]: https://www.home-assistant.io/integrations/intellifire/
[local_calendar docs]: https://www.home-assistant.io/integrations/local_calendar/
[matter docs]: https://www.home-assistant.io/integrations/matter/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[philips_js docs]: https://www.home-assistant.io/integrations/philips_js/
[sensirion_ble docs]: https://www.home-assistant.io/integrations/sensirion_ble/
[simplisafe docs]: https://www.home-assistant.io/integrations/simplisafe/