### PR TITLE
Fix error when describing deCONZ events of removed devices

### DIFF
--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -130,8 +130,7 @@ def async_describe_events(
     @callback
     def async_describe_deconz_alarm_event(event: Event) -> dict[str, str]:
         """Describe deCONZ logbook alarm event."""
-        device = device_registry.devices.get(event.data[ATTR_DEVICE_ID])
-        if device:
+        if device := device_registry.devices.get(event.data[ATTR_DEVICE_ID]):
             deconz_alarm_event = _get_deconz_event_from_device(hass, device)
             name = deconz_alarm_event.device.name
         else:
@@ -147,8 +146,7 @@ def async_describe_events(
     @callback
     def async_describe_deconz_event(event: Event) -> dict[str, str]:
         """Describe deCONZ logbook event."""
-        device = device_registry.devices.get(event.data[ATTR_DEVICE_ID])
-        if device:
+        if device := device_registry.devices.get(event.data[ATTR_DEVICE_ID]):
             deconz_event = _get_deconz_event_from_device(hass, device)
             name = deconz_event.device.name
         else:

--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from homeassistant.components.logbook import LOGBOOK_ENTRY_MESSAGE, LOGBOOK_ENTRY_NAME
-from homeassistant.const import ATTR_DEVICE_ID, CONF_EVENT
+from homeassistant.const import ATTR_DEVICE_ID, CONF_EVENT, CONF_ID
 from homeassistant.core import Event, HomeAssistant, callback
 import homeassistant.helpers.device_registry as dr
 
@@ -130,27 +130,36 @@ def async_describe_events(
     @callback
     def async_describe_deconz_alarm_event(event: Event) -> dict[str, str]:
         """Describe deCONZ logbook alarm event."""
-        device = device_registry.devices[event.data[ATTR_DEVICE_ID]]
-        deconz_alarm_event = _get_deconz_event_from_device(hass, device)
+        device = device_registry.devices.get(event.data[ATTR_DEVICE_ID])
+        if device:
+            deconz_alarm_event = _get_deconz_event_from_device(hass, device)
+            name = deconz_alarm_event.device.name
+        else:
+            name = event.data[CONF_ID]
 
         data = event.data[CONF_EVENT]
 
         return {
-            LOGBOOK_ENTRY_NAME: f"{deconz_alarm_event.device.name}",
+            LOGBOOK_ENTRY_NAME: name,
             LOGBOOK_ENTRY_MESSAGE: f"fired event '{data}'",
         }
 
     @callback
     def async_describe_deconz_event(event: Event) -> dict[str, str]:
         """Describe deCONZ logbook event."""
-        device = device_registry.devices[event.data[ATTR_DEVICE_ID]]
-        deconz_event = _get_deconz_event_from_device(hass, device)
+        device = device_registry.devices.get(event.data[ATTR_DEVICE_ID])
+        if device:
+            deconz_event = _get_deconz_event_from_device(hass, device)
+            name = deconz_event.device.name
+        else:
+            deconz_event = None
+            name = event.data[CONF_ID]
 
         action = None
         interface = None
         data = event.data.get(CONF_EVENT) or event.data.get(CONF_GESTURE, "")
 
-        if data and deconz_event.device.model_id in REMOTES:
+        if data and deconz_event and deconz_event.device.model_id in REMOTES:
             action, interface = _get_device_event_description(
                 deconz_event.device.model_id, data
             )
@@ -158,26 +167,26 @@ def async_describe_events(
         # Unknown event
         if not data:
             return {
-                LOGBOOK_ENTRY_NAME: f"{deconz_event.device.name}",
+                LOGBOOK_ENTRY_NAME: name,
                 LOGBOOK_ENTRY_MESSAGE: "fired an unknown event",
             }
 
         # No device event match
         if not action:
             return {
-                LOGBOOK_ENTRY_NAME: f"{deconz_event.device.name}",
+                LOGBOOK_ENTRY_NAME: name,
                 LOGBOOK_ENTRY_MESSAGE: f"fired event '{data}'",
             }
 
         # Gesture event
         if not interface:
             return {
-                LOGBOOK_ENTRY_NAME: f"{deconz_event.device.name}",
+                LOGBOOK_ENTRY_NAME: name,
                 LOGBOOK_ENTRY_MESSAGE: f"fired event '{ACTIONS[action]}'",
             }
 
         return {
-            LOGBOOK_ENTRY_NAME: f"{deconz_event.device.name}",
+            LOGBOOK_ENTRY_NAME: name,
             LOGBOOK_ENTRY_MESSAGE: f"'{ACTIONS[action]}' event for '{INTERFACES[interface]}' was fired",
         }
 

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -66,6 +66,9 @@ async def test_humanifying_deconz_alarm_event(hass, aioclient_mock):
         identifiers={(DECONZ_DOMAIN, keypad_serial)}
     )
 
+    removed_device_event_id = "removed_device"
+    removed_device_serial = "00:00:00:00:00:00:00:05"
+
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})
 
@@ -82,12 +85,27 @@ async def test_humanifying_deconz_alarm_event(hass, aioclient_mock):
                     CONF_UNIQUE_ID: keypad_serial,
                 },
             ),
+            # Event of a removed device
+            MockRow(
+                CONF_DECONZ_ALARM_EVENT,
+                {
+                    CONF_CODE: 1234,
+                    CONF_DEVICE_ID: "ff99ff99ff99ff99ff99ff99ff99ff99",
+                    CONF_EVENT: STATE_ALARM_ARMED_AWAY,
+                    CONF_ID: removed_device_event_id,
+                    CONF_UNIQUE_ID: removed_device_serial,
+                },
+            ),
         ],
     )
 
     assert events[0]["name"] == "Keypad"
     assert events[0]["domain"] == "deconz"
     assert events[0]["message"] == "fired event 'armed_away'"
+
+    assert events[1]["name"] == "removed_device"
+    assert events[1]["domain"] == "deconz"
+    assert events[1]["message"] == "fired event 'armed_away'"
 
 
 async def test_humanifying_deconz_event(hass, aioclient_mock):
@@ -155,6 +173,9 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
         identifiers={(DECONZ_DOMAIN, faulty_serial)}
     )
 
+    removed_device_event_id = "removed_device"
+    removed_device_serial = "00:00:00:00:00:00:00:05"
+
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})
 
@@ -211,6 +232,16 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
                     CONF_UNIQUE_ID: faulty_serial,
                 },
             ),
+            # Event of a removed device
+            MockRow(
+                CONF_DECONZ_EVENT,
+                {
+                    CONF_DEVICE_ID: "ff99ff99ff99ff99ff99ff99ff99ff99",
+                    CONF_EVENT: 2000,
+                    CONF_ID: removed_device_event_id,
+                    CONF_UNIQUE_ID: removed_device_serial,
+                },
+            ),
         ],
     )
 
@@ -233,3 +264,7 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
     assert events[4]["name"] == "Faulty event"
     assert events[4]["domain"] == "deconz"
     assert events[4]["message"] == "fired an unknown event"
+
+    assert events[5]["name"] == "removed_device"
+    assert events[5]["domain"] == "deconz"
+    assert events[5]["message"] == "fired event '2000'"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix error when describing deCONZ events of removed devices.

After removing a device (which has logbook events) from a deCONZ gateway, opening the Logbook in Home Assistant would make the `async_describe_deconz_alarm_event` or `async_describe_deconz_event` function throw a `KeyError`.

This PR fixes the error by using the event id (slugified device name) as name when the device id is not known in the device registry.

Example event message for a removed device:

>  tradfri_on_off_switch fired event '1002' 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83710
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
