### PR TITLE
Fix title of Matter integration

### DIFF
--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -34,7 +34,7 @@ from .const import (
 ADDON_SETUP_TIMEOUT = 5
 ADDON_SETUP_TIMEOUT_ROUNDS = 40
 DEFAULT_URL = "ws://localhost:5580/ws"
-DEFAULT_TITLE = ""  # empty string = same name as integration
+DEFAULT_TITLE = "Matter"
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
 
 

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -34,6 +34,7 @@ from .const import (
 ADDON_SETUP_TIMEOUT = 5
 ADDON_SETUP_TIMEOUT_ROUNDS = 40
 DEFAULT_URL = "ws://localhost:5580/ws"
+DEFAULT_TITLE = ""  # empty string = same name as integration
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
 
 
@@ -306,7 +307,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_USE_ADDON: self.use_addon,
                     CONF_INTEGRATION_CREATED_ADDON: self.integration_created_addon,
                 },
-                title=self.ws_address,
+                title=DEFAULT_TITLE,
             )
             await self.hass.config_entries.async_reload(config_entry.entry_id)
             raise AbortFlow("reconfiguration_successful")
@@ -316,7 +317,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.hass.config_entries.flow.async_abort(progress["flow_id"])
 
         return self.async_create_entry(
-            title=self.ws_address,
+            title=DEFAULT_TITLE,
             data={
                 CONF_URL: self.ws_address,
                 CONF_USE_ADDON: self.use_addon,

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -172,6 +172,7 @@ async def test_manual_already_configured(
     assert entry.data["url"] == "ws://localhost:5580/ws"
     assert entry.data["use_addon"] is False
     assert entry.data["integration_created_addon"] is False
+    assert entry.title == "Matter"
     assert setup_entry.call_count == 1
 
 

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -99,7 +99,7 @@ async def test_manual_create_entry(
 
     assert client_connect.call_count == 1
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "ws://localhost:5580/ws"
+    assert result["title"] == "Matter"
     assert result["data"] == {
         "url": "ws://localhost:5580/ws",
         "integration_created_addon": False,
@@ -172,7 +172,6 @@ async def test_manual_already_configured(
     assert entry.data["url"] == "ws://localhost:5580/ws"
     assert entry.data["use_addon"] is False
     assert entry.data["integration_created_addon"] is False
-    assert entry.title == "ws://localhost:5580/ws"
     assert setup_entry.call_count == 1
 
 
@@ -202,7 +201,7 @@ async def test_supervisor_discovery(
     assert addon_info.call_count == 1
     assert client_connect.call_count == 0
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "ws://host1:5581/ws"
+    assert result["title"] == "Matter"
     assert result["data"] == {
         "url": "ws://host1:5581/ws",
         "use_addon": True,
@@ -294,7 +293,7 @@ async def test_clean_supervisor_discovery_on_user_create(
     assert len(hass.config_entries.flow.async_progress()) == 0
     assert client_connect.call_count == 1
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "ws://localhost:5580/ws"
+    assert result["title"] == "Matter"
     assert result["data"] == {
         "url": "ws://localhost:5580/ws",
         "use_addon": False,
@@ -313,7 +312,7 @@ async def test_abort_supervisor_discovery_with_existing_entry(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"url": "ws://localhost:5580/ws"},
-        title="ws://localhost:5580/ws",
+        title="Matter",
     )
     entry.add_to_hass(hass)
 
@@ -424,7 +423,7 @@ async def test_supervisor_discovery_addon_not_running(
     assert start_addon.call_args == call(hass, "core_matter_server")
     assert client_connect.call_count == 1
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "ws://host1:5581/ws"
+    assert result["title"] == "Matter"
     assert result["data"] == {
         "url": "ws://host1:5581/ws",
         "use_addon": True,
@@ -481,7 +480,7 @@ async def test_supervisor_discovery_addon_not_installed(
     assert start_addon.call_args == call(hass, "core_matter_server")
     assert client_connect.call_count == 1
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "ws://host1:5581/ws"
+    assert result["title"] == "Matter"
     assert result["data"] == {
         "url": "ws://host1:5581/ws",
         "use_addon": True,
@@ -521,7 +520,7 @@ async def test_not_addon(
 
     assert client_connect.call_count == 1
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "ws://localhost:5581/ws"
+    assert result["title"] == "Matter"
     assert result["data"] == {
         "url": "ws://localhost:5581/ws",
         "use_addon": False,
@@ -555,7 +554,7 @@ async def test_addon_running(
     assert addon_info.call_count == 1
     assert client_connect.call_count == 1
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "ws://host1:5581/ws"
+    assert result["title"] == "Matter"
     assert result["data"] == {
         "url": "ws://host1:5581/ws",
         "use_addon": True,
@@ -656,7 +655,7 @@ async def test_addon_running_already_configured(
         data={
             "url": "ws://localhost:5580/ws",
         },
-        title="ws://localhost:5580/ws",
+        title="Matter",
     )
     entry.add_to_hass(hass)
 
@@ -676,7 +675,7 @@ async def test_addon_running_already_configured(
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reconfiguration_successful"
     assert entry.data["url"] == "ws://host1:5581/ws"
-    assert entry.title == "ws://host1:5581/ws"
+    assert entry.title == "Matter"
     assert setup_entry.call_count == 1
 
 
@@ -711,7 +710,7 @@ async def test_addon_installed(
 
     assert start_addon.call_args == call(hass, "core_matter_server")
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "ws://host1:5581/ws"
+    assert result["title"] == "Matter"
     assert result["data"] == {
         "url": "ws://host1:5581/ws",
         "use_addon": True,
@@ -804,7 +803,7 @@ async def test_addon_installed_already_configured(
         data={
             "url": "ws://localhost:5580/ws",
         },
-        title="ws://localhost:5580/ws",
+        title="Matter",
     )
     entry.add_to_hass(hass)
 
@@ -831,7 +830,7 @@ async def test_addon_installed_already_configured(
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reconfiguration_successful"
     assert entry.data["url"] == "ws://host1:5581/ws"
-    assert entry.title == "ws://host1:5581/ws"
+    assert entry.title == "Matter"
     assert setup_entry.call_count == 1
 
 
@@ -877,7 +876,7 @@ async def test_addon_not_installed(
 
     assert start_addon.call_args == call(hass, "core_matter_server")
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "ws://host1:5581/ws"
+    assert result["title"] == "Matter"
     assert result["data"] == {
         "url": "ws://host1:5581/ws",
         "use_addon": True,
@@ -938,7 +937,7 @@ async def test_addon_not_installed_already_configured(
         data={
             "url": "ws://localhost:5580/ws",
         },
-        title="ws://localhost:5580/ws",
+        title="Matter",
     )
     entry.add_to_hass(hass)
 
@@ -975,5 +974,5 @@ async def test_addon_not_installed_already_configured(
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reconfiguration_successful"
     assert entry.data["url"] == "ws://host1:5581/ws"
-    assert entry.title == "ws://host1:5581/ws"
+    assert entry.title == "Matter"
     assert setup_entry.call_count == 1


### PR DESCRIPTION
## Proposed change
The title of the Matter integration is currently set to the websocket address, this looks a bit weird.
Set the title to an empty string will make sure the frontend will just show the integration name instead.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
