### PR TITLE
Migrate AirVisual Pro devices to the `airvisual_pro` domain

### DIFF
--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -314,7 +314,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
 
     # 2 -> 3: Moving AirVisual Pro to its own domain
-    if version == 2:
+    elif version == 2:
         version = 3
 
         if entry.data[CONF_INTEGRATION_TYPE] == INTEGRATION_TYPE_NODE_PRO:

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -12,7 +12,6 @@ from pyairvisual.cloud_api import InvalidKeyError, KeyExpiredError, Unauthorized
 from pyairvisual.errors import AirVisualError
 from pyairvisual.node import NodeProError
 
-from homeassistant.components.airvisual_pro import DOMAIN as AIRVISUAL_PRO_DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_API_KEY,
@@ -324,7 +323,12 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             tasks = [
                 hass.config_entries.async_remove(entry.entry_id),
                 hass.config_entries.flow.async_init(
-                    AIRVISUAL_PRO_DOMAIN, context={"source": SOURCE_IMPORT}, data=data
+                    # We use a raw string for the airvisual_pro domain (instead of
+                    # importing the actual constant) so that we can avoid listing it
+                    # as a dependency:
+                    "airvisual_pro",
+                    context={"source": SOURCE_IMPORT},
+                    data=data,
                 ),
             ]
             await asyncio.gather(*tasks)

--- a/homeassistant/components/airvisual/config_flow.py
+++ b/homeassistant/components/airvisual/config_flow.py
@@ -64,7 +64,6 @@ PICK_INTEGRATION_TYPE_SCHEMA = vol.Schema(
             [
                 INTEGRATION_TYPE_GEOGRAPHY_COORDS,
                 INTEGRATION_TYPE_GEOGRAPHY_NAME,
-                INTEGRATION_TYPE_NODE_PRO,
             ]
         )
     }
@@ -81,7 +80,7 @@ OPTIONS_FLOW = {
 class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle an AirVisual config flow."""
 
-    VERSION = 2
+    VERSION = 3
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/homeassistant/components/airvisual/manifest.json
+++ b/homeassistant/components/airvisual/manifest.json
@@ -4,6 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/airvisual",
   "requirements": ["pyairvisual==2022.12.1"],
+  "dependencies": ["airvisual_pro"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",
   "loggers": ["pyairvisual", "pysmb"],

--- a/homeassistant/components/airvisual/manifest.json
+++ b/homeassistant/components/airvisual/manifest.json
@@ -4,7 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/airvisual",
   "requirements": ["pyairvisual==2022.12.1"],
-  "dependencies": ["airvisual_pro"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",
   "loggers": ["pyairvisual", "pysmb"],

--- a/homeassistant/components/airvisual/strings.json
+++ b/homeassistant/components/airvisual/strings.json
@@ -87,7 +87,7 @@
   "issues": {
     "airvisual_pro_migration": {
       "title": "{ip_address} is now part of the AirVisual Pro integration",
-      "description": "AirVisual Pro units are now their own Home Assistant integration (as opposed to be included with the original AirVisual integration that uses the AirVisual cloud API). The Pro device located at `{ip_address}` has automatically been migrated.\n\nAs part of that migration, the Pro's device ID has changed from `{old_device_id}` to `{new_device_id}`.\n\nIf you utilize entity IDs belonging to this Pro in automations or scripts, you don't need to do anything; if, however, you utilize the Pro's device ID, please update those automations or scripts accordingly."
+      "description": "AirVisual Pro units are now their own Home Assistant integration (as opposed to be included with the original AirVisual integration that uses the AirVisual cloud API). The Pro device located at `{ip_address}` has automatically been migrated.\n\nAs part of that migration, the Pro's device ID has changed from `{old_device_id}` to `{new_device_id}`. Please update these automations to use the new device ID: {device_automations_string}."
     }
   }
 }

--- a/homeassistant/components/airvisual/strings.json
+++ b/homeassistant/components/airvisual/strings.json
@@ -83,5 +83,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "airvisual_pro_migration": {
+      "title": "{ip_address} is now part of the AirVisual Pro integration",
+      "description": "AirVisual Pro units are now their own Home Assistant integration (as opposed to be included with the original AirVisual integration that uses the AirVisual cloud API). The Pro device located at `{ip_address}` has automatically been migrated.\n\nAs part of that migration, the Pro's device ID has changed from `{old_device_id}` to `{new_device_id}`.\n\nIf you utilize entity IDs belonging to this Pro in automations or scripts, you don't need to do anything; if, however, you utilize the Pro's device ID, please update those automations or scripts accordingly."
+    }
   }
 }

--- a/homeassistant/components/airvisual/translations/en.json
+++ b/homeassistant/components/airvisual/translations/en.json
@@ -74,6 +74,12 @@
             }
         }
     },
+    "issues": {
+        "airvisual_pro_migration": {
+            "description": "AirVisual Pro units are now their own Home Assistant integration (as opposed to be included with the original AirVisual integration that uses the AirVisual cloud API). The Pro device located at `{ip_address}` has automatically been migrated.\n\nAs part of that migration, the Pro's device ID has changed from `{old_device_id}` to `{new_device_id}`.\n\nIf you utilize entity IDs belonging to this Pro in automations or scripts, you don't need to do anything; if, however, you utilize the Pro's device ID, please update those automations or scripts accordingly.",
+            "title": "{ip_address} is now part of the AirVisual Pro integration"
+        }
+    },
     "options": {
         "step": {
             "init": {

--- a/homeassistant/components/airvisual/translations/en.json
+++ b/homeassistant/components/airvisual/translations/en.json
@@ -76,7 +76,7 @@
     },
     "issues": {
         "airvisual_pro_migration": {
-            "description": "AirVisual Pro units are now their own Home Assistant integration (as opposed to be included with the original AirVisual integration that uses the AirVisual cloud API). The Pro device located at `{ip_address}` has automatically been migrated.\n\nAs part of that migration, the Pro's device ID has changed from `{old_device_id}` to `{new_device_id}`.\n\nIf you utilize entity IDs belonging to this Pro in automations or scripts, you don't need to do anything; if, however, you utilize the Pro's device ID, please update those automations or scripts accordingly.",
+            "description": "AirVisual Pro units are now their own Home Assistant integration (as opposed to be included with the original AirVisual integration that uses the AirVisual cloud API). The Pro device located at `{ip_address}` has automatically been migrated.\n\nAs part of that migration, the Pro's device ID has changed from `{old_device_id}` to `{new_device_id}`. Please update these automations to use the new device ID: {device_automations_string}.",
             "title": "{ip_address} is now part of the AirVisual Pro integration"
         }
     },

--- a/homeassistant/components/airvisual_pro/config_flow.py
+++ b/homeassistant/components/airvisual_pro/config_flow.py
@@ -67,6 +67,10 @@ class AirVisualProFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize."""
         self._reauth_entry: ConfigEntry | None = None
 
+    async def async_step_import(self, import_config: dict[str, Any]) -> FlowResult:
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
     async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
         """Handle configuration by re-auth."""
         self._reauth_entry = self.hass.config_entries.async_get_entry(

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     CONF_SHOW_ON_MAP,
     CONF_STATE,
 )
+from homeassistant.setup import async_setup_component
 
 
 @pytest.mark.parametrize(
@@ -174,8 +175,8 @@ async def test_errors(hass, data, exc, errors, integration_type):
         )
     ],
 )
-async def test_migration(hass, config, config_entry, setup_airvisual, unique_id):
-    """Test migrating from version 1 to the current version."""
+async def test_migration_1_2(hass, config, config_entry, setup_airvisual, unique_id):
+    """Test migrating from version 1 to 2."""
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 2
 
@@ -197,6 +198,29 @@ async def test_migration(hass, config, config_entry, setup_airvisual, unique_id)
         CONF_COUNTRY: "China",
         CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY_NAME,
     }
+
+
+@pytest.mark.parametrize(
+    "config,config_entry_version,unique_id",
+    [
+        (
+            {
+                CONF_IP_ADDRESS: "192.168.1.100",
+                CONF_PASSWORD: "abcde12345",
+                CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_NODE_PRO,
+            },
+            2,
+            "192.16.1.100",
+        )
+    ],
+)
+async def test_migration_2_3(hass, config, config_entry, unique_id):
+    """Test migrating from version 2 to 3."""
+    with patch.object(hass.config_entries.flow, "async_init"):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+        config_entries = hass.config_entries.async_entries(DOMAIN)
+        assert len(config_entries) == 0
 
 
 async def test_options_flow(hass, config_entry):

--- a/tests/components/airvisual/test_diagnostics.py
+++ b/tests/components/airvisual/test_diagnostics.py
@@ -9,7 +9,7 @@ async def test_entry_diagnostics(hass, config_entry, hass_client, setup_airvisua
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {
             "entry_id": config_entry.entry_id,
-            "version": 2,
+            "version": 3,
             "domain": "airvisual",
             "title": REDACTED,
             "data": {

--- a/tests/components/airvisual_pro/test_config_flow.py
+++ b/tests/components/airvisual_pro/test_config_flow.py
@@ -10,7 +10,7 @@ import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.airvisual_pro.const import DOMAIN
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 
 
@@ -59,6 +59,19 @@ async def test_duplicate_error(hass, config, config_entry):
     )
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_step_import(hass, config, setup_airvisual_pro):
+    """Test that the user step works."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == "192.168.1.101"
+    assert result["data"] == {
+        CONF_IP_ADDRESS: "192.168.1.101",
+        CONF_PASSWORD: "password123",
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
AirVisual Pro units are now their own Home Assistant integration (as opposed to be included with the original AirVisual integration that uses the AirVisual cloud API). Pro devices will automatically be migrated; as part of that migration, the Pro's device ID will change. If you utilize entity IDs belonging to a Pro in automations or scripts, you don't need to do anything; if, however, you utilize a Pro's device ID, please update those automations or scripts accordingly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on https://github.com/home-assistant/core/pull/79770, this PR migrates AirVisual Pro-based config entries to the new `airvisual_pro` domain. 

Additionally, the PR removes the ability to link to a Pro via the `airvisual` integration. That's the only change to `airvisual` code; I will remove everything Pro-related in a subsequent PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/24427/files

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
