### PR TITLE
Fix matter websocket reconnect

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -728,7 +728,6 @@ omit =
     homeassistant/components/mastodon/notify.py
     homeassistant/components/matrix/*
     homeassistant/components/matter/__init__.py
-    homeassistant/components/matter/entity.py
     homeassistant/components/meater/__init__.py
     homeassistant/components/meater/const.py
     homeassistant/components/meater/sensor.py

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -110,7 +110,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await matter.setup_nodes()
 
     # If the listen task is already failed, we need to raise ConfigEntryNotReady
-    await asyncio.sleep(0)  # yield to the listen task at least once again
     if listen_task.done() and (listen_error := listen_task.exception()) is not None:
         await hass.config_entries.async_unload_platforms(entry, DEVICE_PLATFORM)
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -11,10 +11,11 @@ from matter_server.client.exceptions import (
     FailedCommand,
     InvalidServerVersion,
 )
+from matter_server.common.models.error import MatterError
 import voluptuous as vol
 
 from homeassistant.components.hassio import AddonError, AddonManager, AddonState
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
@@ -32,6 +33,10 @@ from .addon import get_addon_manager
 from .api import async_register_api
 from .const import CONF_INTEGRATION_CREATED_ADDON, CONF_USE_ADDON, DOMAIN, LOGGER
 from .device_platform import DEVICE_PLATFORM
+from .helpers import MatterEntryData, get_matter
+
+CONNECT_TIMEOUT = 10
+LISTEN_READY_TIMEOUT = 30
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -41,8 +46,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     matter_client = MatterClient(entry.data[CONF_URL], async_get_clientsession(hass))
     try:
-        await matter_client.connect()
-    except CannotConnect as err:
+        async with async_timeout.timeout(CONNECT_TIMEOUT):
+            await matter_client.connect()
+    except (CannotConnect, asyncio.TimeoutError) as err:
         raise ConfigEntryNotReady("Failed to connect to matter server") from err
     except InvalidServerVersion as err:
         if use_addon:
@@ -60,7 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(f"Invalid server version: {err}") from err
 
     except Exception as err:
-        matter_client.logger.exception("Failed to connect to matter server")
+        LOGGER.exception("Failed to connect to matter server")
         raise ConfigEntryNotReady(
             "Unknown error connecting to the Matter server"
         ) from err
@@ -75,16 +81,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
     )
 
-    # register websocket api
     async_register_api(hass)
 
     # launch the matter client listen task in the background
-    # use the init_ready event to keep track if it did initialize successfully
+    # use the init_ready event to wait until initialization is done
     init_ready = asyncio.Event()
-    listen_task = asyncio.create_task(matter_client.start_listening(init_ready))
+    listen_task = asyncio.create_task(
+        _client_listen(hass, entry, matter_client, init_ready)
+    )
 
     try:
-        async with async_timeout.timeout(30):
+        async with async_timeout.timeout(LISTEN_READY_TIMEOUT):
             await init_ready.wait()
     except asyncio.TimeoutError as err:
         listen_task.cancel()
@@ -94,18 +101,49 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN] = {}
         _async_init_services(hass)
 
-    # we create an intermediate layer (adapter) which keeps track of our nodes
-    # and discovery of platform entities from the node's attributes
+    # create an intermediate layer (adapter) which keeps track of the nodes
+    # and discovery of platform entities from the node attributes
     matter = MatterAdapter(hass, matter_client, entry)
-    hass.data[DOMAIN][entry.entry_id] = matter
+    hass.data[DOMAIN][entry.entry_id] = MatterEntryData(matter, listen_task)
 
-    # forward platform setup to all platforms in the discovery schema
     await hass.config_entries.async_forward_entry_setups(entry, DEVICE_PLATFORM)
+    await matter.setup_nodes()
 
-    # start discovering of node entities as task
-    asyncio.create_task(matter.setup_nodes())
+    # If the listen task is already failed, we need to raise ConfigEntryNotReady
+    await asyncio.sleep(0)  # yield to the listen task at least once again
+    if listen_task.done() and (listen_error := listen_task.exception()) is not None:
+        await hass.config_entries.async_unload_platforms(entry, DEVICE_PLATFORM)
+        hass.data[DOMAIN].pop(entry.entry_id)
+        try:
+            await matter_client.disconnect()
+        finally:
+            raise ConfigEntryNotReady(listen_error) from listen_error
 
     return True
+
+
+async def _client_listen(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    matter_client: MatterClient,
+    init_ready: asyncio.Event,
+) -> None:
+    """Listen with the client."""
+    try:
+        await matter_client.start_listening(init_ready)
+    except MatterError as err:
+        if entry.state != ConfigEntryState.LOADED:
+            raise
+        LOGGER.error("Failed to listen: %s", err)
+    except Exception as err:  # pylint: disable=broad-except
+        # We need to guard against unknown exceptions to not crash this task.
+        LOGGER.exception("Unexpected exception: %s", err)
+        if entry.state != ConfigEntryState.LOADED:
+            raise
+
+    if not hass.is_stopping:
+        LOGGER.debug("Disconnected from server. Reloading integration")
+        hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -113,8 +151,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, DEVICE_PLATFORM)
 
     if unload_ok:
-        matter: MatterAdapter = hass.data[DOMAIN].pop(entry.entry_id)
-        await matter.matter_client.disconnect()
+        matter_entry_data: MatterEntryData = hass.data[DOMAIN].pop(entry.entry_id)
+        matter_entry_data.listen_task.cancel()
+        await matter_entry_data.adapter.matter_client.disconnect()
 
     if entry.data.get(CONF_USE_ADDON) and entry.disabled_by:
         addon_manager: AddonManager = get_addon_manager(hass)
@@ -165,24 +204,15 @@ async def async_remove_config_entry_device(
     if not unique_id:
         return True
 
-    matter: MatterAdapter = hass.data[DOMAIN][config_entry.entry_id]
+    matter_entry_data: MatterEntryData = hass.data[DOMAIN][config_entry.entry_id]
+    matter_client = matter_entry_data.adapter.matter_client
 
-    for node in await matter.matter_client.get_nodes():
+    for node in await matter_client.get_nodes():
         if node.unique_id == unique_id:
-            await matter.matter_client.remove_node(node.node_id)
+            await matter_client.remove_node(node.node_id)
             break
 
     return True
-
-
-@callback
-def get_matter(hass: HomeAssistant) -> MatterAdapter:
-    """Return MatterAdapter instance."""
-    # NOTE: This assumes only one Matter connection/fabric can exist.
-    # Shall we support connecting to multiple servers in the client or by config entries?
-    # In case of the config entry we need to fix this.
-    matter: MatterAdapter = next(iter(hass.data[DOMAIN].values()))
-    return matter
 
 
 @callback

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -13,7 +13,7 @@ from homeassistant.components.websocket_api import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
 
 from .adapter import MatterAdapter
-from .const import DOMAIN
+from .helpers import get_matter
 
 ID = "id"
 TYPE = "type"
@@ -36,7 +36,7 @@ def async_get_matter_adapter(func: Callable) -> Callable:
         hass: HomeAssistant, connection: ActiveConnection, msg: dict
     ) -> None:
         """Provide the Matter client to the function."""
-        matter: MatterAdapter = next(iter(hass.data[DOMAIN].values()))
+        matter = get_matter(hass)
 
         await func(hass, connection, msg, matter)
 

--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING
 
 from chip.clusters import Objects as clusters
 from matter_server.common.models import device_types
@@ -18,11 +17,8 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
 from .entity import MatterEntity, MatterEntityDescriptionBaseClass
-
-if TYPE_CHECKING:
-    from .adapter import MatterAdapter
+from .helpers import get_matter
 
 
 async def async_setup_entry(
@@ -31,7 +27,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Matter binary sensor from Config Entry."""
-    matter: MatterAdapter = hass.data[DOMAIN][config_entry.entry_id]
+    matter = get_matter(hass)
     matter.register_platform_handler(Platform.BINARY_SENSOR, async_add_entities)
 
 

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -1,0 +1,31 @@
+"""Provide integration helpers that are aware of the matter integration."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from .adapter import MatterAdapter
+
+
+@dataclass
+class MatterEntryData:
+    """Hold Matter data for the config entry."""
+
+    adapter: MatterAdapter
+    listen_task: asyncio.Task
+
+
+@callback
+def get_matter(hass: HomeAssistant) -> MatterAdapter:
+    """Return MatterAdapter instance."""
+    # NOTE: This assumes only one Matter connection/fabric can exist.
+    # Shall we support connecting to multiple servers in the client or by config entries?
+    # In case of the config entry we need to fix this.
+    matter_entry_data: MatterEntryData = next(iter(hass.data[DOMAIN].values()))
+    return matter_entry_data.adapter

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from chip.clusters import Objects as clusters
 from matter_server.common.models import device_types
@@ -19,12 +19,9 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
 from .entity import MatterEntity, MatterEntityDescriptionBaseClass
+from .helpers import get_matter
 from .util import renormalize
-
-if TYPE_CHECKING:
-    from .adapter import MatterAdapter
 
 
 async def async_setup_entry(
@@ -33,7 +30,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Matter Light from Config Entry."""
-    matter: MatterAdapter = hass.data[DOMAIN][config_entry.entry_id]
+    matter = get_matter(hass)
     matter.register_platform_handler(Platform.LIGHT, async_add_entities)
 
 

--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from chip.clusters import Objects as clusters
 from chip.clusters.Types import Nullable, NullValue
@@ -29,11 +29,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
 from .entity import MatterEntity, MatterEntityDescriptionBaseClass
-
-if TYPE_CHECKING:
-    from .adapter import MatterAdapter
+from .helpers import get_matter
 
 
 async def async_setup_entry(
@@ -42,7 +39,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Matter sensors from Config Entry."""
-    matter: MatterAdapter = hass.data[DOMAIN][config_entry.entry_id]
+    matter = get_matter(hass)
     matter.register_platform_handler(Platform.SENSOR, async_add_entities)
 
 

--- a/homeassistant/components/matter/switch.py
+++ b/homeassistant/components/matter/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from chip.clusters import Objects as clusters
 from matter_server.common.models import device_types
@@ -18,11 +18,8 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
 from .entity import MatterEntity, MatterEntityDescriptionBaseClass
-
-if TYPE_CHECKING:
-    from .adapter import MatterAdapter
+from .helpers import get_matter
 
 
 async def async_setup_entry(
@@ -31,7 +28,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Matter switches from Config Entry."""
-    matter: MatterAdapter = hass.data[DOMAIN][config_entry.entry_id]
+    matter = get_matter(hass)
     matter.register_platform_handler(Platform.SWITCH, async_add_entities)
 
 

--- a/tests/components/matter/conftest.py
+++ b/tests/components/matter/conftest.py
@@ -33,6 +33,9 @@ async def matter_client_fixture() -> AsyncGenerator[MagicMock, None]:
             """Mock listen."""
             if init_ready is not None:
                 init_ready.set()
+            listen_block = asyncio.Event()
+            await listen_block.wait()
+            assert False, "Listen was not cancelled!"
 
         client.connect = AsyncMock(side_effect=connect)
         client.start_listening = AsyncMock(side_effect=listen)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add client connect timeout.
- Handle client listen failure and try to reconnect.
- Before listen ready: raise ConfigEntryNotReady
- After listen ready but before config entry loaded: raise ConfigEntryNotReady
- After config entry loaded: reload config entry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
