### PR TITLE
Improve `here_travel_time` generic typing

### DIFF
--- a/homeassistant/components/here_travel_time/const.py
+++ b/homeassistant/components/here_travel_time/const.py
@@ -1,4 +1,6 @@
 """Constants for the HERE Travel Time integration."""
+from typing import Final
+
 DOMAIN = "here_travel_time"
 DEFAULT_SCAN_INTERVAL = 300
 
@@ -51,11 +53,11 @@ ICONS = {
     TRAVEL_MODE_TRUCK: ICON_TRUCK,
 }
 
-ATTR_DURATION = "duration"
-ATTR_DISTANCE = "distance"
-ATTR_ORIGIN = "origin"
-ATTR_DESTINATION = "destination"
+ATTR_DURATION: Final = "duration"
+ATTR_DISTANCE: Final = "distance"
+ATTR_ORIGIN: Final = "origin"
+ATTR_DESTINATION: Final = "destination"
 
-ATTR_DURATION_IN_TRAFFIC = "duration_in_traffic"
-ATTR_ORIGIN_NAME = "origin_name"
-ATTR_DESTINATION_NAME = "destination_name"
+ATTR_DURATION_IN_TRAFFIC: Final = "duration_in_traffic"
+ATTR_ORIGIN_NAME: Final = "origin_name"
+ATTR_DESTINATION_NAME: Final = "destination_name"

--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, time, timedelta
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import here_routing
 from here_routing import (
@@ -40,7 +40,7 @@ BACKOFF_MULTIPLIER = 1.1
 _LOGGER = logging.getLogger(__name__)
 
 
-class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator):
+class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator[HERETravelTimeData]):
     """here_routing DataUpdateCoordinator."""
 
     def __init__(
@@ -59,7 +59,7 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator):
         self._api = HERERoutingApi(api_key)
         self.config = config
 
-    async def _async_update_data(self) -> HERETravelTimeData | None:
+    async def _async_update_data(self) -> HERETravelTimeData:
         """Get the latest data from the HERE Routing API."""
         origin, destination, arrival, departure = prepare_parameters(
             self.hass, self.config
@@ -144,7 +144,9 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
 
-class HERETransitDataUpdateCoordinator(DataUpdateCoordinator):
+class HERETransitDataUpdateCoordinator(
+    DataUpdateCoordinator[Optional[HERETravelTimeData]]
+):
     """HERETravelTime DataUpdateCoordinator."""
 
     def __init__(

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any
+from typing import Any, Union
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -102,7 +102,12 @@ async def async_setup_entry(
     async_add_entities(sensors)
 
 
-class HERETravelTimeSensor(CoordinatorEntity, RestoreSensor):
+class HERETravelTimeSensor(
+    CoordinatorEntity[
+        Union[HERERoutingDataUpdateCoordinator, HERETransitDataUpdateCoordinator]
+    ],
+    RestoreSensor,
+):
     """Representation of a HERE travel time sensor."""
 
     def __init__(
@@ -144,7 +149,7 @@ class HERETravelTimeSensor(CoordinatorEntity, RestoreSensor):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if self.coordinator.data is not None:
-            self._attr_native_value = self.coordinator.data.get(
+            self._attr_native_value = self.coordinator.data.get(  # type: ignore[assignment]
                 self.entity_description.key
             )
             self.async_write_ha_state()


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
