### PR TITLE
Improve ignore_variance typing

### DIFF
--- a/homeassistant/util/variance.py
+++ b/homeassistant/util/variance.py
@@ -6,36 +6,39 @@ from datetime import datetime, timedelta
 import functools
 from typing import Any, TypeVar, overload
 
-T = TypeVar("T", int, float, datetime)
+from typing_extensions import ParamSpec
+
+_R = TypeVar("_R", int, float, datetime)
+_P = ParamSpec("_P")
 
 
 @overload
 def ignore_variance(
-    func: Callable[..., int], ignored_variance: int
-) -> Callable[..., int]:
+    func: Callable[_P, int], ignored_variance: int
+) -> Callable[_P, int]:
     ...
 
 
 @overload
 def ignore_variance(
-    func: Callable[..., float], ignored_variance: float
-) -> Callable[..., float]:
+    func: Callable[_P, float], ignored_variance: float
+) -> Callable[_P, float]:
     ...
 
 
 @overload
 def ignore_variance(
-    func: Callable[..., datetime], ignored_variance: timedelta
-) -> Callable[..., datetime]:
+    func: Callable[_P, datetime], ignored_variance: timedelta
+) -> Callable[_P, datetime]:
     ...
 
 
-def ignore_variance(func: Callable[..., T], ignored_variance: Any) -> Callable[..., T]:
+def ignore_variance(func: Callable[_P, _R], ignored_variance: Any) -> Callable[_P, _R]:
     """Wrap a function that returns old result if new result does not vary enough."""
-    last_value: T | None = None
+    last_value: _R | None = None
 
     @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> T:
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         nonlocal last_value
 
         value = func(*args, **kwargs)


### PR DESCRIPTION
## Proposed change
Use ParamSpec to better type Callable arguments.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
