### PR TITLE
Remove scan_interval and manual options from speedtestdotnet

### DIFF
--- a/homeassistant/components/speedtestdotnet/__init__.py
+++ b/homeassistant/components/speedtestdotnet/__init__.py
@@ -1,21 +1,16 @@
 """Support for testing internet speed via Speedtest.net."""
 from __future__ import annotations
 
-from datetime import timedelta
 from functools import partial
 
 import speedtest
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_SCAN_INTERVAL,
-    EVENT_HOMEASSISTANT_STARTED,
-    Platform,
-)
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import CONF_MANUAL, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import DOMAIN
 from .coordinator import SpeedTestDataCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -32,31 +27,21 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     except speedtest.SpeedtestException as err:
         raise ConfigEntryNotReady from err
 
-    async def _enable_scheduled_speedtests(event: Event | None = None) -> None:
-        """Activate the data update coordinator."""
-        coordinator.update_interval = timedelta(
-            minutes=config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-        )
-        await coordinator.async_refresh()
+    async def _request_refresh(event: Event) -> None:
+        """Request a refresh."""
+        await coordinator.async_request_refresh()
 
-    if not config_entry.options.get(CONF_MANUAL, False):
-        if hass.state == CoreState.running:
-            await _enable_scheduled_speedtests()
-        else:
-            # Running a speed test during startup can prevent
-            # integrations from being able to setup because it
-            # can saturate the network interface.
-            hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_STARTED, _enable_scheduled_speedtests
-            )
+    if hass.state == CoreState.running:
+        await coordinator.async_config_entry_first_refresh()
+    else:
+        # Running a speed test during startup can prevent
+        # integrations from being able to setup because it
+        # can saturate the network interface.
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _request_refresh)
 
     hass.data[DOMAIN] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-
-    config_entry.async_on_unload(
-        config_entry.add_update_listener(options_updated_listener)
-    )
 
     return True
 
@@ -68,14 +53,3 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     ):
         hass.data.pop(DOMAIN)
     return unload_ok
-
-
-async def options_updated_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle options update."""
-    coordinator: SpeedTestDataCoordinator = hass.data[DOMAIN]
-    if entry.options[CONF_MANUAL]:
-        coordinator.update_interval = None
-        return
-
-    coordinator.update_interval = timedelta(minutes=entry.options[CONF_SCAN_INTERVAL])
-    await coordinator.async_request_refresh()

--- a/homeassistant/components/speedtestdotnet/config_flow.py
+++ b/homeassistant/components/speedtestdotnet/config_flow.py
@@ -6,16 +6,13 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
-    CONF_MANUAL,
     CONF_SERVER_ID,
     CONF_SERVER_NAME,
     DEFAULT_NAME,
-    DEFAULT_SCAN_INTERVAL,
     DEFAULT_SERVER,
     DOMAIN,
 )
@@ -78,15 +75,6 @@ class SpeedTestOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_SERVER_NAME,
                 default=self.config_entry.options.get(CONF_SERVER_NAME, DEFAULT_SERVER),
             ): vol.In(self._servers.keys()),
-            vol.Optional(
-                CONF_SCAN_INTERVAL,
-                default=self.config_entry.options.get(
-                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                ),
-            ): int,
-            vol.Optional(
-                CONF_MANUAL, default=self.config_entry.options.get(CONF_MANUAL, False)
-            ): bool,
         }
 
         return self.async_show_form(

--- a/homeassistant/components/speedtestdotnet/const.py
+++ b/homeassistant/components/speedtestdotnet/const.py
@@ -7,7 +7,6 @@ DOMAIN: Final = "speedtestdotnet"
 
 CONF_SERVER_NAME: Final = "server_name"
 CONF_SERVER_ID: Final = "server_id"
-CONF_MANUAL: Final = "manual"
 
 ATTR_BYTES_RECEIVED: Final = "bytes_received"
 ATTR_BYTES_SENT: Final = "bytes_sent"

--- a/homeassistant/components/speedtestdotnet/coordinator.py
+++ b/homeassistant/components/speedtestdotnet/coordinator.py
@@ -1,5 +1,6 @@
 """Coordinator for speedtestdotnet."""
 
+from datetime import timedelta
 import logging
 from typing import Any
 
@@ -9,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_SERVER_ID, DEFAULT_SERVER, DOMAIN
+from .const import CONF_SERVER_ID, DEFAULT_SCAN_INTERVAL, DEFAULT_SERVER, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.hass,
             _LOGGER,
             name=DOMAIN,
+            update_interval=timedelta(minutes=DEFAULT_SCAN_INTERVAL),
         )
 
     def update_servers(self) -> None:

--- a/homeassistant/components/speedtestdotnet/strings.json
+++ b/homeassistant/components/speedtestdotnet/strings.json
@@ -13,8 +13,6 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "Update frequency (minutes)",
-          "manual": "Disable auto update",
           "server_name": "Select test server"
         }
       }

--- a/homeassistant/components/speedtestdotnet/translations/en.json
+++ b/homeassistant/components/speedtestdotnet/translations/en.json
@@ -13,8 +13,6 @@
         "step": {
             "init": {
                 "data": {
-                    "manual": "Disable auto update",
-                    "scan_interval": "Update frequency (minutes)",
                     "server_name": "Select test server"
                 }
             }

--- a/tests/components/speedtestdotnet/test_config_flow.py
+++ b/tests/components/speedtestdotnet/test_config_flow.py
@@ -1,17 +1,15 @@
 """Tests for SpeedTest config flow."""
-from datetime import timedelta
 from unittest.mock import MagicMock
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import speedtestdotnet
 from homeassistant.components.speedtestdotnet.const import (
-    CONF_MANUAL,
     CONF_SERVER_ID,
     CONF_SERVER_NAME,
     DOMAIN,
 )
-from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
@@ -21,13 +19,13 @@ async def test_flow_works(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         speedtestdotnet.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
 async def test_options(hass: HomeAssistant, mock_api: MagicMock) -> None:
@@ -42,67 +40,40 @@ async def test_options(hass: HomeAssistant, mock_api: MagicMock) -> None:
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
             CONF_SERVER_NAME: "Country1 - Sponsor1 - Server1",
-            CONF_SCAN_INTERVAL: 30,
-            CONF_MANUAL: True,
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_SERVER_NAME: "Country1 - Sponsor1 - Server1",
         CONF_SERVER_ID: "1",
-        CONF_SCAN_INTERVAL: 30,
-        CONF_MANUAL: True,
     }
     await hass.async_block_till_done()
 
-    assert hass.data[DOMAIN].update_interval is None
-
     # test setting server name to "*Auto Detect"
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
             CONF_SERVER_NAME: "*Auto Detect",
-            CONF_SCAN_INTERVAL: 30,
-            CONF_MANUAL: True,
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_SERVER_NAME: "*Auto Detect",
         CONF_SERVER_ID: None,
-        CONF_SCAN_INTERVAL: 30,
-        CONF_MANUAL: True,
     }
-
-    # test setting the option to update periodically
-    result2 = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
-    assert result2["step_id"] == "init"
-
-    result2 = await hass.config_entries.options.async_configure(
-        result2["flow_id"],
-        user_input={
-            CONF_SERVER_NAME: "Country1 - Sponsor1 - Server1",
-            CONF_SCAN_INTERVAL: 30,
-            CONF_MANUAL: False,
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert hass.data[DOMAIN].update_interval == timedelta(minutes=30)
 
 
 async def test_integration_already_configured(hass: HomeAssistant) -> None:
@@ -114,5 +85,5 @@ async def test_integration_already_configured(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         speedtestdotnet.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/speedtestdotnet/test_init.py
+++ b/tests/components/speedtestdotnet/test_init.py
@@ -6,13 +6,12 @@ from unittest.mock import MagicMock
 import speedtest
 
 from homeassistant.components.speedtestdotnet.const import (
-    CONF_MANUAL,
     CONF_SERVER_ID,
     CONF_SERVER_NAME,
     DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_SCAN_INTERVAL, STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
@@ -28,8 +27,6 @@ async def test_successful_config_entry(hass: HomeAssistant) -> None:
         options={
             CONF_SERVER_NAME: "Country1 - Sponsor1 - Server1",
             CONF_SERVER_ID: "1",
-            CONF_SCAN_INTERVAL: 30,
-            CONF_MANUAL: False,
         },
     )
     entry.add_to_hass(hass)
@@ -75,10 +72,7 @@ async def test_server_not_found(hass: HomeAssistant, mock_api: MagicMock) -> Non
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        options={
-            CONF_MANUAL: False,
-            CONF_SCAN_INTERVAL: 60,
-        },
+        options={},
     )
     entry.add_to_hass(hass)
 
@@ -89,7 +83,7 @@ async def test_server_not_found(hass: HomeAssistant, mock_api: MagicMock) -> Non
     mock_api.return_value.get_servers.side_effect = speedtest.NoMatchedServers
     async_fire_time_changed(
         hass,
-        dt_util.utcnow() + timedelta(minutes=entry.options[CONF_SCAN_INTERVAL] + 1),
+        dt_util.utcnow() + timedelta(minutes=61),
     )
     await hass.async_block_till_done()
     state = hass.states.get("sensor.speedtest_ping")

--- a/tests/components/speedtestdotnet/test_sensor.py
+++ b/tests/components/speedtestdotnet/test_sensor.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.speedtestdotnet import DOMAIN
-from homeassistant.components.speedtestdotnet.const import CONF_MANUAL, DEFAULT_NAME
+from homeassistant.components.speedtestdotnet.const import DEFAULT_NAME
 from homeassistant.components.speedtestdotnet.sensor import SENSOR_TYPES
 from homeassistant.core import HomeAssistant, State
 
@@ -42,7 +42,7 @@ async def test_restore_last_state(hass: HomeAssistant, mock_api: MagicMock) -> N
             for sensor, state in MOCK_STATES.items()
         ],
     )
-    entry = MockConfigEntry(domain=DOMAIN, data={}, options={CONF_MANUAL: True})
+    entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This PR removes the scan_interval and manual options. The default update_interval is 60 minutes and users can disable polling update from system options. They can also use the `update_entity` service for custom update intervals.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Remove the scan_interval and manual options. 
- Set the default update_interval to 60 minutes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
