### PR TITLE
Try the next best adapter after a BLE connection fails

### DIFF
--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -217,20 +217,19 @@ class BluetoothManager:
         uninstall_multiple_bleak_catcher()
 
     @hass_callback
-    def async_get_discovered_devices_and_advertisement_data_by_address(
+    def async_get_scanner_discovered_devices_and_advertisement_data_by_address(
         self, address: str, connectable: bool
-    ) -> list[tuple[BLEDevice, AdvertisementData]]:
-        """Get devices and advertisement_data by address."""
+    ) -> list[tuple[BaseHaScanner, BLEDevice, AdvertisementData]]:
+        """Get scanner, devices, and advertisement_data by address."""
         types_ = (True,) if connectable else (True, False)
-        return [
-            device_advertisement_data
-            for device_advertisement_data in (
-                scanner.discovered_devices_and_advertisement_data.get(address)
-                for type_ in types_
-                for scanner in self._get_scanners_by_type(type_)
-            )
-            if device_advertisement_data is not None
-        ]
+        results: list[tuple[BaseHaScanner, BLEDevice, AdvertisementData]] = []
+        for type_ in types_:
+            for scanner in self._get_scanners_by_type(type_):
+                if device_advertisement_data := scanner.discovered_devices_and_advertisement_data.get(
+                    address
+                ):
+                    results.append((scanner, *device_advertisement_data))
+        return results
 
     @hass_callback
     def _async_all_discovered_addresses(self, connectable: bool) -> Iterable[str]:

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -7,7 +7,7 @@
   "quality_scale": "internal",
   "requirements": [
     "bleak==0.19.2",
-    "bleak-retry-connector==2.12.1",
+    "bleak-retry-connector==2.13.0",
     "bluetooth-adapters==0.15.2",
     "bluetooth-auto-recovery==1.0.3",
     "bluetooth-data-tools==0.3.1",

--- a/homeassistant/components/bluetooth/wrappers.py
+++ b/homeassistant/components/bluetooth/wrappers.py
@@ -300,7 +300,7 @@ class HaBleakClientWrapper(BleakClient):
         )
 
         # If we have connection failures we adjust the rssi sorting
-        # to prefer the scanner with the less failures so
+        # to prefer the adapter/scanner with the less failures so
         # we don't keep trying to connect with an adapter
         # that is failing
         if (

--- a/homeassistant/components/bluetooth/wrappers.py
+++ b/homeassistant/components/bluetooth/wrappers.py
@@ -168,7 +168,9 @@ def _rssi_sorter_with_connection_failure_penalty(
     scanner, _, advertisement_data = scanner_device_advertisement_data
     base_rssi = advertisement_data.rssi or NO_RSSI_VALUE
     if connect_failures := connection_failure_count.get(scanner):
-        return base_rssi - (max(1, rssi_diff) * connect_failures * 0.51)
+        if connect_failures > 1 and not rssi_diff:
+            rssi_diff = 1
+        return base_rssi - (rssi_diff * connect_failures * 0.51)
     return base_rssi
 
 

--- a/homeassistant/components/bluetooth/wrappers.py
+++ b/homeassistant/components/bluetooth/wrappers.py
@@ -225,14 +225,13 @@ class HaBleakClientWrapper(BleakClient):
     async def connect(self, **kwargs: Any) -> bool:
         """Connect to the specified GATT server."""
         assert models.MANAGER is not None
-        wrapped_backend = self._async_get_best_available_backend_and_device(
-            models.MANAGER
-        )
+        manager = models.MANAGER
+        wrapped_backend = self._async_get_best_available_backend_and_device(manager)
         self._backend = wrapped_backend.client(
             wrapped_backend.device,
             disconnected_callback=self.__disconnected_callback,
             timeout=self.__timeout,
-            hass=models.MANAGER.hass,
+            hass=manager.hass,
         )
         if debug_logging := _LOGGER.isEnabledFor(logging.DEBUG):
             # Only lookup the description if we are going to log it
@@ -250,7 +249,7 @@ class HaBleakClientWrapper(BleakClient):
                     self.__connect_failures.get(wrapped_backend.scanner, 0) + 1
                 )
                 if not wrapped_backend.source:
-                    models.MANAGER.async_release_connection_slot(wrapped_backend.device)
+                    manager.async_release_connection_slot(wrapped_backend.device)
 
         if debug_logging:
             _LOGGER.debug("%s: Connected (last rssi: %s)", description, rssi)

--- a/homeassistant/components/bluetooth/wrappers.py
+++ b/homeassistant/components/bluetooth/wrappers.py
@@ -153,17 +153,22 @@ def _rssi_sorter_with_connection_failure_penalty(
     ],
     connection_failure_count: dict[BaseHaScanner, int],
     rssi_diff: int,
-) -> int:
+) -> float:
     """Get a sorted list of scanner, device, advertisement data adjusting for previous connection failures.
 
     When a connection fails, we want to try the next best adapter so we
     apply a penalty to the RSSI value to make it less likely to be chosen
     for every previous connection failure.
+
+    We use the 51% of the RSSI difference between the first and second
+    best adapter as the penalty. This ensures we will always try the
+    best adapter twice before moving on to the next best adapter since
+    the first failure may be a transient service resolution issue.
     """
     scanner, _, advertisement_data = scanner_device_advertisement_data
     base_rssi = advertisement_data.rssi or NO_RSSI_VALUE
     if connect_failures := connection_failure_count.get(scanner):
-        return base_rssi - max(1, rssi_diff) * connect_failures
+        return base_rssi - (max(1, rssi_diff) * connect_failures * 0.51)
     return base_rssi
 
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -10,7 +10,7 @@ atomicwrites-homeassistant==1.4.1
 attrs==22.1.0
 awesomeversion==22.9.0
 bcrypt==3.1.7
-bleak-retry-connector==2.12.1
+bleak-retry-connector==2.13.0
 bleak==0.19.2
 bluetooth-adapters==0.15.2
 bluetooth-auto-recovery==1.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -428,7 +428,7 @@ bimmer_connected==0.10.4
 bizkaibus==0.1.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.12.1
+bleak-retry-connector==2.13.0
 
 # homeassistant.components.bluetooth
 bleak==0.19.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -352,7 +352,7 @@ bellows==0.34.5
 bimmer_connected==0.10.4
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.12.1
+bleak-retry-connector==2.13.0
 
 # homeassistant.components.bluetooth
 bleak==0.19.2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Try the next best adapter when there are multiple adapter options after a BLE connection fails twice using the same adapter.

Implements the review suggestion here https://github.com/home-assistant/core/pull/84331#issuecomment-1360915596

changelog: https://github.com/Bluetooth-Devices/bleak-retry-connector/compare/v2.12.1...v2.13.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
