### PR TITLE
Fix connectable Bluetooth devices not going available after scanner recovers

### DIFF
--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -369,6 +369,7 @@ class BluetoothManager:
         all_history = self._all_history
         connectable = service_info.connectable
         connectable_history = self._connectable_history
+        old_connectable_service_info = None
 
         source = service_info.source
         debug = _LOGGER.isEnabledFor(logging.DEBUG)
@@ -442,12 +443,20 @@ class BluetoothManager:
             tracker.async_collect(service_info)
 
         # If the advertisement data is the same as the last time we saw it, we
-        # don't need to do anything else.
-        if old_service_info and not (
-            service_info.manufacturer_data != old_service_info.manufacturer_data
-            or service_info.service_data != old_service_info.service_data
-            or service_info.service_uuids != old_service_info.service_uuids
-            or service_info.name != old_service_info.name
+        # don't need to do anything else unless its connectable and we are missing
+        # connectable history for the device so we can make it available again
+        # after unavailable callbacks.
+        if (
+            # Ensure its not a connectable device missing from connectable history
+            not (connectable and not old_connectable_service_info)
+            # Than check if advertisement data is the same
+            and old_service_info
+            and not (
+                service_info.manufacturer_data != old_service_info.manufacturer_data
+                or service_info.service_data != old_service_info.service_data
+                or service_info.service_uuids != old_service_info.service_uuids
+                or service_info.name != old_service_info.name
+            )
         ):
             return
 

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -369,7 +369,7 @@ class BluetoothManager:
         all_history = self._all_history
         connectable = service_info.connectable
         connectable_history = self._connectable_history
-        old_connectable_service_info = None
+        old_connectable_service_info = connectable and connectable_history.get(address)
 
         source = service_info.source
         debug = _LOGGER.isEnabledFor(logging.DEBUG)
@@ -400,7 +400,6 @@ class BluetoothManager:
             # but not in the connectable history or the connectable source is the same
             # as the new source, we need to add it to the connectable history
             if connectable:
-                old_connectable_service_info = connectable_history.get(address)
                 if old_connectable_service_info and (
                     # If its the same as the preferred source, we are done
                     # as we know we prefer the old advertisement

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -459,8 +459,7 @@ class BluetoothManager:
         ):
             return
 
-        is_connectable_by_any_source = address in self._connectable_history
-        if not connectable and is_connectable_by_any_source:
+        if not connectable and old_connectable_service_info:
             # Since we have a connectable path and our BleakClient will
             # route any connection attempts to the connectable path, we
             # mark the service_info as connectable so that the callbacks
@@ -489,7 +488,7 @@ class BluetoothManager:
                 matched_domains,
             )
 
-        if is_connectable_by_any_source:
+        if connectable or old_connectable_service_info:
             # Bleak callbacks must get a connectable device
             for callback_filters in self._bleak_callbacks:
                 _dispatch_bleak_callback(*callback_filters, device, advertisement_data)

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -41,7 +41,7 @@ from . import (
     inject_advertisement_with_time_and_source_connectable,
 )
 
-from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
+from tests.common import async_fire_time_changed, load_fixture
 
 
 @pytest.fixture
@@ -609,11 +609,7 @@ async def test_switching_adapters_when_one_stop_scanning(
 
 async def test_goes_unavailable_connectable_only_and_recovers(hass):
     """Test all connectable scanners go unavailable, and than recover when there is a non-connectable scanner."""
-    entry = MockConfigEntry(domain="bluetooth", unique_id="00:00:00:00:00:01")
-    entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    await hass.config_entries.async_unload(entry.entry_id)
+    assert await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()
 
     assert async_scanner_count(hass, connectable=True) == 0

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -607,7 +607,9 @@ async def test_switching_adapters_when_one_stop_scanning(
     cancel_hci2()
 
 
-async def test_goes_unavailable_connectable_only_and_recovers(hass):
+async def test_goes_unavailable_connectable_only_and_recovers(
+    hass, mock_bluetooth_adapters
+):
     """Test all connectable scanners go unavailable, and than recover when there is a non-connectable scanner."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -1,30 +1,47 @@
 """Tests for the Bluetooth integration manager."""
 
+from datetime import timedelta
 import time
 from unittest.mock import patch
 
-from bleak.backends.scanner import BLEDevice
+from bleak.backends.scanner import AdvertisementData, BLEDevice
 from bluetooth_adapters import AdvertisementHistory
 import pytest
 
 from homeassistant.components import bluetooth
-from homeassistant.components.bluetooth import storage
+from homeassistant.components.bluetooth import (
+    BaseHaRemoteScanner,
+    BluetoothChange,
+    BluetoothScanningMode,
+    BluetoothServiceInfo,
+    BluetoothServiceInfoBleak,
+    HaBluetoothConnector,
+    async_ble_device_from_address,
+    async_get_advertisement_callback,
+    async_scanner_count,
+    async_track_unavailable,
+    storage,
+)
+from homeassistant.components.bluetooth.const import UNAVAILABLE_TRACK_SECONDS
 from homeassistant.components.bluetooth.manager import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.json import json_loads
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from . import (
     FakeScanner,
+    MockBleakClient,
+    _get_manager,
     generate_advertisement_data,
     inject_advertisement_with_source,
     inject_advertisement_with_time_and_source,
     inject_advertisement_with_time_and_source_connectable,
 )
 
-from tests.common import load_fixture
+from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 
 @pytest.fixture
@@ -588,3 +605,174 @@ async def test_switching_adapters_when_one_stop_scanning(
     )
 
     cancel_hci2()
+
+
+async def test_goes_unavailable_connectable_only_and_recovers(hass):
+    """Test all connectable scanners go unavailable, and than recover when there is a non-connectable scanner."""
+    entry = MockConfigEntry(domain="bluetooth", unique_id="00:00:00:00:00:01")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert async_scanner_count(hass, connectable=True) == 0
+    assert async_scanner_count(hass, connectable=False) == 0
+    switchbot_device_connectable = BLEDevice(
+        "44:44:33:11:23:45",
+        "wohand",
+        {},
+        rssi=-100,
+    )
+    switchbot_device_non_connectable = BLEDevice(
+        "44:44:33:11:23:45",
+        "wohand",
+        {},
+        rssi=-100,
+    )
+    switchbot_device_adv = generate_advertisement_data(
+        local_name="wohand",
+        service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
+        service_data={"050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff"},
+        manufacturer_data={1: b"\x01"},
+        rssi=-100,
+    )
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo,
+        change: BluetoothChange,
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+
+    cancel = bluetooth.async_register_callback(
+        hass,
+        _fake_subscriber,
+        {"address": "44:44:33:11:23:45", "connectable": True},
+        BluetoothScanningMode.ACTIVE,
+    )
+
+    class FakeScanner(BaseHaRemoteScanner):
+        def inject_advertisement(
+            self, device: BLEDevice, advertisement_data: AdvertisementData
+        ) -> None:
+            """Inject an advertisement."""
+            self._async_on_advertisement(
+                device.address,
+                advertisement_data.rssi,
+                device.name,
+                advertisement_data.service_uuids,
+                advertisement_data.service_data,
+                advertisement_data.manufacturer_data,
+                advertisement_data.tx_power,
+                {"scanner_specific_data": "test"},
+            )
+
+    new_info_callback = async_get_advertisement_callback(hass)
+    connector = (
+        HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
+    )
+    connectable_scanner = FakeScanner(
+        hass,
+        "connectable",
+        "connectable",
+        new_info_callback,
+        connector,
+        True,
+    )
+    unsetup_connectable_scanner = connectable_scanner.async_setup()
+    cancel_connectable_scanner = _get_manager().async_register_scanner(
+        connectable_scanner, True
+    )
+    connectable_scanner.inject_advertisement(
+        switchbot_device_connectable, switchbot_device_adv
+    )
+    assert async_ble_device_from_address(hass, "44:44:33:11:23:45") is not None
+    assert async_scanner_count(hass, connectable=True) == 1
+    assert len(callbacks) == 1
+
+    assert (
+        "44:44:33:11:23:45"
+        in connectable_scanner.discovered_devices_and_advertisement_data
+    )
+
+    not_connectable_scanner = FakeScanner(
+        hass,
+        "not_connectable",
+        "not_connectable",
+        new_info_callback,
+        connector,
+        False,
+    )
+    unsetup_not_connectable_scanner = not_connectable_scanner.async_setup()
+    cancel_not_connectable_scanner = _get_manager().async_register_scanner(
+        not_connectable_scanner, False
+    )
+    not_connectable_scanner.inject_advertisement(
+        switchbot_device_non_connectable, switchbot_device_adv
+    )
+    assert async_scanner_count(hass, connectable=True) == 1
+    assert async_scanner_count(hass, connectable=False) == 2
+
+    assert (
+        "44:44:33:11:23:45"
+        in not_connectable_scanner.discovered_devices_and_advertisement_data
+    )
+
+    unavailable_callbacks: list[BluetoothServiceInfoBleak] = []
+
+    @callback
+    def _unavailable_callback(service_info: BluetoothServiceInfoBleak) -> None:
+        """Wrong device unavailable callback."""
+        nonlocal unavailable_callbacks
+        unavailable_callbacks.append(service_info.address)
+
+    cancel_unavailable = async_track_unavailable(
+        hass,
+        _unavailable_callback,
+        switchbot_device_connectable.address,
+        connectable=True,
+    )
+
+    assert async_scanner_count(hass, connectable=True) == 1
+    cancel_connectable_scanner()
+    unsetup_connectable_scanner()
+    assert async_scanner_count(hass, connectable=True) == 0
+    assert async_scanner_count(hass, connectable=False) == 1
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=UNAVAILABLE_TRACK_SECONDS)
+    )
+    await hass.async_block_till_done()
+    assert "44:44:33:11:23:45" in unavailable_callbacks
+    cancel_unavailable()
+
+    connectable_scanner_2 = FakeScanner(
+        hass,
+        "connectable",
+        "connectable",
+        new_info_callback,
+        connector,
+        True,
+    )
+    unsetup_connectable_scanner_2 = connectable_scanner_2.async_setup()
+    cancel_connectable_scanner_2 = _get_manager().async_register_scanner(
+        connectable_scanner, True
+    )
+    connectable_scanner_2.inject_advertisement(
+        switchbot_device_connectable, switchbot_device_adv
+    )
+    assert (
+        "44:44:33:11:23:45"
+        in connectable_scanner_2.discovered_devices_and_advertisement_data
+    )
+
+    # We should get another callback to make the device available again
+    assert len(callbacks) == 2
+
+    cancel()
+    cancel_connectable_scanner_2()
+    unsetup_connectable_scanner_2()
+    cancel_not_connectable_scanner()
+    unsetup_not_connectable_scanner()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If all the connectable scanners go down, all connectable devices get marked as unavailable. As soon as one comes back up we need to accept `advertisement_data` for the device even if its in the all history (connectable+non-connectable) and nothing has changed if its not in the connectable history.

This would only happen when there were both types of scanners and only all the connectable ones that can see device all go down since we would check the history and see the `advertisement_data` had not changed and skip doing the callback even though the history we had was non-connectable history.

The source of this issue only became obvious once local scanners gained passive support w/HAOS 9.4 since `advertisement_data` is much more constant with passive scanning.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
