### PR TITLE
Add telegram_voice events

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1287,7 +1287,11 @@ omit =
     homeassistant/components/tautulli/sensor.py
     homeassistant/components/ted5000/sensor.py
     homeassistant/components/telegram/notify.py
-    homeassistant/components/telegram_bot/*
+    homeassistant/components/telegram_bot/__init__.py
+    homeassistant/components/telegram_bot/broadcast.py
+    homeassistant/components/telegram_bot/const.py
+    homeassistant/components/telegram_bot/polling.py
+    homeassistant/components/telegram_bot/webhooks.py
     homeassistant/components/tellduslive/__init__.py
     homeassistant/components/tellduslive/binary_sensor.py
     homeassistant/components/tellduslive/cover.py

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -62,6 +62,7 @@ ATTR_DISABLE_NOTIF = "disable_notification"
 ATTR_DISABLE_WEB_PREV = "disable_web_page_preview"
 ATTR_EDITED_MSG = "edited_message"
 ATTR_FILE = "file"
+ATTR_FILE_MIME_TYPE = "mime_type"
 ATTR_FROM_FIRST = "from_first"
 ATTR_FROM_LAST = "from_last"
 ATTR_KEYBOARD = "keyboard"
@@ -981,6 +982,7 @@ class BaseTelegramBotEntity:
                 mime_type=message.voice.mime_type,
                 bot_platform=self.bot_platform,
             )
+            event_data[ATTR_FILE_MIME_TYPE] = message.voice.mime_type
         else:
             event_type = EVENT_TELEGRAM_TEXT
             event_data[ATTR_TEXT] = message.text

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -13,7 +13,6 @@ from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 from telegram import (
     Bot,
     CallbackQuery,
-    File,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     Message,

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -932,7 +932,6 @@ class BaseTelegramBotEntity:
         # the bot platform is used to identify the bot,
         # since we have one bot per platform.
         self.bot_platform = bot_platform
-        
 
     def handle_update(self, update: Update, context: CallbackContext) -> bool:
         """Handle updates from bot dispatcher set up by the respective platform."""
@@ -978,7 +977,7 @@ class BaseTelegramBotEntity:
             event_type = EVENT_TELEGRAM_COMMAND
             event_data.update(self._get_command_event_data(message.text))
         elif message.voice is not None:
-            file=message.voice.get_file()
+            file = message.voice.get_file()
             event_type = EVENT_TELEGRAM_VOICE
             event_data[ATTR_TEXT] = message.text
             event_data[ATTR_MEDIA_URL] = generate_media_source_id(

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -43,11 +43,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
-from .media_source import (
-    generate_media_source_id,
-    TelegramManager,
-    TelegramView,
-)
+from .media_source import TelegramManager, TelegramView, generate_media_source_id
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/telegram_bot/const.py
+++ b/homeassistant/components/telegram_bot/const.py
@@ -1,0 +1,1 @@
+DOMAIN = "telegram_bot"

--- a/homeassistant/components/telegram_bot/const.py
+++ b/homeassistant/components/telegram_bot/const.py
@@ -1,1 +1,3 @@
+"""Constants shared in the telegram_bot component."""
 DOMAIN = "telegram_bot"
+

--- a/homeassistant/components/telegram_bot/const.py
+++ b/homeassistant/components/telegram_bot/const.py
@@ -1,3 +1,2 @@
 """Constants shared in the telegram_bot component."""
 DOMAIN = "telegram_bot"
-

--- a/homeassistant/components/telegram_bot/media_source.py
+++ b/homeassistant/components/telegram_bot/media_source.py
@@ -1,0 +1,170 @@
+"""Telegram media source."""
+from __future__ import annotations
+
+from functools import partial
+from io import BytesIO
+import mimetypes
+from typing import TYPE_CHECKING, Dict, TypedDict
+
+from aiohttp import web
+import telegram
+from yarl import URL
+
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.media_player import BrowseError, MediaClass
+from homeassistant.components.media_source import (
+    BrowseMediaSource,
+    MediaSource,
+    MediaSourceItem,
+    PlayMedia,
+    Unresolvable,
+    generate_media_source_id as ms_generate_media_source_id,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.network import get_url
+
+from .const import DOMAIN
+
+
+class MediaSourceOptions(TypedDict):
+    """Media source options."""
+    # telefram.File identifier:
+    file_id: str
+    # Play_Media needs the mime and telegram provides it
+    mime_type: str
+    # The bot platform (polling/webhooks)
+    # is currently an identifier of the bot that
+    # is used. We need the bot to refresh the
+    # download token.
+    bot_platform: str
+
+
+
+class TelegramManager:
+    def __init__(self, hass):
+        self.hass = hass
+        self.bots: Dict[str, telegram.Bot] = {}
+        self.mem_cache = {}
+        self.mem_cache_entries = deque([], maxlen=5)
+        # prepare local media directory
+        # cleanup job to rm older files?
+
+    def _generate_cache_key(self, media: MediaSourceOptions) -> str:
+        return media["file_id"]
+
+    async def async_get_url(self, media: MediaSourceOptions) -> str:
+        """Get URL for play message.
+        This method is a coroutine.
+        """
+        cache_key = self._generate_cache_key(media)
+        # Is file already in memory
+        if cache_key in self.mem_cache:
+            filename = media["file_id"]
+        else:
+            filename = await self.hass.async_add_executor_job(
+                partial(self._download_file, media=media)
+            )
+        return get_url(self.hass) + f"/api/telegram_proxy/{filename}"
+
+    def _download_file(self, media) -> str:
+        bot = self.bots[media["bot_platform"]]
+        file = bot.get_file(file_id=media["file_id"])
+        mime_type = media["mime_type"]
+        data = BytesIO()
+        file.download(out=data)
+        # evict oldest if deque is full:
+        if len(self.mem_cache_entries) == self.mem_cache_entries.maxlen:
+            to_remove = self.mem_cache_entries.popleft()
+            del self.mem_cache[to_remove]
+        self.mem_cache_entries.append(media["file_id"])
+        self.mem_cache[media["file_id"]] = (mime_type, data.getvalue())
+        return media["file_id"]
+
+    async def async_read_telegram_file(self, filename: str):
+        try:
+            (mime_type, data) = self.mem_cache[filename]
+        except KeyError as err:
+            raise Unresolvable(str(err)) from err
+        return mime_type, data
+
+async def async_get_media_source(hass: HomeAssistant) -> TelegramMediaSource:
+    """Set up telegram media source."""
+    return TelegramMediaSource(hass)
+
+@callback
+def generate_media_source_id(
+    file_id: str,
+    mime_type: str,
+    bot_platform: str,
+) -> str:
+    """Generate a media source ID for telegram."""
+
+    params = {
+        "mime_type": mime_type,
+        "bot_platform": bot_platform,
+    }
+
+    return ms_generate_media_source_id(
+        DOMAIN,
+        str(URL.build(path=file_id, query=params)),
+    )
+
+@callback
+def media_source_id_to_kwargs(media_source_id: str) -> MediaSourceOptions:
+    """Turn a media source ID into options."""
+    parsed = URL(media_source_id)
+    options = dict(parsed.query)
+    try:
+        kwargs: MediaSourceOptions = {
+            "file_id": parsed.name,
+            "mime_type": options.pop("mime_type"),
+            "bot_platform": options.pop("bot_platform"),
+        }
+    except KeyError as exc:
+        raise Unresolvable(f"No field specified: {str(exc)}") from exc
+    return kwargs
+
+
+class TelegramMediaSource(MediaSource):
+    """A telegram-provided media source."""
+
+    name: str = "Telegram"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize TelegramMediaSource."""
+        super().__init__(DOMAIN)
+        self.hass = hass
+
+    async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
+        """Resolve media to a url."""
+        manager: TelegramManager = self.hass.data[DOMAIN]
+        try:
+            media_args = media_source_id_to_kwargs(item.identifier)
+            url = await manager.async_get_url(media_args)
+        except HomeAssistantError as err:
+            raise Unresolvable(str(err)) from err
+        mime_type = media_args["mime_type"]
+        return PlayMedia(url, mime_type)
+
+class TelegramView(HomeAssistantView):
+    """Telegram view to serve attached files and media."""
+
+    requires_auth = False
+    url = "/api/telegram_proxy/{filename}"
+    name = "api:telegram_file"
+
+    def __init__(self, manager: TelegramManager) -> None:
+        """Initialize a telegram view."""
+        self.manager = manager
+
+    async def get(self, request: web.Request, filename: str) -> web.Response:
+        """Start a get request."""
+        try:
+            content, data = await self.manager.async_read_telegram_file(filename)
+        except HomeAssistantError as err:
+            _LOGGER.error("Error on load telegram file: %s", err)
+            return web.Response(status=HTTPStatus.NOT_FOUND)
+
+        return web.Response(body=data, content_type=content)
+

--- a/homeassistant/components/telegram_bot/media_source.py
+++ b/homeassistant/components/telegram_bot/media_source.py
@@ -1,19 +1,19 @@
 """Telegram media source."""
 from __future__ import annotations
 
+from collections import deque
 from functools import partial
+from http import HTTPStatus
 from io import BytesIO
-import mimetypes
-from typing import TYPE_CHECKING, Dict, TypedDict
+import logging
+from typing import  Dict, TypedDict
 
 from aiohttp import web
 import telegram
 from yarl import URL
 
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.media_player import BrowseError, MediaClass
 from homeassistant.components.media_source import (
-    BrowseMediaSource,
     MediaSource,
     MediaSourceItem,
     PlayMedia,
@@ -25,6 +25,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.network import get_url
 
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class MediaSourceOptions(TypedDict):
@@ -47,8 +49,7 @@ class TelegramManager:
         self.bots: Dict[str, telegram.Bot] = {}
         self.mem_cache = {}
         self.mem_cache_entries = deque([], maxlen=5)
-        # prepare local media directory
-        # cleanup job to rm older files?
+
 
     def _generate_cache_key(self, media: MediaSourceOptions) -> str:
         return media["file_id"]
@@ -167,4 +168,3 @@ class TelegramView(HomeAssistantView):
             return web.Response(status=HTTPStatus.NOT_FOUND)
 
         return web.Response(body=data, content_type=content)
-

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -48,7 +48,7 @@ class PollBot(BaseTelegramBotEntity):
         self.dispatcher = self.updater.dispatcher
         self.dispatcher.add_handler(TypeHandler(Update, self.handle_update))
         self.dispatcher.add_error_handler(process_error)
-        super().__init__(hass, config)
+        super().__init__(hass, config, "polling")
 
     def start_polling(self, event=None):
         """Start the polling task."""

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -49,7 +49,7 @@ class PushBot(BaseTelegramBotEntity):
         # Dumb dispatcher that just gets our updates to our handler callback (self.handle_update)
         self.dispatcher = Dispatcher(bot, None)
         self.dispatcher.add_handler(TypeHandler(Update, self.handle_update))
-        super().__init__(hass, config)
+        super().__init__(hass, config, "webhooks")
 
         self.base_url = config.get(CONF_URL) or get_url(
             hass, require_ssl=True, allow_internal=False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

Special thanks and acknowledgements to @PaarthShah who has been very supportive and has provided great tips and discussion on the design of this event type on discord 


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `telegram_bot` component implements lots of services, to send text messages, location, media... but it only handles receiving bot commands and text messages. 

This pull request improves the `telegram_bot`  integration so it handles incoming voice messages. When an allowed user sends a voice message to the telegram bot, the integration will now fire a `"telegram_voice"` event that includes a media URL pointing to the audio. That event can be used for instance in an automation, to play the voice message on a media player.

The voice audio file is downloaded only if it is needed, and it is saved in memory, with the last 5 most recent audios. Telegram limits those files to 20MiB, so this pull request can use up to 100MiB of RAM in the worst case.

Disk caching, time-based cache eviction, permanent storage of voice messages, support for other telegram media (e.g. audio files, video files, documents...)  or the ability to browse downloaded telegram media files are left out of the scope of this pull request to keep it simple.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
