### PR TITLE
Add a calendar entity to Sonarr

### DIFF
--- a/homeassistant/components/sonarr/__init__.py
+++ b/homeassistant/components/sonarr/__init__.py
@@ -39,7 +39,7 @@ from .coordinator import (
     WantedDataUpdateCoordinator,
 )
 
-PLATFORMS = [Platform.SENSOR, Platform.CALENDAR]
+PLATFORMS = [Platform.CALENDAR, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/sonarr/__init__.py
+++ b/homeassistant/components/sonarr/__init__.py
@@ -39,7 +39,7 @@ from .coordinator import (
     WantedDataUpdateCoordinator,
 )
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS = [Platform.SENSOR, Platform.CALENDAR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/sonarr/calendar.py
+++ b/homeassistant/components/sonarr/calendar.py
@@ -5,12 +5,14 @@ from datetime import datetime, timedelta
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.dt import as_utc
+from homeassistant.util.dt import as_utc, start_of_local_day
 
 from .const import DOMAIN
 from .coordinator import CalendarDataUpdateCoordinator
+from .entity import SonarrEntity
 
 
 async def async_setup_entry(
@@ -20,68 +22,72 @@ async def async_setup_entry(
 ) -> None:
     """Set up Sonarr calendar based on a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["upcoming"]
-    async_add_entities([SonarrCalendarEntity(coordinator, "Sonarr Episodes")])
+    async_add_entities([SonarrCalendarEntity(coordinator, "Episodes")])
 
 
-async def get_sonarr_episode_events(
-    coordinator: CalendarDataUpdateCoordinator,
-) -> list[CalendarEvent]:
-    """Update the list of upcoming episodes."""
-    calendar_entries: list[CalendarEvent] = []
-    for episode in coordinator.data:
-        episode_endtime_utc = episode.airDateUtc + timedelta(
-            minutes=episode.series.runtime
-        )
-        calendar_entries.append(
-            CalendarEvent(
-                summary=episode.series.title,
-                description=episode.title,
-                location=episode.series.network,
-                start=episode.airDateUtc,
-                end=episode_endtime_utc,
-            )
-        )
-    return calendar_entries
-
-
-class SonarrCalendarEntity(CalendarEntity):
-    """Representation of a Sonarr Calendar element."""
-
-    coordinator: CalendarDataUpdateCoordinator
-    _events: list[CalendarEvent]
+class SonarrCalendarEntity(SonarrEntity, CalendarEntity):
+    """Defines a Sonarr Calendar."""
 
     def __init__(self, coordinator: CalendarDataUpdateCoordinator, name: str) -> None:
-        """Initialize Sonarr calendar."""
-        self.coordinator = coordinator
-        self._attr_name = name
-        self._events = []
+        """Initialize the Sonarr Calendar."""
+        super().__init__(
+            coordinator=coordinator,
+            description=EntityDescription(key="sonarr.episodes", name=name),
+        )
+
+        self._coordinator: CalendarDataUpdateCoordinator = coordinator
+        self._events: list[CalendarEvent] = []
 
     @property
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
-        if self._events:
-            return self._events[0]
-        return None
+        return self._events[0] if self._events else None
+
+    def upcoming(self) -> list[str | None]:
+        """Return a list of all upcoming events."""
+        return [ep.uid for ep in self._events if ep.start >= start_of_local_day()]
+
+    def _calc_end_time(self, start_date: datetime, duration: int) -> datetime:
+        """Calculate the end datetime for an episode."""
+        return start_date + timedelta(minutes=duration)
 
     async def async_get_events(
-        self,
-        hass: HomeAssistant,
-        start_date: datetime,
-        end_date: datetime,
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
-        episode_events = await get_sonarr_episode_events(self.coordinator)
         start_date = as_utc(start_date)
         end_date = as_utc(end_date)
-        self._events = [
+        return [
             episode
-            for episode in episode_events
+            for episode in self._events
             if start_date <= episode.start <= end_date
         ]
 
-        return self._events
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._events.extend(
+            CalendarEvent(
+                uid=str(episode.id),
+                summary=episode.series.title,
+                description=episode.title,
+                location=episode.series.network,
+                start=episode.airDateUtc,
+                end=self._calc_end_time(episode.airDateUtc, episode.series.runtime),
+            )
+            for episode in self._coordinator.data
+            if str(episode.id) not in self.upcoming()
+        )
+        coord_upcoming = [str(episode.id) for episode in self._coordinator.data]
+        ids_to_remove = [
+            event.uid for event in self._events if event.uid not in coord_upcoming
+        ]
+        for event in self._events:
+            if event.uid in ids_to_remove:
+                self._events.remove(event)
+        self.async_write_ha_state()
 
-    async def async_update(self) -> None:
-        """Update the calendar for new entries."""
-        episodes = await get_sonarr_episode_events(self.coordinator)
-        self._events = episodes
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()

--- a/homeassistant/components/sonarr/calendar.py
+++ b/homeassistant/components/sonarr/calendar.py
@@ -1,5 +1,5 @@
 """Support for Sonarr calendar."""
-import datetime
+from datetime import datetime, timedelta
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
@@ -33,14 +33,16 @@ async def get_sonarr_episode_events(
     """Update the list of upcoming episodes."""
     calendar_entries: list[CalendarEvent] = []
     for episode in coordinator.data:
+        episode_endtime_utc = episode.airDateUtc + timedelta(
+            minutes=episode.series.runtime
+        )
         calendar_entries.append(
             CalendarEvent(
                 summary=episode.series.title,
                 description=episode.title,
                 location=episode.series.network,
                 start=episode.airDateUtc,
-                end=episode.airDateUtc
-                + datetime.timedelta(minutes=episode.series.runtime),
+                end=episode_endtime_utc,
             )
         )
     return calendar_entries
@@ -62,8 +64,8 @@ class SonarrCalendarEntity(CalendarEntity):
     async def async_get_events(
         self,
         hass: HomeAssistant,
-        start_date: datetime.datetime,
-        end_date: datetime.datetime,
+        start_date: datetime,
+        end_date: datetime,
     ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
         return self._events

--- a/homeassistant/components/sonarr/calendar.py
+++ b/homeassistant/components/sonarr/calendar.py
@@ -1,12 +1,13 @@
 """Support for Sonarr calendar."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.dt import as_utc
 
 from .const import DOMAIN
 from .coordinator import CalendarDataUpdateCoordinator
@@ -70,16 +71,14 @@ class SonarrCalendarEntity(CalendarEntity):
     ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
         episode_events = await get_sonarr_episode_events(self.coordinator)
-        if start_date and end_date:
-            start_date = start_date.replace(tzinfo=timezone.utc)
-            end_date = end_date.replace(tzinfo=timezone.utc)
-            self._events = [
-                episode
-                for episode in episode_events
-                if start_date <= episode.start <= end_date
-            ]
-        else:
-            self._events = episode_events
+        start_date = as_utc(start_date)
+        end_date = as_utc(end_date)
+        self._events = [
+            episode
+            for episode in episode_events
+            if start_date <= episode.start <= end_date
+        ]
+
         return self._events
 
     async def async_update(self) -> None:

--- a/homeassistant/components/sonarr/calendar.py
+++ b/homeassistant/components/sonarr/calendar.py
@@ -58,7 +58,7 @@ class SonarrCalendarEntity(CalendarEntity):
     @property
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
-        if len(self._events) > 0:
+        if self._events:
             return self._events[0]
         return None
 

--- a/homeassistant/components/sonarr/calendar.py
+++ b/homeassistant/components/sonarr/calendar.py
@@ -44,13 +44,13 @@ async def get_sonarr_episode_events(
 
 
 class SonarrCalendarEntity(CalendarEntity):
-    """Representation of a Demo Calendar element."""
+    """Representation of a Sonarr Calendar element."""
 
     coordinator: CalendarDataUpdateCoordinator
     _events: list[CalendarEvent]
 
     def __init__(self, coordinator: CalendarDataUpdateCoordinator, name: str) -> None:
-        """Initialize demo calendar."""
+        """Initialize Sonarr calendar."""
         self.coordinator = coordinator
         self._attr_name = name
         self._events = []

--- a/homeassistant/components/sonarr/calendar.py
+++ b/homeassistant/components/sonarr/calendar.py
@@ -39,7 +39,8 @@ async def get_sonarr_episode_events(
                 description=episode.title,
                 location=episode.series.network,
                 start=episode.airDateUtc,
-                end=episode.airDateUtc + datetime.timedelta(hours=1),
+                end=episode.airDateUtc
+                + datetime.timedelta(minutes=episode.series.runtime),
             )
         )
     return calendar_entries

--- a/homeassistant/components/sonarr/calendar.py
+++ b/homeassistant/components/sonarr/calendar.py
@@ -1,0 +1,68 @@
+"""Support for Sonarr calendar."""
+import datetime
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import CalendarDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Sonarr calendar based on a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["upcoming"]
+    episodes = await get_sonarr_episode_events(coordinator)
+    async_add_entities(
+        [
+            SonarrCalendarEntity(
+                list(ep for ep in episodes), "Sonarr Episodes"  # noqa: C400
+            )
+        ]
+    )
+
+
+async def get_sonarr_episode_events(
+    coordinator: CalendarDataUpdateCoordinator,
+) -> list[CalendarEvent]:
+    """Update the list of upcoming episodes."""
+    calendar_entries: list[CalendarEvent] = []
+    for episode in coordinator.data:
+        calendar_entries.append(
+            CalendarEvent(
+                summary=episode.series.title,
+                description=episode.title,
+                location=episode.series.network,
+                start=episode.airDateUtc,
+                end=episode.airDateUtc + datetime.timedelta(hours=1),
+            )
+        )
+    return calendar_entries
+
+
+class SonarrCalendarEntity(CalendarEntity):
+    """Representation of a Demo Calendar element."""
+
+    def __init__(self, events: list[CalendarEvent], name: str) -> None:
+        """Initialize demo calendar."""
+        self._events = events
+        self._attr_name = name
+
+    @property
+    def event(self) -> CalendarEvent:
+        """Return the next upcoming event."""
+        return self._events[0]
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[CalendarEvent]:
+        """Return calendar events within a datetime range."""
+        return self._events

--- a/tests/components/sonarr/test_calendar.py
+++ b/tests/components/sonarr/test_calendar.py
@@ -1,0 +1,28 @@
+"""Test the Sonarr calendar entity."""
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+CALENDAR_ID = "calendar.sonarr_episodes"
+
+
+async def test_calendar(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_sonarr: MagicMock,
+    entity_registry_enabled_by_default: AsyncMock,
+) -> None:
+    """Test the creation and events in the calendar."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(CALENDAR_ID)
+    assert state.name == "Sonarr Episodes"
+    assert state.state == "off"
+    assert state.attributes.get("message") == "Bob's Burgers"
+    assert state.attributes.get("description") == "Easy Com-mercial, Easy Go-mercial"
+    assert state.attributes.get("start_time") == "2014-01-26 17:30:00"
+    assert state.attributes.get("end_time") == "2014-01-26 18:00:00"

--- a/tests/components/sonarr/test_calendar.py
+++ b/tests/components/sonarr/test_calendar.py
@@ -1,11 +1,13 @@
 """Test the Sonarr calendar entity."""
 from unittest.mock import AsyncMock, MagicMock
 
+from homeassistant.components.sonarr.calendar import get_sonarr_episode_events
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 CALENDAR_ID = "calendar.sonarr_episodes"
+DOMAIN = "sonarr"
 
 
 async def test_calendar(
@@ -20,9 +22,22 @@ async def test_calendar(
     await hass.async_block_till_done()
 
     state = hass.states.get(CALENDAR_ID)
+    assert state
     assert state.name == "Sonarr Episodes"
     assert state.state == "off"
-    assert state.attributes.get("message") == "Bob's Burgers"
-    assert state.attributes.get("description") == "Easy Com-mercial, Easy Go-mercial"
-    assert state.attributes.get("start_time") == "2014-01-26 17:30:00"
-    assert state.attributes.get("end_time") == "2014-01-26 18:00:00"
+
+
+async def test_get_episodes(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_sonarr: MagicMock,
+    entity_registry_enabled_by_default: AsyncMock,
+) -> None:
+    """Test data is extracted from the coordinator."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]["upcoming"]
+    episodes = await get_sonarr_episode_events(coordinator)
+    assert len(episodes) == 1

--- a/tests/components/sonarr/test_calendar.py
+++ b/tests/components/sonarr/test_calendar.py
@@ -1,7 +1,6 @@
 """Test the Sonarr calendar entity."""
-from unittest.mock import AsyncMock, MagicMock
+from http import HTTPStatus
 
-from homeassistant.components.sonarr.calendar import get_sonarr_episode_events
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -12,32 +11,30 @@ DOMAIN = "sonarr"
 
 async def test_calendar(
     hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_sonarr: MagicMock,
-    entity_registry_enabled_by_default: AsyncMock,
+    init_integration: MockConfigEntry,
+    hass_client,
 ) -> None:
-    """Test the creation and events in the calendar."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(CALENDAR_ID)
-    assert state
-    assert state.name == "Sonarr Episodes"
-    assert state.state == "off"
+    """Test the API returns the Sonarr calendar."""
+    client = await hass_client()
+    response = await client.get("/api/calendars")
+    assert response.status == HTTPStatus.OK
+    data = await response.json()
+    assert data == [
+        {
+            "entity_id": "calendar.sonarr_episodes",
+            "name": "Sonarr Episodes",
+        }
+    ]
 
 
 async def test_get_episodes(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_sonarr: MagicMock,
-    entity_registry_enabled_by_default: AsyncMock,
+    hass: HomeAssistant, init_integration: MockConfigEntry, hass_client
 ) -> None:
     """Test data is extracted from the coordinator."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]["upcoming"]
-    episodes = await get_sonarr_episode_events(coordinator)
-    assert len(episodes) == 1
+    client = await hass_client()
+    response = await client.get(
+        "/api/calendars/calendar.sonarr_episodes?start=2014-01-26&end=2014-01-28"
+    )
+    assert response.status == HTTPStatus.OK
+    events = await response.json()
+    assert len(events) == 1

--- a/tests/components/sonarr/test_calendar.py
+++ b/tests/components/sonarr/test_calendar.py
@@ -35,3 +35,16 @@ async def test_get_episodes(
     assert response.status == HTTPStatus.OK
     events = await response.json()
     assert len(events) == 1
+
+
+async def test_dont_get_episodes_outside_date_range(
+    hass: HomeAssistant, init_integration: MockConfigEntry, hass_client
+) -> None:
+    """Test data is extracted from the coordinator."""
+    client = await hass_client()
+    response = await client.get(
+        "/api/calendars/calendar.sonarr_episodes?start=2014-01-30&end=2014-01-31"
+    )
+    assert response.status == HTTPStatus.OK
+    events = await response.json()
+    assert len(events) == 0

--- a/tests/components/sonarr/test_calendar.py
+++ b/tests/components/sonarr/test_calendar.py
@@ -5,9 +5,6 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
-CALENDAR_ID = "calendar.sonarr_episodes"
-DOMAIN = "sonarr"
-
 
 async def test_calendar(
     hass: HomeAssistant,


### PR DESCRIPTION
Calendar displays the upcoming episodes on the HA calendar

Notes:
* Only future episodes are shown, no previous history

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It adds a calendar entity to HomeAssistant with upcoming episodes from Sonarr.

Currently only future episodes are shown

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25351

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
