### PR TITLE
Fix alarm_control_panel representing triggers and conditions based on supported features

### DIFF
--- a/homeassistant/components/alarm_control_panel/device_condition.py
+++ b/homeassistant/components/alarm_control_panel/device_condition.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import condition, config_validation as cv, entity_registry
 from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
-from homeassistant.helpers.entity import get_supported_features
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
 from . import DOMAIN
@@ -35,11 +34,6 @@ from .const import (
     CONDITION_ARMED_VACATION,
     CONDITION_DISARMED,
     CONDITION_TRIGGERED,
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_CUSTOM_BYPASS,
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_NIGHT,
-    SUPPORT_ALARM_ARM_VACATION,
 )
 
 CONDITION_TYPES: Final[set[str]] = {
@@ -72,8 +66,6 @@ async def async_get_conditions(
         if entry.domain != DOMAIN:
             continue
 
-        supported_features = get_supported_features(hass, entry.entity_id)
-
         # Add conditions for each entity that belongs to this integration
         base_condition = {
             CONF_CONDITION: "device",
@@ -85,19 +77,12 @@ async def async_get_conditions(
         conditions += [
             {**base_condition, CONF_TYPE: CONDITION_DISARMED},
             {**base_condition, CONF_TYPE: CONDITION_TRIGGERED},
+            {**base_condition, CONF_TYPE: CONDITION_ARMED_HOME},
+            {**base_condition, CONF_TYPE: CONDITION_ARMED_AWAY},
+            {**base_condition, CONF_TYPE: CONDITION_ARMED_NIGHT},
+            {**base_condition, CONF_TYPE: CONDITION_ARMED_VACATION},
+            {**base_condition, CONF_TYPE: CONDITION_ARMED_CUSTOM_BYPASS},
         ]
-        if supported_features & SUPPORT_ALARM_ARM_HOME:
-            conditions.append({**base_condition, CONF_TYPE: CONDITION_ARMED_HOME})
-        if supported_features & SUPPORT_ALARM_ARM_AWAY:
-            conditions.append({**base_condition, CONF_TYPE: CONDITION_ARMED_AWAY})
-        if supported_features & SUPPORT_ALARM_ARM_NIGHT:
-            conditions.append({**base_condition, CONF_TYPE: CONDITION_ARMED_NIGHT})
-        if supported_features & SUPPORT_ALARM_ARM_VACATION:
-            conditions.append({**base_condition, CONF_TYPE: CONDITION_ARMED_VACATION})
-        if supported_features & SUPPORT_ALARM_ARM_CUSTOM_BYPASS:
-            conditions.append(
-                {**base_condition, CONF_TYPE: CONDITION_ARMED_CUSTOM_BYPASS}
-            )
 
     return conditions
 

--- a/homeassistant/components/alarm_control_panel/device_trigger.py
+++ b/homeassistant/components/alarm_control_panel/device_trigger.py
@@ -24,17 +24,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry
-from homeassistant.helpers.entity import get_supported_features
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from . import DOMAIN
-from .const import (
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_NIGHT,
-    SUPPORT_ALARM_ARM_VACATION,
-)
 
 BASIC_TRIGGER_TYPES: Final[set[str]] = {"triggered", "disarmed", "arming"}
 TRIGGER_TYPES: Final[set[str]] = BASIC_TRIGGER_TYPES | {
@@ -65,8 +58,6 @@ async def async_get_triggers(
         if entry.domain != DOMAIN:
             continue
 
-        supported_features = get_supported_features(hass, entry.entity_id)
-
         # Add triggers for each entity that belongs to this integration
         base_trigger = {
             CONF_PLATFORM: "device",
@@ -80,37 +71,8 @@ async def async_get_triggers(
                 **base_trigger,
                 CONF_TYPE: trigger,
             }
-            for trigger in BASIC_TRIGGER_TYPES
+            for trigger in TRIGGER_TYPES
         ]
-        if supported_features & SUPPORT_ALARM_ARM_HOME:
-            triggers.append(
-                {
-                    **base_trigger,
-                    CONF_TYPE: "armed_home",
-                }
-            )
-        if supported_features & SUPPORT_ALARM_ARM_AWAY:
-            triggers.append(
-                {
-                    **base_trigger,
-                    CONF_TYPE: "armed_away",
-                }
-            )
-        if supported_features & SUPPORT_ALARM_ARM_NIGHT:
-            triggers.append(
-                {
-                    **base_trigger,
-                    CONF_TYPE: "armed_night",
-                }
-            )
-        if supported_features & SUPPORT_ALARM_ARM_VACATION:
-            triggers.append(
-                {
-                    **base_trigger,
-                    CONF_TYPE: "armed_vacation",
-                }
-            )
-
     return triggers
 
 

--- a/homeassistant/components/sia/alarm_control_panel.py
+++ b/homeassistant/components/sia/alarm_control_panel.py
@@ -8,9 +8,8 @@ from pysiaalarm import SIAEvent
 
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
-    AlarmControlPanelEntityDescription,
-)
-from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
+    AlarmControlPanelEntityDescription
+) 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
@@ -18,7 +17,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
-    STATE_UNAVAILABLE
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/homeassistant/components/sia/alarm_control_panel.py
+++ b/homeassistant/components/sia/alarm_control_panel.py
@@ -9,7 +9,6 @@ from pysiaalarm import SIAEvent
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityDescription,
-    AlarmControlPanelEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -109,11 +108,6 @@ class SIAAlarmControlPanel(SIABaseEntity, AlarmControlPanelEntity):
 
         self._attr_state: StateType = None
         self._old_state: StateType = None
-        self._attr_supported_features = (
-            AlarmControlPanelEntityFeature.ARM_AWAY
-            | AlarmControlPanelEntityFeature.ARM_NIGHT
-            | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
-        )
 
     def handle_last_state(self, last_state: State | None) -> None:
         """Handle the last state."""

--- a/homeassistant/components/sia/alarm_control_panel.py
+++ b/homeassistant/components/sia/alarm_control_panel.py
@@ -109,7 +109,11 @@ class SIAAlarmControlPanel(SIABaseEntity, AlarmControlPanelEntity):
 
         self._attr_state: StateType = None
         self._old_state: StateType = None
-        self._attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY | AlarmControlPanelEntityFeature.ARM_NIGHT | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+        self._attr_supported_features = (
+                AlarmControlPanelEntityFeature.ARM_AWAY
+                | AlarmControlPanelEntityFeature.ARM_NIGHT
+                | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+        )
 
     def handle_last_state(self, last_state: State | None) -> None:
         """Handle the last state."""

--- a/homeassistant/components/sia/alarm_control_panel.py
+++ b/homeassistant/components/sia/alarm_control_panel.py
@@ -8,8 +8,9 @@ from pysiaalarm import SIAEvent
 
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
-    AlarmControlPanelEntityDescription
-) 
+    AlarmControlPanelEntityDescription,
+    AlarmControlPanelEntityFeature,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
@@ -109,9 +110,9 @@ class SIAAlarmControlPanel(SIABaseEntity, AlarmControlPanelEntity):
         self._attr_state: StateType = None
         self._old_state: StateType = None
         self._attr_supported_features = (
-                AlarmControlPanelEntityFeature.ARM_AWAY
-                | AlarmControlPanelEntityFeature.ARM_NIGHT
-                | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+            AlarmControlPanelEntityFeature.ARM_AWAY
+            | AlarmControlPanelEntityFeature.ARM_NIGHT
+            | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
         )
 
     def handle_last_state(self, last_state: State | None) -> None:

--- a/homeassistant/components/sia/alarm_control_panel.py
+++ b/homeassistant/components/sia/alarm_control_panel.py
@@ -10,6 +10,7 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityDescription,
 )
+from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
@@ -17,7 +18,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
-    STATE_UNAVAILABLE,
+    STATE_UNAVAILABLE
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -108,6 +109,7 @@ class SIAAlarmControlPanel(SIABaseEntity, AlarmControlPanelEntity):
 
         self._attr_state: StateType = None
         self._old_state: StateType = None
+        self._attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY | AlarmControlPanelEntityFeature.ARM_NIGHT | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
 
     def handle_last_state(self, last_state: State | None) -> None:
         """Handle the last state."""

--- a/tests/components/alarm_control_panel/test_device_condition.py
+++ b/tests/components/alarm_control_panel/test_device_condition.py
@@ -114,17 +114,14 @@ async def test_get_conditions(
             {"supported_features": features_state},
         )
     expected_conditions = []
-    basic_condition_types = ["is_disarmed", "is_triggered"]
-    expected_conditions += [
-        {
-            "condition": "device",
-            "domain": DOMAIN,
-            "type": condition,
-            "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
-            "metadata": {"secondary": False},
-        }
-        for condition in basic_condition_types
+    basic_condition_types = [
+        "is_disarmed",
+        "is_triggered",
+        "is_armed_home",
+        "is_armed_away",
+        "is_armed_night",
+        "is_armed_vacation",
+        "is_armed_custom_bypass",
     ]
     expected_conditions += [
         {
@@ -135,7 +132,7 @@ async def test_get_conditions(
             "entity_id": f"{DOMAIN}.test_5678",
             "metadata": {"secondary": False},
         }
-        for condition in expected_condition_types
+        for condition in basic_condition_types
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
@@ -174,6 +171,15 @@ async def test_get_conditions_hidden_auxiliary(
         entity_category=entity_category,
         hidden_by=hidden_by,
     )
+    basic_condition_types = [
+        "is_disarmed",
+        "is_triggered",
+        "is_armed_home",
+        "is_armed_away",
+        "is_armed_night",
+        "is_armed_vacation",
+        "is_armed_custom_bypass",
+    ]
     expected_conditions = [
         {
             "condition": "device",
@@ -183,7 +189,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": f"{DOMAIN}.test_5678",
             "metadata": {"secondary": True},
         }
-        for condition in ["is_disarmed", "is_triggered"]
+        for condition in basic_condition_types
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/alarm_control_panel/test_device_trigger.py
+++ b/tests/components/alarm_control_panel/test_device_trigger.py
@@ -55,7 +55,20 @@ def calls(hass):
 @pytest.mark.parametrize(
     "set_state,features_reg,features_state,expected_trigger_types",
     [
-        (False, 0, 0, ["triggered", "disarmed", "arming"]),
+        (
+            False,
+            0,
+            0,
+            [
+                "triggered",
+                "disarmed",
+                "arming",
+                "armed_home",
+                "armed_away",
+                "armed_night",
+                "armed_vacation",
+            ],
+        ),
         (
             False,
             47,
@@ -70,7 +83,20 @@ def calls(hass):
                 "armed_vacation",
             ],
         ),
-        (True, 0, 0, ["triggered", "disarmed", "arming"]),
+        (
+            True,
+            0,
+            0,
+            [
+                "triggered",
+                "disarmed",
+                "arming",
+                "armed_home",
+                "armed_away",
+                "armed_night",
+                "armed_vacation",
+            ],
+        ),
         (
             True,
             0,
@@ -175,7 +201,15 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": f"{DOMAIN}.test_5678",
             "metadata": {"secondary": True},
         }
-        for trigger in ["triggered", "disarmed", "arming"]
+        for trigger in [
+            "triggered",
+            "disarmed",
+            "arming",
+            "armed_home",
+            "armed_away",
+            "armed_night",
+            "armed_vacation",
+        ]
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -199,7 +233,7 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
-    assert len(triggers) == 6
+    assert len(triggers) == 7
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(
             hass, DeviceAutomationType.TRIGGER, trigger


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alarm_control_panel was using supported features for triggers and conditions, which is not always the case, triggers and conditions are therefore now inclusive of all types of states.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #84279 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
