### PR TITLE
Hide Aranet update interval by default

### DIFF
--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -77,6 +77,8 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=TIME_SECONDS,
         state_class=SensorStateClass.MEASUREMENT,
+        # The interval setting is not a generally useful entity for most users.
+        entity_registry_enabled_default=False,
     ),
 }
 

--- a/tests/components/aranet/test_sensor.py
+++ b/tests/components/aranet/test_sensor.py
@@ -25,7 +25,7 @@ async def test_sensors(hass):
     assert len(hass.states.async_all("sensor")) == 0
     inject_bluetooth_service_info(hass, VALID_DATA_SERVICE_INFO)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("sensor")) == 6
+    assert len(hass.states.async_all("sensor")) == 5
 
     batt_sensor = hass.states.get("sensor.aranet4_12345_battery")
     batt_sensor_attrs = batt_sensor.attributes
@@ -62,13 +62,6 @@ async def test_sensors(hass):
     assert press_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "hPa"
     assert press_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
-    interval_sensor = hass.states.get("sensor.aranet4_12345_update_interval")
-    interval_sensor_attrs = interval_sensor.attributes
-    assert interval_sensor.state == "300"
-    assert interval_sensor_attrs[ATTR_FRIENDLY_NAME] == "Aranet4 12345 Update Interval"
-    assert interval_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "s"
-    assert interval_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
-
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
@@ -87,7 +80,7 @@ async def test_smart_home_integration_disabled(hass):
     assert len(hass.states.async_all("sensor")) == 0
     inject_bluetooth_service_info(hass, DISABLED_INTEGRATIONS_SERVICE_INFO)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("sensor")) == 6
+    assert len(hass.states.async_all("sensor")) == 5
 
     batt_sensor = hass.states.get("sensor.aranet4_12345_battery")
     assert batt_sensor.state == "unavailable"
@@ -103,9 +96,6 @@ async def test_smart_home_integration_disabled(hass):
 
     press_sensor = hass.states.get("sensor.aranet4_12345_pressure")
     assert press_sensor.state == "unavailable"
-
-    interval_sensor = hass.states.get("sensor.aranet4_12345_update_interval")
-    assert interval_sensor.state == "unavailable"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
This hides the "Update Interval" entity from Aranet sensors by default, as it is not typically information that people will care about seeing change in Home Assistant.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

As requested by @balloob at https://github.com/home-assistant/core/pull/80865#discussion_r1043794089.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
