### PR TITLE
Make google calendar fail louder on invalid google_calendars.yaml

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -329,8 +329,7 @@ def load_config(path: str) -> dict[str, Any]:
         with open(path, encoding="utf8") as file:
             data = yaml.safe_load(file)
             for calendar in data:
-                validated = DEVICE_SCHEMA(calendar)
-                calendars.update({validated[CONF_CAL_ID]: validated})
+                calendars[calendar[CONF_CAL_ID]] =  DEVICE_SCHEMA(calendar)
     except FileNotFoundError as err:
         _LOGGER.debug("Error reading calendar configuration: %s", err)
         # When YAML file could not be loaded/did not contain a dict

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -11,7 +11,6 @@ from gcal_sync.api import GoogleCalendarService
 from gcal_sync.exceptions import ApiException, AuthException
 from gcal_sync.model import DateOrDatetime, Event
 import voluptuous as vol
-from voluptuous.error import Error as VoluptuousError
 import yaml
 
 from homeassistant.config_entries import ConfigEntry
@@ -142,6 +141,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Google from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {}
+
+    # Validate google_calendars.yaml (if present) as soon as possible to return
+    # helpful error messages.
+    try:
+        await hass.async_add_executor_job(load_config, hass.config.path(YAML_DEVICES))
+    except vol.Invalid as err:
+        _LOGGER.error("Configuration error in %s: %s", YAML_DEVICES, str(err))
+        return False
 
     implementation = (
         await config_entry_oauth2_flow.async_get_config_entry_implementation(
@@ -322,11 +329,8 @@ def load_config(path: str) -> dict[str, Any]:
         with open(path, encoding="utf8") as file:
             data = yaml.safe_load(file)
             for calendar in data:
-                try:
-                    calendars.update({calendar[CONF_CAL_ID]: DEVICE_SCHEMA(calendar)})
-                except VoluptuousError as exception:
-                    # keep going
-                    _LOGGER.warning("Calendar Invalid Data: %s", exception)
+                validated = DEVICE_SCHEMA(calendar)
+                calendars.update({validated[CONF_CAL_ID]: validated})
     except FileNotFoundError as err:
         _LOGGER.debug("Error reading calendar configuration: %s", err)
         # When YAML file could not be loaded/did not contain a dict

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -329,7 +329,7 @@ def load_config(path: str) -> dict[str, Any]:
         with open(path, encoding="utf8") as file:
             data = yaml.safe_load(file)
             for calendar in data:
-                calendars[calendar[CONF_CAL_ID]] =  DEVICE_SCHEMA(calendar)
+                calendars[calendar[CONF_CAL_ID]] = DEVICE_SCHEMA(calendar)
     except FileNotFoundError as err:
         _LOGGER.debug("Error reading calendar configuration: %s", err)
         # When YAML file could not be loaded/did not contain a dict

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -152,11 +152,12 @@ async def test_calendar_yaml_missing_required_fields(
     component_setup: ComponentSetup,
     calendars_config: list[dict[str, Any]],
     mock_calendars_yaml: None,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test setup with a missing schema fields, ignores the error and continues."""
-    assert await component_setup()
+    assert not await component_setup()
 
-    assert not hass.states.get(TEST_YAML_ENTITY)
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 @pytest.mark.parametrize("calendars_config", [[{"missing-cal_id": "invalid-schema"}]])
@@ -165,23 +166,12 @@ async def test_invalid_calendar_yaml(
     component_setup: ComponentSetup,
     calendars_config: list[dict[str, Any]],
     mock_calendars_yaml: None,
-    mock_calendars_list: ApiResult,
-    test_api_calendar: dict[str, Any],
-    mock_events_list: ApiResult,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test setup with missing entity id fields fails to load the platform."""
-    mock_calendars_list({"items": [test_api_calendar]})
-    mock_events_list({})
+    assert not await component_setup()
 
-    assert await component_setup()
-
-    entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(entries) == 1
-    entry = entries[0]
-    assert entry.state is ConfigEntryState.LOADED
-
-    assert not hass.states.get(TEST_YAML_ENTITY)
-    assert not hass.states.get(TEST_API_ENTITY)
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_calendar_yaml_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make google calendar fail louder on invalid google_calendars.yaml by moving the validation back to the initial config entry setup. Historically, errors here have been ignored but log an error message which just results in the ui as an empty calendar. Also this fixes an error where the schema validation is happening after accessing the first element, so now it will return the voluptuous error isntead of a `KeyError`

An invalid config previously would fail with an error in the log like this:
```
2022-12-09 13:15:06.836 ERROR (MainThread) [homeassistant.components.calendar] Error while setting up google platform for calendar
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 281, in _async_setup_platform
    await asyncio.shield(task)
  File "/usr/src/homeassistant/homeassistant/components/google/calendar.py", line 144, in async_setup_entry
    calendars = await hass.async_add_executor_job(
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/google/__init__.py", line 326, in load_config
    calendars.update({calendar[CONF_CAL_ID]: DEVICE_SCHEMA(calendar)})
KeyError: 'cal_id'
```

But now it will instead fail to setup more loudly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83617
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
