### PR TITLE
Add custom ssl_context to aiohttp helper

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -152,7 +152,7 @@ async def async_setup_entry(
         https = False
         port = host.port or 80
         session = aiohttp_client.async_create_clientsession(
-            hass, verify_ssl=False, cookie_jar=CookieJar(unsafe=True)
+            hass, ssl_context=False, cookie_jar=CookieJar(unsafe=True)
         )
     elif host.scheme == "https":
         https = True

--- a/homeassistant/components/isy994/config_flow.py
+++ b/homeassistant/components/isy994/config_flow.py
@@ -72,7 +72,7 @@ async def validate_input(
         https = False
         port = host.port or HTTP_PORT
         session = aiohttp_client.async_create_clientsession(
-            hass, verify_ssl=False, cookie_jar=CookieJar(unsafe=True)
+            hass, ssl_context=False, cookie_jar=CookieJar(unsafe=True)
         )
     elif host.scheme == SCHEME_HTTPS:
         https = True

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -451,7 +451,7 @@ async def get_unifi_controller(
             sslcontext = ssl.create_default_context(cafile=verify_ssl)
     else:
         session = aiohttp_client.async_create_clientsession(
-            hass, verify_ssl=verify_ssl, cookie_jar=CookieJar(unsafe=True)
+            hass, ssl_context=verify_ssl, cookie_jar=CookieJar(unsafe=True)
         )
 
     controller = aiounifi.Controller(

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -77,7 +77,7 @@ def async_get_clientsession(
 @bind_hass
 def async_create_clientsession(
     hass: HomeAssistant,
-    ssl_context: bool | SSLContext = True
+    ssl_context: bool | SSLContext = True,
     auto_cleanup: bool = True,
     **kwargs: Any,
 ) -> aiohttp.ClientSession:
@@ -107,7 +107,7 @@ def async_create_clientsession(
 @callback
 def _async_create_clientsession(
     hass: HomeAssistant,
-    ssl_context: bool | SSLContext = True
+    ssl_context: bool | SSLContext = True,
     auto_cleanup_method: Callable[[HomeAssistant, aiohttp.ClientSession], None]
     | None = None,
     **kwargs: Any,
@@ -247,13 +247,13 @@ def _async_get_connector(
     """
     key = None
     if isinstance(ssl_context, bool):
-        key = DATA_CONNECTOR if verify_ssl else DATA_CONNECTOR_NOTVERIFY
+        key = DATA_CONNECTOR if ssl_context else DATA_CONNECTOR_NOTVERIFY
 
         if key in hass.data:
             return cast(aiohttp.BaseConnector, hass.data[key])
 
     if ssl_context is True:
-        ssl_context: bool | SSLContext = ssl_util.client_context()
+        ssl_context = ssl_util.client_context()
 
     connector = aiohttp.TCPConnector(enable_cleanup_closed=True, ssl=ssl_context)
     if key is not None:

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
+import logging
 from ssl import SSLContext
 import sys
 from types import MappingProxyType
@@ -27,6 +28,7 @@ from .json import json_dumps, json_loads
 if TYPE_CHECKING:
     from aiohttp.typedefs import JSONDecoder
 
+_LOGGER = logging.getLogger(__name__)
 
 DATA_CONNECTOR = "aiohttp_connector"
 DATA_CONNECTOR_NOTVERIFY = "aiohttp_connector_notverify"
@@ -77,6 +79,7 @@ def async_get_clientsession(
 @bind_hass
 def async_create_clientsession(
     hass: HomeAssistant,
+    verify_ssl: bool | None = None,
     ssl_context: bool | SSLContext = True,
     auto_cleanup: bool = True,
     **kwargs: Any,
@@ -90,6 +93,12 @@ def async_create_clientsession(
 
     This method must be run in the event loop.
     """
+    if verify_ssl is not None:
+        ssl_context = verify_ssl
+        _LOGGER.error(
+            "The 'verify_ssl' argument of 'async_create_clientsession' is deprecated and replaced by the 'ssl_context' parameter."
+        )
+
     auto_cleanup_method = None
     if auto_cleanup:
         auto_cleanup_method = _async_register_clientsession_shutdown

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -96,7 +96,7 @@ def async_create_clientsession(
     if verify_ssl is not None:
         ssl_context = verify_ssl
         _LOGGER.error(
-            "The 'verify_ssl' argument of 'async_create_clientsession' is deprecated and replaced by the 'ssl_context' parameter."
+            "The 'verify_ssl' argument of 'async_create_clientsession' is deprecated and replaced by the 'ssl_context' parameter"
         )
 
     auto_cleanup_method = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For custom components only:
The verify_ssl optional argument of the `async_create_clientsession` has been renamed to `ssl_context` and now allows to pass in a ssl_context besides a boolean value.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow to specify custom ssl_context in the `async_create_clientsession` function of the aiohttp_client helper.
This can be needed to prevent the` [[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:992)]` error.
This error can be solved by passing in a custom ssl_context:
```
SSL_CONTEXT=ssl.create_default_context()
SSL_CONTEXT.set_ciphers("DEFAULT")
SSL_CONTEXT.check_hostname = False
SSL_CONTEXT.verify_mode = ssl.CERT_NONE
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
