### PR TITLE
Update ESPHome bluetooth repair issue for unique id change and 2022.12.0

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -66,8 +66,12 @@ CONF_NOISE_PSK = "noise_psk"
 _LOGGER = logging.getLogger(__name__)
 _R = TypeVar("_R")
 
-STABLE_BLE_VERSION_STR = "2022.11.0"
+STABLE_BLE_VERSION_STR = "2022.12.0"
 STABLE_BLE_VERSION = AwesomeVersion(STABLE_BLE_VERSION_STR)
+PROJECT_URLS = {
+    "esphome.bluetooth-proxy": "https://esphome.github.io/bluetooth-proxies/",
+}
+DEFAULT_URL = f"https://esphome.io/changelog/{STABLE_BLE_VERSION_STR}.html"
 
 
 @callback
@@ -75,13 +79,13 @@ def _async_check_firmware_version(
     hass: HomeAssistant, device_info: EsphomeDeviceInfo
 ) -> None:
     """Create or delete an the ble_firmware_outdated issue."""
-    # ESPHome device_info.name is the unique_id
-    issue = f"ble_firmware_outdated-{device_info.name}"
+    # ESPHome device_info.mac_address is the unique_id
+    issue = f"ble_firmware_outdated-{device_info.mac_address}"
     if (
         not device_info.bluetooth_proxy_version
         # If the device has a project name its up to that project
         # to tell them about the firmware version update so we don't notify here
-        or device_info.project_name
+        or (device_info.project_name and device_info.project_name not in PROJECT_URLS)
         or AwesomeVersion(device_info.esphome_version) >= STABLE_BLE_VERSION
     ):
         async_delete_issue(hass, DOMAIN, issue)
@@ -92,9 +96,12 @@ def _async_check_firmware_version(
         issue,
         is_fixable=False,
         severity=IssueSeverity.WARNING,
-        learn_more_url=f"https://esphome.io/changelog/{STABLE_BLE_VERSION_STR}.html",
+        learn_more_url=PROJECT_URLS.get(device_info.project_name, DEFAULT_URL),
         translation_key="ble_firmware_outdated",
-        translation_placeholders={"name": device_info.name},
+        translation_placeholders={
+            "name": device_info.name,
+            "version": STABLE_BLE_VERSION_STR,
+        },
     )
 
 

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -47,8 +47,8 @@
   },
   "issues": {
     "ble_firmware_outdated": {
-      "title": "Update {name} with ESPHome 2022.11.0 or later",
-      "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome 2022.11.0 or later."
+      "title": "Update {name} with ESPHome {version} or later",
+      "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome {version} or later. When updating to ESPHome {version}, it is recommended to use a serial cable instead of an over the air update to take advantage of the new partition scheme."
     }
   }
 }

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -48,7 +48,7 @@
   "issues": {
     "ble_firmware_outdated": {
       "title": "Update {name} with ESPHome {version} or later",
-      "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome {version} or later. When updating to ESPHome {version}, it is recommended to use a serial cable instead of an over the air update to take advantage of the new partition scheme."
+      "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome {version} or later. When updating the device to ESPHome {version}, it is recommended to use a serial cable instead of an over-the-air update to take advantage of the new partition scheme.",
     }
   }
 }

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -48,7 +48,7 @@
   "issues": {
     "ble_firmware_outdated": {
       "title": "Update {name} with ESPHome {version} or later",
-      "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome {version} or later. When updating the device to ESPHome {version}, it is recommended to use a serial cable instead of an over-the-air update to take advantage of the new partition scheme.",
+      "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome {version} or later. When updating the device to ESPHome {version}, it is recommended to use a serial cable instead of an over-the-air update to take advantage of the new partition scheme."
     }
   }
 }

--- a/homeassistant/components/esphome/translations/en.json
+++ b/homeassistant/components/esphome/translations/en.json
@@ -47,7 +47,7 @@
     },
     "issues": {
         "ble_firmware_outdated": {
-            "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome {version} or later. When updating to ESPHome {version}, it is recommended to use a serial cable instead of an over the air update to take advantage of the new partition scheme.",
+            "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome {version} or later. When updating the device to ESPHome {version}, it is recommended to use a serial cable instead of an over-the-air update to take advantage of the new partition scheme.",
             "title": "Update {name} with ESPHome {version} or later"
         }
     }

--- a/homeassistant/components/esphome/translations/en.json
+++ b/homeassistant/components/esphome/translations/en.json
@@ -47,8 +47,8 @@
     },
     "issues": {
         "ble_firmware_outdated": {
-            "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome 2022.11.0 or later.",
-            "title": "Update {name} with ESPHome 2022.11.0 or later"
+            "description": "To improve Bluetooth reliability and performance, we highly recommend updating {name} with ESPHome {version} or later. When updating to ESPHome {version}, it is recommended to use a serial cable instead of an over the air update to take advantage of the new partition scheme.",
+            "title": "Update {name} with ESPHome {version} or later"
         }
     }
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The name is no longer the unique id after #83741

2022.12.0 has important stability and performance fixes
that will close many of the issues


2022.11.x:
<img width="613" alt="Screenshot 2022-12-14 at 8 55 39 PM" src="https://user-images.githubusercontent.com/663432/207794204-9391a6a7-eddf-45ee-9c5a-67619ec27812.png">
<img width="581" alt="Screenshot 2022-12-14 at 8 55 43 PM" src="https://user-images.githubusercontent.com/663432/207794215-7ea3c9c6-d7f2-4f19-bc66-40083959fa75.png">
<img width="324" alt="Screenshot 2022-12-14 at 9 00 15 PM" src="https://user-images.githubusercontent.com/663432/207794235-9f153197-b195-44da-b481-2bac889d7538.png">

Flash to 2022.12.0 and message goes away
<img width="335" alt="Screenshot 2022-12-14 at 9 00 26 PM" src="https://user-images.githubusercontent.com/663432/207794271-6bd5435b-9691-4f56-8d37-402ff5281388.png">



## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
