### PR TITLE
Fix for gst class messages

### DIFF
--- a/homeassistant/components/gpsd/manifest.json
+++ b/homeassistant/components/gpsd/manifest.json
@@ -2,7 +2,7 @@
   "domain": "gpsd",
   "name": "GPSD",
   "documentation": "https://www.home-assistant.io/integrations/gpsd",
-  "requirements": ["gps3==0.33.3"],
+  "requirements": ["agps3==0.36.1"],
   "codeowners": ["@fabaff"],
   "iot_class": "local_polling",
   "loggers": ["gps3"]

--- a/homeassistant/components/gpsd/sensor.py
+++ b/homeassistant/components/gpsd/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import socket
 
-from gps3.agps3threaded import AGPS3mechanism
+from agps3.agps3threaded import AGPS3mechanism
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
@@ -105,6 +105,7 @@ class GpsdSensor(SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the GPS."""
+
         return {
             ATTR_LATITUDE: self.agps_thread.data_stream.lat,
             ATTR_LONGITUDE: self.agps_thread.data_stream.lon,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -97,6 +97,9 @@ afsapi==0.2.7
 # homeassistant.components.agent_dvr
 agent-py==0.0.23
 
+# homeassistant.components.gpsd
+agps3==0.36.1
+
 # homeassistant.components.geo_json_events
 aio_geojson_generic_client==0.1
 
@@ -804,9 +807,6 @@ govee-ble==0.19.1
 
 # homeassistant.components.remote_rpi_gpio
 gpiozero==1.6.2
-
-# homeassistant.components.gpsd
-gps3==0.33.3
 
 # homeassistant.components.gree
 greeclimate==1.3.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a fix for the GST class messages that were interpreted as position data rather than error data. While a number of changes to the gps3 package were made when forking the project to agps3, the only logic change is this:

agps3.py line 270:
from:     `if class_name == "GST" and key == "lat" or "lon":`
 to:       ` if class_name == "GST" and (key == "lat" or "lon"):`
                

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The previous code referenced gps3 package which has not been maintained.  I forked this code and created a package called "agps3" with the necessary fixes.  The only change to the home assistant code is the import statement. 

- This PR fixes or closes issue: fixes #82887
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
