### PR TITLE
Huawei LTE sensor improvements

### DIFF
--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -409,6 +409,16 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
             r"^(currentday|month)(duration|lastcleartime)$", re.IGNORECASE
         ),
         descriptions={
+            "CurrentDayUsed": HuaweiSensorEntityDescription(
+                key="CurrentDayUsed",
+                name="Current day transfer",
+                native_unit_of_measurement=UnitOfInformation.BYTES,
+                device_class=SensorDeviceClass.DATA_SIZE,
+                icon="mdi:arrow-up-down-bold",
+                state_class=SensorStateClass.TOTAL,
+                last_reset_item="CurrentDayDuration",
+                last_reset_formatter=last_reset_elapsed_seconds,
+            ),
             "CurrentMonthDownload": HuaweiSensorEntityDescription(
                 key="CurrentMonthDownload",
                 name="Current month download",

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -115,9 +115,19 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
     #
     KEY_DEVICE_SIGNAL: HuaweiSensorGroup(
         descriptions={
+            "arfcn": HuaweiSensorEntityDescription(
+                key="arfcn",
+                name="ARFCN",
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
             "band": HuaweiSensorEntityDescription(
                 key="band",
                 name="Band",
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
+            "bsic": HuaweiSensorEntityDescription(
+                key="bsic",
+                name="Base station identity code",
                 entity_category=EntityCategory.DIAGNOSTIC,
             ),
             "cell_id": HuaweiSensorEntityDescription(
@@ -152,6 +162,12 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
                 )[bisect((8, 15), x if x is not None else -1000)],
                 entity_category=EntityCategory.DIAGNOSTIC,
             ),
+            "dlfrequency": HuaweiSensorEntityDescription(
+                key="dlfrequency",
+                name="Downlink frequency",
+                device_class=SensorDeviceClass.FREQUENCY,
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
             "earfcn": HuaweiSensorEntityDescription(
                 key="earfcn",
                 name="EARFCN",
@@ -184,7 +200,7 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
             ),
             "ltedlfreq": HuaweiSensorEntityDescription(
                 key="ltedlfreq",
-                name="Downlink frequency",
+                name="LTE downlink frequency",
                 formatter=lambda x: (
                     round(int(x) / 10) if x is not None else None,
                     UnitOfFrequency.MEGAHERTZ,
@@ -194,7 +210,7 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
             ),
             "lteulfreq": HuaweiSensorEntityDescription(
                 key="lteulfreq",
-                name="Uplink frequency",
+                name="LTE uplink frequency",
                 formatter=lambda x: (
                     round(int(x) / 10) if x is not None else None,
                     UnitOfFrequency.MEGAHERTZ,
@@ -349,6 +365,12 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
                     "mdi:speedometer-medium",
                     "mdi:speedometer",
                 )[bisect((8, 15), x if x is not None else -1000)],
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
+            "ulfrequency": HuaweiSensorEntityDescription(
+                key="ulfrequency",
+                name="Uplink frequency",
+                device_class=SensorDeviceClass.FREQUENCY,
                 entity_category=EntityCategory.DIAGNOSTIC,
             ),
         }

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 import logging
 import re
 
+from huawei_lte_api.enums.net import NetworkModeEnum
+
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
@@ -536,13 +538,13 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
                 name="Preferred mode",
                 formatter=lambda x: (
                     {
-                        "00": "4G/3G/2G",
-                        "01": "2G",
-                        "02": "3G",
-                        "03": "4G",
-                        "0301": "4G/2G",
-                        "0302": "4G/3G",
-                        "0201": "3G/2G",
+                        NetworkModeEnum.MODE_AUTO.value: "4G/3G/2G",
+                        NetworkModeEnum.MODE_4G_3G_AUTO.value: "4G/3G",
+                        NetworkModeEnum.MODE_4G_2G_AUTO.value: "4G/2G",
+                        NetworkModeEnum.MODE_4G_ONLY.value: "4G",
+                        NetworkModeEnum.MODE_3G_2G_AUTO.value: "3G/2G",
+                        NetworkModeEnum.MODE_3G_ONLY.value: "3G",
+                        NetworkModeEnum.MODE_2G_ONLY.value: "2G",
                     }.get(x),
                     None,
                 ),

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -17,7 +17,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
-    STATE_UNKNOWN,
     UnitOfDataRate,
     UnitOfFrequency,
     UnitOfInformation,
@@ -205,7 +204,7 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
                 key="mode",
                 name="Mode",
                 formatter=lambda x: (
-                    {"0": "2G", "2": "3G", "7": "4G"}.get(x, "Unknown"),
+                    {"0": "2G", "2": "3G", "7": "4G"}.get(x),
                     None,
                 ),
                 icon_fn=lambda x: (
@@ -522,7 +521,7 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
                 key="State",
                 name="Operator search mode",
                 formatter=lambda x: (
-                    {"0": "Auto", "1": "Manual"}.get(x, "Unknown"),
+                    {"0": "Auto", "1": "Manual"}.get(x),
                     None,
                 ),
                 entity_category=EntityCategory.CONFIG,
@@ -544,7 +543,7 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
                         "0301": "4G/2G",
                         "0302": "4G/3G",
                         "0201": "3G/2G",
-                    }.get(x, "Unknown"),
+                    }.get(x),
                     None,
                 ),
                 entity_category=EntityCategory.CONFIG,
@@ -660,7 +659,7 @@ class HuaweiLteSensor(HuaweiLteBaseEntityWithDevice, SensorEntity):
     item: str
     entity_description: HuaweiSensorEntityDescription
 
-    _state: StateType = field(default=STATE_UNKNOWN, init=False)
+    _state: StateType = field(default=None, init=False)
     _unit: str | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -390,7 +390,9 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
         },
     ),
     KEY_MONITORING_MONTH_STATISTICS: HuaweiSensorGroup(
-        exclude=re.compile(r"^month(duration|lastcleartime)$", re.IGNORECASE),
+        exclude=re.compile(
+            r"^(currentday|month)(duration|lastcleartime)$", re.IGNORECASE
+        ),
         descriptions={
             "CurrentMonthDownload": HuaweiSensorEntityDescription(
                 key="CurrentMonthDownload",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Various improvements to Huawei LTE sensors.

- Fix current month download/upload amount state classes (totals resetting monthly/manually, not total increasing)
- Exclude current day duration (running number from start of day) sensor, like we already do for the corresponding month one
- Make ARFCN, BSIC, current day transfer, EARFCN, downlink frequency, and uplink frequency sensors more human readable, distinguish last two from the similar LTE ones
- Let HA handle unknown states by returning `None`
- Make use of huawei_lte_api's `NetworkModeEnum`
- Code reuse and function naming consistency improvements

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/83904#discussion_r1047778416
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
