### PR TITLE
Fix issue on Overkiz Domestic Hot water heater entities with away mode

### DIFF
--- a/homeassistant/components/overkiz/water_heater_entities/domestic_hot_water_production.py
+++ b/homeassistant/components/overkiz/water_heater_entities/domestic_hot_water_production.py
@@ -306,14 +306,6 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
                     OverkizCommand.SET_BOOST_MODE, OverkizCommand.OFF
                 )
 
-            if self.executor.has_command(OverkizCommand.SET_BOOST_MODE_DURATION):
-                await self.executor.async_execute_command(
-                    OverkizCommand.SET_BOOST_MODE_DURATION, 0
-                )
-                await self.executor.async_execute_command(
-                    OverkizCommand.REFRESH_BOOST_MODE_DURATION
-                )
-
             if self.executor.has_command(OverkizCommand.SET_CURRENT_OPERATING_MODE):
                 current_operating_mode = self.executor.select_state(
                     OverkizState.CORE_OPERATING_MODE
@@ -331,6 +323,11 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
         await self.executor.async_execute_command(
             OverkizCommand.SET_DHW_MODE, self.overkiz_to_operation_mode[operation_mode]
         )
+
+        if self.executor.has_command(OverkizCommand.REFRESH_BOOST_MODE_DURATION):
+            await self.executor.async_execute_command(
+                OverkizCommand.REFRESH_BOOST_MODE_DURATION
+            )
 
         if self.executor.has_command(OverkizCommand.REFRESH_DHW_MODE):
             await self.executor.async_execute_command(OverkizCommand.REFRESH_DHW_MODE)

--- a/homeassistant/components/overkiz/water_heater_entities/domestic_hot_water_production.py
+++ b/homeassistant/components/overkiz/water_heater_entities/domestic_hot_water_production.py
@@ -158,7 +158,9 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
-        min_temp = self.device.states[OverkizState.CORE_MINIMAL_TEMPERATURE_MANUAL_MODE]
+        min_temp = self.device.states.get(
+            OverkizState.CORE_MINIMAL_TEMPERATURE_MANUAL_MODE
+        )
         if min_temp:
             return cast(float, min_temp.value_as_float)
         return DEFAULT_MIN_TEMP
@@ -166,7 +168,9 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def max_temp(self) -> float:
         """Return the maximum temperature."""
-        max_temp = self.device.states[OverkizState.CORE_MAXIMAL_TEMPERATURE_MANUAL_MODE]
+        max_temp = self.device.states.get(
+            OverkizState.CORE_MAXIMAL_TEMPERATURE_MANUAL_MODE
+        )
         if max_temp:
             return cast(float, max_temp.value_as_float)
         return DEFAULT_MAX_TEMP
@@ -174,14 +178,14 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        current_temperature = self.device.states[
+        current_temperature = self.device.states.get(
             OverkizState.IO_MIDDLE_WATER_TEMPERATURE
-        ]
+        )
         if current_temperature:
             return current_temperature.value_as_float
-        current_temperature = self.device.states[
+        current_temperature = self.device.states.get(
             OverkizState.MODBUSLINK_MIDDLE_WATER_TEMPERATURE
-        ]
+        )
         if current_temperature:
             return current_temperature.value_as_float
         return None
@@ -190,19 +194,21 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
 
-        target_temperature = self.device.states[
+        target_temperature = self.device.states.get(
             OverkizState.CORE_WATER_TARGET_TEMPERATURE
-        ]
+        )
         if target_temperature:
             return target_temperature.value_as_float
 
-        target_temperature = self.device.states[
+        target_temperature = self.device.states.get(
             OverkizState.CORE_TARGET_DWH_TEMPERATURE
-        ]
+        )
         if target_temperature:
             return target_temperature.value_as_float
 
-        target_temperature = self.device.states[OverkizState.CORE_TARGET_TEMPERATURE]
+        target_temperature = self.device.states.get(
+            OverkizState.CORE_TARGET_TEMPERATURE
+        )
         if target_temperature:
             return target_temperature.value_as_float
 
@@ -211,9 +217,9 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
-        target_temperature_high = self.device.states[
+        target_temperature_high = self.device.states.get(
             OverkizState.CORE_MAXIMAL_TEMPERATURE_MANUAL_MODE
-        ]
+        )
         if target_temperature_high:
             return target_temperature_high.value_as_float
         return None
@@ -221,9 +227,9 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
-        target_temperature_low = self.device.states[
+        target_temperature_low = self.device.states.get(
             OverkizState.CORE_MINIMAL_TEMPERATURE_MANUAL_MODE
-        ]
+        )
         if target_temperature_low:
             return target_temperature_low.value_as_float
         return None

--- a/homeassistant/components/overkiz/water_heater_entities/domestic_hot_water_production.py
+++ b/homeassistant/components/overkiz/water_heater_entities/domestic_hot_water_production.py
@@ -158,9 +158,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
-        min_temp = self.device.states.get(
-            OverkizState.CORE_MINIMAL_TEMPERATURE_MANUAL_MODE
-        )
+        min_temp = self.device.states[OverkizState.CORE_MINIMAL_TEMPERATURE_MANUAL_MODE]
         if min_temp:
             return cast(float, min_temp.value_as_float)
         return DEFAULT_MIN_TEMP
@@ -168,9 +166,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def max_temp(self) -> float:
         """Return the maximum temperature."""
-        max_temp = self.device.states.get(
-            OverkizState.CORE_MAXIMAL_TEMPERATURE_MANUAL_MODE
-        )
+        max_temp = self.device.states[OverkizState.CORE_MAXIMAL_TEMPERATURE_MANUAL_MODE]
         if max_temp:
             return cast(float, max_temp.value_as_float)
         return DEFAULT_MAX_TEMP
@@ -178,14 +174,14 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        current_temperature = self.device.states.get(
+        current_temperature = self.device.states[
             OverkizState.IO_MIDDLE_WATER_TEMPERATURE
-        )
+        ]
         if current_temperature:
             return current_temperature.value_as_float
-        current_temperature = self.device.states.get(
+        current_temperature = self.device.states[
             OverkizState.MODBUSLINK_MIDDLE_WATER_TEMPERATURE
-        )
+        ]
         if current_temperature:
             return current_temperature.value_as_float
         return None
@@ -194,21 +190,19 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
 
-        target_temperature = self.device.states.get(
+        target_temperature = self.device.states[
             OverkizState.CORE_WATER_TARGET_TEMPERATURE
-        )
+        ]
         if target_temperature:
             return target_temperature.value_as_float
 
-        target_temperature = self.device.states.get(
+        target_temperature = self.device.states[
             OverkizState.CORE_TARGET_DWH_TEMPERATURE
-        )
+        ]
         if target_temperature:
             return target_temperature.value_as_float
 
-        target_temperature = self.device.states.get(
-            OverkizState.CORE_TARGET_TEMPERATURE
-        )
+        target_temperature = self.device.states[OverkizState.CORE_TARGET_TEMPERATURE]
         if target_temperature:
             return target_temperature.value_as_float
 
@@ -217,9 +211,9 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
-        target_temperature_high = self.device.states.get(
+        target_temperature_high = self.device.states[
             OverkizState.CORE_MAXIMAL_TEMPERATURE_MANUAL_MODE
-        )
+        ]
         if target_temperature_high:
             return target_temperature_high.value_as_float
         return None
@@ -227,9 +221,9 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
-        target_temperature_low = self.device.states.get(
+        target_temperature_low = self.device.states[
             OverkizState.CORE_MINIMAL_TEMPERATURE_MANUAL_MODE
-        )
+        ]
         if target_temperature_low:
             return target_temperature_low.value_as_float
         return None

--- a/homeassistant/components/overkiz/water_heater_entities/hitachi_dhw.py
+++ b/homeassistant/components/overkiz/water_heater_entities/hitachi_dhw.py
@@ -46,7 +46,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        current_temperature = self.device.states[OverkizState.CORE_DHW_TEMPERATURE]
+        current_temperature = self.device.states.get(OverkizState.CORE_DHW_TEMPERATURE)
         if current_temperature:
             return current_temperature.value_as_float
         return None
@@ -54,9 +54,9 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        target_temperature = self.device.states[
+        target_temperature = self.device.states.get(
             OverkizState.MODBUS_CONTROL_DHW_SETTING_TEMPERATURE
-        ]
+        )
         if target_temperature:
             return target_temperature.value_as_float
         return None
@@ -72,11 +72,11 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     @property
     def current_operation(self) -> str | None:
         """Return current operation ie. eco, electric, performance, ..."""
-        modbus_control = self.device.states[OverkizState.MODBUS_CONTROL_DHW]
+        modbus_control = self.device.states.get(OverkizState.MODBUS_CONTROL_DHW)
         if modbus_control and modbus_control.value_as_str == OverkizCommandParam.STOP:
             return STATE_OFF
 
-        current_mode = self.device.states[OverkizState.MODBUS_DHW_MODE]
+        current_mode = self.device.states.get(OverkizState.MODBUS_DHW_MODE)
         if current_mode and current_mode.value_as_str in OVERKIZ_TO_OPERATION_MODE:
             return OVERKIZ_TO_OPERATION_MODE[current_mode.value_as_str]
 

--- a/homeassistant/components/overkiz/water_heater_entities/hitachi_dhw.py
+++ b/homeassistant/components/overkiz/water_heater_entities/hitachi_dhw.py
@@ -46,7 +46,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        current_temperature = self.device.states.get(OverkizState.CORE_DHW_TEMPERATURE)
+        current_temperature = self.device.states[OverkizState.CORE_DHW_TEMPERATURE]
         if current_temperature:
             return current_temperature.value_as_float
         return None
@@ -54,9 +54,9 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        target_temperature = self.device.states.get(
+        target_temperature = self.device.states[
             OverkizState.MODBUS_CONTROL_DHW_SETTING_TEMPERATURE
-        )
+        ]
         if target_temperature:
             return target_temperature.value_as_float
         return None
@@ -72,11 +72,11 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     @property
     def current_operation(self) -> str | None:
         """Return current operation ie. eco, electric, performance, ..."""
-        modbus_control = self.device.states.get(OverkizState.MODBUS_CONTROL_DHW)
+        modbus_control = self.device.states[OverkizState.MODBUS_CONTROL_DHW]
         if modbus_control and modbus_control.value_as_str == OverkizCommandParam.STOP:
             return STATE_OFF
 
-        current_mode = self.device.states.get(OverkizState.MODBUS_DHW_MODE)
+        current_mode = self.device.states[OverkizState.MODBUS_DHW_MODE]
         if current_mode and current_mode.value_as_str in OVERKIZ_TO_OPERATION_MODE:
             return OVERKIZ_TO_OPERATION_MODE[current_mode.value_as_str]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is an attempt to fix for #83326
I'm not sure if the target branch should still be dev in this case, sorry if I'm doing it wrong.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue) #83326 
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
#83326 should be fixed by not calling set boost mode duration with 0

- This PR fixes or closes issue: fixes #83326
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
