### PR TITLE
Add text platform for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -63,6 +63,7 @@ PLATFORMS = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TEXT,
 ]
 
 DISPATCH_ADD = "add_device"

--- a/homeassistant/components/unifiprotect/text.py
+++ b/homeassistant/components/unifiprotect/text.py
@@ -1,0 +1,107 @@
+"""Text entities for UniFi Protect."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pyunifiprotect.data import (
+    Camera,
+    DoorbellMessageType,
+    ProtectAdoptableDeviceModel,
+    ProtectModelWithId,
+)
+
+from homeassistant.components.text import TextEntity, TextEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DISPATCH_ADOPT, DOMAIN
+from .data import ProtectData
+from .entity import ProtectDeviceEntity, async_all_device_entities
+from .models import PermRequired, ProtectSetableKeysMixin, T
+from .utils import async_dispatch_id as _ufpd
+
+
+@dataclass
+class ProtectTextEntityDescription(ProtectSetableKeysMixin[T], TextEntityDescription):
+    """Describes UniFi Protect Text entity."""
+
+
+def _get_doorbell_current(obj: Camera) -> str | None:
+    if obj.lcd_message is None:
+        return obj.api.bootstrap.nvr.doorbell_settings.default_message_text
+    return obj.lcd_message.text
+
+
+async def _set_doorbell_message(obj: Camera, message: str) -> None:
+    await obj.set_lcd_text(DoorbellMessageType.CUSTOM_MESSAGE, text=message)
+
+
+CAMERA: tuple[ProtectTextEntityDescription, ...] = (
+    ProtectTextEntityDescription(
+        key="doorbell",
+        name="Doorbell",
+        entity_category=EntityCategory.CONFIG,
+        ufp_value_fn=_get_doorbell_current,
+        ufp_set_method_fn=_set_doorbell_message,
+        ufp_required_field="feature_flags.has_lcd_screen",
+        ufp_perm=PermRequired.WRITE,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors for UniFi Protect integration."""
+    data: ProtectData = hass.data[DOMAIN][entry.entry_id]
+
+    async def _add_new_device(device: ProtectAdoptableDeviceModel) -> None:
+        entities = async_all_device_entities(
+            data,
+            ProtectDeviceText,
+            camera_descs=CAMERA,
+            ufp_device=device,
+        )
+        async_add_entities(entities)
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, _ufpd(entry, DISPATCH_ADOPT), _add_new_device)
+    )
+
+    entities: list[ProtectDeviceEntity] = async_all_device_entities(
+        data,
+        ProtectDeviceText,
+        camera_descs=CAMERA,
+    )
+
+    async_add_entities(entities)
+
+
+class ProtectDeviceText(ProtectDeviceEntity, TextEntity):
+    """A Ubiquiti UniFi Protect Sensor."""
+
+    entity_description: ProtectTextEntityDescription
+
+    def __init__(
+        self,
+        data: ProtectData,
+        device: ProtectAdoptableDeviceModel,
+        description: ProtectTextEntityDescription,
+    ) -> None:
+        """Initialize an UniFi Protect sensor."""
+        super().__init__(data, device, description)
+
+    @callback
+    def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
+        super()._async_update_device_from_protect(device)
+        self._attr_native_value = self.entity_description.get_ufp_value(self.device)
+
+    async def async_set_value(self, value: str) -> None:
+        """Change the value."""
+
+        await self.entity_description.ufp_set(self.device, value)

--- a/tests/components/unifiprotect/test_text.py
+++ b/tests/components/unifiprotect/test_text.py
@@ -1,0 +1,92 @@
+"""Test the UniFi Protect text platform."""
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+from pyunifiprotect.data import Camera, DoorbellMessageType, LCDMessage
+
+from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
+from homeassistant.components.unifiprotect.text import CAMERA
+from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .utils import (
+    MockUFPFixture,
+    adopt_devices,
+    assert_entity_counts,
+    ids_from_device_description,
+    init_entry,
+    remove_entities,
+)
+
+
+async def test_text_camera_remove(
+    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, unadopted_camera: Camera
+):
+    """Test removing and re-adding a camera device."""
+
+    ufp.api.bootstrap.nvr.system_info.ustorage = None
+    await init_entry(hass, ufp, [doorbell, unadopted_camera])
+    assert_entity_counts(hass, Platform.TEXT, 1, 1)
+    await remove_entities(hass, ufp, [doorbell, unadopted_camera])
+    assert_entity_counts(hass, Platform.TEXT, 0, 0)
+    await adopt_devices(hass, ufp, [doorbell, unadopted_camera])
+    assert_entity_counts(hass, Platform.TEXT, 1, 1)
+
+
+async def test_text_camera_setup(
+    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
+):
+    """Test text entity setup for camera devices."""
+
+    doorbell.lcd_message = LCDMessage(
+        type=DoorbellMessageType.CUSTOM_MESSAGE, text="Test"
+    )
+    await init_entry(hass, ufp, [doorbell])
+    assert_entity_counts(hass, Platform.TEXT, 1, 1)
+
+    entity_registry = er.async_get(hass)
+
+    description = CAMERA[0]
+    unique_id, entity_id = ids_from_device_description(
+        Platform.TEXT, doorbell, description
+    )
+
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    assert entity.unique_id == unique_id
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "Test"
+    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+
+
+async def test_text_camera_set(
+    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
+):
+    """Test text entity setting value camera devices."""
+
+    await init_entry(hass, ufp, [doorbell])
+    assert_entity_counts(hass, Platform.TEXT, 1, 1)
+
+    description = CAMERA[0]
+    unique_id, entity_id = ids_from_device_description(
+        Platform.TEXT, doorbell, description
+    )
+
+    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
+    doorbell.set_lcd_text = AsyncMock()
+
+    await hass.services.async_call(
+        "text",
+        "set_value",
+        {ATTR_ENTITY_ID: entity_id, "value": "Test test"},
+        blocking=True,
+    )
+
+    doorbell.set_lcd_text.assert_called_once_with(
+        DoorbellMessageType.CUSTOM_MESSAGE, text="Test test"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds text entity for UniFi Protect LCD screen. The `unifiprotect.set_doorbell_message` service is deprecated as part of a separate PR: https://github.com/home-assistant/core/pull/83675

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25217

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
