### PR TITLE
Add filter for duplicate NINA warnings

### DIFF
--- a/homeassistant/components/nina/__init__.py
+++ b/homeassistant/components/nina/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from async_timeout import timeout
 from pynina import ApiError, Nina
@@ -89,12 +90,38 @@ class NINADataUpdateCoordinator(
                 raise UpdateFailed(err) from err
             return self._parse_data()
 
+    @staticmethod
+    def _remove_duplicate_warnings(
+        warnings: dict[str, list[Any]]
+    ) -> dict[str, list[Any]]:
+        """Remove warnings with the same title and expires timestamp in a region."""
+        all_filtered_warnings: dict[str, list[Any]] = {}
+
+        for region_id, raw_warnings in warnings.items():
+
+            filtered_warnings: list[Any] = []
+            processed_details: list[tuple[str, str]] = []
+
+            for raw_warn in raw_warnings:
+                if (raw_warn.headline, raw_warn.expires) in processed_details:
+                    continue
+
+                processed_details.append((raw_warn.headline, raw_warn.expires))
+
+                filtered_warnings.append(raw_warn)
+
+            all_filtered_warnings[region_id] = filtered_warnings
+
+        return all_filtered_warnings
+
     def _parse_data(self) -> dict[str, list[NinaWarningData]]:
         """Parse warning data."""
 
         return_data: dict[str, list[NinaWarningData]] = {}
 
-        for region_id, raw_warnings in self._nina.warnings.items():
+        for region_id, raw_warnings in self._remove_duplicate_warnings(
+            self._nina.warnings
+        ).items():
             warnings_for_regions: list[NinaWarningData] = []
 
             for raw_warn in raw_warnings:

--- a/tests/components/nina/fixtures/sample_warning_details.json
+++ b/tests/components/nina/fixtures/sample_warning_details.json
@@ -158,6 +158,88 @@
       }
     ]
   },
+  "mow.DE-NW-BN-SE030-20201014-30-011": {
+    "identifier": "mow.DE-NW-BN-SE030-20201014-30-011",
+    "sender": "opendata@dwd.de",
+    "sent": "2021-10-11T05:21:00+01:00",
+    "status": "Actual",
+    "msgType": "Alert",
+    "source": "PVW",
+    "scope": "Public",
+    "code": [
+      "DVN:2",
+      "id:2.49.0.0.276.0.DWD.PVW.1645004040000.5a168da8-ac20-4b6d-86be-d616526a7914"
+    ],
+    "info": [
+      {
+        "language": "de-DE",
+        "category": ["Met"],
+        "event": "STURMBÖEN",
+        "responseType": ["Prepare"],
+        "urgency": "Immediate",
+        "severity": "Moderate",
+        "certainty": "Likely",
+        "eventCode": [
+          {
+            "valueName": "PROFILE_VERSION",
+            "value": "2.1.11"
+          },
+          {
+            "valueName": "LICENSE",
+            "value": "© GeoBasis-DE / BKG 2019  (Daten modifiziert)"
+          },
+          {
+            "valueName": "II",
+            "value": "52"
+          },
+          {
+            "valueName": "GROUP",
+            "value": "WIND"
+          },
+          {
+            "valueName": "AREA_COLOR",
+            "value": "251 140 0"
+          }
+        ],
+        "effective": "2021-11-01T03:20:00+01:00",
+        "onset": "2021-11-01T05:20:00+01:00",
+        "expires": "3021-11-22T05:19:00+01:00",
+        "senderName": "Deutscher Wetterdienst",
+        "headline": "Ausfall Notruf 112",
+        "description": "Es treten Sturmböen mit Geschwindigkeiten zwischen 70 km/h (20m/s, 38kn, Bft 8) und 85 km/h (24m/s, 47kn, Bft 9) aus westlicher Richtung auf. In Schauernähe sowie in exponierten Lagen muss mit schweren Sturmböen bis 90 km/h (25m/s, 48kn, Bft 10) gerechnet werden.",
+        "instruction": "ACHTUNG! Hinweis auf mögliche Gefahren: Es können zum Beispiel einzelne Äste herabstürzen. Achten Sie besonders auf herabfallende Gegenstände.",
+        "web": "https://www.wettergefahren.de",
+        "contact": "Deutscher Wetterdienst",
+        "parameter": [
+          {
+            "valueName": "gusts",
+            "value": "70-85 [km/h]"
+          },
+          {
+            "valueName": "exposed gusts",
+            "value": "<90 [km/h]"
+          },
+          {
+            "valueName": "wind direction",
+            "value": "west"
+          },
+          {
+            "valueName": "PHGEM",
+            "value": "3243+168,3413+1,3424+52,3478+1,3495+2,3499,3639+2527,6168+1,6175+22,6199+36,6238,6241+7,6256,9956+184,10142,10154,10164+7,10173,10176+6,10186+1,10195+2,10199,10201+6,10214+4,10220,10249+117,10368,10373+2,10425+9,10436+1,10440+8,10450+1,10453+7,10462+1,10467+5,10474+2,10484+5,10773+68,10843+2,10847+9,10858,10867+8,10878+1,10882+68,10952+7,10961+2,11046,11056+1"
+          },
+          {
+            "valueName": "ZGEM",
+            "value": "3243+168,3413+1,3424+52,3478+1,3495+2,3499,3639+2527,6168+1,6175+22,6199+36,6238,6241+7,6256,9956+184,10142,10154,10164+7,10173,10176+6,10186+1,10195+2,10199,10201+6,10214+4,10220,10249+117,10368,10373+2,10425+9,10436+1,10440+8,10450+1,10453+7,10462+1,10467+5,10474+2,10484+5,10773+68,10843+2,10847+9,10858,10867+8,10878+1,10882+68,10952+7,10961+2,11046,11056+1"
+          }
+        ],
+        "area": [
+          {
+            "areaDesc": "Gemeinde Oberreichenbach, Gemeinde Neuweiler, Stadt Nagold, Stadt Neubulach, Gemeinde Schömberg, Gemeinde Simmersfeld, Gemeinde Simmozheim, Gemeinde Rohrdorf, Gemeinde Ostelsheim, Gemeinde Ebhausen, Gemeinde Egenhausen, Gemeinde Dobel, Stadt Bad Liebenzell, Stadt Solingen, Stadt Haiterbach, Stadt Bad Herrenalb, Gemeinde Höfen an der Enz, Gemeinde Gechingen, Gemeinde Enzklösterle, Gemeinde Gutach (Schwarzwaldbahn) und 3392 weitere."
+          }
+        ]
+      }
+    ]
+  },
   "biw.BIWAPP-69634": {
     "identifier": "biw.BIWAPP-69634",
     "sender": "CAP@biwapp.de",

--- a/tests/components/nina/fixtures/sample_warnings.json
+++ b/tests/components/nina/fixtures/sample_warnings.json
@@ -42,6 +42,27 @@
     "expires": "3021-11-22T05:19:00+01:00"
   },
   {
+    "id": "mow.DE-NW-BN-SE030-20201014-30-011",
+    "payload": {
+      "version": 1,
+      "type": "ALERT",
+      "id": "mow.DE-NW-BN-SE030-20201014-30-011",
+      "hash": "551db820a43be7e4f39283e1dfb71b212cd520c3ee478d44f43519e9c42fde1c",
+      "data": {
+        "headline": "Ausfall Notruf 112",
+        "provider": "MOWAS",
+        "severity": "Minor",
+        "msgType": "Update",
+        "transKeys": { "event": "BBK-EVC-040" },
+        "area": { "type": "ZGEM", "data": "1+11057,100001" }
+      }
+    },
+    "i18nTitle": { "de": "Ausfall Notruf 112" },
+    "onset": "2021-11-01T05:20:00+01:00",
+    "sent": "2021-10-11T05:21:00+01:00",
+    "expires": "3021-11-22T05:19:00+01:00"
+  },
+  {
     "id": "biw.BIWAPP-69634",
     "payload": {
       "version": 2,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a filter that filters out duplicate warnings in an area.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83992
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
