### PR TITLE
2022.12.5

### DIFF
--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -264,6 +264,12 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
 
         sources = coordinator.source_map.values()
         source_list = [item["title"] for item in sources]
+        ignored_sources = self.options.get(CONF_IGNORED_SOURCES, [])
+
+        for item in ignored_sources:
+            if item not in source_list:
+                source_list.append(item)
+
         self.data_schema = vol.Schema(
             {
                 vol.Optional(CONF_IGNORED_SOURCES): cv.multi_select(source_list),

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==13.0.3"],
+  "requirements": ["pychromecast==13.0.4"],
   "after_dependencies": [
     "cloud",
     "http",

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -2,7 +2,7 @@
   "domain": "frontend",
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
-  "requirements": ["home-assistant-frontend==20221212.0"],
+  "requirements": ["home-assistant-frontend==20221213.0"],
   "dependencies": [
     "api",
     "auth",

--- a/homeassistant/components/justnimbus/entity.py
+++ b/homeassistant/components/justnimbus/entity.py
@@ -30,4 +30,4 @@ class JustNimbusEntity(
     @property
     def available(self) -> bool:
         """Return device availability."""
-        return super().available and getattr(self.coordinator.data, "error_code") == 0
+        return super().available and self.coordinator.data is not None

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,7 @@ from .backports.enum import StrEnum
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 12
-PATCH_VERSION: Final = "4"
+PATCH_VERSION: Final = "5"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -22,7 +22,7 @@ dbus-fast==1.75.0
 fnvhash==0.1.0
 hass-nabucasa==0.61.0
 home-assistant-bluetooth==1.8.1
-home-assistant-frontend==20221212.0
+home-assistant-frontend==20221213.0
 httpx==0.23.1
 ifaddr==0.1.7
 janus==1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2022.12.4"
+version     = "2022.12.5"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -884,7 +884,7 @@ hole==0.7.0
 holidays==0.17.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20221212.0
+home-assistant-frontend==20221213.0
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1504,7 +1504,7 @@ pycfdns==2.0.1
 pychannels==1.2.3
 
 # homeassistant.components.cast
-pychromecast==13.0.3
+pychromecast==13.0.4
 
 # homeassistant.components.pocketcasts
 pycketcasts==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -664,7 +664,7 @@ hole==0.7.0
 holidays==0.17.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20221212.0
+home-assistant-frontend==20221213.0
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1077,7 +1077,7 @@ pybravia==0.2.3
 pycfdns==2.0.1
 
 # homeassistant.components.cast
-pychromecast==13.0.3
+pychromecast==13.0.4
 
 # homeassistant.components.comfoconnect
 pycomfoconnect==0.4

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -422,6 +422,19 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert config_entry.options == {CONF_IGNORED_SOURCES: ["HDMI 1", "HDMI 2"]}
 
+        # Test that saving with missing sources is ok
+        with patch(
+            "pybravia.BraviaTV.get_external_status",
+            return_value=BRAVIA_SOURCES[1:],
+        ):
+            result = await hass.config_entries.options.async_init(config_entry.entry_id)
+            result = await hass.config_entries.options.async_configure(
+                result["flow_id"], user_input={CONF_IGNORED_SOURCES: ["HDMI 1"]}
+            )
+            await hass.async_block_till_done()
+            assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+            assert config_entry.options == {CONF_IGNORED_SOURCES: ["HDMI 1"]}
+
 
 async def test_options_flow_error(hass: HomeAssistant) -> None:
     """Test config flow options."""


### PR DESCRIPTION
- Fix Just Nimbus error codes ([@kvanzuijlen] - [#83856]) ([justnimbus docs])
- Fix saving options with missing ignored sources in BraviaTV ([@Drafteed] - [#83891]) ([braviatv docs])
- Bump pychromecast to 13.0.4 ([@emontnemery] - [#83896]) ([cast docs])
- Update frontend to 20221213.0 ([@bramkragten] - [#83940]) ([frontend docs])

[#83482]: https://github.com/home-assistant/core/pull/83482
[#83592]: https://github.com/home-assistant/core/pull/83592
[#83778]: https://github.com/home-assistant/core/pull/83778
[#83797]: https://github.com/home-assistant/core/pull/83797
[#83856]: https://github.com/home-assistant/core/pull/83856
[#83870]: https://github.com/home-assistant/core/pull/83870
[#83891]: https://github.com/home-assistant/core/pull/83891
[#83896]: https://github.com/home-assistant/core/pull/83896
[#83940]: https://github.com/home-assistant/core/pull/83940
[@Drafteed]: https://github.com/Drafteed
[@balloob]: https://github.com/balloob
[@bramkragten]: https://github.com/bramkragten
[@emontnemery]: https://github.com/emontnemery
[@frenck]: https://github.com/frenck
[@kvanzuijlen]: https://github.com/kvanzuijlen
[abode docs]: https://www.home-assistant.io/integrations/abode/
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/
[bluetooth docs]: https://www.home-assistant.io/integrations/bluetooth/
[braviatv docs]: https://www.home-assistant.io/integrations/braviatv/
[cast docs]: https://www.home-assistant.io/integrations/cast/
[fritzbox docs]: https://www.home-assistant.io/integrations/fritzbox/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[justnimbus docs]: https://www.home-assistant.io/integrations/justnimbus/
[sleepiq docs]: https://www.home-assistant.io/integrations/sleepiq/
[zha docs]: https://www.home-assistant.io/integrations/zha/