### PR TITLE
Make all ARMED states available for manual_mqtt

### DIFF
--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -21,8 +21,10 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TRIGGER_TIME,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMED_VACATION,
     STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
@@ -46,6 +48,8 @@ CONF_PAYLOAD_DISARM = "payload_disarm"
 CONF_PAYLOAD_ARM_HOME = "payload_arm_home"
 CONF_PAYLOAD_ARM_AWAY = "payload_arm_away"
 CONF_PAYLOAD_ARM_NIGHT = "payload_arm_night"
+CONF_PAYLOAD_ARM_VACATION = "payload_arm_vacation"
+CONF_PAYLOAD_ARM_CUSTOM_BYPASS = "payload_arm_custom_bypass"
 
 DEFAULT_ALARM_NAME = "HA Alarm"
 DEFAULT_DELAY_TIME = datetime.timedelta(seconds=0)
@@ -55,6 +59,8 @@ DEFAULT_DISARM_AFTER_TRIGGER = False
 DEFAULT_ARM_AWAY = "ARM_AWAY"
 DEFAULT_ARM_HOME = "ARM_HOME"
 DEFAULT_ARM_NIGHT = "ARM_NIGHT"
+DEFAULT_ARM_VACATION = "ARM_VACATION"
+DEFAULT_ARM_CUSTOM_BYPASS = "ARM_CUSTOM_BYPASS"
 DEFAULT_DISARM = "DISARM"
 
 SUPPORTED_STATES = [
@@ -62,6 +68,8 @@ SUPPORTED_STATES = [
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMED_VACATION,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_TRIGGERED,
 ]
 
@@ -138,6 +146,12 @@ PLATFORM_SCHEMA = vol.Schema(
                 vol.Optional(STATE_ALARM_ARMED_NIGHT, default={}): _state_schema(
                     STATE_ALARM_ARMED_NIGHT
                 ),
+                vol.Optional(STATE_ALARM_ARMED_VACATION, default={}): _state_schema(
+                    STATE_ALARM_ARMED_VACATION
+                ),
+                vol.Optional(
+                    STATE_ALARM_ARMED_CUSTOM_BYPASS, default={}
+                ): _state_schema(STATE_ALARM_ARMED_CUSTOM_BYPASS),
                 vol.Optional(STATE_ALARM_DISARMED, default={}): _state_schema(
                     STATE_ALARM_DISARMED
                 ),
@@ -155,6 +169,12 @@ PLATFORM_SCHEMA = vol.Schema(
                 ): cv.string,
                 vol.Optional(
                     CONF_PAYLOAD_ARM_NIGHT, default=DEFAULT_ARM_NIGHT
+                ): cv.string,
+                vol.Optional(
+                    CONF_PAYLOAD_ARM_VACATION, default=DEFAULT_ARM_VACATION
+                ): cv.string,
+                vol.Optional(
+                    CONF_PAYLOAD_ARM_CUSTOM_BYPASS, default=DEFAULT_ARM_CUSTOM_BYPASS
                 ): cv.string,
                 vol.Optional(CONF_PAYLOAD_DISARM, default=DEFAULT_DISARM): cv.string,
             }
@@ -187,6 +207,8 @@ def setup_platform(
                 config.get(CONF_PAYLOAD_ARM_HOME),
                 config.get(CONF_PAYLOAD_ARM_AWAY),
                 config.get(CONF_PAYLOAD_ARM_NIGHT),
+                config.get(CONF_PAYLOAD_ARM_VACATION),
+                config.get(CONF_PAYLOAD_ARM_CUSTOM_BYPASS),
                 config,
             )
         ]
@@ -210,7 +232,9 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         AlarmControlPanelEntityFeature.ARM_HOME
         | AlarmControlPanelEntityFeature.ARM_AWAY
         | AlarmControlPanelEntityFeature.ARM_NIGHT
+        | AlarmControlPanelEntityFeature.ARM_VACATION
         | AlarmControlPanelEntityFeature.TRIGGER
+        | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
     )
 
     def __init__(
@@ -228,6 +252,8 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         payload_arm_home,
         payload_arm_away,
         payload_arm_night,
+        payload_arm_vacation,
+        payload_arm_custom_bypass,
         config,
     ):
         """Init the manual MQTT alarm panel."""
@@ -264,6 +290,8 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         self._payload_arm_home = payload_arm_home
         self._payload_arm_away = payload_arm_away
         self._payload_arm_night = payload_arm_night
+        self._payload_arm_vacation = payload_arm_vacation
+        self._payload_arm_custom_bypass = payload_arm_custom_bypass
 
     @property
     def state(self) -> str:
@@ -350,6 +378,24 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
 
         self._async_update_state(STATE_ALARM_ARMED_NIGHT)
 
+    async def async_alarm_arm_vacation(self, code: str | None = None) -> None:
+        """Send arm vacation command."""
+        if self.code_arm_required and not self._async_validate_code(
+            code, STATE_ALARM_ARMED_VACATION
+        ):
+            return
+
+        self._async_update_state(STATE_ALARM_ARMED_VACATION)
+
+    async def async_alarm_arm_custom_bypass(self, code: str | None = None) -> None:
+        """Send arm custom bypass command."""
+        if self.code_arm_required and not self._async_validate_code(
+            code, STATE_ALARM_ARMED_CUSTOM_BYPASS
+        ):
+            return
+
+        self._async_update_state(STATE_ALARM_ARMED_CUSTOM_BYPASS)
+
     async def async_alarm_trigger(self, code: str | None = None) -> None:
         """
         Send alarm trigger command.
@@ -434,6 +480,10 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
                 await self.async_alarm_arm_away(self._code)
             elif msg.payload == self._payload_arm_night:
                 await self.async_alarm_arm_night(self._code)
+            elif msg.payload == self._payload_arm_vacation:
+                await self.async_alarm_arm_vacation(self._code)
+            elif msg.payload == self._payload_arm_custom_bypass:
+                await self.async_alarm_arm_custom_bypass(self._code)
             else:
                 _LOGGER.warning("Received unexpected payload: %s", msg.payload)
                 return

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -10,11 +10,15 @@ from homeassistant.const import (
     ATTR_CODE,
     ATTR_ENTITY_ID,
     SERVICE_ALARM_ARM_AWAY,
+    SERVICE_ALARM_ARM_CUSTOM_BYPASS,
     SERVICE_ALARM_ARM_HOME,
     SERVICE_ALARM_ARM_NIGHT,
+    SERVICE_ALARM_ARM_VACATION,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMED_VACATION,
     STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
@@ -67,8 +71,10 @@ async def test_fail_setup_without_command_topic(hass, mqtt_mock_entry_with_yaml_
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_no_pending(
@@ -110,8 +116,10 @@ async def test_no_pending(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_no_pending_when_code_not_req(
@@ -154,8 +162,10 @@ async def test_no_pending_when_code_not_req(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_with_pending(
@@ -221,8 +231,10 @@ async def test_with_pending(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_with_invalid_code(
@@ -264,8 +276,10 @@ async def test_with_invalid_code(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_with_template_code(
@@ -308,8 +322,10 @@ async def test_with_template_code(
     "service,expected_state",
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
+        (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
         (SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),
         (SERVICE_ALARM_ARM_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_with_specific_pending(
@@ -1258,8 +1274,10 @@ async def test_disarm_with_template_code(hass, mqtt_mock_entry_with_yaml_config)
     "config,expected_state",
     [
         ("payload_arm_away", STATE_ALARM_ARMED_AWAY),
+        ("payload_arm_custom_bypass", STATE_ALARM_ARMED_CUSTOM_BYPASS),
         ("payload_arm_home", STATE_ALARM_ARMED_HOME),
         ("payload_arm_night", STATE_ALARM_ARMED_NIGHT),
+        ("payload_arm_vacation", STATE_ALARM_ARMED_VACATION),
     ],
 )
 async def test_arm_via_command_topic(

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -417,12 +417,10 @@ async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -464,7 +462,6 @@ async def test_trigger_zero_trigger_time(hass, mqtt_mock_entry_with_yaml_config)
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
@@ -495,7 +492,6 @@ async def test_trigger_zero_trigger_time_with_pending(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
@@ -524,7 +520,6 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
@@ -578,7 +573,6 @@ async def test_trigger_with_disarm_after_trigger(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -620,7 +614,6 @@ async def test_trigger_with_zero_specific_trigger_time(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
@@ -652,7 +645,6 @@ async def test_trigger_with_unused_zero_specific_trigger_time(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -693,7 +685,6 @@ async def test_trigger_with_specific_trigger_time(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -734,12 +725,10 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE, entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -754,7 +743,6 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
@@ -792,12 +780,10 @@ async def test_disarm_while_pending_trigger(hass, mqtt_mock_entry_with_yaml_conf
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
     await common.async_alarm_disarm(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
@@ -838,12 +824,10 @@ async def test_disarm_during_trigger_with_invalid_code(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
     await common.async_alarm_disarm(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
@@ -886,12 +870,10 @@ async def test_trigger_with_unused_specific_delay(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -935,12 +917,10 @@ async def test_trigger_with_specific_delay(hass, mqtt_mock_entry_with_yaml_confi
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -984,12 +964,10 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -1048,12 +1026,10 @@ async def test_trigger_with_pending_and_specific_delay(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -1106,7 +1082,6 @@ async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_con
     entity_id = "alarm_control_panel.test"
 
     await common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
@@ -1158,7 +1133,6 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -1166,7 +1140,6 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
     assert state.attributes["post_pending_state"] == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -1182,7 +1155,6 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
         assert state.state == STATE_ALARM_ARMED_AWAY
 
         await common.async_alarm_trigger(hass, entity_id=entity_id)
-        await hass.async_block_till_done()
 
         state = hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
@@ -1222,19 +1194,16 @@ async def test_disarm_with_template_code(hass, mqtt_mock_entry_with_yaml_config)
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
     await common.async_alarm_arm_home(hass, "def")
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_ARMED_HOME
 
     await common.async_alarm_disarm(hass, "def")
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_ARMED_HOME
 
     await common.async_alarm_disarm(hass, "abc")
-    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_DISARMED

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -1106,6 +1106,51 @@ async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_con
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
+async def test_trigger_with_no_disarm_after_trigger(
+    hass, mqtt_mock_entry_with_yaml_config
+):
+    """Test disarm after trigger."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "trigger_time": 5,
+                "pending_time": 0,
+                "delay_time": 0,
+                "disarm_after_trigger": False,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
+
+    await common.async_alarm_arm_away(hass, CODE, entity_id)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    with patch(
+        ("homeassistant.components.manual_mqtt.alarm_control_panel.dt_util.utcnow"),
+        return_value=future,
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
+
+
 async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_config):
     """Test pending state with and without zero trigger time."""
     assert await async_setup_component(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Add new states ARMED_CUSTOM_BYPASS and ARMED_VACATION to the `manual_mqtt` platform. These states were added to `manual` over the years but never to the MQTT equivalent.

As part of the change, the tests are also synchronized as much as possible with the `manual` platform, in particular with respect to usage of pytest parametrization.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#25363

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
