### PR TITLE
Disable multi-pan

### DIFF
--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -236,7 +236,16 @@ class OptionsFlowHandler(BaseMultiPanFlow, config_entries.OptionsFlow):
         if not is_hassio(self.hass):
             return self.async_abort(reason="not_hassio")
 
-        return await self.async_step_on_supervisor()
+        return self.async_abort(
+            reason="disabled_due_to_bug",
+            description_placeholders={
+                "url": "https://developers.home-assistant.io/blog/2022/12/08/multi-pan-rollback"
+            },
+        )
+
+        # pylint: disable=unreachable
+
+        return await self.async_step_on_supervisor()  # type: ignore[unreachable]
 
     async def async_step_on_supervisor(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -32,7 +32,8 @@
         "addon_set_config_failed": "Failed to set Silicon Labs Multiprotocol configuration.",
         "addon_start_failed": "Failed to start the Silicon Labs Multiprotocol add-on.",
         "not_hassio": "The hardware options can only be configured on HassOS installations.",
-        "zha_migration_failed": "The ZHA migration did not succeed."
+        "zha_migration_failed": "The ZHA migration did not succeed.",
+        "disabled_due_to_bug": "The hardware options are temporarily disabled while we fix a bug. [Learn more]({url})"
       },
       "progress": {
         "install_addon": "Please wait while the Silicon Labs Multiprotocol add-on installation finishes. This can take several minutes.",

--- a/homeassistant/components/homeassistant_hardware/translations/en.json
+++ b/homeassistant/components/homeassistant_hardware/translations/en.json
@@ -6,6 +6,7 @@
                 "addon_install_failed": "Failed to install the Silicon Labs Multiprotocol add-on.",
                 "addon_set_config_failed": "Failed to set Silicon Labs Multiprotocol configuration.",
                 "addon_start_failed": "Failed to start the Silicon Labs Multiprotocol add-on.",
+                "disabled_due_to_bug": "The hardware options are temporarily disabled while we fix a bug. [Learn more]({url})",
                 "not_hassio": "The hardware options can only be configured on HassOS installations.",
                 "zha_migration_failed": "The ZHA migration did not succeed."
             },

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -31,7 +31,8 @@
       "addon_set_config_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::addon_set_config_failed%]",
       "addon_start_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::addon_start_failed%]",
       "not_hassio": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::not_hassio%]",
-      "zha_migration_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::zha_migration_failed%]"
+      "zha_migration_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::zha_migration_failed%]",
+      "disabled_due_to_bug": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::disabled_due_to_bug%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",

--- a/homeassistant/components/homeassistant_sky_connect/translations/en.json
+++ b/homeassistant/components/homeassistant_sky_connect/translations/en.json
@@ -5,6 +5,7 @@
             "addon_install_failed": "Failed to install the Silicon Labs Multiprotocol add-on.",
             "addon_set_config_failed": "Failed to set Silicon Labs Multiprotocol configuration.",
             "addon_start_failed": "Failed to start the Silicon Labs Multiprotocol add-on.",
+            "disabled_due_to_bug": "The hardware options are temporarily disabled while we fix a bug. [Learn more]({url})",
             "not_hassio": "The hardware options can only be configured on HassOS installations.",
             "zha_migration_failed": "The ZHA migration did not succeed."
         },

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -31,7 +31,8 @@
       "addon_set_config_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::addon_set_config_failed%]",
       "addon_start_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::addon_start_failed%]",
       "not_hassio": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::not_hassio%]",
-      "zha_migration_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::zha_migration_failed%]"
+      "zha_migration_failed": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::zha_migration_failed%]",
+      "disabled_due_to_bug": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::disabled_due_to_bug%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",

--- a/homeassistant/components/homeassistant_yellow/translations/en.json
+++ b/homeassistant/components/homeassistant_yellow/translations/en.json
@@ -5,6 +5,7 @@
             "addon_install_failed": "Failed to install the Silicon Labs Multiprotocol add-on.",
             "addon_set_config_failed": "Failed to set Silicon Labs Multiprotocol configuration.",
             "addon_start_failed": "Failed to start the Silicon Labs Multiprotocol add-on.",
+            "disabled_due_to_bug": "The hardware options are temporarily disabled while we fix a bug. [Learn more]({url})",
             "not_hassio": "The hardware options can only be configured on HassOS installations.",
             "zha_migration_failed": "The ZHA migration did not succeed."
         },

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -20,6 +20,9 @@ from tests.common import MockConfigEntry, MockModule, mock_integration, mock_pla
 TEST_DOMAIN = "test"
 
 
+pytest.skip(reason="Temporarily disabled", allow_module_level=True)
+
+
 class TestConfigFlow(ConfigFlow, domain=TEST_DOMAIN):
     """Handle a config flow for the silabs multiprotocol add-on."""
 

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -2,6 +2,8 @@
 import copy
 from unittest.mock import Mock, patch
 
+import pytest
+
 from homeassistant.components import homeassistant_sky_connect, usb
 from homeassistant.components.homeassistant_sky_connect.const import DOMAIN
 from homeassistant.components.zha.core.const import (
@@ -150,6 +152,7 @@ async def test_config_flow_update_device(hass: HomeAssistant) -> None:
     assert len(mock_unload_entry.mock_calls) == 1
 
 
+@pytest.mark.skip(reason="Temporarily disabled")
 async def test_option_flow_install_multi_pan_addon(
     hass: HomeAssistant,
     addon_store_info,
@@ -240,6 +243,7 @@ def mock_detect_radio_type(radio_type=RadioType.ezsp, ret=True):
     return detect
 
 
+@pytest.mark.skip(reason="Temporarily disabled")
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaRadioManager.detect_radio_type",
     mock_detect_radio_type(),

--- a/tests/components/homeassistant_yellow/test_config_flow.py
+++ b/tests/components/homeassistant_yellow/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the Home Assistant Yellow config flow."""
 from unittest.mock import Mock, patch
 
+import pytest
+
 from homeassistant.components.homeassistant_yellow.const import DOMAIN
 from homeassistant.components.zha.core.const import DOMAIN as ZHA_DOMAIN
 from homeassistant.core import HomeAssistant
@@ -59,6 +61,7 @@ async def test_config_flow_single_entry(hass: HomeAssistant) -> None:
     mock_setup_entry.assert_not_called()
 
 
+@pytest.mark.skip(reason="Temporarily disabled")
 async def test_option_flow_install_multi_pan_addon(
     hass: HomeAssistant,
     addon_store_info,
@@ -127,6 +130,7 @@ async def test_option_flow_install_multi_pan_addon(
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.skip(reason="Temporarily disabled")
 async def test_option_flow_install_multi_pan_addon_zha(
     hass: HomeAssistant,
     addon_store_info,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We found a serious bug in multi-pan that can cause some Zigbee devices to be dropped. 
More info @ https://developers.home-assistant.io/blog/2022/12/08/multi-pan-rollback

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
