### PR TITLE
Ignore certain device trigger validation errors

### DIFF
--- a/homeassistant/components/device_automation/trigger.py
+++ b/homeassistant/components/device_automation/trigger.py
@@ -68,7 +68,7 @@ async def async_validate_trigger_config(
         # Only call the dynamic validator if the relevant config entry is loaded
         registry = dr.async_get(hass)
         if not (device := registry.async_get(config[CONF_DEVICE_ID])):
-            raise InvalidDeviceAutomationConfig
+            return config
 
         device_config_entry = None
         for entry_id in device.config_entries:
@@ -80,7 +80,7 @@ async def async_validate_trigger_config(
             break
 
         if not device_config_entry:
-            raise InvalidDeviceAutomationConfig
+            return config
 
         if not await hass.config_entries.async_wait_component(device_config_entry):
             return config

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -349,6 +349,7 @@ async def test_functional_device_trigger(
     assert automation_calls[0].data["some"] == "test_trigger_button_press"
 
 
+@pytest.mark.skip(reason="Temporarily disabled until automation validation is improved")
 async def test_validate_trigger_unknown_device(hass, aioclient_mock):
     """Test unknown device does not return a trigger config."""
     await setup_deconz_integration(hass, aioclient_mock)

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -372,6 +372,7 @@ async def test_exception_bad_trigger(hass, mock_devices, calls, caplog):
     assert "Invalid config for [automation]" in caplog.text
 
 
+@pytest.mark.skip(reason="Temporarily disabled until automation validation is improved")
 async def test_exception_no_device(hass, mock_devices, calls, caplog):
     """Test for exception on event triggers firing."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ignore device trigger validation errors if:
- A device trigger is configured for a removed device
- A device trigger is configured for a removed config entry

Raising on these errors was introduced by #76980, but the raised error is very difficult to understand.

In a follow-up, the errors will be re-introduced, but with improved error messages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #83913 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
