### PR TITLE
Add econet device and state classes

### DIFF
--- a/homeassistant/components/econet/__init__.py
+++ b/homeassistant/components/econet/__init__.py
@@ -116,6 +116,8 @@ class EcoNetEntity(Entity):
     def __init__(self, econet):
         """Initialize."""
         self._econet = econet
+        self._attr_name = econet.device_name
+        self._attr_unique_id = f"{econet.device_id}_{econet.device_name}"
 
     async def async_added_to_hass(self):
         """Subscribe to device events."""
@@ -142,16 +144,6 @@ class EcoNetEntity(Entity):
             manufacturer="Rheem",
             name=self._econet.device_name,
         )
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return self._econet.device_name
-
-    @property
-    def unique_id(self):
-        """Return the unique ID of the entity."""
-        return f"{self._econet.device_id}_{self._econet.device_name}"
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/econet/binary_sensor.py
+++ b/homeassistant/components/econet/binary_sensor.py
@@ -64,19 +64,10 @@ class EcoNetBinarySensor(EcoNetEntity, BinarySensorEntity):
         """Initialize."""
         super().__init__(econet_device)
         self.entity_description = description
-        self._econet = econet_device
+        self._attr_name = f"{self._econet.device_name}_{self.entity_description.name}"
+        self._attr_unique_id = f"{self._econet.device_id}_{self._econet.device_name}_{self.entity_description.name}"
 
     @property
     def is_on(self):
         """Return true if the binary sensor is on."""
         return getattr(self._econet, self.entity_description.key)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._econet.device_name}_{self.entity_description.name}"
-
-    @property
-    def unique_id(self):
-        """Return the unique ID of the entity."""
-        return f"{self._econet.device_id}_{self._econet.device_name}_{self.entity_description.name}"

--- a/homeassistant/components/econet/binary_sensor.py
+++ b/homeassistant/components/econet/binary_sensor.py
@@ -64,8 +64,8 @@ class EcoNetBinarySensor(EcoNetEntity, BinarySensorEntity):
         """Initialize."""
         super().__init__(econet_device)
         self.entity_description = description
-        self._attr_name = f"{self._econet.device_name}_{self.entity_description.name}"
-        self._attr_unique_id = f"{self._econet.device_id}_{self._econet.device_name}_{self.entity_description.name}"
+        self._attr_name = f"{econet_device.device_name}_{self.entity_description.name}"
+        self._attr_unique_id = f"{econet_device.device_id}_{econet_device.device_name}_{self.entity_description.name}"
 
     @property
     def is_on(self):

--- a/homeassistant/components/econet/binary_sensor.py
+++ b/homeassistant/components/econet/binary_sensor.py
@@ -64,8 +64,10 @@ class EcoNetBinarySensor(EcoNetEntity, BinarySensorEntity):
         """Initialize."""
         super().__init__(econet_device)
         self.entity_description = description
-        self._attr_name = f"{econet_device.device_name}_{self.entity_description.name}"
-        self._attr_unique_id = f"{econet_device.device_id}_{econet_device.device_name}_{self.entity_description.name}"
+        self._attr_name = f"{econet_device.device_name}_{description.name}"
+        self._attr_unique_id = (
+            f"{econet_device.device_id}_{econet_device.device_name}_{description.name}"
+        )
 
     @property
     def is_on(self):

--- a/homeassistant/components/econet/sensor.py
+++ b/homeassistant/components/econet/sensor.py
@@ -142,6 +142,9 @@ class EcoNetSensor(EcoNetEntity, SensorEntity):
     def native_value(self):
         """Return sensors state."""
         value = getattr(self._econet, self.entity_description.key)
+        if self._device_name == "power_usage_today":
+            if self._econet.energy_type == ENERGY_KILO_BRITISH_THERMAL_UNIT.upper():
+                value = value * 0.2930710702  # Convert kBtu to kWh
         if isinstance(value, float):
             value = round(value, 2)
         return value
@@ -149,11 +152,7 @@ class EcoNetSensor(EcoNetEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        unit_of_measurement = self.entity_description.native_unit_of_measurement
-        if self._device_name == "power_usage_today":
-            if self._econet.energy_type == ENERGY_KILO_BRITISH_THERMAL_UNIT.upper():
-                unit_of_measurement = ENERGY_KILO_BRITISH_THERMAL_UNIT
-        return unit_of_measurement
+        return self.entity_description.native_unit_of_measurement
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/econet/sensor.py
+++ b/homeassistant/components/econet/sensor.py
@@ -1,8 +1,6 @@
 """Support for Rheem EcoNet water heaters."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from pyeconet.equipment import EquipmentType
 
 from homeassistant.components.sensor import (
@@ -24,75 +22,57 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import EcoNetEntity
 from .const import DOMAIN, EQUIPMENT
 
-
-@dataclass
-class EcoNetSensorEntityDescription(SensorEntityDescription):
-    """Represent the econet sensor entity description."""
-
-
-SENSOR_TYPES: tuple[EcoNetSensorEntityDescription, ...] = (
-    EcoNetSensorEntityDescription(
+SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
         key="tank_health",
         name="tank_health",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    EcoNetSensorEntityDescription(
+    SensorEntityDescription(
         key="tank_hot_water_availability",
         name="available_hot_water",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    EcoNetSensorEntityDescription(
+    SensorEntityDescription(
         key="compressor_health",
         name="compressor_health",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    EcoNetSensorEntityDescription(
+    SensorEntityDescription(
         key="override_status",
         name="override_status",
-        native_unit_of_measurement=None,
-        device_class=None,
-        state_class=None,
     ),
-    EcoNetSensorEntityDescription(
+    SensorEntityDescription(
         key="todays_water_usage",
         name="water_usage_today",
         native_unit_of_measurement=UnitOfVolume.GALLONS,
         device_class=SensorDeviceClass.WATER,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    EcoNetSensorEntityDescription(
+    SensorEntityDescription(
         key="todays_energy_usage",
         name="power_usage_today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    EcoNetSensorEntityDescription(
+    SensorEntityDescription(
         key="alert_count",
         name="alert_count",
-        native_unit_of_measurement=None,
-        device_class=None,
-        state_class=None,
     ),
-    EcoNetSensorEntityDescription(
+    SensorEntityDescription(
         key="wifi_signal",
         name="wifi_signal",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    EcoNetSensorEntityDescription(
+    SensorEntityDescription(
         key="running_state",
         name="running_state",
-        native_unit_of_measurement=None,
-        device_class=None,
-        state_class=None,
     ),
 )
 
@@ -112,7 +92,7 @@ async def async_setup_entry(
     sensors = []
 
     sensors = [
-        EcoNetSensor(_equip, description.name, description)
+        EcoNetSensor(_equip, description)
         for _equip in equipment
         for description in SENSOR_TYPES
         if getattr(_equip, description.key, False) is not False
@@ -124,25 +104,23 @@ async def async_setup_entry(
 class EcoNetSensor(EcoNetEntity, SensorEntity):
     """Define a Econet sensor."""
 
-    entity_description: EcoNetSensorEntityDescription
+    entity_description: SensorEntityDescription
 
     def __init__(
         self,
         econet_device,
-        device_name,
-        description: EcoNetSensorEntityDescription,
-    ):
+        description: SensorEntityDescription,
+    ) -> None:
         """Initialize."""
         super().__init__(econet_device)
         self.entity_description = description
         self._econet = econet_device
-        self._device_name = device_name
 
     @property
     def native_value(self):
         """Return sensors state."""
         value = getattr(self._econet, self.entity_description.key)
-        if self._device_name == "power_usage_today":
+        if self.entity_description.name == "power_usage_today":
             if self._econet.energy_type == ENERGY_KILO_BRITISH_THERMAL_UNIT.upper():
                 value = value * 0.2930710702  # Convert kBtu to kWh
         if isinstance(value, float):
@@ -157,11 +135,9 @@ class EcoNetSensor(EcoNetEntity, SensorEntity):
     @property
     def name(self) -> str:
         """Return the name of the entity."""
-        return f"{self._econet.device_name}_{self._device_name}"
+        return f"{self._econet.device_name}_{self.entity_description.name}"
 
     @property
     def unique_id(self) -> str:
         """Return the unique ID of the entity."""
-        return (
-            f"{self._econet.device_id}_{self._econet.device_name}_{self._device_name}"
-        )
+        return f"{self._econet.device_id}_{self._econet.device_name}_{self.entity_description.name}"

--- a/homeassistant/components/econet/sensor.py
+++ b/homeassistant/components/econet/sensor.py
@@ -99,8 +99,6 @@ async def async_setup_entry(
 class EcoNetSensor(EcoNetEntity, SensorEntity):
     """Define a Econet sensor."""
 
-    entity_description: SensorEntityDescription
-
     def __init__(
         self,
         econet_device: Equipment,
@@ -109,7 +107,6 @@ class EcoNetSensor(EcoNetEntity, SensorEntity):
         """Initialize."""
         super().__init__(econet_device)
         self.entity_description = description
-        self._econet = econet_device
 
     @property
     def native_value(self):

--- a/homeassistant/components/econet/sensor.py
+++ b/homeassistant/components/econet/sensor.py
@@ -1,9 +1,9 @@
 """Support for Rheem EcoNet water heaters."""
 from pyeconet.equipment import EquipmentType
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfVolume
+from homeassistant.const import PERCENTAGE, SIGNAL_STRENGTH_DECIBELS, UnitOfEnergy, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -42,8 +42,32 @@ SENSOR_NAMES_TO_UNIT_OF_MEASUREMENT = {
     WATER_USAGE_TODAY: UnitOfVolume.GALLONS,
     POWER_USAGE_TODAY: None,  # Depends on unit type
     ALERT_COUNT: None,
-    WIFI_SIGNAL: None,
+    WIFI_SIGNAL: SIGNAL_STRENGTH_DECIBELS,
     RUNNING_STATE: None,  # This is just a string
+}
+
+SENSOR_NAMES_TO_STATE_CLASS = {
+    TANK_HEALTH: SensorStateClass.MEASUREMENT,
+    AVAILABLE_HOT_WATER: SensorStateClass.MEASUREMENT,
+    COMPRESSOR_HEALTH: SensorStateClass.MEASUREMENT,
+    OVERRIDE_STATUS: None,
+    WATER_USAGE_TODAY: SensorStateClass.TOTAL_INCREASING,
+    POWER_USAGE_TODAY: SensorStateClass.TOTAL_INCREASING,
+    ALERT_COUNT: None,
+    WIFI_SIGNAL: SensorStateClass.MEASUREMENT,
+    RUNNING_STATE: None,
+}
+
+SENSOR_NAMES_TO_DEVICE_CLASS = {
+    TANK_HEALTH: None,
+    AVAILABLE_HOT_WATER: None,
+    COMPRESSOR_HEALTH: None,
+    OVERRIDE_STATUS: None,
+    WATER_USAGE_TODAY: SensorDeviceClass.WATER,
+    POWER_USAGE_TODAY: SensorDeviceClass.ENERGY,
+    ALERT_COUNT: None,
+    WIFI_SIGNAL: SensorDeviceClass.SIGNAL_STRENGTH,
+    RUNNING_STATE: None,
 }
 
 
@@ -111,3 +135,13 @@ class EcoNetSensor(EcoNetEntity, SensorEntity):
         return (
             f"{self._econet.device_id}_{self._econet.device_name}_{self._device_name}"
         )
+    
+    @property
+    def state_class(self):
+        '''Return the state class'''
+        return SENSOR_NAMES_TO_STATE_CLASS[self._device_name]
+    
+    @property
+    def device_class(self):
+        '''Return the device class'''
+        return SENSOR_NAMES_TO_DEVICE_CLASS[self._device_name]

--- a/homeassistant/components/econet/sensor.py
+++ b/homeassistant/components/econet/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import EcoNetEntity
@@ -69,6 +70,8 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="running_state",

--- a/homeassistant/components/econet/sensor.py
+++ b/homeassistant/components/econet/sensor.py
@@ -107,6 +107,8 @@ class EcoNetSensor(EcoNetEntity, SensorEntity):
         """Initialize."""
         super().__init__(econet_device)
         self.entity_description = description
+        self._attr_name = f"{self._econet.device_name}_{self.entity_description.name}"
+        self._attr_unique_id = f"{self._econet.device_id}_{self._econet.device_name}_{self.entity_description.name}"
 
     @property
     def native_value(self):
@@ -118,13 +120,3 @@ class EcoNetSensor(EcoNetEntity, SensorEntity):
         if isinstance(value, float):
             value = round(value, 2)
         return value
-
-    @property
-    def name(self) -> str:
-        """Return the name of the entity."""
-        return f"{self._econet.device_name}_{self.entity_description.name}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID of the entity."""
-        return f"{self._econet.device_id}_{self._econet.device_name}_{self.entity_description.name}"

--- a/homeassistant/components/econet/sensor.py
+++ b/homeassistant/components/econet/sensor.py
@@ -107,8 +107,10 @@ class EcoNetSensor(EcoNetEntity, SensorEntity):
         """Initialize."""
         super().__init__(econet_device)
         self.entity_description = description
-        self._attr_name = f"{econet_device.device_name}_{self.entity_description.name}"
-        self._attr_unique_id = f"{econet_device.device_id}_{econet_device.device_name}_{self.entity_description.name}"
+        self._attr_name = f"{econet_device.device_name}_{description.name}"
+        self._attr_unique_id = (
+            f"{econet_device.device_id}_{econet_device.device_name}_{description.name}"
+        )
 
     @property
     def native_value(self):

--- a/homeassistant/components/econet/sensor.py
+++ b/homeassistant/components/econet/sensor.py
@@ -70,7 +70,6 @@ SENSOR_NAMES_TO_DEVICE_CLASS = {
     RUNNING_STATE: None,
 }
 
-
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:

--- a/homeassistant/components/econet/sensor.py
+++ b/homeassistant/components/econet/sensor.py
@@ -107,8 +107,8 @@ class EcoNetSensor(EcoNetEntity, SensorEntity):
         """Initialize."""
         super().__init__(econet_device)
         self.entity_description = description
-        self._attr_name = f"{self._econet.device_name}_{self.entity_description.name}"
-        self._attr_unique_id = f"{self._econet.device_id}_{self._econet.device_name}_{self.entity_description.name}"
+        self._attr_name = f"{econet_device.device_name}_{self.entity_description.name}"
+        self._attr_unique_id = f"{econet_device.device_id}_{econet_device.device_name}_{self.entity_description.name}"
 
     @property
     def native_value(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Adding device classes and state classes to econet sensors.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #84200
- This PR is related to issue: #84200
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
