### PR TITLE
Add support for multiple mbus devices in dsmr 

### DIFF
--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -29,6 +29,7 @@ DATA_TASK = "task"
 
 DEVICE_NAME_ELECTRICITY = "Electricity Meter"
 DEVICE_NAME_GAS = "Gas Meter"
+DEVICE_NAME_WATER = "Water Meter"
 
 DSMR_VERSIONS = {"2.2", "4", "5", "5B", "5L", "5S", "Q3D"}
 

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -465,6 +465,12 @@ def rename_old_gas_to_mbus(
                         entity.unique_id,
                         mbus_device_id,
                     )
+        # Cleanup old device
+        dev_entities = er.async_entries_for_device(
+            ent_reg, device_id, include_disabled_entities=True
+        )
+        if not dev_entities:
+            dev_reg.async_remove_device(device_id)
 
 
 def create_mbus_entities(

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -392,7 +392,7 @@ def create_mbus_entity(
     ):
         return DSMRSensorEntityDescription(
             key=f"mbus{mbus}_gas_reading",
-            name=f"Gas consumption mbus{mbus}",
+            translation_key="gas_meter_reading",
             obis_reference=obis_reference,
             is_gas=True,
             device_class=SensorDeviceClass.GAS,
@@ -409,7 +409,7 @@ def create_mbus_entity(
     ):
         return DSMRSensorEntityDescription(
             key=f"mbus{mbus}_water_reading",
-            name=f"Water consumption mbus{mbus}",
+            translation_key="water_meter_reading",
             obis_reference=obis_reference,
             is_water=True,
             device_class=SensorDeviceClass.WATER,
@@ -451,7 +451,9 @@ def rename_old_gas_to_mbus(
             if entity.unique_id.endswith("belgium_5min_gas_meter_reading"):
                 try:
                     ent_reg.async_update_entity(
-                        entity.entity_id, new_unique_id=mbus_device_id
+                        entity.entity_id,
+                        new_unique_id=mbus_device_id,
+                        device_id=mbus_device_id,
                     )
                 except ValueError:
                     LOGGER.warning(
@@ -748,7 +750,10 @@ class DSMREntity(SensorEntity):
             name=device_name,
         )
         if mbus_id != 0:
-            self._attr_unique_id = f"{device_serial}"
+            if serial_id:
+                self._attr_unique_id = f"{device_serial}"
+            else:
+                self._attr_unique_id = f"{device_serial}_{mbus_id}"
         else:
             self._attr_unique_id = f"{device_serial}_{entity_description.key}"
 

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -505,9 +505,7 @@ def create_mbus_entities(
                     description,
                     entry,
                     telegram,
-                    *device_class_and_uom(
-                        telegram, description
-                    ),  # type: ignore[arg-type]
+                    *device_class_and_uom(telegram, description),  # type: ignore[arg-type]
                     serial_,
                     idx,
                 )

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -476,12 +476,10 @@ def rename_old_gas_to_mbus(
 
 
 def create_mbus_entities(
-    hass: HomeAssistant, telegram: dict[str, DSMRObject] | None, entry: ConfigEntry
+    hass: HomeAssistant, telegram: dict[str, DSMRObject], entry: ConfigEntry
 ) -> list[DSMREntity]:
     """Create MBUS Entities."""
     entities = []
-    if not telegram:
-        return []
     for idx in range(1, 5):
         if (
             device_type := getattr(obis_references, f"BELGIUM_MBUS{idx}_DEVICE_TYPE")

--- a/homeassistant/components/dsmr/strings.json
+++ b/homeassistant/components/dsmr/strings.json
@@ -147,6 +147,9 @@
       },
       "voltage_swell_l3_count": {
         "name": "Voltage swells phase L3"
+      },
+      "water_meter_reading": {
+        "name": "Water consumption"
       }
     }
   },

--- a/tests/components/dsmr/test_mbus_migration.py
+++ b/tests/components/dsmr/test_mbus_migration.py
@@ -1,0 +1,212 @@
+"""Tests for the DSMR integration."""
+import datetime
+from decimal import Decimal
+
+from homeassistant.components.dsmr.const import DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_migrate_gas_to_mbus(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, dsmr_connection_fixture
+) -> None:
+    """Test migration of unique_id."""
+    (connection_factory, transport, protocol) = dsmr_connection_fixture
+
+    from dsmr_parser.obis_references import (
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS1_METER_READING2,
+    )
+    from dsmr_parser.objects import CosemObject, MBusObject
+
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="/dev/ttyUSB0",
+        data={
+            "port": "/dev/ttyUSB0",
+            "dsmr_version": "5B",
+            "precision": 4,
+            "reconnect_interval": 30,
+            "serial_id": "1234",
+            "serial_id_gas": "37464C4F32313139303333373331",
+        },
+        options={
+            "time_between_update": 0,
+        },
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    old_unique_id = "37464C4F32313139303333373331_belgium_5min_gas_meter_reading"
+
+    device_registry = hass.helpers.device_registry.async_get(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_entry.entry_id,
+        identifiers={(DOMAIN, mock_entry.entry_id)},
+        name="Gas Meter",
+    )
+    await hass.async_block_till_done()
+
+    entity: er.RegistryEntry = entity_registry.async_get_or_create(
+        suggested_object_id="gas_meter_reading",
+        disabled_by=None,
+        domain=SENSOR_DOMAIN,
+        platform=DOMAIN,
+        device_id=device.id,
+        unique_id=old_unique_id,
+        config_entry=mock_entry,
+    )
+    assert entity.unique_id == old_unique_id
+    await hass.async_block_till_done()
+
+    telegram = {
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "003", "unit": ""}]
+        ),
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373331", "unit": ""}],
+        ),
+        BELGIUM_MBUS1_METER_READING2: MBusObject(
+            BELGIUM_MBUS1_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": "m3"},
+            ],
+        ),
+    }
+
+    assert await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to be created
+    await hass.async_block_till_done()
+
+    dev_entities = er.async_entries_for_device(
+        entity_registry, device.id, include_disabled_entities=True
+    )
+    assert not dev_entities
+
+    assert (
+        entity_registry.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, old_unique_id)
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            SENSOR_DOMAIN, DOMAIN, "37464C4F32313139303333373331"
+        )
+        == "sensor.gas_meter_reading"
+    )
+
+
+async def test_migrate_gas_to_mbus_exists(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, dsmr_connection_fixture
+) -> None:
+    """Test migration of unique_id."""
+    (connection_factory, transport, protocol) = dsmr_connection_fixture
+
+    from dsmr_parser.obis_references import (
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS1_METER_READING2,
+    )
+    from dsmr_parser.objects import CosemObject, MBusObject
+
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="/dev/ttyUSB0",
+        data={
+            "port": "/dev/ttyUSB0",
+            "dsmr_version": "5B",
+            "precision": 4,
+            "reconnect_interval": 30,
+            "serial_id": "1234",
+            "serial_id_gas": "37464C4F32313139303333373331",
+        },
+        options={
+            "time_between_update": 0,
+        },
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    old_unique_id = "37464C4F32313139303333373331_belgium_5min_gas_meter_reading"
+
+    device_registry = hass.helpers.device_registry.async_get(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_entry.entry_id,
+        identifiers={(DOMAIN, mock_entry.entry_id)},
+        name="Gas Meter",
+    )
+    await hass.async_block_till_done()
+
+    entity: er.RegistryEntry = entity_registry.async_get_or_create(
+        suggested_object_id="gas_meter_reading",
+        disabled_by=None,
+        domain=SENSOR_DOMAIN,
+        platform=DOMAIN,
+        device_id=device.id,
+        unique_id=old_unique_id,
+        config_entry=mock_entry,
+    )
+    assert entity.unique_id == old_unique_id
+
+    device2 = device_registry.async_get_or_create(
+        config_entry_id=mock_entry.entry_id,
+        identifiers={(DOMAIN, "37464C4F32313139303333373331")},
+        name="Gas Meter",
+    )
+    await hass.async_block_till_done()
+
+    entity_registry.async_get_or_create(
+        suggested_object_id="gas_meter_reading_alt",
+        disabled_by=None,
+        domain=SENSOR_DOMAIN,
+        platform=DOMAIN,
+        device_id=device2.id,
+        unique_id="37464C4F32313139303333373331",
+        config_entry=mock_entry,
+    )
+    await hass.async_block_till_done()
+
+    telegram = {
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "003", "unit": ""}]
+        ),
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373331", "unit": ""}],
+        ),
+        BELGIUM_MBUS1_METER_READING2: MBusObject(
+            BELGIUM_MBUS1_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": "m3"},
+            ],
+        ),
+    }
+
+    assert await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to be created
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, old_unique_id)
+        == "sensor.gas_meter_reading"
+    )

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -145,8 +145,8 @@ async def test_default_setup(
     # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
     telegram_callback(telegram)
 
-    # after receiving telegram entities need to have the chance to update
-    await asyncio.sleep(0)
+    # after receiving telegram entities need to have the chance to be created
+    await hass.async_block_till_done()
 
     # ensure entities have new state value after incoming telegram
     power_consumption = hass.states.get("sensor.electricity_meter_power_consumption")
@@ -495,10 +495,18 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     from dsmr_parser.obis_references import (
         BELGIUM_CURRENT_AVERAGE_DEMAND,
         BELGIUM_MAXIMUM_DEMAND_MONTH,
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
         BELGIUM_MBUS1_METER_READING2,
-        BELGIUM_MBUS2_METER_READING2,
+        BELGIUM_MBUS2_DEVICE_TYPE,
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS2_METER_READING1,
+        BELGIUM_MBUS3_DEVICE_TYPE,
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
         BELGIUM_MBUS3_METER_READING2,
-        BELGIUM_MBUS4_METER_READING2,
+        BELGIUM_MBUS4_DEVICE_TYPE,
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS4_METER_READING1,
         ELECTRICITY_ACTIVE_TARIFF,
     )
     from dsmr_parser.objects import CosemObject, MBusObject
@@ -509,41 +517,13 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
         "precision": 4,
         "reconnect_interval": 30,
         "serial_id": "1234",
-        "serial_id_gas": "5678",
+        "serial_id_gas": None,
     }
     entry_options = {
         "time_between_update": 0,
     }
 
     telegram = {
-        BELGIUM_MBUS1_METER_READING2: MBusObject(
-            BELGIUM_MBUS1_METER_READING2,
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642213)},
-                {"value": Decimal(745.695), "unit": "m3"},
-            ],
-        ),
-        BELGIUM_MBUS2_METER_READING2: MBusObject(
-            BELGIUM_MBUS2_METER_READING2,
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642214)},
-                {"value": Decimal(745.696), "unit": "m3"},
-            ],
-        ),
-        BELGIUM_MBUS3_METER_READING2: MBusObject(
-            BELGIUM_MBUS3_METER_READING2,
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642215)},
-                {"value": Decimal(745.697), "unit": "m3"},
-            ],
-        ),
-        BELGIUM_MBUS4_METER_READING2: MBusObject(
-            BELGIUM_MBUS4_METER_READING2,
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642216)},
-                {"value": Decimal(745.698), "unit": "m3"},
-            ],
-        ),
         BELGIUM_CURRENT_AVERAGE_DEMAND: CosemObject(
             BELGIUM_CURRENT_AVERAGE_DEMAND,
             [{"value": Decimal(1.75), "unit": "kW"}],
@@ -553,6 +533,62 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(4.11), "unit": "kW"},
+            ],
+        ),
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "003", "unit": ""}]
+        ),
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373331", "unit": ""}],
+        ),
+        BELGIUM_MBUS1_METER_READING2: MBusObject(
+            BELGIUM_MBUS1_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS2_DEVICE_TYPE, [{"value": "007", "unit": ""}]
+        ),
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373332", "unit": ""}],
+        ),
+        BELGIUM_MBUS2_METER_READING1: MBusObject(
+            BELGIUM_MBUS2_METER_READING1,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642214)},
+                {"value": Decimal(678.695), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS3_DEVICE_TYPE, [{"value": "003", "unit": ""}]
+        ),
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373333", "unit": ""}],
+        ),
+        BELGIUM_MBUS3_METER_READING2: MBusObject(
+            BELGIUM_MBUS3_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642215)},
+                {"value": Decimal(12.12), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "007", "unit": ""}]
+        ),
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373334", "unit": ""}],
+        ),
+        BELGIUM_MBUS4_METER_READING1: MBusObject(
+            BELGIUM_MBUS4_METER_READING1,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642216)},
+                {"value": Decimal(13.13), "unit": "m3"},
             ],
         ),
         ELECTRICITY_ACTIVE_TARIFF: CosemObject(
@@ -600,8 +636,8 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     assert max_demand.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.KILO_WATT
     assert max_demand.attributes.get(ATTR_STATE_CLASS) is None
 
-    # check if gas consumption is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
+    # check if gas consumption mbus1 is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus1")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
@@ -612,6 +648,331 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
         gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == UnitOfVolume.CUBIC_METERS
     )
+
+    # check if water usage mbus2 is parsed correctly
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus2")
+    assert water_consumption.state == "678.695"
+    assert (
+        water_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WATER
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
+
+    # check if gas consumption mbus1 is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus3")
+    assert gas_consumption.state == "12.12"
+    assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
+
+    # check if water usage mbus2 is parsed correctly
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus4")
+    assert water_consumption.state == "13.13"
+    assert (
+        water_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WATER
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
+
+
+async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+    """Test if Belgian meter is correctly parsed."""
+    (connection_factory, transport, protocol) = dsmr_connection_fixture
+
+    from dsmr_parser.obis_references import (
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS1_METER_READING1,
+        BELGIUM_MBUS2_DEVICE_TYPE,
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS2_METER_READING2,
+        BELGIUM_MBUS3_DEVICE_TYPE,
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS3_METER_READING1,
+        BELGIUM_MBUS4_DEVICE_TYPE,
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS4_METER_READING2,
+    )
+    from dsmr_parser.objects import CosemObject, MBusObject
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "5B",
+        "precision": 4,
+        "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": None,
+    }
+    entry_options = {
+        "time_between_update": 0,
+    }
+
+    telegram = {
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "007", "unit": ""}]
+        ),
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373331", "unit": ""}],
+        ),
+        BELGIUM_MBUS1_METER_READING1: MBusObject(
+            BELGIUM_MBUS1_METER_READING1,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642215)},
+                {"value": Decimal(123.456), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS2_DEVICE_TYPE, [{"value": "003", "unit": ""}]
+        ),
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373332", "unit": ""}],
+        ),
+        BELGIUM_MBUS2_METER_READING2: MBusObject(
+            BELGIUM_MBUS2_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642216)},
+                {"value": Decimal(678.901), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS3_DEVICE_TYPE, [{"value": "007", "unit": ""}]
+        ),
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373333", "unit": ""}],
+        ),
+        BELGIUM_MBUS3_METER_READING1: MBusObject(
+            BELGIUM_MBUS3_METER_READING1,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642217)},
+                {"value": Decimal(12.12), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "003", "unit": ""}]
+        ),
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373334", "unit": ""}],
+        ),
+        BELGIUM_MBUS4_METER_READING2: MBusObject(
+            BELGIUM_MBUS4_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642218)},
+                {"value": Decimal(13.13), "unit": "m3"},
+            ],
+        ),
+    }
+
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to be created
+    await hass.async_block_till_done()
+
+    # check if water usage mbus1 is parsed correctly
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus1")
+    assert water_consumption.state == "123.456"
+    assert (
+        water_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WATER
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
+
+    # check if gas consumption mbus2 is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus2")
+    assert gas_consumption.state == "678.901"
+    assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
+
+    # check if water usage mbus3 is parsed correctly
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus3")
+    assert water_consumption.state == "12.12"
+    assert (
+        water_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WATER
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
+
+    # check if gas consumption mbus4 is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus4")
+    assert gas_consumption.state == "13.13"
+    assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
+
+
+async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+    """Test if Belgian meter is correctly parsed."""
+    (connection_factory, transport, protocol) = dsmr_connection_fixture
+
+    from dsmr_parser.obis_references import (
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS2_DEVICE_TYPE,
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS3_DEVICE_TYPE,
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS3_METER_READING2,
+        BELGIUM_MBUS4_DEVICE_TYPE,
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+        BELGIUM_MBUS4_METER_READING1,
+        ELECTRICITY_ACTIVE_TARIFF,
+    )
+    from dsmr_parser.objects import CosemObject, MBusObject
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "5B",
+        "precision": 4,
+        "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": None,
+    }
+    entry_options = {
+        "time_between_update": 0,
+    }
+
+    telegram = {
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
+            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0003", "unit": ""}]
+        ),
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "006", "unit": ""}]
+        ),
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373331", "unit": ""}],
+        ),
+        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS2_DEVICE_TYPE, [{"value": "003", "unit": ""}]
+        ),
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373332", "unit": ""}],
+        ),
+        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS3_DEVICE_TYPE, [{"value": "007", "unit": ""}]
+        ),
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373333", "unit": ""}],
+        ),
+        BELGIUM_MBUS3_METER_READING2: MBusObject(
+            BELGIUM_MBUS3_METER_READING2,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642217)},
+                {"value": Decimal(12.12), "unit": "m3"},
+            ],
+        ),
+        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
+            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "003", "unit": ""}]
+        ),
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
+            BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+            [{"value": "37464C4F32313139303333373334", "unit": ""}],
+        ),
+        BELGIUM_MBUS4_METER_READING1: MBusObject(
+            BELGIUM_MBUS4_METER_READING1,
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642218)},
+                {"value": Decimal(13.13), "unit": "m3"},
+            ],
+        ),
+    }
+
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to be created
+    await hass.async_block_till_done()
+
+    # tariff should be translated in human readable and have no unit
+    active_tariff = hass.states.get("sensor.electricity_meter_active_tariff")
+    assert active_tariff.state == "unknown"
+
+    # check if water usage mbus1 is parsed correctly
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus1")
+    assert water_consumption is None
+
+    # check if gas consumption mbus2 is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus2")
+    assert gas_consumption is None
+
+    # check if water usage mbus3 is parsed correctly
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus3")
+    assert water_consumption is None
+
+    # check if gas consumption mbus4 is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus4")
+    assert gas_consumption is None
 
 
 @pytest.mark.parametrize(
@@ -643,7 +1004,7 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
         ),
     ],
 )
-async def test_belgian_meter_alt(
+async def test_belgian_meter_mbus_gas(
     hass: HomeAssistant,
     dsmr_connection_fixture,
     key1: Literal,

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -624,7 +624,7 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     assert max_demand.attributes.get(ATTR_STATE_CLASS) is None
 
     # check if gas consumption mbus1 is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus1")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
@@ -637,7 +637,7 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     )
 
     # check if water usage mbus2 is parsed correctly
-    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus2")
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption")
     assert water_consumption.state == "678.695"
     assert (
         water_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WATER
@@ -652,7 +652,7 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     )
 
     # check if gas consumption mbus1 is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus3")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_2")
     assert gas_consumption.state == "12.12"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
@@ -665,7 +665,7 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     )
 
     # check if water usage mbus2 is parsed correctly
-    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus4")
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption_2")
     assert water_consumption.state == "13.13"
     assert (
         water_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WATER
@@ -789,7 +789,7 @@ async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -
     await hass.async_block_till_done()
 
     # check if water usage mbus1 is parsed correctly
-    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus1")
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption")
     assert water_consumption.state == "123.456"
     assert (
         water_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WATER
@@ -804,7 +804,7 @@ async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -
     )
 
     # check if gas consumption mbus2 is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus2")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
     assert gas_consumption.state == "678.901"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
@@ -817,7 +817,7 @@ async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -
     )
 
     # check if water usage mbus3 is parsed correctly
-    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus3")
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption_2")
     assert water_consumption.state == "12.12"
     assert (
         water_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WATER
@@ -832,7 +832,7 @@ async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -
     )
 
     # check if gas consumption mbus4 is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus4")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_2")
     assert gas_consumption.state == "13.13"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
     assert (
@@ -858,7 +858,6 @@ async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) 
         BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
         BELGIUM_MBUS3_METER_READING2,
         BELGIUM_MBUS4_DEVICE_TYPE,
-        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
         BELGIUM_MBUS4_METER_READING1,
         ELECTRICITY_ACTIVE_TARIFF,
     )
@@ -910,10 +909,6 @@ async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) 
         ),
         BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
             BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
-        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
-            [{"value": "37464C4F32313139303333373334", "unit": ""}],
         ),
         BELGIUM_MBUS4_METER_READING1: MBusObject(
             BELGIUM_MBUS4_METER_READING1,

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -908,7 +908,7 @@ async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) 
             ],
         ),
         BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "003", "unit": ""}]
+            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "007", "unit": ""}]
         ),
         BELGIUM_MBUS4_METER_READING1: MBusObject(
             BELGIUM_MBUS4_METER_READING1,
@@ -940,21 +940,32 @@ async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) 
     active_tariff = hass.states.get("sensor.electricity_meter_active_tariff")
     assert active_tariff.state == "unknown"
 
-    # check if water usage mbus1 is parsed correctly
-    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus1")
-    assert water_consumption is None
-
     # check if gas consumption mbus2 is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus2")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
     assert gas_consumption is None
 
     # check if water usage mbus3 is parsed correctly
-    water_consumption = hass.states.get("sensor.water_meter_water_consumption_mbus3")
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption_2")
     assert water_consumption is None
 
     # check if gas consumption mbus4 is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus4")
+    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_2")
     assert gas_consumption is None
+
+    # check if gas consumption mbus4 is parsed correctly
+    water_consumption = hass.states.get("sensor.water_meter_water_consumption")
+    assert water_consumption.state == "13.13"
+    assert (
+        water_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WATER
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        water_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolume.CUBIC_METERS
+    )
 
 
 async def test_belgian_meter_low(hass: HomeAssistant, dsmr_connection_fixture) -> None:

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -8,20 +8,7 @@ import asyncio
 import datetime
 from decimal import Decimal
 from itertools import chain, repeat
-from typing import Literal
 from unittest.mock import DEFAULT, MagicMock
-
-from dsmr_parser.obis_references import (
-    BELGIUM_MBUS1_METER_READING1,
-    BELGIUM_MBUS1_METER_READING2,
-    BELGIUM_MBUS2_METER_READING1,
-    BELGIUM_MBUS2_METER_READING2,
-    BELGIUM_MBUS3_METER_READING1,
-    BELGIUM_MBUS3_METER_READING2,
-    BELGIUM_MBUS4_METER_READING1,
-    BELGIUM_MBUS4_METER_READING2,
-)
-import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.sensor import (
@@ -973,115 +960,6 @@ async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) 
     # check if gas consumption mbus4 is parsed correctly
     gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption_mbus4")
     assert gas_consumption is None
-
-
-@pytest.mark.parametrize(
-    ("key1", "key2", "key3", "gas_value"),
-    [
-        (
-            BELGIUM_MBUS1_METER_READING1,
-            BELGIUM_MBUS2_METER_READING2,
-            BELGIUM_MBUS3_METER_READING1,
-            "745.696",
-        ),
-        (
-            BELGIUM_MBUS1_METER_READING2,
-            BELGIUM_MBUS2_METER_READING1,
-            BELGIUM_MBUS3_METER_READING2,
-            "745.695",
-        ),
-        (
-            BELGIUM_MBUS4_METER_READING2,
-            BELGIUM_MBUS2_METER_READING1,
-            BELGIUM_MBUS3_METER_READING1,
-            "745.695",
-        ),
-        (
-            BELGIUM_MBUS4_METER_READING1,
-            BELGIUM_MBUS2_METER_READING1,
-            BELGIUM_MBUS3_METER_READING2,
-            "745.697",
-        ),
-    ],
-)
-async def test_belgian_meter_mbus_gas(
-    hass: HomeAssistant,
-    dsmr_connection_fixture,
-    key1: Literal,
-    key2: Literal,
-    key3: Literal,
-    gas_value: str,
-) -> None:
-    """Test if Belgian meter is correctly parsed."""
-    (connection_factory, transport, protocol) = dsmr_connection_fixture
-
-    from dsmr_parser.objects import MBusObject
-
-    entry_data = {
-        "port": "/dev/ttyUSB0",
-        "dsmr_version": "5B",
-        "precision": 4,
-        "reconnect_interval": 30,
-        "serial_id": "1234",
-        "serial_id_gas": "5678",
-    }
-    entry_options = {
-        "time_between_update": 0,
-    }
-
-    telegram = {
-        key1: MBusObject(
-            key1,
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642213)},
-                {"value": Decimal(745.695), "unit": "m3"},
-            ],
-        ),
-        key2: MBusObject(
-            key2,
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642214)},
-                {"value": Decimal(745.696), "unit": "m3"},
-            ],
-        ),
-        key3: MBusObject(
-            key3,
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642215)},
-                {"value": Decimal(745.697), "unit": "m3"},
-            ],
-        ),
-    }
-
-    mock_entry = MockConfigEntry(
-        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
-    )
-
-    mock_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-
-    telegram_callback = connection_factory.call_args_list[0][0][2]
-
-    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
-    telegram_callback(telegram)
-
-    # after receiving telegram entities need to have the chance to be created
-    await hass.async_block_till_done()
-
-    # check if gas consumption is parsed correctly
-    gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
-    assert gas_consumption.state == gas_value
-    assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
-    assert (
-        gas_consumption.attributes.get(ATTR_STATE_CLASS)
-        == SensorStateClass.TOTAL_INCREASING
-    )
-    assert (
-        gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == UnitOfVolume.CUBIC_METERS
-    )
 
 
 async def test_belgian_meter_low(hass: HomeAssistant, dsmr_connection_fixture) -> None:


### PR DESCRIPTION
## Breaking change
For users using the 5B version: 
The previous gas sensor (Gas consumption) will change to Gas consumption mbusX.
Also multiple gas sensors will be possible.

## Proposed change

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30052

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io