### PR TITLE
Add device classes to bloomsky

### DIFF
--- a/homeassistant/components/bloomsky/sensor.py
+++ b/homeassistant/components/bloomsky/sensor.py
@@ -11,12 +11,10 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     AREA_SQUARE_METERS,
     CONF_MONITORED_CONDITIONS,
-    ELECTRIC_POTENTIAL_MILLIVOLT,
     PERCENTAGE,
-    PRESSURE_INHG,
-    PRESSURE_MBAR,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
+    UnitOfElectricPotential,
+    UnitOfPressure,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -37,25 +35,28 @@ SENSOR_TYPES = [
 
 # Sensor units - these do not currently align with the API documentation
 SENSOR_UNITS_IMPERIAL = {
-    "Temperature": TEMP_FAHRENHEIT,
+    "Temperature": UnitOfTemperature.FAHRENHEIT,
     "Humidity": PERCENTAGE,
-    "Pressure": PRESSURE_INHG,
+    "Pressure": UnitOfPressure.INHG,
     "Luminance": f"cd/{AREA_SQUARE_METERS}",
-    "Voltage": ELECTRIC_POTENTIAL_MILLIVOLT,
+    "Voltage": UnitOfElectricPotential.MILLIVOLT,
 }
 
 # Metric units
 SENSOR_UNITS_METRIC = {
-    "Temperature": TEMP_CELSIUS,
+    "Temperature": UnitOfTemperature.CELSIUS,
     "Humidity": PERCENTAGE,
-    "Pressure": PRESSURE_MBAR,
+    "Pressure": UnitOfPressure.MBAR,
     "Luminance": f"cd/{AREA_SQUARE_METERS}",
-    "Voltage": ELECTRIC_POTENTIAL_MILLIVOLT,
+    "Voltage": UnitOfElectricPotential.MILLIVOLT,
 }
 
 # Device class
 SENSOR_DEVICE_CLASS = {
     "Temperature": SensorDeviceClass.TEMPERATURE,
+    "Humidity": SensorDeviceClass.HUMIDITY,
+    "Pressure": SensorDeviceClass.PRESSURE,
+    "Voltage": SensorDeviceClass.VOLTAGE,
 }
 
 # Which sensors to format numerically
@@ -108,7 +109,7 @@ class BloomSkySensor(SensorEntity):
             )
 
     @property
-    def device_class(self):
+    def device_class(self) -> SensorDeviceClass | None:
         """Return the class of this device, from component DEVICE_CLASSES."""
         return SENSOR_DEVICE_CLASS.get(self._sensor_name)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add device classes to bloomsky
Also move to unit enums

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
