### PR TITLE
Bump pySwitchbee to 1.7.11 

### DIFF
--- a/homeassistant/components/switchbee/__init__.py
+++ b/homeassistant/components/switchbee/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from switchbee.api import CentralUnitAPI, SwitchBeeError
+from switchbee.api.central_unit import SwitchBeeError
+from switchbee.api.polling import CentralUnitPolling
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
@@ -29,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     user = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     websession = async_get_clientsession(hass, verify_ssl=False)
-    api = CentralUnitAPI(central_unit, user, password, websession)
+    api = CentralUnitPolling(central_unit, user, password, websession)
     try:
         await api.connect()
     except SwitchBeeError as exp:

--- a/homeassistant/components/switchbee/button.py
+++ b/homeassistant/components/switchbee/button.py
@@ -1,6 +1,6 @@
 """Support for SwitchBee scenario button."""
 
-from switchbee.api import SwitchBeeError
+from switchbee.api.central_unit import SwitchBeeError
 from switchbee.device import ApiStateCommand, DeviceType
 
 from homeassistant.components.button import ButtonEntity

--- a/homeassistant/components/switchbee/climate.py
+++ b/homeassistant/components/switchbee/climate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from switchbee.api import SwitchBeeDeviceOfflineError, SwitchBeeError
+from switchbee.api.central_unit import SwitchBeeDeviceOfflineError, SwitchBeeError
 from switchbee.const import (
     ApiAttribute,
     ThermostatFanSpeed,

--- a/homeassistant/components/switchbee/config_flow.py
+++ b/homeassistant/components/switchbee/config_flow.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from switchbee.api import CentralUnitAPI, SwitchBeeError
+from switchbee.api.central_unit import SwitchBeeError
+from switchbee.api.polling import CentralUnitPolling
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -33,7 +34,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> str:
     """Validate the user input allows us to connect."""
 
     websession = async_get_clientsession(hass, verify_ssl=False)
-    api = CentralUnitAPI(
+    api = CentralUnitPolling(
         data[CONF_HOST], data[CONF_USERNAME], data[CONF_PASSWORD], websession
     )
     try:

--- a/homeassistant/components/switchbee/coordinator.py
+++ b/homeassistant/components/switchbee/coordinator.py
@@ -6,7 +6,8 @@ from collections.abc import Mapping
 from datetime import timedelta
 import logging
 
-from switchbee.api import CentralUnitAPI, SwitchBeeError
+from switchbee.api.central_unit import SwitchBeeError
+from switchbee.api.polling import CentralUnitPolling
 from switchbee.device import DeviceType, SwitchBeeBaseDevice
 
 from homeassistant.core import HomeAssistant
@@ -24,10 +25,10 @@ class SwitchBeeCoordinator(DataUpdateCoordinator[Mapping[int, SwitchBeeBaseDevic
     def __init__(
         self,
         hass: HomeAssistant,
-        swb_api: CentralUnitAPI,
+        swb_api: CentralUnitPolling,
     ) -> None:
         """Initialize."""
-        self.api: CentralUnitAPI = swb_api
+        self.api: CentralUnitPolling = swb_api
         self._reconnect_counts: int = 0
         self.mac_formatted: str | None = (
             None if self.api.mac is None else format_mac(self.api.mac)

--- a/homeassistant/components/switchbee/cover.py
+++ b/homeassistant/components/switchbee/cover.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from switchbee.api import SwitchBeeError, SwitchBeeTokenError
+from switchbee.api.central_unit import SwitchBeeError, SwitchBeeTokenError
 from switchbee.const import SomfyCommand
 from switchbee.device import SwitchBeeShutter, SwitchBeeSomfy
 

--- a/homeassistant/components/switchbee/entity.py
+++ b/homeassistant/components/switchbee/entity.py
@@ -3,7 +3,7 @@ import logging
 from typing import Generic, TypeVar, cast
 
 from switchbee import SWITCHBEE_BRAND
-from switchbee.api import SwitchBeeDeviceOfflineError, SwitchBeeError
+from switchbee.api.central_unit import SwitchBeeDeviceOfflineError, SwitchBeeError
 from switchbee.device import DeviceType, SwitchBeeBaseDevice
 
 from homeassistant.helpers.entity import DeviceInfo

--- a/homeassistant/components/switchbee/light.py
+++ b/homeassistant/components/switchbee/light.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from switchbee.api import SwitchBeeDeviceOfflineError, SwitchBeeError
+from switchbee.api.central_unit import SwitchBeeDeviceOfflineError, SwitchBeeError
 from switchbee.device import ApiStateCommand, DeviceType, SwitchBeeDimmer
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity

--- a/homeassistant/components/switchbee/manifest.json
+++ b/homeassistant/components/switchbee/manifest.json
@@ -3,7 +3,7 @@
   "name": "SwitchBee",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/switchbee",
-  "requirements": ["pyswitchbee==1.6.1"],
+  "requirements": ["pyswitchbee==1.7.3"],
   "codeowners": ["@jafar-atili"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/switchbee/switch.py
+++ b/homeassistant/components/switchbee/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, TypeVar, Union
 
-from switchbee.api import SwitchBeeDeviceOfflineError, SwitchBeeError
+from switchbee.api.central_unit import SwitchBeeDeviceOfflineError, SwitchBeeError
 from switchbee.device import (
     ApiStateCommand,
     SwitchBeeGroupSwitch,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1952,7 +1952,7 @@ pystiebeleltron==0.0.1.dev2
 pysuez==0.1.19
 
 # homeassistant.components.switchbee
-pyswitchbee==1.6.1
+pyswitchbee==1.7.3
 
 # homeassistant.components.syncthru
 pysyncthru==0.7.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1381,7 +1381,7 @@ pyspcwebgw==0.4.0
 pysqueezebox==0.6.1
 
 # homeassistant.components.switchbee
-pyswitchbee==1.6.1
+pyswitchbee==1.7.3
 
 # homeassistant.components.syncthru
 pysyncthru==0.7.10

--- a/tests/components/switchbee/test_config_flow.py
+++ b/tests/components/switchbee/test_config_flow.py
@@ -31,9 +31,9 @@ async def test_form(hass):
         "homeassistant.components.switchbee.async_setup_entry",
         return_value=True,
     ), patch(
-        "switchbee.api.CentralUnitAPI.fetch_states", return_value=None
+        "switchbee.api.polling.CentralUnitPolling.fetch_states", return_value=None
     ), patch(
-        "switchbee.api.CentralUnitAPI._login", return_value=None
+        "switchbee.api.polling.CentralUnitPolling._login", return_value=None
     ):
 
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/switchbee/test_config_flow.py
+++ b/tests/components/switchbee/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch(
-        "switchbee.api.CentralUnitAPI.get_configuration",
+        "switchbee.api.polling.CentralUnitPolling.get_configuration",
         return_value=coordinator_data,
     ), patch(
         "homeassistant.components.switchbee.async_setup_entry",
@@ -62,7 +62,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "switchbee.api.CentralUnitAPI._login",
+        "switchbee.api.polling.CentralUnitPolling._login",
         side_effect=SwitchBeeError(MOCK_FAILED_TO_LOGIN_MSG),
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -86,7 +86,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "switchbee.api.CentralUnitAPI._login",
+        "switchbee.api.polling.CentralUnitPolling._login",
         side_effect=SwitchBeeError(MOCK_INVALID_TOKEN_MGS),
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -109,7 +109,7 @@ async def test_form_unknown_error(hass):
     )
 
     with patch(
-        "switchbee.api.CentralUnitAPI._login",
+        "switchbee.api.polling.CentralUnitPolling._login",
         side_effect=Exception,
     ):
         form_result = await hass.config_entries.flow.async_configure(
@@ -144,14 +144,16 @@ async def test_form_entry_exists(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch("switchbee.api.CentralUnitAPI._login", return_value=None), patch(
+    with patch(
+        "switchbee.api.polling.CentralUnitPolling._login", return_value=None
+    ), patch(
         "homeassistant.components.switchbee.async_setup_entry",
         return_value=True,
     ), patch(
-        "switchbee.api.CentralUnitAPI.get_configuration",
+        "switchbee.api.polling.CentralUnitPolling.get_configuration",
         return_value=coordinator_data,
     ), patch(
-        "switchbee.api.CentralUnitAPI.fetch_states", return_value=None
+        "switchbee.api.polling.CentralUnitPolling.fetch_states", return_value=None
     ):
         form_result = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/jafar-atili/pySwitchbee/releases/tag/1.7.11

Switchbee integration `iot_class`  changed from `local_polling` to `local_push`
This change is effective from Central Unit version 1.4.6 and above


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
