### PR TITLE
Drop title from repairs flows

### DIFF
--- a/homeassistant/components/cloud/repairs.py
+++ b/homeassistant/components/cloud/repairs.py
@@ -106,7 +106,7 @@ class LegacySubscriptionRepairFlow(RepairsFlow):
 
     async def async_step_complete(self, _: None = None) -> FlowResult:
         """Handle the final step of a fix flow."""
-        return self.async_create_entry(title="", data={})
+        return self.async_create_entry(data={})
 
     async def async_step_timeout(self, _: None = None) -> FlowResult:
         """Handle the final step of a fix flow."""

--- a/homeassistant/components/demo/repairs.py
+++ b/homeassistant/components/demo/repairs.py
@@ -24,7 +24,7 @@ class DemoFixFlow(RepairsFlow):
     ) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
-            return self.async_create_entry(title="", data={})
+            return self.async_create_entry(data={})
 
         return self.async_show_form(step_id="confirm", data_schema=vol.Schema({}))
 

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -62,7 +62,7 @@ class EAConfirm(RepairsFlow):
         if await nvr.get_is_prerelease():
             return await self.async_step_confirm()
         await self.hass.config_entries.async_reload(self._entry.entry_id)
-        return self.async_create_entry(title="", data={})
+        return self.async_create_entry(data={})
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
@@ -72,7 +72,7 @@ class EAConfirm(RepairsFlow):
             options = dict(self._entry.options)
             options[CONF_ALLOW_EA] = True
             self.hass.config_entries.async_update_entry(self._entry, options=options)
-            return self.async_create_entry(title="", data={})
+            return self.async_create_entry(data={})
 
         placeholders = self._async_get_placeholders()
         return self.async_show_form(

--- a/tests/components/cloud/test_repairs.py
+++ b/tests/components/cloud/test_repairs.py
@@ -152,7 +152,6 @@ async def test_legacy_subscription_repair_flow(
         "type": "create_entry",
         "flow_id": flow_id,
         "handler": DOMAIN,
-        "title": "",
         "description": None,
         "description_placeholders": None,
     }

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -243,7 +243,6 @@ async def test_issues_created(mock_history, hass, hass_client, hass_ws_client):
         "description_placeholders": None,
         "flow_id": flow_id,
         "handler": "demo",
-        "title": "",
         "type": "create_entry",
         "version": 1,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop title from repairs flows

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
