### PR TITLE
Replace attrs with dataclasses in hassfest

### DIFF
--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -1,44 +1,43 @@
 """Models for manifest validator."""
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 import json
 import pathlib
 from typing import Any
 
-import attr
 
-
-@attr.s
+@dataclass
 class Error:
     """Error validating an integration."""
 
-    plugin: str = attr.ib()
-    error: str = attr.ib()
-    fixable: bool = attr.ib(default=False)
+    plugin: str
+    error: str
+    fixable: bool = False
 
     def __str__(self) -> str:
         """Represent error as string."""
         return f"[{self.plugin.upper()}] {self.error}"
 
 
-@attr.s
+@dataclass
 class Config:
     """Config for the run."""
 
-    specific_integrations: list[pathlib.Path] | None = attr.ib()
-    root: pathlib.Path = attr.ib()
-    action: str = attr.ib()
-    requirements: bool = attr.ib()
-    errors: list[Error] = attr.ib(factory=list)
-    cache: dict[str, Any] = attr.ib(factory=dict)
-    plugins: set[str] = attr.ib(factory=set)
+    specific_integrations: list[pathlib.Path] | None
+    root: pathlib.Path
+    action: str
+    requirements: bool
+    errors: list[Error] = field(default_factory=list)
+    cache: dict[str, Any] = field(default_factory=dict)
+    plugins: set[str] = field(default_factory=set)
 
     def add_error(self, *args: Any, **kwargs: Any) -> None:
         """Add an error."""
         self.errors.append(Error(*args, **kwargs))
 
 
-@attr.s
+@dataclass
 class Brand:
     """Represent a brand in our validator."""
 
@@ -54,8 +53,8 @@ class Brand:
 
         return brands
 
-    path: pathlib.Path = attr.ib()
-    _brand: dict[str, Any] | None = attr.ib(default=None)
+    path: pathlib.Path
+    _brand: dict[str, Any] | None = None
 
     @property
     def brand(self) -> dict[str, Any]:
@@ -100,7 +99,7 @@ class Brand:
         self._brand = brand
 
 
-@attr.s
+@dataclass
 class Integration:
     """Represent an integration in our validator."""
 
@@ -129,11 +128,11 @@ class Integration:
 
         return integrations
 
-    path: pathlib.Path = attr.ib()
-    _manifest: dict[str, Any] | None = attr.ib(default=None)
-    errors: list[Error] = attr.ib(factory=list)
-    warnings: list[Error] = attr.ib(factory=list)
-    translated_name: bool = attr.ib(default=False)
+    path: pathlib.Path
+    _manifest: dict[str, Any] | None = None
+    errors: list[Error] = field(default_factory=list)
+    warnings: list[Error] = field(default_factory=list)
+    translated_name: bool = False
 
     @property
     def manifest(self) -> dict[str, Any]:

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -12,7 +12,7 @@ def integration():
     """Fixture for hassfest integration model."""
     integration = Integration(
         path=Path("homeassistant/components/test"),
-        manifest={
+        _manifest={
             "domain": "test",
             "documentation": "https://example.com",
             "name": "test",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replaces the use of attrs with just dataclasses in hassfest. There is no specific advantage of using an external dependency in these specific cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
