### PR TITLE
Improve `gogogate2` generic typing

### DIFF
--- a/homeassistant/components/gogogate2/common.py
+++ b/homeassistant/components/gogogate2/common.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import timedelta
 import logging
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, Union
 
-from ismartgate import AbstractGateApi, GogoGate2Api, ISmartGateApi
+from ismartgate import (
+    AbstractGateApi,
+    GogoGate2Api,
+    GogoGate2InfoResponse,
+    ISmartGateApi,
+    ISmartGateInfoResponse,
+)
 from ismartgate.common import AbstractDoor, get_door_by_id
 
 from homeassistant.config_entries import ConfigEntry
@@ -39,7 +45,9 @@ class StateData(NamedTuple):
     door: AbstractDoor | None
 
 
-class DeviceDataUpdateCoordinator(DataUpdateCoordinator):
+class DeviceDataUpdateCoordinator(
+    DataUpdateCoordinator[Union[GogoGate2InfoResponse, ISmartGateInfoResponse]]
+):
     """Manages polling for state changes from the device."""
 
     def __init__(
@@ -50,7 +58,10 @@ class DeviceDataUpdateCoordinator(DataUpdateCoordinator):
         *,
         name: str,
         update_interval: timedelta,
-        update_method: Callable[[], Awaitable] | None = None,
+        update_method: Callable[
+            [], Awaitable[GogoGate2InfoResponse | ISmartGateInfoResponse]
+        ]
+        | None = None,
         request_refresh_debouncer: Debouncer | None = None,
     ) -> None:
         """Initialize the data update coordinator."""
@@ -131,7 +142,7 @@ def get_data_update_coordinator(
     if DATA_UPDATE_COORDINATOR not in config_entry_data:
         api = get_api(hass, config_entry.data)
 
-        async def async_update_data():
+        async def async_update_data() -> GogoGate2InfoResponse | ISmartGateInfoResponse:
             try:
                 return await api.async_info()
             except Exception as exception:


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
