### PR TITLE
Allow MQTT device trackers to be able to the reset the location name for auto zone inference

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -126,7 +126,7 @@ ABBREVIATIONS = {
     "pl_arm_nite": "payload_arm_night",
     "pl_arm_vacation": "payload_arm_vacation",
     "pl_arm_custom_b": "payload_arm_custom_bypass",
-    "pl_auto_zone": "payload_auto_zone",
+    "pl_aut_zn": "payload_auto_zone",
     "pl_avail": "payload_available",
     "pl_cln_sp": "payload_clean_spot",
     "pl_cls": "payload_close",

--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -126,7 +126,6 @@ ABBREVIATIONS = {
     "pl_arm_nite": "payload_arm_night",
     "pl_arm_vacation": "payload_arm_vacation",
     "pl_arm_custom_b": "payload_arm_custom_bypass",
-    "pl_aut_zn": "payload_auto_zone",
     "pl_avail": "payload_available",
     "pl_cln_sp": "payload_clean_spot",
     "pl_cls": "payload_close",

--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -126,6 +126,7 @@ ABBREVIATIONS = {
     "pl_arm_nite": "payload_arm_night",
     "pl_arm_vacation": "payload_arm_vacation",
     "pl_arm_custom_b": "payload_arm_custom_bypass",
+    "pl_auto_zone": "payload_auto_zone",
     "pl_avail": "payload_available",
     "pl_cln_sp": "payload_clean_spot",
     "pl_cls": "payload_close",

--- a/homeassistant/components/mqtt/const.py
+++ b/homeassistant/components/mqtt/const.py
@@ -27,6 +27,7 @@ CONF_TRANSPORT = "transport"
 CONF_WS_PATH = "ws_path"
 CONF_WS_HEADERS = "ws_headers"
 CONF_WILL_MESSAGE = "will_message"
+CONF_PAYLOAD_RESET = "payload_reset"
 
 CONF_CERTIFICATE = "certificate"
 CONF_CLIENT_KEY = "client_key"

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -53,7 +53,9 @@ PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): cv.string,
         vol.Optional(CONF_PAYLOAD_NOT_HOME, default=STATE_NOT_HOME): cv.string,
-        vol.Optional(CONF_PAYLOAD_AUTO_ZONE, default=DEFAULT_PAYLOAD_AUTO_ZONE): cv.string,
+        vol.Optional(
+            CONF_PAYLOAD_AUTO_ZONE, default=DEFAULT_PAYLOAD_AUTO_ZONE
+        ): cv.string,
         vol.Optional(CONF_SOURCE_TYPE, default=DEFAULT_SOURCE_TYPE): vol.In(
             SOURCE_TYPES
         ),

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import subscription
 from .config import MQTT_RO_SCHEMA
-from .const import CONF_QOS, CONF_STATE_TOPIC, CONF_PAYLOAD_RESET
+from .const import CONF_PAYLOAD_RESET, CONF_QOS, CONF_STATE_TOPIC
 from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
@@ -44,7 +44,7 @@ CONF_PAYLOAD_HOME = "payload_home"
 CONF_PAYLOAD_NOT_HOME = "payload_not_home"
 CONF_SOURCE_TYPE = "source_type"
 
-DEFAULT_PAYLOAD_RESET = "RST"
+DEFAULT_PAYLOAD_RESET = "None"
 DEFAULT_SOURCE_TYPE = SourceType.GPS
 
 PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import subscription
 from .config import MQTT_RO_SCHEMA
-from .const import CONF_QOS, CONF_STATE_TOPIC
+from .const import CONF_QOS, CONF_STATE_TOPIC, CONF_PAYLOAD_RESET
 from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
@@ -42,10 +42,9 @@ from .util import get_mqtt_data
 
 CONF_PAYLOAD_HOME = "payload_home"
 CONF_PAYLOAD_NOT_HOME = "payload_not_home"
-CONF_PAYLOAD_AUTO_ZONE = "payload_auto_zone"
 CONF_SOURCE_TYPE = "source_type"
 
-DEFAULT_PAYLOAD_AUTO_ZONE = "auto_zone"
+DEFAULT_PAYLOAD_RESET = "RST"
 DEFAULT_SOURCE_TYPE = SourceType.GPS
 
 PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
@@ -53,9 +52,7 @@ PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): cv.string,
         vol.Optional(CONF_PAYLOAD_NOT_HOME, default=STATE_NOT_HOME): cv.string,
-        vol.Optional(
-            CONF_PAYLOAD_AUTO_ZONE, default=DEFAULT_PAYLOAD_AUTO_ZONE
-        ): cv.string,
+        vol.Optional(CONF_PAYLOAD_RESET, default=DEFAULT_PAYLOAD_RESET): cv.string,
         vol.Optional(CONF_SOURCE_TYPE, default=DEFAULT_SOURCE_TYPE): vol.In(
             SOURCE_TYPES
         ),
@@ -132,7 +129,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
                 self._location_name = STATE_HOME
             elif payload == self._config[CONF_PAYLOAD_NOT_HOME]:
                 self._location_name = STATE_NOT_HOME
-            elif payload == self._config[CONF_PAYLOAD_AUTO_ZONE]:
+            elif payload == self._config[CONF_PAYLOAD_RESET]:
                 self._location_name = None
             else:
                 assert isinstance(msg.payload, str)

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -42,8 +42,10 @@ from .util import get_mqtt_data
 
 CONF_PAYLOAD_HOME = "payload_home"
 CONF_PAYLOAD_NOT_HOME = "payload_not_home"
+CONF_PAYLOAD_AUTO_ZONE = "payload_auto_zone"
 CONF_SOURCE_TYPE = "source_type"
 
+DEFAULT_PAYLOAD_AUTO_ZONE = "auto_zone"
 DEFAULT_SOURCE_TYPE = SourceType.GPS
 
 PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
@@ -51,6 +53,7 @@ PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): cv.string,
         vol.Optional(CONF_PAYLOAD_NOT_HOME, default=STATE_NOT_HOME): cv.string,
+        vol.Optional(CONF_PAYLOAD_AUTO_ZONE, default=DEFAULT_PAYLOAD_AUTO_ZONE): cv.string,
         vol.Optional(CONF_SOURCE_TYPE, default=DEFAULT_SOURCE_TYPE): vol.In(
             SOURCE_TYPES
         ),
@@ -127,6 +130,8 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
                 self._location_name = STATE_HOME
             elif payload == self._config[CONF_PAYLOAD_NOT_HOME]:
                 self._location_name = STATE_NOT_HOME
+            elif payload == self._config[CONF_PAYLOAD_AUTO_ZONE]:
+                self._location_name = None
             else:
                 assert isinstance(msg.payload, str)
                 self._location_name = msg.payload

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -36,10 +36,10 @@ from .const import (
     CONF_COMMAND_TEMPLATE,
     CONF_COMMAND_TOPIC,
     CONF_ENCODING,
+    CONF_PAYLOAD_RESET,
     CONF_QOS,
     CONF_RETAIN,
     CONF_STATE_TOPIC,
-    CONF_PAYLOAD_RESET,
 )
 from .debug_info import log_messages
 from .mixins import (

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -39,6 +39,7 @@ from .const import (
     CONF_QOS,
     CONF_RETAIN,
     CONF_STATE_TOPIC,
+    CONF_PAYLOAD_RESET,
 )
 from .debug_info import log_messages
 from .mixins import (
@@ -60,7 +61,6 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_MIN = "min"
 CONF_MAX = "max"
-CONF_PAYLOAD_RESET = "payload_reset"
 CONF_STEP = "step"
 
 DEFAULT_NAME = "MQTT Number"

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -429,6 +429,84 @@ async def test_setting_device_tracker_location_via_lat_lon_message(
     assert state.state == STATE_UNKNOWN
 
 
+async def test_setting_device_tracker_location_via_auto_zone_message(
+    hass, mqtt_mock_entry_no_yaml_config, caplog
+):
+    """Test the setting of the latitude and longitude via MQTT."""
+    await mqtt_mock_entry_no_yaml_config()
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        "{ "
+        '"name": "test", '
+        '"state_topic": "test-topic", '
+        '"json_attributes_topic": "attributes-topic" '
+        "}",
+    )
+
+    hass.states.async_set(
+        "zone.school",
+        "zoning",
+        {"latitude": 30.0, "longitude": -100.0, "radius": 100, "friendly_name": "School"},
+    )
+
+    assert await async_setup_component(
+        hass, "zone", {"zone": [{
+            "name": "School",
+            "latitude": 30.0,
+            "longitude": -100.0,
+            "radius": 100
+        }]}
+    )
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.test")
+    assert state.attributes["source_type"] == "gps"
+
+    assert state.state == STATE_UNKNOWN
+
+    hass.config.latitude = 32.87336
+    hass.config.longitude = -117.22743
+
+    # test auto zone and gps attributes
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
+    )
+    async_fire_mqtt_message(hass, "test-topic", "auto_zone")
+
+    state = hass.states.get("device_tracker.test")
+    assert state.attributes["latitude"] == 32.87336
+    assert state.attributes["longitude"] == -117.22743
+    assert state.attributes["gps_accuracy"] == 1.5
+    assert state.attributes["source_type"] == "gps"
+    assert state.state == STATE_HOME
+
+    # test manual state override
+    async_fire_mqtt_message(hass, "test-topic", STATE_UNKNOWN)
+
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_UNKNOWN
+
+    # test auto_zone
+    async_fire_mqtt_message(hass, "test-topic", "auto_zone")
+
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_HOME
+
+    # test auto_zone inferring correct school area
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude":30.0,"longitude":-100.0,"gps_accuracy":1.5}',
+    )
+
+    state = hass.states.get("device_tracker.test")
+    assert state.state == "School"
+
+
 async def test_setting_blocked_attribute_via_mqtt_json_message(
     hass, mqtt_mock_entry_no_yaml_config
 ):

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -429,10 +429,10 @@ async def test_setting_device_tracker_location_via_lat_lon_message(
     assert state.state == STATE_UNKNOWN
 
 
-async def test_setting_device_tracker_location_via_auto_zone_message(
+async def test_setting_device_tracker_location_via_reset_message(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
-    """Test the automatic inference of zones via MQTT."""
+    """Test the automatic inference of zones via MQTT via reset."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
         hass,
@@ -465,13 +465,13 @@ async def test_setting_device_tracker_location_via_auto_zone_message(
     hass.config.latitude = 32.87336
     hass.config.longitude = -117.22743
 
-    # test auto zone and gps attributes
+    # test reset and gps attributes
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
         '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
     )
-    async_fire_mqtt_message(hass, "test-topic", "auto_zone")
+    async_fire_mqtt_message(hass, "test-topic", "RST")
 
     state = hass.states.get("device_tracker.test")
     assert state.attributes["latitude"] == 32.87336
@@ -486,13 +486,13 @@ async def test_setting_device_tracker_location_via_auto_zone_message(
     state = hass.states.get("device_tracker.test")
     assert state.state == "Work"
 
-    # test auto_zone
-    async_fire_mqtt_message(hass, "test-topic", "auto_zone")
+    # test reset
+    async_fire_mqtt_message(hass, "test-topic", "RST")
 
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_HOME
 
-    # test auto_zone inferring correct school area
+    # test reset inferring correct school area
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
@@ -503,10 +503,10 @@ async def test_setting_device_tracker_location_via_auto_zone_message(
     assert state.state == "School"
 
 
-async def test_setting_device_tracker_location_via_abbr_auto_zone_message(
+async def test_setting_device_tracker_location_via_abbr_reset_message(
     hass, mqtt_mock_entry_no_yaml_config, caplog
 ):
-    """Test the setting of auto_zone via abbreviated names and custom payloads via MQTT."""
+    """Test the setting of reset via abbreviated names and custom payloads via MQTT."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
         hass,
@@ -515,7 +515,7 @@ async def test_setting_device_tracker_location_via_abbr_auto_zone_message(
         '"name": "test", '
         '"state_topic": "test-topic", '
         '"json_attributes_topic": "attributes-topic", '
-        '"pl_aut_zn": "auto" '
+        '"pl_rst": "reset" '
         "}",
     )
 
@@ -529,13 +529,13 @@ async def test_setting_device_tracker_location_via_abbr_auto_zone_message(
     hass.config.latitude = 32.87336
     hass.config.longitude = -117.22743
 
-    # test custom auto zone payload and gps attributes
+    # test custom reset payload and gps attributes
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
         '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
     )
-    async_fire_mqtt_message(hass, "test-topic", "auto")
+    async_fire_mqtt_message(hass, "test-topic", "reset")
 
     state = hass.states.get("device_tracker.test")
     assert state.attributes["latitude"] == 32.87336

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -471,7 +471,7 @@ async def test_setting_device_tracker_location_via_reset_message(
         "attributes-topic",
         '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
     )
-    async_fire_mqtt_message(hass, "test-topic", "RST")
+    async_fire_mqtt_message(hass, "test-topic", "None")
 
     state = hass.states.get("device_tracker.test")
     assert state.attributes["latitude"] == 32.87336
@@ -487,7 +487,7 @@ async def test_setting_device_tracker_location_via_reset_message(
     assert state.state == "Work"
 
     # test reset
-    async_fire_mqtt_message(hass, "test-topic", "RST")
+    async_fire_mqtt_message(hass, "test-topic", "None")
 
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_HOME

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -447,16 +447,12 @@ async def test_setting_device_tracker_location_via_auto_zone_message(
     hass.states.async_set(
         "zone.school",
         "zoning",
-        {"latitude": 30.0, "longitude": -100.0, "radius": 100, "friendly_name": "School"},
-    )
-
-    assert await async_setup_component(
-        hass, "zone", {"zone": [{
-            "name": "School",
+        {
             "latitude": 30.0,
             "longitude": -100.0,
-            "radius": 100
-        }]}
+            "radius": 100,
+            "friendly_name": "School",
+        },
     )
 
     await hass.async_block_till_done()

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -481,10 +481,10 @@ async def test_setting_device_tracker_location_via_auto_zone_message(
     assert state.state == STATE_HOME
 
     # test manual state override
-    async_fire_mqtt_message(hass, "test-topic", STATE_UNKNOWN)
+    async_fire_mqtt_message(hass, "test-topic", "Work")
 
     state = hass.states.get("device_tracker.test")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == "Work"
 
     # test auto_zone
     async_fire_mqtt_message(hass, "test-topic", "auto_zone")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows to reset the MQTT Device Trackers state. Reset, where if the payload is recognized as the string pertaining that, it'll infer the current zone name from the gps coordinates, removing any pre-existing location name.

Under the hood, it'll let [`location_name` under TrackerEntity](https://developers.home-assistant.io/docs/core/entity/device-tracker/#trackerentity) fall-through to `None`, letting home assistant infer the right zone [here](https://github.com/home-assistant/core/blob/4ef7bb9bbe810fa8e4e6f9724132bdd15520dd8c/homeassistant/components/device_tracker/config_entry.py#L247-L264).

We have this functionality at the initial state of the MQTT device tracker, but once the location is set it could never be reset, as the MQTT device tracker's `location_name` already initializes to `None`. But but after setting a location_name we we cannot reset it (until a restart). 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/24703
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25276

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
