### PR TITLE
2022.12.3

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,7 @@ from .backports.enum import StrEnum
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 12
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,7 +1,7 @@
 PyJWT==2.5.0
 PyNaCl==1.5.0
 aiodiscover==1.4.13
-aiohttp==3.8.3
+aiohttp==3.8.1
 aiohttp_cors==0.7.0
 astral==2.2
 async-upnp-client==0.32.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2022.12.2"
+version     = "2022.12.3"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.9.0"
 dependencies    = [
-    "aiohttp==3.8.3",
+    "aiohttp==3.8.1",
     "astral==2.2",
     "async_timeout==4.0.2",
     "attrs==21.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -c homeassistant/package_constraints.txt
 
 # Home Assistant Core
-aiohttp==3.8.3
+aiohttp==3.8.1
 astral==2.2
 async_timeout==4.0.2
 attrs==21.2.0


### PR DESCRIPTION
- Drop aiohttp to 3.8.1 ([@balloob] - [#83795])

[#83482]: https://github.com/home-assistant/core/pull/83482
[#83592]: https://github.com/home-assistant/core/pull/83592
[#83778]: https://github.com/home-assistant/core/pull/83778
[#83795]: https://github.com/home-assistant/core/pull/83795
[@balloob]: https://github.com/balloob
[@frenck]: https://github.com/frenck
[abode docs]: https://www.home-assistant.io/integrations/abode/
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/