### PR TITLE
Make manual_mqtt state attributes compatible with manual, add state restore

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -30,6 +30,8 @@ from homeassistant.helpers.typing import ConfigType
 from .const import (  # noqa: F401
     ATTR_CHANGED_BY,
     ATTR_CODE_ARM_REQUIRED,
+    ATTR_NEXT_STATE,
+    ATTR_PREVIOUS_STATE,
     DOMAIN,
     FORMAT_NUMBER,
     FORMAT_TEXT,

--- a/homeassistant/components/alarm_control_panel/const.py
+++ b/homeassistant/components/alarm_control_panel/const.py
@@ -9,6 +9,9 @@ DOMAIN: Final = "alarm_control_panel"
 ATTR_CHANGED_BY: Final = "changed_by"
 ATTR_CODE_ARM_REQUIRED: Final = "code_arm_required"
 
+ATTR_PREVIOUS_STATE: Final = "previous_state"
+ATTR_NEXT_STATE: Final = "next_state"
+
 
 class CodeFormat(StrEnum):
     """Code formats for the Alarm Control Panel."""

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -10,7 +10,11 @@ from typing import Any
 import voluptuous as vol
 
 import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
+from homeassistant.components.alarm_control_panel import (
+    ATTR_NEXT_STATE,
+    ATTR_PREVIOUS_STATE,
+    AlarmControlPanelEntityFeature,
+)
 from homeassistant.const import (
     CONF_ARMING_TIME,
     CONF_CODE,
@@ -67,9 +71,6 @@ SUPPORTED_ARMING_STATES = [
     for state in SUPPORTED_STATES
     if state not in (STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED)
 ]
-
-ATTR_PREVIOUS_STATE = "previous_state"
-ATTR_NEXT_STATE = "next_state"
 
 
 def _state_validator(config):

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -11,7 +11,11 @@ import voluptuous as vol
 
 from homeassistant.components import mqtt
 import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
+from homeassistant.components.alarm_control_panel import (
+    ATTR_NEXT_STATE,
+    ATTR_PREVIOUS_STATE,
+    AlarmControlPanelEntityFeature,
+)
 from homeassistant.const import (
     CONF_CODE,
     CONF_DELAY_TIME,
@@ -455,6 +459,9 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         if self.state != STATE_ALARM_PENDING:
             return {}
         return {
+            ATTR_PREVIOUS_STATE: self._previous_state,
+            ATTR_NEXT_STATE: self._state,
+            # deprecated
             ATTR_PRE_PENDING_STATE: self._previous_state,
             ATTR_POST_PENDING_STATE: self._state,
         }

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -456,15 +456,21 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        if self.state != STATE_ALARM_PENDING:
-            return {}
-        return {
-            ATTR_PREVIOUS_STATE: self._previous_state,
-            ATTR_NEXT_STATE: self._state,
-            # deprecated
-            ATTR_PRE_PENDING_STATE: self._previous_state,
-            ATTR_POST_PENDING_STATE: self._state,
-        }
+        if self.state == STATE_ALARM_PENDING:
+            return {
+                ATTR_PREVIOUS_STATE: self._previous_state,
+                ATTR_NEXT_STATE: self._state,
+                # deprecated
+                ATTR_PRE_PENDING_STATE: self._previous_state,
+                ATTR_POST_PENDING_STATE: self._state,
+            }
+        if self.state == STATE_ALARM_TRIGGERED:
+            return {
+                ATTR_PREVIOUS_STATE: self._previous_state,
+                # deprecated
+                ATTR_PRE_PENDING_STATE: self._previous_state,
+            }
+        return {}
 
     @callback
     def async_scheduled_update(self, now):

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -203,7 +203,7 @@ async def test_with_pending(
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
     state = hass.states.get(entity_id)
-    assert state.attributes["post_pending_state"] == expected_state
+    assert state.attributes["next_state"] == expected_state
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -440,7 +440,7 @@ async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -540,7 +540,7 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get(entity_id).state == STATE_ALARM_PENDING
 
     state = hass.states.get(entity_id)
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=2)
     with patch(
@@ -897,7 +897,7 @@ async def test_trigger_with_unused_specific_delay(
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -944,7 +944,7 @@ async def test_trigger_with_specific_delay(hass, mqtt_mock_entry_with_yaml_confi
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -991,7 +991,7 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -1003,7 +1003,7 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future += timedelta(seconds=1)
     with patch(
@@ -1053,7 +1053,7 @@ async def test_trigger_with_pending_and_specific_delay(
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with patch(
@@ -1065,7 +1065,7 @@ async def test_trigger_with_pending_and_specific_delay(
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future += timedelta(seconds=1)
     with patch(
@@ -1201,15 +1201,15 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["pre_pending_state"] == STATE_ALARM_DISARMED
-    assert state.attributes["post_pending_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.attributes["next_state"] == STATE_ALARM_ARMED_AWAY
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
-    assert state.attributes["pre_pending_state"] == STATE_ALARM_DISARMED
-    assert state.attributes["post_pending_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.attributes["next_state"] == STATE_ALARM_ARMED_AWAY
 
     future = dt_util.utcnow() + timedelta(seconds=1)
     with freeze_time(future):
@@ -1223,8 +1223,8 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
 
         state = hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes["pre_pending_state"] == STATE_ALARM_ARMED_AWAY
-        assert state.attributes["post_pending_state"] == STATE_ALARM_TRIGGERED
+        assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+        assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
 
     future += timedelta(seconds=1)
     with freeze_time(future):

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
 )
+from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -30,6 +31,8 @@ from tests.common import (
     assert_setup_component,
     async_fire_mqtt_message,
     async_fire_time_changed,
+    mock_component,
+    mock_restore_cache,
 )
 from tests.components.alarm_control_panel import common
 
@@ -1480,3 +1483,270 @@ async def test_state_changes_are_published_to_mqtt(
     mqtt_mock.async_publish.assert_called_once_with(
         "alarm/state", STATE_ALARM_DISARMED, 0, True
     )
+
+
+@pytest.mark.parametrize(
+    "expected_state",
+    [
+        (STATE_ALARM_ARMED_AWAY),
+        (STATE_ALARM_ARMED_CUSTOM_BYPASS),
+        (STATE_ALARM_ARMED_HOME),
+        (STATE_ALARM_ARMED_NIGHT),
+        (STATE_ALARM_ARMED_VACATION),
+        (STATE_ALARM_DISARMED),
+    ],
+)
+async def test_restore_state(hass, expected_state, mqtt_mock_entry_with_yaml_config):
+    """Ensure state is restored on startup."""
+    mock_restore_cache(hass, (State("alarm_control_panel.test", expected_state),))
+
+    hass.state = CoreState.starting
+    mock_component(hass, "recorder")
+
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "pending_time": 0,
+                "trigger_time": 0,
+                "disarm_after_trigger": False,
+                "state_topic": "alarm/state",
+                "command_topic": "alarm/command",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("alarm_control_panel.test")
+    assert state
+    assert state.state == expected_state
+
+
+@pytest.mark.parametrize(
+    "expected_state",
+    [
+        (STATE_ALARM_ARMED_AWAY),
+        (STATE_ALARM_ARMED_CUSTOM_BYPASS),
+        (STATE_ALARM_ARMED_HOME),
+        (STATE_ALARM_ARMED_NIGHT),
+        (STATE_ALARM_ARMED_VACATION),
+    ],
+)
+async def test_restore_state_arming(
+    hass, expected_state, mqtt_mock_entry_with_yaml_config
+):
+    """Ensure PENDING state is restored on startup."""
+    time = dt_util.utcnow() - timedelta(seconds=15)
+    entity_id = "alarm_control_panel.test"
+    attributes = {
+        "previous_state": STATE_ALARM_DISARMED,
+        "next_state": expected_state,
+    }
+    mock_restore_cache(
+        hass, (State(entity_id, expected_state, attributes, last_updated=time),)
+    )
+
+    hass.state = CoreState.starting
+    mock_component(hass, "recorder")
+
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "pending_time": 60,
+                "trigger_time": 0,
+                "disarm_after_trigger": False,
+                "state_topic": "alarm/state",
+                "command_topic": "alarm/command",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.attributes["next_state"] == expected_state
+    assert state.state == STATE_ALARM_PENDING
+
+    future = time + timedelta(seconds=61)
+    with freeze_time(future):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == expected_state
+
+
+@pytest.mark.parametrize(
+    "previous_state",
+    [
+        (STATE_ALARM_ARMED_AWAY),
+        (STATE_ALARM_ARMED_CUSTOM_BYPASS),
+        (STATE_ALARM_ARMED_HOME),
+        (STATE_ALARM_ARMED_NIGHT),
+        (STATE_ALARM_ARMED_VACATION),
+        (STATE_ALARM_DISARMED),
+    ],
+)
+async def test_restore_state_pending(
+    hass, previous_state, mqtt_mock_entry_with_yaml_config
+):
+    """Ensure PENDING state is restored on startup."""
+    time = dt_util.utcnow() - timedelta(seconds=15)
+    entity_id = "alarm_control_panel.test"
+    attributes = {
+        "previous_state": previous_state,
+        "next_state": STATE_ALARM_TRIGGERED,
+    }
+    mock_restore_cache(
+        hass,
+        (State(entity_id, STATE_ALARM_TRIGGERED, attributes, last_updated=time),),
+    )
+
+    hass.state = CoreState.starting
+    mock_component(hass, "recorder")
+
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "pending_time": 0,
+                "delay_time": 60,
+                "trigger_time": 60,
+                "disarm_after_trigger": False,
+                "state_topic": "alarm/state",
+                "command_topic": "alarm/command",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["previous_state"] == previous_state
+    assert state.attributes["next_state"] == STATE_ALARM_TRIGGERED
+    assert state.state == STATE_ALARM_PENDING
+
+    future = time + timedelta(seconds=61)
+    with freeze_time(future):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ALARM_TRIGGERED
+
+    future = time + timedelta(seconds=121)
+    with freeze_time(future):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == previous_state
+
+
+@pytest.mark.parametrize(
+    "previous_state",
+    [
+        (STATE_ALARM_ARMED_AWAY),
+        (STATE_ALARM_ARMED_CUSTOM_BYPASS),
+        (STATE_ALARM_ARMED_HOME),
+        (STATE_ALARM_ARMED_NIGHT),
+        (STATE_ALARM_ARMED_VACATION),
+        (STATE_ALARM_DISARMED),
+    ],
+)
+async def test_restore_state_triggered(
+    hass, previous_state, mqtt_mock_entry_with_yaml_config
+):
+    """Ensure PENDING state is resolved to TRIGGERED on startup."""
+    time = dt_util.utcnow() - timedelta(seconds=75)
+    entity_id = "alarm_control_panel.test"
+    attributes = {
+        "previous_state": previous_state,
+    }
+    mock_restore_cache(
+        hass,
+        (State(entity_id, STATE_ALARM_TRIGGERED, attributes, last_updated=time),),
+    )
+
+    hass.state = CoreState.starting
+    mock_component(hass, "recorder")
+
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "pending_time": 0,
+                "delay_time": 60,
+                "trigger_time": 60,
+                "disarm_after_trigger": False,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["previous_state"] == previous_state
+    assert "next_state" not in state.attributes
+    assert state.state == STATE_ALARM_TRIGGERED
+
+    future = time + timedelta(seconds=121)
+    with freeze_time(future):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == previous_state
+
+
+async def test_restore_state_triggered_disarm(hass, mqtt_mock_entry_with_yaml_config):
+    """Ensure TRIGGERED state is resolved on startup."""
+    time = dt_util.utcnow() - timedelta(seconds=125)
+    entity_id = "alarm_control_panel.test"
+    attributes = {
+        "previous_state": STATE_ALARM_ARMED_AWAY,
+    }
+    mock_restore_cache(
+        hass,
+        (State(entity_id, STATE_ALARM_TRIGGERED, attributes, last_updated=time),),
+    )
+
+    hass.state = CoreState.starting
+    mock_component(hass, "recorder")
+
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual_mqtt",
+                "name": "test",
+                "pending_time": 0,
+                "delay_time": 60,
+                "trigger_time": 60,
+                "disarm_after_trigger": True,
+                "command_topic": "alarm/command",
+                "state_topic": "alarm/state",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ALARM_DISARMED

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -405,7 +405,9 @@ async def test_trigger_no_pending(hass, mqtt_mock_entry_with_yaml_config):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
 
 async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
@@ -451,6 +453,7 @@ async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -550,7 +553,9 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -590,7 +595,9 @@ async def test_trigger_with_disarm_after_trigger(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -662,7 +669,9 @@ async def test_trigger_with_unused_zero_specific_trigger_time(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -702,7 +711,9 @@ async def test_trigger_with_specific_trigger_time(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -746,7 +757,9 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -760,7 +773,9 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -859,7 +874,9 @@ async def test_disarm_during_trigger_with_invalid_code(
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
 
 async def test_trigger_with_unused_specific_delay(
@@ -908,6 +925,7 @@ async def test_trigger_with_unused_specific_delay(
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -955,6 +973,7 @@ async def test_trigger_with_specific_delay(hass, mqtt_mock_entry_with_yaml_confi
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -1014,6 +1033,7 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -1076,6 +1096,7 @@ async def test_trigger_with_pending_and_specific_delay(
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 
@@ -1113,7 +1134,9 @@ async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_con
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_DISARMED
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -1158,7 +1181,9 @@ async def test_trigger_with_no_disarm_after_trigger(
 
     await common.async_alarm_trigger(hass, entity_id=entity_id)
 
-    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+    state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
+    assert state.state == STATE_ALARM_TRIGGERED
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     with patch(
@@ -1232,6 +1257,7 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
+    assert state.attributes["previous_state"] == STATE_ALARM_ARMED_AWAY
     assert state.state == STATE_ALARM_TRIGGERED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The [`manual_mqtt`](https://www.home-assistant.io/integrations/manual_mqtt/) alarm control panel integration used state attributes that are slightly different from the [`manual`](https://www.home-assistant.io/integrations/manual/) integration. With this release, `manual_mqtt` provides `previous_state` and `next_state` attributes compatible with `manual`.

The backwards-compatible `pre_pending_state` and `post_pending_state` attributes still exist, but will be removed in Home Assistant 2023.3.

In addition, "manual MQTT" now supports restoring the previous state when Home Assistant restarts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
