### PR TITLE
Split out part of update sensor to a common UniFi entity class

### DIFF
--- a/homeassistant/components/unifi/entity.py
+++ b/homeassistant/components/unifi/entity.py
@@ -1,0 +1,176 @@
+"""UniFi entity representation."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+import aiounifi
+from aiounifi.interfaces.api_handlers import CallbackType, ItemEvent, UnsubscribeType
+from aiounifi.interfaces.devices import Devices
+from aiounifi.models.device import Device
+from aiounifi.models.event import Event, EventKey
+
+from homeassistant.core import callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
+
+from .controller import UniFiController
+
+DataT = TypeVar("DataT", bound=Device)
+HandlerT = TypeVar("HandlerT", bound=Devices)
+SubscriptionT = Callable[[CallbackType, ItemEvent], UnsubscribeType]
+
+
+@dataclass
+class UnifiDescription(Generic[HandlerT, DataT]):
+    """Validate and load entities from different UniFi handlers."""
+
+    allowed_fn: Callable[[UniFiController, str], bool]
+    api_handler_fn: Callable[[aiounifi.Controller], HandlerT]
+    available_fn: Callable[[UniFiController, str], bool]
+    device_info_fn: Callable[[aiounifi.Controller, str], DeviceInfo | None]
+    event_is_on: tuple[EventKey, ...] | None
+    event_to_subscribe: tuple[EventKey, ...] | None
+    name_fn: Callable[[DataT], str | None]
+    object_fn: Callable[[aiounifi.Controller, str], DataT]
+    supported_fn: Callable[[UniFiController, str], bool | None]
+    unique_id_fn: Callable[[UniFiController, str], str]
+
+
+@dataclass
+class UnifiEntityDescription(EntityDescription, UnifiDescription[HandlerT, DataT]):
+    """UniFi Entity Description."""
+
+
+class UnifiEntity(Entity, Generic[HandlerT, DataT]):
+    """Representation of a UniFi entity."""
+
+    entity_description: UnifiEntityDescription[HandlerT, DataT]
+    _attr_should_poll = False
+
+    _attr_unique_id: str
+
+    def __init__(
+        self,
+        obj_id: str,
+        controller: UniFiController,
+        description: UnifiEntityDescription[HandlerT, DataT],
+    ) -> None:
+        """Set up UniFi switch entity."""
+        self._obj_id = obj_id
+        self.controller = controller
+        self.entity_description = description
+
+        self._removed = False
+
+        self._attr_available = description.available_fn(controller, obj_id)
+        self._attr_device_info = description.device_info_fn(controller.api, obj_id)
+        self._attr_unique_id = description.unique_id_fn(controller, obj_id)
+
+        obj = description.object_fn(self.controller.api, obj_id)
+        self._attr_name = description.name_fn(obj)
+        self.async_initiate_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        description = self.entity_description
+        handler = description.api_handler_fn(self.controller.api)
+
+        # New data from handler
+        self.async_on_remove(
+            handler.subscribe(
+                self.async_signalling_callback,
+            )
+        )
+
+        # State change from controller or websocket
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_reachable,
+                self.async_signal_reachable_callback,
+            )
+        )
+
+        # Config entry options updated
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.controller.signal_options_update,
+                self.async_signal_options_updated,
+            )
+        )
+
+        # Subscribe to events if defined
+        if description.event_to_subscribe is not None:
+            self.async_on_remove(
+                self.controller.api.events.subscribe(
+                    self.async_event_callback,
+                    description.event_to_subscribe,
+                )
+            )
+
+        self.async_custom_subscribe()
+
+    @callback
+    def async_signalling_callback(self, event: ItemEvent, obj_id: str) -> None:
+        """Update the entity state."""
+        if event == ItemEvent.DELETED and obj_id == self._obj_id:
+            self.hass.async_create_task(self.remove_item({self._obj_id}))
+            return
+
+        description = self.entity_description
+        if not description.supported_fn(self.controller, self._obj_id):
+            self.hass.async_create_task(self.remove_item({self._obj_id}))
+            return
+
+        self._attr_available = description.available_fn(self.controller, self._obj_id)
+        self.async_update_state(event, obj_id)
+        self.async_write_ha_state()
+
+    @callback
+    def async_signal_reachable_callback(self) -> None:
+        """Call when controller connection state change."""
+        self.async_signalling_callback(ItemEvent.ADDED, self._obj_id)
+
+    async def async_signal_options_updated(self) -> None:
+        """Config entry options are updated, remove entity if option is disabled."""
+        if not self.entity_description.allowed_fn(self.controller, self._obj_id):
+            await self.remove_item({self._obj_id})
+
+    async def remove_item(self, keys: set) -> None:
+        """Remove entity if object ID is part of set."""
+        if self._obj_id not in keys or self._removed:
+            return
+        self._removed = True
+        if self.registry_entry:
+            er.async_get(self.hass).async_remove(self.entity_id)
+        else:
+            await self.async_remove(force_remove=True)
+
+    @callback
+    def async_initiate_state(self) -> None:
+        """Initiate entity state.
+
+        Perform additional actions setting up platform entity child class state.
+        """
+
+    @callback
+    def async_update_state(self, event: ItemEvent, obj_id: str) -> None:
+        """Update entity state.
+
+        Perform additional actions updating platform entity child class state.
+        """
+
+    @callback
+    def async_event_callback(self, event: Event) -> None:
+        """Update entity state based on subscribed event.
+
+        Perform additional action updating platform entity child class state.
+        """
+
+    @callback
+    def async_custom_subscribe(self) -> None:
+        """Do custom subscriptions."""

--- a/homeassistant/components/unifi/entity.py
+++ b/homeassistant/components/unifi/entity.py
@@ -1,6 +1,7 @@
 """UniFi entity representation."""
 from __future__ import annotations
 
+from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Generic, TypeVar
@@ -151,18 +152,22 @@ class UnifiEntity(Entity, Generic[HandlerT, DataT]):
             await self.async_remove(force_remove=True)
 
     @callback
+    @abstractmethod
     def async_initiate_state(self) -> None:
         """Initiate entity state.
 
         Perform additional actions setting up platform entity child class state.
         """
+        raise NotImplementedError()
 
     @callback
+    @abstractmethod
     def async_update_state(self, event: ItemEvent, obj_id: str) -> None:
         """Update entity state.
 
         Perform additional actions updating platform entity child class state.
         """
+        raise NotImplementedError()
 
     @callback
     def async_event_callback(self, event: Event) -> None:
@@ -170,6 +175,7 @@ class UnifiEntity(Entity, Generic[HandlerT, DataT]):
 
         Perform additional action updating platform entity child class state.
         """
+        raise NotImplementedError()
 
     @callback
     def async_custom_subscribe(self) -> None:

--- a/homeassistant/components/unifi/entity.py
+++ b/homeassistant/components/unifi/entity.py
@@ -10,7 +10,7 @@ import aiounifi
 from aiounifi.interfaces.api_handlers import CallbackType, ItemEvent, UnsubscribeType
 from aiounifi.interfaces.devices import Devices
 from aiounifi.models.device import Device
-from aiounifi.models.event import Event, EventKey
+from aiounifi.models.event import EventKey
 
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
@@ -104,17 +104,6 @@ class UnifiEntity(Entity, Generic[HandlerT, DataT]):
             )
         )
 
-        # Subscribe to events if defined
-        if description.event_to_subscribe is not None:
-            self.async_on_remove(
-                self.controller.api.events.subscribe(
-                    self.async_event_callback,
-                    description.event_to_subscribe,
-                )
-            )
-
-        self.async_custom_subscribe()
-
     @callback
     def async_signalling_callback(self, event: ItemEvent, obj_id: str) -> None:
         """Update the entity state."""
@@ -158,7 +147,6 @@ class UnifiEntity(Entity, Generic[HandlerT, DataT]):
 
         Perform additional actions setting up platform entity child class state.
         """
-        raise NotImplementedError()
 
     @callback
     @abstractmethod
@@ -167,16 +155,3 @@ class UnifiEntity(Entity, Generic[HandlerT, DataT]):
 
         Perform additional actions updating platform entity child class state.
         """
-        raise NotImplementedError()
-
-    @callback
-    def async_event_callback(self, event: Event) -> None:
-        """Update entity state based on subscribed event.
-
-        Perform additional action updating platform entity child class state.
-        """
-        raise NotImplementedError()
-
-    @callback
-    def async_custom_subscribe(self) -> None:
-        """Do custom subscriptions."""

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import CallbackType, ItemEvent, UnsubscribeType
+from aiounifi.interfaces.api_handlers import ItemEvent
 from aiounifi.interfaces.devices import Devices
 from aiounifi.models.device import Device, DeviceUpgradeRequest
 
@@ -19,23 +19,15 @@ from homeassistant.components.update import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ATTR_MANUFACTURER, DOMAIN as UNIFI_DOMAIN
+from .entity import DataT, HandlerT, SubscriptionT, UnifiEntity, UnifiEntityDescription
 
 if TYPE_CHECKING:
-    from aiounifi.models.event import EventKey
-
     from .controller import UniFiController
-
-_DataT = TypeVar("_DataT", bound=Device)
-_HandlerT = TypeVar("_HandlerT", bound=Devices)
-
-Subscription = Callable[[CallbackType, ItemEvent], UnsubscribeType]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -67,34 +59,26 @@ def async_device_device_info_fn(api: aiounifi.Controller, obj_id: str) -> Device
 
 
 @dataclass
-class UnifiEntityLoader(Generic[_HandlerT, _DataT]):
+class UnifiEntityLoader(Generic[HandlerT, DataT]):
     """Validate and load entities from different UniFi handlers."""
 
-    allowed_fn: Callable[[UniFiController, str], bool]
-    api_handler_fn: Callable[[aiounifi.Controller], _HandlerT]
-    available_fn: Callable[[UniFiController, str], bool]
     control_fn: Callable[[aiounifi.Controller, str], Coroutine[Any, Any, None]]
-    device_info_fn: Callable[[aiounifi.Controller, str], DeviceInfo]
-    event_is_on: tuple[EventKey, ...] | None
-    event_to_subscribe: tuple[EventKey, ...] | None
-    name_fn: Callable[[_DataT], str | None]
-    object_fn: Callable[[aiounifi.Controller, str], _DataT]
-    state_fn: Callable[[aiounifi.Controller, _DataT], bool]
-    supported_fn: Callable[[aiounifi.Controller, str], bool | None]
-    unique_id_fn: Callable[[str], str]
+    state_fn: Callable[[aiounifi.Controller, DataT], bool]
 
 
 @dataclass
-class UnifiEntityDescription(
-    UpdateEntityDescription, UnifiEntityLoader[_HandlerT, _DataT]
+class UnifiUpdateEntityDescription(
+    UpdateEntityDescription,
+    UnifiEntityDescription[HandlerT, DataT],
+    UnifiEntityLoader[HandlerT, DataT],
 ):
     """Class describing UniFi update entity."""
 
-    custom_subscribe: Callable[[aiounifi.Controller], Subscription] | None = None
+    custom_subscribe: Callable[[aiounifi.Controller], SubscriptionT] | None = None
 
 
-ENTITY_DESCRIPTIONS: tuple[UnifiEntityDescription, ...] = (
-    UnifiEntityDescription[Devices, Device](
+ENTITY_DESCRIPTIONS: tuple[UnifiUpdateEntityDescription, ...] = (
+    UnifiUpdateEntityDescription[Devices, Device](
         key="Upgrade device",
         device_class=UpdateDeviceClass.FIRMWARE,
         has_entity_name=True,
@@ -108,8 +92,8 @@ ENTITY_DESCRIPTIONS: tuple[UnifiEntityDescription, ...] = (
         name_fn=lambda device: None,
         object_fn=lambda api, obj_id: api.devices[obj_id],
         state_fn=lambda api, device: device.state == 4,
-        supported_fn=lambda api, obj_id: True,
-        unique_id_fn=lambda obj_id: f"device_update-{obj_id}",
+        supported_fn=lambda controller, obj_id: True,
+        unique_id_fn=lambda controller, obj_id: f"device_update-{obj_id}",
     ),
 )
 
@@ -123,7 +107,7 @@ async def async_setup_entry(
     controller: UniFiController = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     @callback
-    def async_load_entities(description: UnifiEntityDescription) -> None:
+    def async_load_entities(description: UnifiUpdateEntityDescription) -> None:
         """Load and subscribe to UniFi devices."""
         entities: list[UpdateEntity] = []
         api_handler = description.api_handler_fn(controller.api)
@@ -152,38 +136,19 @@ async def async_setup_entry(
         async_load_entities(description)
 
 
-class UnifiDeviceUpdateEntity(UpdateEntity, Generic[_HandlerT, _DataT]):
+class UnifiDeviceUpdateEntity(UnifiEntity[HandlerT, DataT], UpdateEntity):
     """Representation of a UniFi device update entity."""
 
-    entity_description: UnifiEntityDescription[_HandlerT, _DataT]
-    _attr_should_poll = False
+    entity_description: UnifiUpdateEntityDescription[HandlerT, DataT]
 
-    def __init__(
-        self,
-        obj_id: str,
-        controller: UniFiController,
-        description: UnifiEntityDescription[_HandlerT, _DataT],
-    ) -> None:
-        """Set up UniFi update entity."""
-        self._obj_id = obj_id
-        self.controller = controller
-        self.entity_description = description
-
-        self._removed = False
-
+    @callback
+    def async_initiate_state(self) -> None:
+        """Initiate entity state."""
         self._attr_supported_features = UpdateEntityFeature.PROGRESS
-        if controller.site_role == "admin":
+        if self.controller.site_role == "admin":
             self._attr_supported_features |= UpdateEntityFeature.INSTALL
 
-        self._attr_available = description.available_fn(controller, obj_id)
-        self._attr_device_info = description.device_info_fn(controller.api, obj_id)
-        self._attr_unique_id = description.unique_id_fn(obj_id)
-
-        obj = description.object_fn(self.controller.api, obj_id)
-        self._attr_in_progress = description.state_fn(controller.api, obj)
-        self._attr_name = description.name_fn(obj)
-        self._attr_installed_version = obj.version
-        self._attr_latest_version = obj.upgrade_to_firmware or obj.version
+        self.async_update_state(ItemEvent.ADDED, self._obj_id)
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
@@ -191,56 +156,15 @@ class UnifiDeviceUpdateEntity(UpdateEntity, Generic[_HandlerT, _DataT]):
         """Install an update."""
         await self.entity_description.control_fn(self.controller.api, self._obj_id)
 
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        description = self.entity_description
-        handler = description.api_handler_fn(self.controller.api)
-        self.async_on_remove(
-            handler.subscribe(
-                self.async_signalling_callback,
-            )
-        )
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                self.controller.signal_reachable,
-                self.async_signal_reachable_callback,
-            )
-        )
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                self.controller.signal_remove,
-                self.remove_item,
-            )
-        )
-
     @callback
-    def async_signalling_callback(self, event: ItemEvent, obj_id: str) -> None:
-        """Update the switch state."""
-        if event == ItemEvent.DELETED and obj_id == self._obj_id:
-            self.hass.async_create_task(self.remove_item({self._obj_id}))
-            return
+    def async_update_state(self, event: ItemEvent, obj_id: str) -> None:
+        """Update entity state.
 
+        Update in_progress, installed_version and latest_version.
+        """
         description = self.entity_description
+
         obj = description.object_fn(self.controller.api, self._obj_id)
-        self._attr_available = description.available_fn(self.controller, self._obj_id)
         self._attr_in_progress = description.state_fn(self.controller.api, obj)
         self._attr_installed_version = obj.version
         self._attr_latest_version = obj.upgrade_to_firmware or obj.version
-        self.async_write_ha_state()
-
-    @callback
-    def async_signal_reachable_callback(self) -> None:
-        """Call when controller connection state change."""
-        self.async_signalling_callback(ItemEvent.ADDED, self._obj_id)
-
-    async def remove_item(self, keys: set) -> None:
-        """Remove entity if object ID is part of set."""
-        if self._obj_id not in keys or self._removed:
-            return
-        self._removed = True
-        if self.registry_entry:
-            er.async_get(self.hass).async_remove(self.entity_id)
-        else:
-            await self.async_remove(force_remove=True)

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ATTR_MANUFACTURER, DOMAIN as UNIFI_DOMAIN
-from .entity import DataT, HandlerT, SubscriptionT, UnifiEntity, UnifiEntityDescription
+from .entity import DataT, HandlerT, UnifiEntity, UnifiEntityDescription
 
 if TYPE_CHECKING:
     from .controller import UniFiController
@@ -73,8 +73,6 @@ class UnifiUpdateEntityDescription(
     UnifiEntityLoader[HandlerT, DataT],
 ):
     """Class describing UniFi update entity."""
-
-    custom_subscribe: Callable[[aiounifi.Controller], SubscriptionT] | None = None
 
 
 ENTITY_DESCRIPTIONS: tuple[UnifiUpdateEntityDescription, ...] = (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As the rewrite is coming along it is time to merge the common aspects together to a new common entity class. The device tracker platform still depends on the old common classes so they are kept until that has been rewritten.

Related PRs
- #81680
- #81821
- #81930
- #81979
- #84262
- #84458

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
