### PR TITLE
Clean up matter adapter

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -728,7 +728,6 @@ omit =
     homeassistant/components/mastodon/notify.py
     homeassistant/components/matrix/*
     homeassistant/components/matter/__init__.py
-    homeassistant/components/matter/adapter.py
     homeassistant/components/matter/entity.py
     homeassistant/components/meater/__init__.py
     homeassistant/components/meater/const.py

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -1,8 +1,6 @@
 """Matter to Home Assistant adapter."""
 from __future__ import annotations
 
-import asyncio
-import logging
 from typing import TYPE_CHECKING
 
 from chip.clusters import Objects as all_clusters
@@ -14,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 from .device_platform import DEVICE_PLATFORM
 
 if TYPE_CHECKING:
@@ -35,27 +33,22 @@ class MatterAdapter:
         self.matter_client = matter_client
         self.hass = hass
         self.config_entry = config_entry
-        self.logger = logging.getLogger(__name__)
         self.platform_handlers: dict[Platform, AddEntitiesCallback] = {}
-        self._platforms_set_up = asyncio.Event()
 
     def register_platform_handler(
         self, platform: Platform, add_entities: AddEntitiesCallback
     ) -> None:
         """Register a platform handler."""
         self.platform_handlers[platform] = add_entities
-        if len(self.platform_handlers) == len(DEVICE_PLATFORM):
-            self._platforms_set_up.set()
 
     async def setup_nodes(self) -> None:
         """Set up all existing nodes."""
-        await self._platforms_set_up.wait()
         for node in await self.matter_client.get_nodes():
-            await self._setup_node(node)
+            self._setup_node(node)
 
-    async def _setup_node(self, node: MatterNode) -> None:
+    def _setup_node(self, node: MatterNode) -> None:
         """Set up an node."""
-        self.logger.debug("Setting up entities for node %s", node.node_id)
+        LOGGER.debug("Setting up entities for node %s", node.node_id)
 
         bridge_unique_id: str | None = None
 
@@ -115,7 +108,7 @@ class MatterAdapter:
 
                 entities = []
                 for entity_description in entity_descriptions:
-                    self.logger.debug(
+                    LOGGER.debug(
                         "Creating %s entity for %s (%s)",
                         platform,
                         instance.device_type.__name__,
@@ -134,7 +127,7 @@ class MatterAdapter:
                 created = True
 
             if not created:
-                self.logger.warning(
+                LOGGER.warning(
                     "Found unsupported device %s (%s)",
                     type(instance).__name__,
                     hex(instance.device_type.device_type),

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -1,7 +1,7 @@
 """Test the adapter."""
 from __future__ import annotations
 
-from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,36 +11,40 @@ from homeassistant.helpers import device_registry as dr
 
 from .common import setup_integration_with_node_fixture
 
-# TEMP: Tests need to be fixed
-pytestmark = pytest.mark.skip("all tests still WIP")
-
 
 async def test_device_registry_single_node_device(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
+    hass: HomeAssistant,
+    matter_client: MagicMock,
 ) -> None:
     """Test bridge devices are set up correctly with via_device."""
     await setup_integration_with_node_fixture(
-        hass, hass_storage, "lighting-example-app"
+        hass,
+        "onoff-light",
+        matter_client,
     )
 
     dev_reg = dr.async_get(hass)
 
-    entry = dev_reg.async_get_device({(DOMAIN, "BE8F70AA40DDAE41")})
+    entry = dev_reg.async_get_device({(DOMAIN, "mock-onoff-light")})
     assert entry is not None
 
-    assert entry.name == "My Cool Light"
+    assert entry.name == "Mock OnOff Light"
     assert entry.manufacturer == "Nabu Casa"
-    assert entry.model == "M5STAMP Lighting App"
+    assert entry.model == "Mock Light"
     assert entry.hw_version == "v1.0"
-    assert entry.sw_version == "55ab764bea"
+    assert entry.sw_version == "v1.0"
 
 
+@pytest.mark.skip("Waiting for a new test fixture")
 async def test_device_registry_bridge(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
+    hass: HomeAssistant,
+    matter_client: MagicMock,
 ) -> None:
     """Test bridge devices are set up correctly with via_device."""
     await setup_integration_with_node_fixture(
-        hass, hass_storage, "fake-bridge-two-light"
+        hass,
+        "fake-bridge-two-light",
+        matter_client,
     )
 
     dev_reg = dr.async_get(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Clean up the matter adapter.
  - We don't need an event for the platforms as we await the config entry forwarding to the platforms.
  - We don't need to write a coroutine function unless we await inside.
  - Use the package logger consistently.
- Activate one of the skipped adapter tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
