### PR TITLE
Add `cooldown` and `respond_to_read` options for KNX expose

### DIFF
--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -21,7 +21,7 @@ from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, StateType
 
-from .const import KNX_ADDRESS
+from .const import CONF_RESPOND_TO_READ, KNX_ADDRESS
 from .schema import ExposeSchema
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,27 +32,23 @@ def create_knx_exposure(
     hass: HomeAssistant, xknx: XKNX, config: ConfigType
 ) -> KNXExposeSensor | KNXExposeTime:
     """Create exposures from config."""
-    address = config[KNX_ADDRESS]
+
     expose_type = config[ExposeSchema.CONF_KNX_EXPOSE_TYPE]
-    attribute = config.get(ExposeSchema.CONF_KNX_EXPOSE_ATTRIBUTE)
-    default = config.get(ExposeSchema.CONF_KNX_EXPOSE_DEFAULT)
 
     exposure: KNXExposeSensor | KNXExposeTime
     if (
         isinstance(expose_type, str)
         and expose_type.lower() in ExposeSchema.EXPOSE_TIME_TYPES
     ):
-        exposure = KNXExposeTime(xknx, expose_type, address)
+        exposure = KNXExposeTime(
+            xknx=xknx,
+            config=config,
+        )
     else:
-        entity_id = config[CONF_ENTITY_ID]
         exposure = KNXExposeSensor(
             hass,
-            xknx,
-            expose_type,
-            entity_id,
-            attribute,
-            default,
-            address,
+            xknx=xknx,
+            config=config,
         )
     return exposure
 
@@ -64,36 +60,37 @@ class KNXExposeSensor:
         self,
         hass: HomeAssistant,
         xknx: XKNX,
-        expose_type: int | str,
-        entity_id: str,
-        attribute: str | None,
-        default: StateType,
-        address: str,
+        config: ConfigType,
     ) -> None:
         """Initialize of Expose class."""
         self.hass = hass
         self.xknx = xknx
-        self.type = expose_type
-        self.entity_id = entity_id
-        self.expose_attribute = attribute
-        self.expose_default = default
-        self.address = address
+
+        self.entity_id: str = config[CONF_ENTITY_ID]
+        self.expose_attribute: str | None = config.get(
+            ExposeSchema.CONF_KNX_EXPOSE_ATTRIBUTE
+        )
+        self.expose_default = config.get(ExposeSchema.CONF_KNX_EXPOSE_DEFAULT)
+        self.expose_type: int | str = config[ExposeSchema.CONF_KNX_EXPOSE_TYPE]
+
         self._remove_listener: Callable[[], None] | None = None
-        self.device: ExposeSensor = self.async_register()
+        self.device: ExposeSensor = self.async_register(config)
         self._init_expose_state()
 
     @callback
-    def async_register(self) -> ExposeSensor:
+    def async_register(self, config: ConfigType) -> ExposeSensor:
         """Register listener."""
         if self.expose_attribute is not None:
             _name = self.entity_id + "__" + self.expose_attribute
         else:
             _name = self.entity_id
         device = ExposeSensor(
-            self.xknx,
+            xknx=self.xknx,
             name=_name,
-            group_address=self.address,
-            value_type=self.type,
+            group_address=config[KNX_ADDRESS],
+            respond_to_read=config[CONF_RESPOND_TO_READ],
+            value_type=self.expose_type,
+            cooldown=config[ExposeSchema.CONF_KNX_EXPOSE_COOLDOWN],
         )
         self._remove_listener = async_track_state_change_event(
             self.hass, [self.entity_id], self._async_entity_changed
@@ -118,7 +115,7 @@ class KNXExposeSensor:
             self._remove_listener = None
         self.device.shutdown()
 
-    def _get_expose_value(self, state: State | None) -> StateType:
+    def _get_expose_value(self, state: State | None) -> bool | int | float | str | None:
         """Extract value from state."""
         if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             value = self.expose_default
@@ -128,7 +125,7 @@ class KNXExposeSensor:
                 if self.expose_attribute is None
                 else state.attributes.get(self.expose_attribute, self.expose_default)
             )
-        if self.type == "binary":
+        if self.expose_type == "binary":
             if value in (1, STATE_ON, "True"):
                 return True
             if value in (0, STATE_OFF, "False"):
@@ -171,22 +168,21 @@ class KNXExposeSensor:
 class KNXExposeTime:
     """Object to Expose Time/Date object to KNX bus."""
 
-    def __init__(self, xknx: XKNX, expose_type: str, address: str) -> None:
+    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
         """Initialize of Expose class."""
         self.xknx = xknx
-        self.expose_type = expose_type
-        self.address = address
-        self.device: DateTime = self.async_register()
+        self.device: DateTime = self.async_register(config)
 
     @callback
-    def async_register(self) -> DateTime:
+    def async_register(self, config: ConfigType) -> DateTime:
         """Register listener."""
+        expose_type = config[ExposeSchema.CONF_KNX_EXPOSE_TYPE]
         return DateTime(
             self.xknx,
-            name=self.expose_type.capitalize(),
-            broadcast_type=self.expose_type.upper(),
+            name=expose_type.capitalize(),
+            broadcast_type=expose_type.upper(),
             localtime=True,
-            group_address=self.address,
+            group_address=config[KNX_ADDRESS],
         )
 
     @callback

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -561,6 +561,7 @@ class ExposeSchema(KNXPlatformSchema):
     CONF_KNX_EXPOSE_TYPE = CONF_TYPE
     CONF_KNX_EXPOSE_ATTRIBUTE = "attribute"
     CONF_KNX_EXPOSE_BINARY = "binary"
+    CONF_KNX_EXPOSE_COOLDOWN = "cooldown"
     CONF_KNX_EXPOSE_DEFAULT = "default"
     EXPOSE_TIME_TYPES: Final = [
         "time",
@@ -578,6 +579,8 @@ class ExposeSchema(KNXPlatformSchema):
     )
     EXPOSE_SENSOR_SCHEMA = vol.Schema(
         {
+            vol.Optional(CONF_KNX_EXPOSE_COOLDOWN, default=0): cv.positive_float,
+            vol.Optional(CONF_RESPOND_TO_READ, default=True): cv.boolean,
             vol.Required(CONF_KNX_EXPOSE_TYPE): vol.Any(
                 CONF_KNX_EXPOSE_BINARY, sensor_type_validator
             ),

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -1,4 +1,5 @@
 """Test KNX expose."""
+from datetime import timedelta
 import time
 from unittest.mock import patch
 
@@ -6,8 +7,11 @@ from homeassistant.components.knx import CONF_KNX_EXPOSE, DOMAIN, KNX_ADDRESS
 from homeassistant.components.knx.schema import ExposeSchema
 from homeassistant.const import CONF_ATTRIBUTE, CONF_ENTITY_ID, CONF_TYPE
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt
 
 from .conftest import KNXTestKit
+
+from tests.common import async_fire_time_changed_exact
 
 
 async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit):
@@ -161,6 +165,37 @@ async def test_expose_string(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_write(
         "1/1/8", (84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 118, 101, 114, 121)
     )
+
+
+async def test_expose_cooldown(hass: HomeAssistant, knx: KNXTestKit):
+    """Test an expose with cooldown."""
+    cooldown_time = 2
+    entity_id = "fake.entity"
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: {
+                CONF_TYPE: "percentU8",
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: entity_id,
+                ExposeSchema.CONF_KNX_EXPOSE_COOLDOWN: cooldown_time,
+            }
+        },
+    )
+    assert not hass.states.async_all()
+    # Change state to 1
+    hass.states.async_set(entity_id, "1", {})
+    await knx.assert_write("1/1/8", (1,))
+    # Change state to 2 - skip because of cooldown
+    hass.states.async_set(entity_id, "2", {})
+    await knx.assert_no_telegram()
+
+    # Change state to 3
+    hass.states.async_set(entity_id, "3", {})
+    await knx.assert_no_telegram()
+    # Wait for cooldown to pass
+    async_fire_time_changed_exact(hass, dt.utcnow() + timedelta(seconds=cooldown_time))
+    await hass.async_block_till_done()
+    await knx.assert_write("1/1/8", (3,))
 
 
 async def test_expose_conversion_exception(hass: HomeAssistant, knx: KNXTestKit):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `cooldown` and `respond_to_read` options for KNX expose.

`cooldown` reduces bus load on high frequent updating entities exposures.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25417

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
