### PR TITLE
2022.12.6

### DIFF
--- a/homeassistant/components/device_automation/trigger.py
+++ b/homeassistant/components/device_automation/trigger.py
@@ -68,7 +68,7 @@ async def async_validate_trigger_config(
         # Only call the dynamic validator if the relevant config entry is loaded
         registry = dr.async_get(hass)
         if not (device := registry.async_get(config[CONF_DEVICE_ID])):
-            raise InvalidDeviceAutomationConfig
+            return config
 
         device_config_entry = None
         for entry_id in device.config_entries:
@@ -80,7 +80,7 @@ async def async_validate_trigger_config(
             break
 
         if not device_config_entry:
-            raise InvalidDeviceAutomationConfig
+            return config
 
         if not await hass.config_entries.async_wait_component(device_config_entry):
             return config

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "requirements": ["aioesphomeapi==13.0.1"],
+  "requirements": ["aioesphomeapi==13.0.2"],
   "zeroconf": ["_esphomelib._tcp.local."],
   "dhcp": [{ "registered_devices": true }],
   "codeowners": ["@OttoWinter", "@jesserockz"],

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -130,6 +130,7 @@ class HassIOIngress(HomeAssistantView):
             allow_redirects=False,
             data=request.content,
             timeout=ClientTimeout(total=None),
+            skip_auto_headers={hdrs.CONTENT_TYPE},
         ) as result:
             headers = _response_header(result)
 

--- a/homeassistant/components/lupusec/manifest.json
+++ b/homeassistant/components/lupusec/manifest.json
@@ -2,7 +2,7 @@
   "domain": "lupusec",
   "name": "Lupus Electronics LUPUSEC",
   "documentation": "https://www.home-assistant.io/integrations/lupusec",
-  "requirements": ["lupupy==0.2.1"],
+  "requirements": ["lupupy==0.2.3"],
   "codeowners": ["@majuss"],
   "iot_class": "local_polling",
   "loggers": ["lupupy"]

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "requirements": ["aioshelly==5.1.1"],
+  "requirements": ["aioshelly==5.1.2"],
   "dependencies": ["bluetooth", "http"],
   "zeroconf": [
     {

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,7 @@ from .backports.enum import StrEnum
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 12
-PATCH_VERSION: Final = "5"
+PATCH_VERSION: Final = "6"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2022.12.5"
+version     = "2022.12.6"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -261,7 +261,7 @@ aiosenseme==0.6.1
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==5.1.1
+aioshelly==5.1.2
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -156,7 +156,7 @@ aioecowitt==2022.11.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==13.0.1
+aioesphomeapi==13.0.2
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1052,7 +1052,7 @@ london-tube-status==0.5
 luftdaten==0.7.4
 
 # homeassistant.components.lupusec
-lupupy==0.2.1
+lupupy==0.2.3
 
 # homeassistant.components.lw12wifi
 lw12==0.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -236,7 +236,7 @@ aiosenseme==0.6.1
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==5.1.1
+aioshelly==5.1.2
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -143,7 +143,7 @@ aioecowitt==2022.11.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==13.0.1
+aioesphomeapi==13.0.2
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -349,6 +349,7 @@ async def test_functional_device_trigger(
     assert automation_calls[0].data["some"] == "test_trigger_button_press"
 
 
+@pytest.mark.skip(reason="Temporarily disabled until automation validation is improved")
 async def test_validate_trigger_unknown_device(hass, aioclient_mock):
     """Test unknown device does not return a trigger config."""
     await setup_deconz_integration(hass, aioclient_mock)

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -372,6 +372,7 @@ async def test_exception_bad_trigger(hass, mock_devices, calls, caplog):
     assert "Invalid config for [automation]" in caplog.text
 
 
+@pytest.mark.skip(reason="Temporarily disabled until automation validation is improved")
 async def test_exception_no_device(hass, mock_devices, calls, caplog):
     """Test for exception on event triggers firing."""
 


### PR DESCRIPTION
- Do not add a Content-Type header to ingress ([@zeehio] - [#83425]) ([hassio docs])
- Bump lupupy dependency to v0.2.3 ([@majuss] - [#83765]) ([lupusec docs])
- Bump aioshelly to 5.1.2 to fix state updates not firing after reconnect ([@bdraco] - [#83950]) ([shelly docs])
- Bump aioesphomeapi to 13.0.2 to fix reconnects after bad protobuf message ([@bdraco] - [#83951]) ([esphome docs])
- Ignore certain device trigger validation errors ([@emontnemery] - [#83972]) ([device_automation docs])

[#83425]: https://github.com/home-assistant/core/pull/83425
[#83482]: https://github.com/home-assistant/core/pull/83482
[#83592]: https://github.com/home-assistant/core/pull/83592
[#83765]: https://github.com/home-assistant/core/pull/83765
[#83778]: https://github.com/home-assistant/core/pull/83778
[#83797]: https://github.com/home-assistant/core/pull/83797
[#83870]: https://github.com/home-assistant/core/pull/83870
[#83944]: https://github.com/home-assistant/core/pull/83944
[#83950]: https://github.com/home-assistant/core/pull/83950
[#83951]: https://github.com/home-assistant/core/pull/83951
[#83972]: https://github.com/home-assistant/core/pull/83972
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@emontnemery]: https://github.com/emontnemery
[@frenck]: https://github.com/frenck
[@majuss]: https://github.com/majuss
[@zeehio]: https://github.com/zeehio
[abode docs]: https://www.home-assistant.io/integrations/abode/
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/
[bluetooth docs]: https://www.home-assistant.io/integrations/bluetooth/
[braviatv docs]: https://www.home-assistant.io/integrations/braviatv/
[cast docs]: https://www.home-assistant.io/integrations/cast/
[device_automation docs]: https://www.home-assistant.io/integrations/device_automation/
[esphome docs]: https://www.home-assistant.io/integrations/esphome/
[fritzbox docs]: https://www.home-assistant.io/integrations/fritzbox/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[hassio docs]: https://www.home-assistant.io/integrations/hassio/
[justnimbus docs]: https://www.home-assistant.io/integrations/justnimbus/
[lupusec docs]: https://www.home-assistant.io/integrations/lupusec/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[sleepiq docs]: https://www.home-assistant.io/integrations/sleepiq/
[zha docs]: https://www.home-assistant.io/integrations/zha/
