### PR TITLE
Bump here_transit/here_routing and Implement backoff mechanism for here_travel_time

### DIFF
--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -92,15 +92,6 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator):
                 return_values=[Return.POLYINE, Return.SUMMARY],
                 spans=[Spans.NAMES],
             )
-            _LOGGER.debug("Raw response is: %s", response)
-
-            if self.update_interval != timedelta(seconds=DEFAULT_SCAN_INTERVAL):
-                _LOGGER.debug(
-                    "Resetting update interval to %s",
-                    DEFAULT_SCAN_INTERVAL,
-                )
-                self.update_interval = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
-            return self._parse_routing_response(response)
         except HERERoutingTooManyRequestsError as error:
             assert self.update_interval is not None
             _LOGGER.debug(
@@ -111,6 +102,15 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator):
                 seconds=self.update_interval.total_seconds() * BACKOFF_MULTIPLIER
             )
             raise UpdateFailed("Rate limit has been reached") from error
+        _LOGGER.debug("Raw response is: %s", response)
+
+        if self.update_interval != timedelta(seconds=DEFAULT_SCAN_INTERVAL):
+            _LOGGER.debug(
+                "Resetting update interval to %s",
+                DEFAULT_SCAN_INTERVAL,
+            )
+            self.update_interval = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
+        return self._parse_routing_response(response)
 
     def _parse_routing_response(self, response: dict[str, Any]) -> HERETravelTimeData:
         """Parse the routing response dict to a HERETravelTimeData."""
@@ -186,16 +186,6 @@ class HERETransitDataUpdateCoordinator(DataUpdateCoordinator):
                     here_transit.Return.TRAVEL_SUMMARY,
                 ],
             )
-
-            _LOGGER.debug("Raw response is: %s", response)
-
-            if self.update_interval != timedelta(seconds=DEFAULT_SCAN_INTERVAL):
-                _LOGGER.debug(
-                    "Resetting update interval to %s",
-                    DEFAULT_SCAN_INTERVAL,
-                )
-                self.update_interval = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
-            return self._parse_transit_response(response)
         except HERETransitTooManyRequestsError as error:
             assert self.update_interval is not None
             _LOGGER.debug(
@@ -211,6 +201,15 @@ class HERETransitDataUpdateCoordinator(DataUpdateCoordinator):
             return None
         except (HERETransitConnectionError, HERETransitNoRouteFoundError) as error:
             raise UpdateFailed from error
+
+        _LOGGER.debug("Raw response is: %s", response)
+        if self.update_interval != timedelta(seconds=DEFAULT_SCAN_INTERVAL):
+            _LOGGER.debug(
+                "Resetting update interval to %s",
+                DEFAULT_SCAN_INTERVAL,
+            )
+            self.update_interval = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
+        return self._parse_transit_response(response)
 
     def _parse_transit_response(self, response: dict[str, Any]) -> HERETravelTimeData:
         """Parse the transit response dict to a HERETravelTimeData."""

--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -35,6 +35,8 @@ from homeassistant.util.unit_conversion import DistanceConverter
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, ROUTE_MODE_FASTEST
 from .model import HERETravelTimeConfig, HERETravelTimeData
 
+BACKOFF_MULTIPLIER = 1.1
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -102,13 +104,13 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator):
         except HERERoutingTooManyRequestsError as error:
             assert self.update_interval is not None
             _LOGGER.debug(
-                "API reported too many requests. Increasing update interval to %s",
-                self.update_interval.total_seconds() * 1.1,
+                "Rate limit has been reached. Increasing update interval to %s",
+                self.update_interval.total_seconds() * BACKOFF_MULTIPLIER,
             )
             self.update_interval = timedelta(
-                seconds=self.update_interval.total_seconds() * 1.1
+                seconds=self.update_interval.total_seconds() * BACKOFF_MULTIPLIER
             )
-            raise UpdateFailed from error
+            raise UpdateFailed("Rate limit has been reached") from error
 
     def _parse_routing_response(self, response: dict[str, Any]) -> HERETravelTimeData:
         """Parse the routing response dict to a HERETravelTimeData."""
@@ -197,13 +199,13 @@ class HERETransitDataUpdateCoordinator(DataUpdateCoordinator):
         except HERETransitTooManyRequestsError as error:
             assert self.update_interval is not None
             _LOGGER.debug(
-                "API reported too many requests. Increasing update interval to %s",
-                self.update_interval.total_seconds() * 1.1,
+                "Rate limit has been reached. Increasing update interval to %s",
+                self.update_interval.total_seconds() * BACKOFF_MULTIPLIER,
             )
             self.update_interval = timedelta(
-                seconds=self.update_interval.total_seconds() * 1.1
+                seconds=self.update_interval.total_seconds() * BACKOFF_MULTIPLIER
             )
-            raise UpdateFailed from error
+            raise UpdateFailed("Rate limit has been reached") from error
         except HERETransitDepartureArrivalTooCloseError:
             _LOGGER.debug("Ignoring HERETransitDepartureArrivalTooCloseError")
             return None

--- a/homeassistant/components/here_travel_time/manifest.json
+++ b/homeassistant/components/here_travel_time/manifest.json
@@ -3,7 +3,7 @@
   "name": "HERE Travel Time",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/here_travel_time",
-  "requirements": ["here_routing==0.1.1", "here_transit==1.1.1"],
+  "requirements": ["here_routing==0.2.0", "here_transit==1.2.0"],
   "codeowners": ["@eifinger"],
   "iot_class": "cloud_polling",
   "loggers": ["here_routing", "here_transit", "homeassistant.helpers.location"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -867,10 +867,10 @@ hdate==0.10.4
 heatmiserV3==1.1.18
 
 # homeassistant.components.here_travel_time
-here_routing==0.1.1
+here_routing==0.2.0
 
 # homeassistant.components.here_travel_time
-here_transit==1.1.1
+here_transit==1.2.0
 
 # homeassistant.components.hikvisioncam
 hikvision==0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -653,10 +653,10 @@ hatasmota==0.6.1
 hdate==0.10.4
 
 # homeassistant.components.here_travel_time
-here_routing==0.1.1
+here_routing==0.2.0
 
 # homeassistant.components.here_travel_time
-here_transit==1.1.1
+here_transit==1.2.0
 
 # homeassistant.components.hlk_sw16
 hlk-sw16==0.0.9


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Increase the update rate when encountering a HTTP 429.
Inspired by the [BMW Connected Drive integration](https://github.com/home-assistant/core/pull/73675/files#diff-e3e78f86cd17696e8c2d95fb620faba38121c67b9cf017fd4b299cf40113a968)

[here_transit bump to 1.2.0](https://github.com/eifinger/here_transit/releases/tag/v1.2.0):
>Add HERETransitTooManyRequestsError

[here_routing bump to 0.2.0](https://github.com/eifinger/here_routing/releases/tag/v0.2.0):
>Add HERERoutingTooManyRequestsError 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83833
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
