### PR TITLE
Fix delay setting up new Yale Access Bluetooth entries

### DIFF
--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Yale Access Bluetooth integration."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -27,7 +26,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import CONF_KEY, CONF_LOCAL_NAME, CONF_SLOT, DOMAIN
-from .util import async_get_service_info, human_readable_name
+from .util import async_find_existing_service_info, human_readable_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,11 +109,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                 raise AbortFlow(reason="already_configured")
 
-        try:
-            self._discovery_info = await async_get_service_info(
-                hass, local_name, address
-            )
-        except asyncio.TimeoutError:
+        self._discovery_info = async_find_existing_service_info(
+            hass, local_name, address
+        )
+        if not self._discovery_info:
             return self.async_abort(reason="no_devices_found")
 
         # Integration discovery should abort other flows unless they

--- a/homeassistant/components/yalexs_ble/util.py
+++ b/homeassistant/components/yalexs_ble/util.py
@@ -6,10 +6,8 @@ import platform
 from yalexs_ble import local_name_is_unique
 
 from homeassistant.components.bluetooth import (
-    BluetoothScanningMode,
     BluetoothServiceInfoBleak,
     async_discovered_service_info,
-    async_process_advertisements,
 )
 from homeassistant.components.bluetooth.match import (
     ADDRESS,
@@ -17,8 +15,6 @@ from homeassistant.components.bluetooth.match import (
     BluetoothCallbackMatcher,
 )
 from homeassistant.core import HomeAssistant, callback
-
-from .const import DEVICE_TIMEOUT
 
 
 def bluetooth_callback_matcher(
@@ -49,21 +45,6 @@ def async_find_existing_service_info(
         ) or device.address == address:
             return service_info
     return None
-
-
-async def async_get_service_info(
-    hass: HomeAssistant, local_name: str, address: str
-) -> BluetoothServiceInfoBleak:
-    """Wait for the service info for the given local_name and address."""
-    if service_info := async_find_existing_service_info(hass, local_name, address):
-        return service_info
-    return await async_process_advertisements(
-        hass,
-        lambda service_info: True,
-        bluetooth_callback_matcher(local_name, address),
-        BluetoothScanningMode.ACTIVE,
-        DEVICE_TIMEOUT,
-    )
 
 
 def short_address(address: str) -> str:

--- a/tests/components/yalexs_ble/test_config_flow.py
+++ b/tests/components/yalexs_ble/test_config_flow.py
@@ -400,8 +400,8 @@ async def test_bluetooth_step_success(hass: HomeAssistant) -> None:
 async def test_integration_discovery_success(hass: HomeAssistant) -> None:
     """Test integration discovery step success path."""
     with patch(
-        "homeassistant.components.yalexs_ble.util.async_process_advertisements",
-        return_value=YALE_ACCESS_LOCK_DISCOVERY_INFO,
+        "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+        return_value=[YALE_ACCESS_LOCK_DISCOVERY_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -443,8 +443,8 @@ async def test_integration_discovery_success(hass: HomeAssistant) -> None:
 async def test_integration_discovery_device_not_found(hass: HomeAssistant) -> None:
     """Test integration discovery when the device is not found."""
     with patch(
-        "homeassistant.components.yalexs_ble.util.async_process_advertisements",
-        side_effect=asyncio.TimeoutError,
+        "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+        return_value=[],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -483,8 +483,8 @@ async def test_integration_discovery_takes_precedence_over_bluetooth(
     assert flows[0]["context"]["local_name"] == YALE_ACCESS_LOCK_DISCOVERY_INFO.name
 
     with patch(
-        "homeassistant.components.yalexs_ble.util.async_process_advertisements",
-        return_value=YALE_ACCESS_LOCK_DISCOVERY_INFO,
+        "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+        return_value=[YALE_ACCESS_LOCK_DISCOVERY_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -558,8 +558,8 @@ async def test_integration_discovery_updates_key_unique_local_name(
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.yalexs_ble.util.async_process_advertisements",
-        return_value=LOCK_DISCOVERY_INFO_UUID_ADDRESS,
+        "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+        return_value=[LOCK_DISCOVERY_INFO_UUID_ADDRESS],
     ), patch(
         "homeassistant.components.yalexs_ble.async_setup_entry",
         return_value=True,
@@ -600,8 +600,8 @@ async def test_integration_discovery_updates_key_without_unique_local_name(
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.yalexs_ble.util.async_process_advertisements",
-        return_value=LOCK_DISCOVERY_INFO_UUID_ADDRESS,
+        "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+        return_value=[LOCK_DISCOVERY_INFO_UUID_ADDRESS],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -649,8 +649,8 @@ async def test_integration_discovery_updates_key_duplicate_local_name(
     entry2.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.yalexs_ble.util.async_process_advertisements",
-        return_value=LOCK_DISCOVERY_INFO_UUID_ADDRESS,
+        "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+        return_value=[LOCK_DISCOVERY_INFO_UUID_ADDRESS],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -695,8 +695,8 @@ async def test_integration_discovery_takes_precedence_over_bluetooth_uuid_addres
     assert flows[0]["context"]["local_name"] == LOCK_DISCOVERY_INFO_UUID_ADDRESS.name
 
     with patch(
-        "homeassistant.components.yalexs_ble.util.async_process_advertisements",
-        return_value=LOCK_DISCOVERY_INFO_UUID_ADDRESS,
+        "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+        return_value=[LOCK_DISCOVERY_INFO_UUID_ADDRESS],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -775,8 +775,8 @@ async def test_integration_discovery_takes_precedence_over_bluetooth_non_unique_
     assert flows[0]["context"]["local_name"] == OLD_FIRMWARE_LOCK_DISCOVERY_INFO.name
 
     with patch(
-        "homeassistant.components.yalexs_ble.util.async_process_advertisements",
-        return_value=OLD_FIRMWARE_LOCK_DISCOVERY_INFO,
+        "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+        return_value=[OLD_FIRMWARE_LOCK_DISCOVERY_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -851,8 +851,8 @@ async def test_user_is_setting_up_lock_and_discovery_happens_in_the_middle(
         await valdidate_started.wait()
 
         with patch(
-            "homeassistant.components.yalexs_ble.util.async_process_advertisements",
-            return_value=LOCK_DISCOVERY_INFO_UUID_ADDRESS,
+            "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+            return_value=[LOCK_DISCOVERY_INFO_UUID_ADDRESS],
         ):
             discovery_result = await hass.config_entries.flow.async_init(
                 DOMAIN,


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Entries took a while to setup because of the
`async_wait_init_flow_finish` call in `_async_setup_component`

The delay was so long that users thought the integration was broken

We had a wait in place for advertisements to arrive during discovery in case the lock was not
yet seen.  Since integration discovery is now deferred until after startup this wait it no longer needed


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
