### PR TITLE
Add stones to mass units

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -767,6 +767,7 @@ class UnitOfMass(StrEnum):
     MICROGRAMS = "µg"
     OUNCES = "oz"
     POUNDS = "lb"
+    STONES = "st"
 
 
 MASS_GRAMS: Final = "g"

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -33,7 +33,8 @@ _DAYS_TO_SECS = 24 * _HRS_TO_SECS  # 1 day = 24 hours = 86400 seconds
 
 # Mass conversion constants
 _POUND_TO_G = 453.59237
-_OUNCE_TO_G = _POUND_TO_G / 16
+_OUNCE_TO_G = _POUND_TO_G / 16  # 16 ounces to a pound
+_STONE_TO_G = _POUND_TO_G * 14  # 14 pounds to a stone
 
 # Pressure conversion constants
 _STANDARD_GRAVITY = 9.80665
@@ -143,6 +144,7 @@ class MassConverter(BaseUnitConverter):
         UnitOfMass.KILOGRAMS: 1 / 1000,
         UnitOfMass.OUNCES: 1 / _OUNCE_TO_G,
         UnitOfMass.POUNDS: 1 / _POUND_TO_G,
+        UnitOfMass.STONES: 1 / _STONE_TO_G,
     }
     VALID_UNITS = {
         UnitOfMass.GRAMS,
@@ -151,6 +153,7 @@ class MassConverter(BaseUnitConverter):
         UnitOfMass.MICROGRAMS,
         UnitOfMass.OUNCES,
         UnitOfMass.POUNDS,
+        UnitOfMass.STONES,
     }
 
 

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -345,6 +345,11 @@ def test_energy_convert(
         (16, UnitOfMass.OUNCES, 453592.37, UnitOfMass.MILLIGRAMS),
         (16, UnitOfMass.OUNCES, 453592370, UnitOfMass.MICROGRAMS),
         (16, UnitOfMass.OUNCES, 1, UnitOfMass.POUNDS),
+        (1, UnitOfMass.STONES, pytest.approx(6.350293), UnitOfMass.KILOGRAMS),
+        (1, UnitOfMass.STONES, pytest.approx(6350.293), UnitOfMass.GRAMS),
+        (1, UnitOfMass.STONES, pytest.approx(6350293), UnitOfMass.MILLIGRAMS),
+        (1, UnitOfMass.STONES, pytest.approx(14), UnitOfMass.POUNDS),
+        (1, UnitOfMass.STONES, pytest.approx(224), UnitOfMass.OUNCES),
     ],
 )
 def test_mass_convert(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add stones to mass units
Stones are used as body weight measures in UK

- [x] Frontend https://github.com/home-assistant/frontend/pull/14749
- [x] Dev docs https://github.com/home-assistant/developers.home-assistant/pull/1585
- [x] Docs https://github.com/home-assistant/home-assistant.io/pull/25271

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
