### PR TITLE
Use UnitOfTime in integrations (a-g)

### DIFF
--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -15,12 +15,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_CUBIC_METER,
     PERCENTAGE,
-    TIME_HOURS,
     UV_INDEX,
     UnitOfLength,
     UnitOfPrecipitationDepth,
     UnitOfSpeed,
     UnitOfTemperature,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -95,7 +95,7 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         key="HoursOfSun",
         icon="mdi:weather-partly-cloudy",
         name="Hours of sun",
-        native_unit_of_measurement=TIME_HOURS,
+        native_unit_of_measurement=UnitOfTime.HOURS,
         value_fn=lambda data, _: cast(float, data),
     ),
     AccuWeatherSensorDescription(

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -10,7 +10,7 @@ from adguardhome import AdGuardHome, AdGuardHomeConnectionError
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, TIME_MILLISECONDS
+from homeassistant.const import PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -83,7 +83,7 @@ SENSORS: tuple[AdGuardHomeEntityDescription, ...] = (
         key="average_speed",
         name="Average processing speed",
         icon="mdi:speedometer",
-        native_unit_of_measurement=TIME_MILLISECONDS,
+        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
         value_fn=lambda adguard: adguard.stats.avg_processing_time(),
     ),
     AdGuardHomeEntityDescription(

--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -26,8 +26,8 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     TEMP_CELSIUS,
-    TIME_SECONDS,
     UnitOfPressure,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -75,7 +75,7 @@ SENSOR_DESCRIPTIONS = {
         key="update_interval",
         name="Update Interval",
         device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         state_class=SensorStateClass.MEASUREMENT,
         # The interval setting is not a generally useful entity for most users.
         entity_registry_enabled_default=False,

--- a/homeassistant/components/atag/sensor.py
+++ b/homeassistant/components/atag/sensor.py
@@ -5,8 +5,8 @@ from homeassistant.const import (
     PERCENTAGE,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
-    TIME_HOURS,
     UnitOfPressure,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -52,7 +52,7 @@ class AtagSensor(AtagEntity, SensorEntity):
             TEMP_CELSIUS,
             TEMP_FAHRENHEIT,
             PERCENTAGE,
-            TIME_HOURS,
+            UnitOfTime.HOURS,
         ):
             self._attr_native_unit_of_measurement = coordinator.data.report[
                 self._id

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TIME_DAYS, UnitOfInformation
+from homeassistant.const import UnitOfInformation, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
@@ -113,13 +113,13 @@ SENSOR_DESCRIPTIONS: tuple[SensorValueEntityDescription, ...] = (
     SensorValueEntityDescription(
         key="daysTotal",
         name="Billing cycle length",
-        native_unit_of_measurement=TIME_DAYS,
+        native_unit_of_measurement=UnitOfTime.DAYS,
         icon="mdi:calendar-range",
     ),
     SensorValueEntityDescription(
         key="daysRemaining",
         name="Billing cycle remaining",
-        native_unit_of_measurement=TIME_DAYS,
+        native_unit_of_measurement=UnitOfTime.DAYS,
         icon="mdi:calendar-clock",
     ),
 )

--- a/homeassistant/components/baf/number.py
+++ b/homeassistant/components/baf/number.py
@@ -13,7 +13,7 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.const import TIME_SECONDS
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -73,7 +73,7 @@ FAN_NUMBER_DESCRIPTIONS = (
         native_min_value=ONE_MIN_SECS,
         native_max_value=HALF_DAY_SECS,
         entity_category=EntityCategory.CONFIG,
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         value_fn=lambda device: cast(Optional[int], device.return_to_auto_timeout),
         mode=NumberMode.SLIDER,
     ),
@@ -83,7 +83,7 @@ FAN_NUMBER_DESCRIPTIONS = (
         native_min_value=ONE_MIN_SECS,
         native_max_value=ONE_DAY_SECS,
         entity_category=EntityCategory.CONFIG,
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         value_fn=lambda device: cast(Optional[int], device.motion_sense_timeout),
         mode=NumberMode.SLIDER,
     ),
@@ -96,7 +96,7 @@ LIGHT_NUMBER_DESCRIPTIONS = (
         native_min_value=ONE_MIN_SECS,
         native_max_value=HALF_DAY_SECS,
         entity_category=EntityCategory.CONFIG,
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         value_fn=lambda device: cast(
             Optional[int], device.light_return_to_auto_timeout
         ),
@@ -108,7 +108,7 @@ LIGHT_NUMBER_DESCRIPTIONS = (
         native_min_value=ONE_MIN_SECS,
         native_max_value=ONE_DAY_SECS,
         entity_category=EntityCategory.CONFIG,
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         value_fn=lambda device: cast(Optional[int], device.light_auto_motion_timeout),
         mode=NumberMode.SLIDER,
     ),

--- a/homeassistant/components/bitcoin/sensor.py
+++ b/homeassistant/components/bitcoin/sensor.py
@@ -12,12 +12,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import (
-    CONF_CURRENCY,
-    CONF_DISPLAY_OPTIONS,
-    TIME_MINUTES,
-    TIME_SECONDS,
-)
+from homeassistant.const import CONF_CURRENCY, CONF_DISPLAY_OPTIONS, UnitOfTime
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -65,7 +60,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="minutes_between_blocks",
         name="Time between Blocks",
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
     SensorEntityDescription(
         key="number_of_transactions",
@@ -74,7 +69,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="hash_rate",
         name="Hash rate",
-        native_unit_of_measurement=f"PH/{TIME_SECONDS}",
+        native_unit_of_measurement=f"PH/{UnitOfTime.SECONDS}",
     ),
     SensorEntityDescription(
         key="timestamp",

--- a/homeassistant/components/bizkaibus/sensor.py
+++ b/homeassistant/components/bizkaibus/sensor.py
@@ -7,7 +7,7 @@ from bizkaibus.bizkaibus import BizkaibusData
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.const import CONF_NAME, TIME_MINUTES
+from homeassistant.const import CONF_NAME, UnitOfTime
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -47,7 +47,7 @@ def setup_platform(
 class BizkaibusSensor(SensorEntity):
     """The class for handling the data."""
 
-    _attr_native_unit_of_measurement = TIME_MINUTES
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
 
     def __init__(self, data, name):
         """Initialize the sensor."""

--- a/homeassistant/components/bthome/sensor.py
+++ b/homeassistant/components/bthome/sensor.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    TIME_SECONDS,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -35,6 +34,7 @@ from homeassistant.const import (
     UnitOfPressure,
     UnitOfSpeed,
     UnitOfTemperature,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
@@ -207,7 +207,7 @@ SENSOR_DESCRIPTIONS = {
     (BTHomeSensorDeviceClass.DURATION, Units.TIME_SECONDS): SensorEntityDescription(
         key=f"{BTHomeSensorDeviceClass.DURATION}_{Units.TIME_SECONDS}",
         device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     # Used for current sensor

--- a/homeassistant/components/comfoconnect/sensor.py
+++ b/homeassistant/components/comfoconnect/sensor.py
@@ -41,10 +41,10 @@ from homeassistant.const import (
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
     TEMP_CELSIUS,
-    TIME_DAYS,
     VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR,
     UnitOfEnergy,
     UnitOfPower,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -232,7 +232,7 @@ SENSOR_TYPES = (
     ComfoconnectSensorEntityDescription(
         key=ATTR_DAYS_TO_REPLACE_FILTER,
         name="Days to replace filter",
-        native_unit_of_measurement=TIME_DAYS,
+        native_unit_of_measurement=UnitOfTime.DAYS,
         icon="mdi:calendar",
         sensor_id=SENSOR_DAYS_TO_REPLACE_FILTER,
     ),

--- a/homeassistant/components/derivative/config_flow.py
+++ b/homeassistant/components/derivative/config_flow.py
@@ -7,14 +7,7 @@ from typing import Any, cast
 import voluptuous as vol
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_SOURCE,
-    TIME_DAYS,
-    TIME_HOURS,
-    TIME_MINUTES,
-    TIME_SECONDS,
-)
+from homeassistant.const import CONF_NAME, CONF_SOURCE, UnitOfTime
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaConfigFlowHandler,
@@ -41,10 +34,10 @@ UNIT_PREFIXES = [
     selector.SelectOptionDict(value="P", label="P (peta)"),
 ]
 TIME_UNITS = [
-    selector.SelectOptionDict(value=TIME_SECONDS, label="Seconds"),
-    selector.SelectOptionDict(value=TIME_MINUTES, label="Minutes"),
-    selector.SelectOptionDict(value=TIME_HOURS, label="Hours"),
-    selector.SelectOptionDict(value=TIME_DAYS, label="Days"),
+    selector.SelectOptionDict(value=UnitOfTime.SECONDS, label="Seconds"),
+    selector.SelectOptionDict(value=UnitOfTime.MINUTES, label="Minutes"),
+    selector.SelectOptionDict(value=UnitOfTime.HOURS, label="Hours"),
+    selector.SelectOptionDict(value=UnitOfTime.DAYS, label="Days"),
 ]
 
 OPTIONS_SCHEMA = vol.Schema(
@@ -61,7 +54,7 @@ OPTIONS_SCHEMA = vol.Schema(
         vol.Required(CONF_UNIT_PREFIX, default="none"): selector.SelectSelector(
             selector.SelectSelectorConfig(options=UNIT_PREFIXES),
         ),
-        vol.Required(CONF_UNIT_TIME, default=TIME_HOURS): selector.SelectSelector(
+        vol.Required(CONF_UNIT_TIME, default=UnitOfTime.HOURS): selector.SelectSelector(
             selector.SelectSelectorConfig(options=TIME_UNITS),
         ),
     }

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -16,10 +16,7 @@ from homeassistant.const import (
     CONF_SOURCE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
-    TIME_DAYS,
-    TIME_HOURS,
-    TIME_MINUTES,
-    TIME_SECONDS,
+    UnitOfTime,
 )
 from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -54,10 +51,10 @@ UNIT_PREFIXES = {
 
 # SI Time prefixes
 UNIT_TIME = {
-    TIME_SECONDS: 1,
-    TIME_MINUTES: 60,
-    TIME_HOURS: 60 * 60,
-    TIME_DAYS: 24 * 60 * 60,
+    UnitOfTime.SECONDS: 1,
+    UnitOfTime.MINUTES: 60,
+    UnitOfTime.HOURS: 60 * 60,
+    UnitOfTime.DAYS: 24 * 60 * 60,
 }
 
 ICON = "mdi:chart-line"
@@ -71,7 +68,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_SOURCE): cv.entity_id,
         vol.Optional(CONF_ROUND_DIGITS, default=DEFAULT_ROUND): vol.Coerce(int),
         vol.Optional(CONF_UNIT_PREFIX, default=None): vol.In(UNIT_PREFIXES),
-        vol.Optional(CONF_UNIT_TIME, default=TIME_HOURS): vol.In(UNIT_TIME),
+        vol.Optional(CONF_UNIT_TIME, default=UnitOfTime.HOURS): vol.In(UNIT_TIME),
         vol.Optional(CONF_UNIT): cv.string,
         vol.Optional(CONF_TIME_WINDOW, default=DEFAULT_TIME_WINDOW): cv.time_period,
     }
@@ -144,7 +141,7 @@ class DerivativeSensor(RestoreEntity, SensorEntity):
         time_window: timedelta,
         unit_of_measurement: str | None,
         unit_prefix: str | None,
-        unit_time: str,
+        unit_time: UnitOfTime,
         unique_id: str | None,
     ) -> None:
         """Initialize the derivative sensor."""

--- a/homeassistant/components/dublin_bus_transport/sensor.py
+++ b/homeassistant/components/dublin_bus_transport/sensor.py
@@ -14,7 +14,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.const import CONF_NAME, TIME_MINUTES
+from homeassistant.const import CONF_NAME, UnitOfTime
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -117,7 +117,7 @@ class DublinPublicTransportSensor(SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the unit this state is expressed in."""
-        return TIME_MINUTES
+        return UnitOfTime.MINUTES
 
     @property
     def icon(self):

--- a/homeassistant/components/ebox/sensor.py
+++ b/homeassistant/components/ebox/sensor.py
@@ -24,8 +24,8 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
     PERCENTAGE,
-    TIME_DAYS,
     UnitOfInformation,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
@@ -69,7 +69,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="days_left",
         name="Days left",
-        native_unit_of_measurement=TIME_DAYS,
+        native_unit_of_measurement=UnitOfTime.DAYS,
         icon="mdi:calendar-today",
     ),
     SensorEntityDescription(

--- a/homeassistant/components/entur_public_transport/sensor.py
+++ b/homeassistant/components/entur_public_transport/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_NAME,
     CONF_SHOW_ON_MAP,
-    TIME_MINUTES,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -190,7 +190,7 @@ class EnturPublicTransportSensor(SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str:
         """Return the unit this state is expressed in."""
-        return TIME_MINUTES
+        return UnitOfTime.MINUTES
 
     @property
     def icon(self) -> str:

--- a/homeassistant/components/fido/sensor.py
+++ b/homeassistant/components/fido/sensor.py
@@ -24,8 +24,8 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_USERNAME,
-    TIME_MINUTES,
     UnitOfInformation,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -135,37 +135,37 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="talk_used",
         name="Talk used",
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         icon="mdi:cellphone",
     ),
     SensorEntityDescription(
         key="talk_limit",
         name="Talk limit",
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         icon="mdi:cellphone",
     ),
     SensorEntityDescription(
         key="talk_remaining",
         name="Talk remaining",
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         icon="mdi:cellphone",
     ),
     SensorEntityDescription(
         key="other_talk_used",
         name="Other Talk used",
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         icon="mdi:cellphone",
     ),
     SensorEntityDescription(
         key="other_talk_limit",
         name="Other Talk limit",
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         icon="mdi:cellphone",
     ),
     SensorEntityDescription(
         key="other_talk_remaining",
         name="Other Talk remaining",
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         icon="mdi:cellphone",
     ),
 )

--- a/homeassistant/components/fjaraskupan/number.py
+++ b/homeassistant/components/fjaraskupan/number.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TIME_MINUTES
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -36,7 +36,7 @@ class PeriodicVentingTime(CoordinatorEntity[Coordinator], NumberEntity):
     _attr_native_min_value: float = 0
     _attr_native_step: float = 1
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_native_unit_of_measurement = TIME_MINUTES
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
 
     def __init__(
         self,

--- a/homeassistant/components/fully_kiosk/number.py
+++ b/homeassistant/components/fully_kiosk/number.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TIME_SECONDS
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -21,7 +21,7 @@ ENTITY_TYPES: tuple[NumberEntityDescription, ...] = (
         native_max_value=9999,
         native_step=1,
         native_min_value=0,
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         entity_category=EntityCategory.CONFIG,
     ),
     NumberEntityDescription(
@@ -38,7 +38,7 @@ ENTITY_TYPES: tuple[NumberEntityDescription, ...] = (
         native_max_value=9999,
         native_step=1,
         native_min_value=0,
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         entity_category=EntityCategory.CONFIG,
     ),
     NumberEntityDescription(

--- a/homeassistant/components/goalzero/sensor.py
+++ b/homeassistant/components/goalzero/sensor.py
@@ -14,12 +14,11 @@ from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS,
     TEMP_CELSIUS,
-    TIME_MINUTES,
-    TIME_SECONDS,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfPower,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
@@ -92,7 +91,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="timeToEmptyFull",
         name="Time to empty/full",
         device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
     SensorEntityDescription(
         key="temperature",
@@ -112,7 +111,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="timestamp",
         name="Total run time",
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),

--- a/homeassistant/components/google_travel_time/sensor.py
+++ b/homeassistant/components/google_travel_time/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     CONF_API_KEY,
     CONF_NAME,
     EVENT_HOMEASSISTANT_STARTED,
-    TIME_MINUTES,
+    UnitOfTime,
 )
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -76,7 +76,7 @@ class GoogleTravelTimeSensor(SensorEntity):
         """Initialize the sensor."""
         self._name = name
         self._config_entry = config_entry
-        self._unit_of_measurement = TIME_MINUTES
+        self._unit_of_measurement = UnitOfTime.MINUTES
         self._matrix = None
         self._api_key = api_key
         self._unique_id = config_entry.entry_id

--- a/homeassistant/components/google_wifi/sensor.py
+++ b/homeassistant/components/google_wifi/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_MONITORED_CONDITIONS,
     CONF_NAME,
     STATE_UNKNOWN,
-    TIME_DAYS,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -75,7 +75,7 @@ SENSOR_TYPES: tuple[GoogleWifiSensorEntityDescription, ...] = (
         key=ATTR_UPTIME,
         primary_key="system",
         sensor_key="uptime",
-        native_unit_of_measurement=TIME_DAYS,
+        native_unit_of_measurement=UnitOfTime.DAYS,
         icon="mdi:timelapse",
     ),
     GoogleWifiSensorEntityDescription(

--- a/homeassistant/components/greeneye_monitor/__init__.py
+++ b/homeassistant/components/greeneye_monitor/__init__.py
@@ -65,7 +65,7 @@ PULSE_COUNTER_SCHEMA = vol.Schema(
         vol.Required(CONF_COUNTED_QUANTITY): cv.string,
         vol.Optional(CONF_COUNTED_QUANTITY_PER_PULSE, default=1.0): vol.Coerce(float),
         vol.Optional(CONF_TIME_UNIT, default=UnitOfTime.SECONDS): vol.Any(
-            UnitOfTime.SECONDS, UnitOfTime.MINUTES, UnitOfTime.HOURS
+            UnitOfTime.SECONDS.value, UnitOfTime.MINUTES.value, UnitOfTime.HOURS.value
         ),
     }
 )

--- a/homeassistant/components/greeneye_monitor/__init__.py
+++ b/homeassistant/components/greeneye_monitor/__init__.py
@@ -12,10 +12,8 @@ from homeassistant.const import (
     CONF_SENSORS,
     CONF_TEMPERATURE_UNIT,
     EVENT_HOMEASSISTANT_STOP,
-    TIME_HOURS,
-    TIME_MINUTES,
-    TIME_SECONDS,
     Platform,
+    UnitOfTime,
 )
 from homeassistant.core import Event, HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -66,8 +64,8 @@ PULSE_COUNTER_SCHEMA = vol.Schema(
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_COUNTED_QUANTITY): cv.string,
         vol.Optional(CONF_COUNTED_QUANTITY_PER_PULSE, default=1.0): vol.Coerce(float),
-        vol.Optional(CONF_TIME_UNIT, default=TIME_SECONDS): vol.Any(
-            TIME_SECONDS, TIME_MINUTES, TIME_HOURS
+        vol.Optional(CONF_TIME_UNIT, default=UnitOfTime.SECONDS): vol.Any(
+            UnitOfTime.SECONDS, UnitOfTime.MINUTES, UnitOfTime.HOURS
         ),
     }
 )

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -10,11 +10,9 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_SENSORS,
     CONF_TEMPERATURE_UNIT,
-    TIME_HOURS,
-    TIME_MINUTES,
-    TIME_SECONDS,
     UnitOfElectricPotential,
     UnitOfPower,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -233,16 +231,16 @@ class PulseCounter(GEMSensor):
     @property
     def _seconds_per_time_unit(self) -> int:
         """Return the number of seconds in the given display time unit."""
-        if self._time_unit == TIME_SECONDS:
+        if self._time_unit == UnitOfTime.SECONDS:
             return 1
-        if self._time_unit == TIME_MINUTES:
+        if self._time_unit == UnitOfTime.MINUTES:
             return 60
-        if self._time_unit == TIME_HOURS:
+        if self._time_unit == UnitOfTime.HOURS:
             return 3600
 
         # Config schema should have ensured it is one of the above values
         raise Exception(
-            f"Invalid value for time unit: {self._time_unit}. Expected one of {TIME_SECONDS}, {TIME_MINUTES}, or {TIME_HOURS}"
+            f"Invalid value for time unit: {self._time_unit}. Expected one of {UnitOfTime.SECONDS}, {UnitOfTime.MINUTES}, or {UnitOfTime.HOURS}"
         )
 
     @property

--- a/homeassistant/components/guardian/sensor.py
+++ b/homeassistant/components/guardian/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_FAHRENHEIT, TIME_MINUTES, UnitOfElectricPotential
+from homeassistant.const import TEMP_FAHRENHEIT, UnitOfElectricPotential, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
@@ -72,7 +72,7 @@ VALVE_CONTROLLER_DESCRIPTIONS = (
         name="Uptime",
         icon="mdi:timer",
         entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         api_category=API_SYSTEM_DIAGNOSTICS,
     ),
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use UnitOfTime in integrations (a-g)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
