### PR TITLE
Revert "Move esphome gatt services cache to be per device" #81265

### DIFF
--- a/homeassistant/components/esphome/domain_data.py
+++ b/homeassistant/components/esphome/domain_data.py
@@ -1,8 +1,12 @@
 """Support for esphome domain data."""
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from dataclasses import dataclass, field
 from typing import TypeVar, cast
+
+from bleak.backends.service import BleakGATTServiceCollection
+from lru import LRU  # pylint: disable=no-name-in-module
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,6 +17,7 @@ from .entry_data import RuntimeEntryData
 
 STORAGE_VERSION = 1
 DOMAIN = "esphome"
+MAX_CACHED_SERVICES = 128
 
 _DomainDataSelfT = TypeVar("_DomainDataSelfT", bound="DomainData")
 
@@ -23,6 +28,40 @@ class DomainData:
 
     _entry_datas: dict[str, RuntimeEntryData] = field(default_factory=dict)
     _stores: dict[str, Store] = field(default_factory=dict)
+    _gatt_services_cache: MutableMapping[int, BleakGATTServiceCollection] = field(
+        default_factory=lambda: LRU(MAX_CACHED_SERVICES)  # type: ignore[no-any-return]
+    )
+    _gatt_mtu_cache: MutableMapping[int, int] = field(
+        default_factory=lambda: LRU(MAX_CACHED_SERVICES)  # type: ignore[no-any-return]
+    )
+
+    def get_gatt_services_cache(
+        self, address: int
+    ) -> BleakGATTServiceCollection | None:
+        """Get the BleakGATTServiceCollection for the given address."""
+        return self._gatt_services_cache.get(address)
+
+    def set_gatt_services_cache(
+        self, address: int, services: BleakGATTServiceCollection
+    ) -> None:
+        """Set the BleakGATTServiceCollection for the given address."""
+        self._gatt_services_cache[address] = services
+
+    def clear_gatt_services_cache(self, address: int) -> None:
+        """Clear the BleakGATTServiceCollection for the given address."""
+        self._gatt_services_cache.pop(address, None)
+
+    def get_gatt_mtu_cache(self, address: int) -> int | None:
+        """Get the mtu cache for the given address."""
+        return self._gatt_mtu_cache.get(address)
+
+    def set_gatt_mtu_cache(self, address: int, mtu: int) -> None:
+        """Set the mtu cache for the given address."""
+        self._gatt_mtu_cache[address] = mtu
+
+    def clear_gatt_mtu_cache(self, address: int) -> None:
+        """Clear the mtu cache for the given address."""
+        self._gatt_mtu_cache.pop(address, None)
 
     def get_entry_data(self, entry: ConfigEntry) -> RuntimeEntryData:
         """Return the runtime entry data associated with this config entry.

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, MutableMapping
+from collections.abc import Callable
 from dataclasses import dataclass, field
 import logging
 from typing import Any, cast
@@ -30,8 +30,6 @@ from aioesphomeapi import (
     UserService,
 )
 from aioesphomeapi.model import ButtonInfo
-from bleak.backends.service import BleakGATTServiceCollection
-from lru import LRU  # pylint: disable=no-name-in-module
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -59,7 +57,6 @@ INFO_TYPE_TO_PLATFORM: dict[type[EntityInfo], str] = {
     SwitchInfo: Platform.SWITCH,
     TextSensorInfo: Platform.SENSOR,
 }
-MAX_CACHED_SERVICES = 128
 
 
 @dataclass
@@ -95,45 +92,11 @@ class RuntimeEntryData:
     _ble_connection_free_futures: list[asyncio.Future[int]] = field(
         default_factory=list
     )
-    _gatt_services_cache: MutableMapping[int, BleakGATTServiceCollection] = field(
-        default_factory=lambda: LRU(MAX_CACHED_SERVICES)  # type: ignore[no-any-return]
-    )
-    _gatt_mtu_cache: MutableMapping[int, int] = field(
-        default_factory=lambda: LRU(MAX_CACHED_SERVICES)  # type: ignore[no-any-return]
-    )
 
     @property
     def name(self) -> str:
         """Return the name of the device."""
         return self.device_info.name if self.device_info else self.entry_id
-
-    def get_gatt_services_cache(
-        self, address: int
-    ) -> BleakGATTServiceCollection | None:
-        """Get the BleakGATTServiceCollection for the given address."""
-        return self._gatt_services_cache.get(address)
-
-    def set_gatt_services_cache(
-        self, address: int, services: BleakGATTServiceCollection
-    ) -> None:
-        """Set the BleakGATTServiceCollection for the given address."""
-        self._gatt_services_cache[address] = services
-
-    def clear_gatt_services_cache(self, address: int) -> None:
-        """Clear the BleakGATTServiceCollection for the given address."""
-        self._gatt_services_cache.pop(address, None)
-
-    def get_gatt_mtu_cache(self, address: int) -> int | None:
-        """Get the mtu cache for the given address."""
-        return self._gatt_mtu_cache.get(address)
-
-    def set_gatt_mtu_cache(self, address: int, mtu: int) -> None:
-        """Set the mtu cache for the given address."""
-        self._gatt_mtu_cache[address] = mtu
-
-    def clear_gatt_mtu_cache(self, address: int) -> None:
-        """Clear the mtu cache for the given address."""
-        self._gatt_mtu_cache.pop(address, None)
 
     @callback
     def async_update_ble_connection_limits(self, free: int, limit: int) -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reverts the services cache to be per device and restores the integration level cache. The reason it was previously unstable was because of an issue with the esphome implementation that accidentally mixed services between devices

related pr https://github.com/esphome/esphome/pull/4171

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
