### PR TITLE
Move Rainbird to async client library

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1033,7 +1033,6 @@ omit =
     homeassistant/components/radiotherm/entity.py
     homeassistant/components/radiotherm/switch.py
     homeassistant/components/radiotherm/util.py
-    homeassistant/components/rainbird/*
     homeassistant/components/raincloud/*
     homeassistant/components/rainmachine/__init__.py
     homeassistant/components/rainmachine/binary_sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -926,6 +926,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/radiotherm/ @bdraco @vinnyfuria
 /tests/components/radiotherm/ @bdraco @vinnyfuria
 /homeassistant/components/rainbird/ @konikvranik @allenporter
+/tests/components/rainbird/ @konikvranik @allenporter
 /homeassistant/components/raincloud/ @vanstinator
 /homeassistant/components/rainforest_eagle/ @gtdiehl @jcalbert @hastarin
 /tests/components/rainforest_eagle/ @gtdiehl @jcalbert @hastarin

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -11,8 +11,6 @@ from pyrainbird.async_client import (
 )
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorEntityDescription
-from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.const import (
     CONF_FRIENDLY_NAME,
     CONF_HOST,
@@ -26,47 +24,20 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
+from .const import (
+    CONF_ZONES,
+    RAINBIRD_CONTROLLER,
+    SENSOR_TYPE_RAINDELAY,
+    SENSOR_TYPE_RAINSENSOR,
+)
 from .coordinator import RainbirdUpdateCoordinator
-
-CONF_ZONES = "zones"
 
 PLATFORMS = [Platform.SWITCH, Platform.SENSOR, Platform.BINARY_SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
-RAINBIRD_CONTROLLER = "controller"
 DATA_RAINBIRD = "rainbird"
 DOMAIN = "rainbird"
-
-SENSOR_TYPE_RAINDELAY = "raindelay"
-SENSOR_TYPE_RAINSENSOR = "rainsensor"
-
-
-SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
-        key=SENSOR_TYPE_RAINSENSOR,
-        name="Rainsensor",
-        icon="mdi:water",
-    ),
-    SensorEntityDescription(
-        key=SENSOR_TYPE_RAINDELAY,
-        name="Raindelay",
-        icon="mdi:water-off",
-    ),
-)
-
-BINARY_SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
-    BinarySensorEntityDescription(
-        key=SENSOR_TYPE_RAINSENSOR,
-        name="Rainsensor",
-        icon="mdi:water",
-    ),
-    BinarySensorEntityDescription(
-        key=SENSOR_TYPE_RAINDELAY,
-        name="Raindelay",
-        icon="mdi:water-off",
-    ),
-)
 
 TRIGGER_TIME_SCHEMA = vol.All(
     cv.time_period, cv.positive_timedelta, lambda td: (td.total_seconds() // 60)

--- a/homeassistant/components/rainbird/binary_sensor.py
+++ b/homeassistant/components/rainbird/binary_sensor.py
@@ -15,9 +15,23 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from . import BINARY_SENSOR_TYPES
+from .const import SENSOR_TYPE_RAINDELAY, SENSOR_TYPE_RAINSENSOR
 
 _LOGGER = logging.getLogger(__name__)
+
+
+BINARY_SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
+    BinarySensorEntityDescription(
+        key=SENSOR_TYPE_RAINSENSOR,
+        name="Rainsensor",
+        icon="mdi:water",
+    ),
+    BinarySensorEntityDescription(
+        key=SENSOR_TYPE_RAINDELAY,
+        name="Raindelay",
+        icon="mdi:water-off",
+    ),
+)
 
 
 async def async_setup_platform(

--- a/homeassistant/components/rainbird/binary_sensor.py
+++ b/homeassistant/components/rainbird/binary_sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from pyrainbird import RainbirdController
+from pyrainbird.async_client import AsyncRainbirdController
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -49,19 +49,19 @@ class RainBirdSensor(BinarySensorEntity):
 
     def __init__(
         self,
-        controller: RainbirdController,
+        controller: AsyncRainbirdController,
         description: BinarySensorEntityDescription,
     ) -> None:
         """Initialize the Rain Bird sensor."""
         self.entity_description = description
         self._controller = controller
 
-    def update(self) -> None:
+    async def async_update(self) -> None:
         """Get the latest data and updates the states."""
         _LOGGER.debug("Updating sensor: %s", self.name)
         state = None
         if self.entity_description.key == SENSOR_TYPE_RAINSENSOR:
-            state = self._controller.get_rain_sensor_state()
+            state = await self._controller.get_rain_sensor_state()
         elif self.entity_description.key == SENSOR_TYPE_RAINDELAY:
-            state = self._controller.get_rain_delay()
+            state = await self._controller.get_rain_delay()
         self._attr_is_on = None if state is None else bool(state)

--- a/homeassistant/components/rainbird/binary_sensor.py
+++ b/homeassistant/components/rainbird/binary_sensor.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 import logging
 
-from pyrainbird.async_client import AsyncRainbirdController
-
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
@@ -12,56 +10,48 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-
-from . import (
-    BINARY_SENSOR_TYPES,
-    DATA_RAINBIRD,
-    RAINBIRD_CONTROLLER,
-    SENSOR_TYPE_RAINDELAY,
-    SENSOR_TYPE_RAINSENSOR,
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
 )
+
+from . import BINARY_SENSOR_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up a Rain Bird sensor."""
     if discovery_info is None:
         return
 
-    controller = hass.data[DATA_RAINBIRD][discovery_info[RAINBIRD_CONTROLLER]]
-    add_entities(
+    async_add_entities(
         [
-            RainBirdSensor(controller, description)
+            RainBirdSensor(discovery_info[description.key], description)
             for description in BINARY_SENSOR_TYPES
         ],
         True,
     )
 
 
-class RainBirdSensor(BinarySensorEntity):
+class RainBirdSensor(CoordinatorEntity, BinarySensorEntity):
     """A sensor implementation for Rain Bird device."""
 
     def __init__(
         self,
-        controller: AsyncRainbirdController,
+        coordinator: DataUpdateCoordinator,
         description: BinarySensorEntityDescription,
     ) -> None:
         """Initialize the Rain Bird sensor."""
+        super().__init__(coordinator)
         self.entity_description = description
-        self._controller = controller
 
-    async def async_update(self) -> None:
-        """Get the latest data and updates the states."""
-        _LOGGER.debug("Updating sensor: %s", self.name)
-        state = None
-        if self.entity_description.key == SENSOR_TYPE_RAINSENSOR:
-            state = await self._controller.get_rain_sensor_state()
-        elif self.entity_description.key == SENSOR_TYPE_RAINDELAY:
-            state = await self._controller.get_rain_delay()
-        self._attr_is_on = None if state is None else bool(state)
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if entity is on."""
+        return None if self.coordinator.data is None else bool(self.coordinator.data)

--- a/homeassistant/components/rainbird/const.py
+++ b/homeassistant/components/rainbird/const.py
@@ -1,0 +1,10 @@
+"""Constants for rainbird."""
+
+DOMAIN = "rainbird"
+
+SENSOR_TYPE_RAINDELAY = "raindelay"
+SENSOR_TYPE_RAINSENSOR = "rainsensor"
+
+RAINBIRD_CONTROLLER = "controller"
+
+CONF_ZONES = "zones"

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -1,0 +1,47 @@
+"""Update coordinators for rainbird."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import datetime
+import logging
+from typing import TypeVar
+
+import async_timeout
+from pyrainbird.async_client import RainbirdApiException
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+TIMEOUT_SECONDS = 20
+UPDATE_INTERVAL = datetime.timedelta(minutes=1)
+
+_LOGGER = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+
+class RainbirdUpdateCoordinator(DataUpdateCoordinator[_T]):
+    """Coordinator for rainbird API calls."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        update_method: Callable[[], Awaitable[_T]],
+    ) -> None:
+        """Initialize ZoneStateUpdateCoordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Rainbird Zones",
+            update_method=update_method,
+            update_interval=UPDATE_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> _T:
+        """Fetch data from API endpoint."""
+        try:
+            async with async_timeout.timeout(TIMEOUT_SECONDS):
+                return await self.update_method()  # type: ignore[misc]
+        except RainbirdApiException as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err

--- a/homeassistant/components/rainbird/sensor.py
+++ b/homeassistant/components/rainbird/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from pyrainbird import RainbirdController
+from pyrainbird.async_client import AsyncRainbirdController
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.core import HomeAssistant
@@ -44,17 +44,17 @@ class RainBirdSensor(SensorEntity):
 
     def __init__(
         self,
-        controller: RainbirdController,
+        controller: AsyncRainbirdController,
         description: SensorEntityDescription,
     ) -> None:
         """Initialize the Rain Bird sensor."""
         self.entity_description = description
         self._controller = controller
 
-    def update(self) -> None:
+    async def async_update(self) -> None:
         """Get the latest data and updates the states."""
         _LOGGER.debug("Updating sensor: %s", self.name)
         if self.entity_description.key == SENSOR_TYPE_RAINSENSOR:
-            self._attr_native_value = self._controller.get_rain_sensor_state()
+            self._attr_native_value = await self._controller.get_rain_sensor_state()
         elif self.entity_description.key == SENSOR_TYPE_RAINDELAY:
-            self._attr_native_value = self._controller.get_rain_delay()
+            self._attr_native_value = await self._controller.get_rain_delay()

--- a/homeassistant/components/rainbird/sensor.py
+++ b/homeassistant/components/rainbird/sensor.py
@@ -12,9 +12,23 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from . import SENSOR_TYPES
+from .const import SENSOR_TYPE_RAINDELAY, SENSOR_TYPE_RAINSENSOR
 
 _LOGGER = logging.getLogger(__name__)
+
+
+SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key=SENSOR_TYPE_RAINSENSOR,
+        name="Rainsensor",
+        icon="mdi:water",
+    ),
+    SensorEntityDescription(
+        key=SENSOR_TYPE_RAINDELAY,
+        name="Raindelay",
+        icon="mdi:water-off",
+    ),
+)
 
 
 async def async_setup_platform(

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -82,7 +82,6 @@ async def async_setup_platform(
     except ConfigEntryNotReady as err:
         raise PlatformNotReady(f"Failed to load zone state: {str(err)}") from err
 
-    # async_add_entities(devices, True)
     async_add_entities(devices)
 
     async def start_irrigation(service: ServiceCall) -> None:

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -5,6 +5,7 @@ import logging
 
 from pyrainbird import AvailableStations
 from pyrainbird.async_client import AsyncRainbirdController, RainbirdApiException
+from pyrainbird.data import States
 import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity
@@ -16,7 +17,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import CONF_ZONES, DOMAIN, RAINBIRD_CONTROLLER
+from .const import CONF_ZONES, DOMAIN, RAINBIRD_CONTROLLER
 from .coordinator import RainbirdUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -117,7 +118,7 @@ class RainBirdSwitch(CoordinatorEntity, SwitchEntity):
 
     def __init__(
         self,
-        coordinator: RainbirdUpdateCoordinator,
+        coordinator: RainbirdUpdateCoordinator[States],
         rainbird: AsyncRainbirdController,
         zone: int,
         time: int,

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1329,6 +1329,9 @@ pyps4-2ndscreen==1.3.1
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93
 
+# homeassistant.components.rainbird
+pyrainbird==0.7.0
+
 # homeassistant.components.risco
 pyrisco==0.5.7
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1330,7 +1330,7 @@ pyps4-2ndscreen==1.3.1
 pyqwikswitch==0.93
 
 # homeassistant.components.rainbird
-pyrainbird==0.7.0
+pyrainbird==0.7.1
 
 # homeassistant.components.risco
 pyrisco==0.5.7

--- a/tests/components/rainbird/__init__.py
+++ b/tests/components/rainbird/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the rainbird integration."""

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -1,4 +1,4 @@
-"""Tests for RTSPtoWebRTC initialization."""
+"""Test fixtures for rainbird."""
 
 from __future__ import annotations
 

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Generator
+from typing import Any
 from unittest.mock import patch
 
 from pyrainbird import encryption
@@ -60,16 +61,23 @@ def platforms() -> list[Platform]:
 
 
 @pytest.fixture
+def yaml_config() -> dict[str, Any]:
+    """Fixture for configuration.yaml."""
+    return CONFIG
+
+
+@pytest.fixture
 async def setup_integration(
     hass: HomeAssistant,
     platforms: list[str],
+    yaml_config: dict[str, Any],
 ) -> Generator[ComponentSetup, None, None]:
     """Fixture for setting up the component."""
 
     with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", platforms):
 
         async def func() -> bool:
-            result = await async_setup_component(hass, DOMAIN, CONFIG)
+            result = await async_setup_component(hass, DOMAIN, yaml_config)
             await hass.async_block_till_done()
             return result
 

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -1,0 +1,108 @@
+"""Tests for RTSPtoWebRTC initialization."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Generator
+from unittest.mock import patch
+
+from pyrainbird import encryption
+import pytest
+
+from homeassistant.components.rainbird import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
+
+ComponentSetup = Callable[[], Awaitable[bool]]
+
+HOST = "example.com"
+URL = "http://example.com/stick"
+PASSWORD = "password"
+
+#
+# Response payloads below come from pyrainbird test cases.
+#
+
+# Get serial number Command 0x85. Serial is 0x12635436566
+SERIAL_RESPONSE = "850000012635436566"
+# Get available stations command 0x83
+AVAILABLE_STATIONS_RESPONSE = "83017F000000"  # Mask for 7 zones
+EMPTY_STATIONS_RESPONSE = "830000000000"
+# Get zone state command 0xBF.
+ZONE_3_ON_RESPONSE = "BF0004000000"  # Zone 3 is on
+ZONE_5_ON_RESPONSE = "BF0010000000"  # Zone 5 is on
+ZONE_OFF_RESPONSE = "BF0000000000"  # All zones off
+ZONE_STATE_OFF_RESPONSE = "BF0000000000"
+# Get rain sensor state command 0XBE
+RAIN_SENSOR_OFF = "BE00"
+RAIN_SENSOR_ON = "BE01"
+# Get rain delay command 0xB6
+RAIN_DELAY = "B60010"  # 0x10 is 16
+RAIN_DELAY_OFF = "B60000"
+# ACK command 0x10, Echo 0x06
+ACK_ECHO = "0106"
+
+CONFIG = {
+    DOMAIN: {
+        "host": HOST,
+        "password": PASSWORD,
+        "trigger_time": 360,
+    }
+}
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return []
+
+
+@pytest.fixture
+async def setup_integration(
+    hass: HomeAssistant,
+    platforms: list[str],
+) -> Generator[ComponentSetup, None, None]:
+    """Fixture for setting up the component."""
+
+    with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", platforms):
+
+        async def func() -> bool:
+            result = await async_setup_component(hass, DOMAIN, CONFIG)
+            await hass.async_block_till_done()
+            return result
+
+        yield func
+
+
+def rainbird_response(data: str) -> bytes:
+    """Create a fake API response."""
+    return encryption.encrypt(
+        '{"jsonrpc": "2.0", "result": {"data":"%s"}, "id": 1} ' % data,
+        PASSWORD,
+    )
+
+
+def mock_response(data: str) -> AiohttpClientMockResponse:
+    """Create a fake AiohttpClientMockResponse."""
+    return AiohttpClientMockResponse("POST", URL, response=rainbird_response(data))
+
+
+@pytest.fixture(name="responses")
+def mock_responses() -> list[AiohttpClientMockResponse]:
+    """Fixture to set up a list of fake API responsees for tests to extend."""
+    return [mock_response(SERIAL_RESPONSE)]
+
+
+@pytest.fixture(autouse=True)
+def handle_responses(
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Fixture for command mocking for fake responses to the API url."""
+
+    async def handle(method, url, data) -> AiohttpClientMockResponse:
+        return responses.pop(0)
+
+    aioclient_mock.post(URL, side_effect=handle)

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -1,0 +1,78 @@
+"""Tests for rainbird sensor platform."""
+
+
+import pytest
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import (
+    RAIN_DELAY,
+    RAIN_DELAY_OFF,
+    RAIN_SENSOR_OFF,
+    RAIN_SENSOR_ON,
+    ComponentSetup,
+    mock_response,
+)
+
+from tests.test_util.aiohttp import AiohttpClientMockResponse
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return [Platform.BINARY_SENSOR]
+
+
+@pytest.mark.parametrize(
+    "sensor_payload,expected_state",
+    [(RAIN_SENSOR_OFF, "off"), (RAIN_SENSOR_ON, "on")],
+)
+async def test_rainsensor(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    responses: list[AiohttpClientMockResponse],
+    sensor_payload: str,
+    expected_state: bool,
+) -> None:
+    """Test rainsensor binary sensor."""
+
+    responses.extend(
+        [
+            mock_response(sensor_payload),
+            mock_response(RAIN_DELAY),
+        ]
+    )
+
+    assert await setup_integration()
+
+    rainsensor = hass.states.get("binary_sensor.rainsensor")
+    assert rainsensor is not None
+    assert rainsensor.state == expected_state
+
+
+@pytest.mark.parametrize(
+    "sensor_payload,expected_state",
+    [(RAIN_DELAY_OFF, "off"), (RAIN_DELAY, "on")],
+)
+async def test_raindelay(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    responses: list[AiohttpClientMockResponse],
+    sensor_payload: str,
+    expected_state: bool,
+) -> None:
+    """Test raindelay binary sensor."""
+
+    responses.extend(
+        [
+            mock_response(RAIN_SENSOR_OFF),
+            mock_response(sensor_payload),
+        ]
+    )
+
+    assert await setup_integration()
+
+    raindelay = hass.states.get("binary_sensor.raindelay")
+    assert raindelay is not None
+    assert raindelay.state == expected_state

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -1,0 +1,34 @@
+"""Tests for rainbird initialization."""
+
+from http import HTTPStatus
+
+from homeassistant.core import HomeAssistant
+
+from .conftest import URL, ComponentSetup
+
+from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
+
+
+async def test_setup_success(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+) -> None:
+    """Test successful setup and unload."""
+
+    assert await setup_integration()
+
+
+async def test_setup_communication_failure(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    responses: list[AiohttpClientMockResponse],
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test unable to talk to server on startup, which permanently fails setup."""
+
+    responses.clear()
+    responses.append(
+        AiohttpClientMockResponse("POST", URL, status=HTTPStatus.SERVICE_UNAVAILABLE)
+    )
+
+    assert not await setup_integration()

--- a/tests/components/rainbird/test_sensor.py
+++ b/tests/components/rainbird/test_sensor.py
@@ -1,0 +1,49 @@
+"""Tests for rainbird sensor platform."""
+
+
+import pytest
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import (
+    RAIN_DELAY,
+    RAIN_SENSOR_OFF,
+    RAIN_SENSOR_ON,
+    ComponentSetup,
+    mock_response,
+)
+
+from tests.test_util.aiohttp import AiohttpClientMockResponse
+
+
+@pytest.fixture
+def platforms() -> list[str]:
+    """Fixture to specify platforms to test."""
+    return [Platform.SENSOR]
+
+
+@pytest.mark.parametrize(
+    "sensor_payload,expected_state",
+    [(RAIN_SENSOR_OFF, "False"), (RAIN_SENSOR_ON, "True")],
+)
+async def test_sensors(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    responses: list[AiohttpClientMockResponse],
+    sensor_payload: str,
+    expected_state: bool,
+) -> None:
+    """Test sensor platform."""
+
+    responses.extend([mock_response(sensor_payload), mock_response(RAIN_DELAY)])
+
+    assert await setup_integration()
+
+    rainsensor = hass.states.get("sensor.rainsensor")
+    assert rainsensor is not None
+    assert rainsensor.state == expected_state
+
+    raindelay = hass.states.get("sensor.raindelay")
+    assert raindelay is not None
+    assert raindelay.state == "16"

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -1,0 +1,259 @@
+"""Tests for rainbird sensor platform."""
+
+
+from http import HTTPStatus
+import logging
+
+import pytest
+
+from homeassistant.components.rainbird import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import (
+    ACK_ECHO,
+    AVAILABLE_STATIONS_RESPONSE,
+    EMPTY_STATIONS_RESPONSE,
+    URL,
+    ZONE_3_ON_RESPONSE,
+    ZONE_5_ON_RESPONSE,
+    ZONE_OFF_RESPONSE,
+    ComponentSetup,
+    mock_response,
+)
+
+from tests.components.switch import common as switch_common
+from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
+
+
+@pytest.fixture
+def platforms() -> list[str]:
+    """Fixture to specify platforms to test."""
+    return [Platform.SWITCH]
+
+
+async def test_no_zones(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Test case where listing stations returns no stations."""
+
+    responses.append(mock_response(EMPTY_STATIONS_RESPONSE))
+    assert await setup_integration()
+
+    zone = hass.states.get("switch.sprinkler_1")
+    assert zone is None
+
+
+async def test_zones(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Test switch platform with fake data that creates 7 zones with one enabled."""
+
+    responses.extend(
+        [mock_response(AVAILABLE_STATIONS_RESPONSE), mock_response(ZONE_5_ON_RESPONSE)]
+    )
+
+    assert await setup_integration()
+
+    zone = hass.states.get("switch.sprinkler_1")
+    assert zone is not None
+    assert zone.state == "off"
+
+    zone = hass.states.get("switch.sprinkler_2")
+    assert zone is not None
+    assert zone.state == "off"
+
+    zone = hass.states.get("switch.sprinkler_3")
+    assert zone is not None
+    assert zone.state == "off"
+
+    zone = hass.states.get("switch.sprinkler_4")
+    assert zone is not None
+    assert zone.state == "off"
+
+    zone = hass.states.get("switch.sprinkler_5")
+    assert zone is not None
+    assert zone.state == "on"
+
+    zone = hass.states.get("switch.sprinkler_6")
+    assert zone is not None
+    assert zone.state == "off"
+
+    zone = hass.states.get("switch.sprinkler_7")
+    assert zone is not None
+    assert zone.state == "off"
+
+    assert not hass.states.get("switch.sprinkler_8")
+
+
+async def test_switch_on(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Test turning on irrigation switch."""
+
+    responses.extend(
+        [mock_response(AVAILABLE_STATIONS_RESPONSE), mock_response(ZONE_OFF_RESPONSE)]
+    )
+    assert await setup_integration()
+
+    # Initially all zones are off. Pick zone3 as an arbitrary to assert
+    # state, then update below as a switch.
+    zone = hass.states.get("switch.sprinkler_3")
+    assert zone is not None
+    assert zone.state == "off"
+
+    aioclient_mock.mock_calls.clear()
+    responses.extend(
+        [
+            mock_response(ACK_ECHO),  # Switch on response
+            mock_response(ZONE_3_ON_RESPONSE),  # Updated zone state
+        ]
+    )
+    await switch_common.async_turn_on(hass, "switch.sprinkler_3")
+    await hass.async_block_till_done()
+    assert len(aioclient_mock.mock_calls) == 2
+    aioclient_mock.mock_calls.clear()
+
+    # Verify switch state is updated
+    zone = hass.states.get("switch.sprinkler_3")
+    assert zone is not None
+    assert zone.state == "on"
+
+
+async def test_switch_off(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Test turning off irrigation switch."""
+
+    responses.extend(
+        [mock_response(AVAILABLE_STATIONS_RESPONSE), mock_response(ZONE_3_ON_RESPONSE)]
+    )
+    assert await setup_integration()
+
+    # Initially the test zone is on
+    zone = hass.states.get("switch.sprinkler_3")
+    assert zone is not None
+    assert zone.state == "on"
+
+    aioclient_mock.mock_calls.clear()
+    responses.extend(
+        [
+            mock_response(ACK_ECHO),  # Switch off response
+            mock_response(ZONE_OFF_RESPONSE),  # Updated zone state
+        ]
+    )
+    await switch_common.async_turn_off(hass, "switch.sprinkler_3")
+    await hass.async_block_till_done()
+
+    # One call to change the service and one to refresh state
+    assert len(aioclient_mock.mock_calls) == 2
+
+    # Verify switch state is updated
+    zone = hass.states.get("switch.sprinkler_3")
+    assert zone is not None
+    assert zone.state == "off"
+
+
+async def test_irrigation_service(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Test calling the irrigation service."""
+
+    responses.extend(
+        [mock_response(AVAILABLE_STATIONS_RESPONSE), mock_response(ZONE_3_ON_RESPONSE)]
+    )
+    assert await setup_integration()
+
+    aioclient_mock.mock_calls.clear()
+    responses.extend([mock_response(ACK_ECHO), mock_response(ZONE_OFF_RESPONSE)])
+
+    await hass.services.async_call(
+        DOMAIN,
+        "start_irrigation",
+        {ATTR_ENTITY_ID: "switch.sprinkler_5", "duration": 30},
+        blocking=True,
+    )
+
+    # One call to change the service and one to refresh state
+    assert len(aioclient_mock.mock_calls) == 2
+
+
+async def test_rain_delay_service(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Test calling the rain delay service."""
+
+    responses.extend(
+        [mock_response(AVAILABLE_STATIONS_RESPONSE), mock_response(ZONE_3_ON_RESPONSE)]
+    )
+    assert await setup_integration()
+
+    aioclient_mock.mock_calls.clear()
+    responses.extend(
+        [
+            mock_response(ACK_ECHO),
+        ]
+    )
+
+    await hass.services.async_call(
+        DOMAIN, "set_rain_delay", {"duration": 30}, blocking=True
+    )
+
+    assert len(aioclient_mock.mock_calls) == 1
+
+
+async def test_platform_unavailable(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    responses: list[AiohttpClientMockResponse],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test failure while listing the stations when setting up the platform."""
+
+    responses.append(
+        AiohttpClientMockResponse("POST", URL, status=HTTPStatus.SERVICE_UNAVAILABLE)
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert await setup_integration()
+
+    assert "Failed to get stations" in caplog.text
+
+
+async def test_coordinator_unavailable(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    responses: list[AiohttpClientMockResponse],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test failure to refresh the update coordinator."""
+
+    responses.extend(
+        [
+            mock_response(AVAILABLE_STATIONS_RESPONSE),
+            AiohttpClientMockResponse(
+                "POST", URL, status=HTTPStatus.SERVICE_UNAVAILABLE
+            ),
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert await setup_integration()
+
+    assert "Failed to load zone state" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move Rainbird to an async client library. Tests are added to achive 98% test coverage. There are some behavior changes:
- The new async client library doesn't send so much log spam, relying on data update coordinator to log all errors
- The new client library doesn't retry on its own or have its own timeout. Now the update coordinator just handles that
- The old library had its own cache and expiration, which is gone. The data update coordinator now is responsible for caching values (e.g. between the sensor and binary sensor)

Followup PRs will deprecate YAML and move to config entries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
