### PR TITLE
Use device classes in apcupsd

### DIFF
--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -17,15 +17,14 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     CONF_RESOURCES,
-    ELECTRIC_CURRENT_AMPERE,
-    ELECTRIC_POTENTIAL_VOLT,
-    FREQUENCY_HERTZ,
     PERCENTAGE,
-    POWER_WATT,
-    TEMP_CELSIUS,
-    TIME_MINUTES,
-    TIME_SECONDS,
     UnitOfApparentPower,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfFrequency,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -79,8 +78,8 @@ SENSORS: dict[str, SensorEntityDescription] = {
     "battv": SensorEntityDescription(
         key="battv",
         name="UPS Battery Voltage",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "bcharge": SensorEntityDescription(
         key="bcharge",
@@ -151,8 +150,8 @@ SENSORS: dict[str, SensorEntityDescription] = {
     "hitrans": SensorEntityDescription(
         key="hitrans",
         name="UPS Transfer High",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "hostname": SensorEntityDescription(
         key="hostname",
@@ -169,7 +168,7 @@ SENSORS: dict[str, SensorEntityDescription] = {
     "itemp": SensorEntityDescription(
         key="itemp",
         name="UPS Internal Temperature",
-        native_unit_of_measurement=TEMP_CELSIUS,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
     "laststest": SensorEntityDescription(
@@ -191,14 +190,14 @@ SENSORS: dict[str, SensorEntityDescription] = {
     "linefreq": SensorEntityDescription(
         key="linefreq",
         name="UPS Line Frequency",
-        native_unit_of_measurement=FREQUENCY_HERTZ,
-        icon="mdi:information-outline",
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        device_class=SensorDeviceClass.FREQUENCY,
     ),
     "linev": SensorEntityDescription(
         key="linev",
         name="UPS Input Voltage",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "loadpct": SensorEntityDescription(
         key="loadpct",
@@ -215,8 +214,8 @@ SENSORS: dict[str, SensorEntityDescription] = {
     "lotrans": SensorEntityDescription(
         key="lotrans",
         name="UPS Transfer Low",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "mandate": SensorEntityDescription(
         key="mandate",
@@ -232,8 +231,8 @@ SENSORS: dict[str, SensorEntityDescription] = {
     "maxlinev": SensorEntityDescription(
         key="maxlinev",
         name="UPS Input Voltage High",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "maxtime": SensorEntityDescription(
         key="maxtime",
@@ -249,8 +248,8 @@ SENSORS: dict[str, SensorEntityDescription] = {
     "minlinev": SensorEntityDescription(
         key="minlinev",
         name="UPS Input Voltage Low",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "mintimel": SensorEntityDescription(
         key="mintimel",
@@ -266,26 +265,26 @@ SENSORS: dict[str, SensorEntityDescription] = {
     "nombattv": SensorEntityDescription(
         key="nombattv",
         name="UPS Battery Nominal Voltage",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "nominv": SensorEntityDescription(
         key="nominv",
         name="UPS Nominal Input Voltage",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "nomoutv": SensorEntityDescription(
         key="nomoutv",
         name="UPS Nominal Output Voltage",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "nompower": SensorEntityDescription(
         key="nompower",
         name="UPS Nominal Output Power",
-        native_unit_of_measurement=POWER_WATT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
     ),
     "nomapnt": SensorEntityDescription(
         key="nomapnt",
@@ -301,14 +300,14 @@ SENSORS: dict[str, SensorEntityDescription] = {
     "outcurnt": SensorEntityDescription(
         key="outcurnt",
         name="UPS Output Current",
-        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
     ),
     "outputv": SensorEntityDescription(
         key="outputv",
         name="UPS Output Voltage",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        icon="mdi:flash",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     "reg1": SensorEntityDescription(
         key="reg1",
@@ -416,17 +415,17 @@ SENSORS: dict[str, SensorEntityDescription] = {
     ),
 }
 
-SPECIFIC_UNITS = {"ITEMP": TEMP_CELSIUS}
+SPECIFIC_UNITS = {"ITEMP": UnitOfTemperature.CELSIUS}
 INFERRED_UNITS = {
-    " Minutes": TIME_MINUTES,
-    " Seconds": TIME_SECONDS,
+    " Minutes": UnitOfTime.MINUTES,
+    " Seconds": UnitOfTime.SECONDS,
     " Percent": PERCENTAGE,
-    " Volts": ELECTRIC_POTENTIAL_VOLT,
-    " Ampere": ELECTRIC_CURRENT_AMPERE,
+    " Volts": UnitOfElectricPotential.VOLT,
+    " Ampere": UnitOfElectricCurrent.AMPERE,
     " Volt-Ampere": UnitOfApparentPower.VOLT_AMPERE,
-    " Watts": POWER_WATT,
-    " Hz": FREQUENCY_HERTZ,
-    " C": TEMP_CELSIUS,
+    " Watts": UnitOfPower.WATT,
+    " Hz": UnitOfFrequency.HERTZ,
+    " C": UnitOfTemperature.CELSIUS,
     " Percent Load Capacity": PERCENTAGE,
 }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use device classes in apcupsd
Also adjust to use unit enums

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
