### PR TITLE
Mark RuuviTag devices not connectable

### DIFF
--- a/homeassistant/components/ruuvitag_ble/manifest.json
+++ b/homeassistant/components/ruuvitag_ble/manifest.json
@@ -5,10 +5,12 @@
   "documentation": "https://www.home-assistant.io/integrations/ruuvitag_ble",
   "bluetooth": [
     {
-      "manufacturer_id": 1177
+      "manufacturer_id": 1177,
+      "connectable": false
     },
     {
-      "local_name": "Ruuvi *"
+      "local_name": "Ruuvi *",
+      "connectable": false
     }
   ],
   "requirements": ["ruuvitag-ble==0.1.1"],

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -265,10 +265,12 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
         "service_data_uuid": "0000fdcd-0000-1000-8000-00805f9b34fb",
     },
     {
+        "connectable": False,
         "domain": "ruuvitag_ble",
         "manufacturer_id": 1177,
     },
     {
+        "connectable": False,
         "domain": "ruuvitag_ble",
         "local_name": "Ruuvi *",
     },


### PR DESCRIPTION
## Proposed change

RuuviTag devices just emit BLE advertisements and aren't connected to by HA, so mark them as such (as per #77132).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
  - After fixing https://github.com/hbldh/bleak/issues/761#issuecomment-1036437107 the Ruuvitag devices still show up just fine in HA 👍  
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
