### PR TITLE
Improve `lookin` generic typing

### DIFF
--- a/homeassistant/components/lookin/__init__.py
+++ b/homeassistant/components/lookin/__init__.py
@@ -102,7 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     push_coordinator = LookinPushCoordinator(entry.title)
 
     if lookin_device.model >= 2:
-        meteo_coordinator: LookinDataUpdateCoordinator = LookinDataUpdateCoordinator(
+        meteo_coordinator = LookinDataUpdateCoordinator[MeteoSensor](
             hass,
             push_coordinator,
             name=entry.title,
@@ -113,7 +113,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         await meteo_coordinator.async_config_entry_first_refresh()
 
-    device_coordinators: dict[str, LookinDataUpdateCoordinator] = {}
+    device_coordinators: dict[str, LookinDataUpdateCoordinator[Remote]] = {}
     for remote in devices:
         if (platform := TYPE_TO_PLATFORM.get(remote["Type"])) is None:
             continue

--- a/homeassistant/components/lookin/climate.py
+++ b/homeassistant/components/lookin/climate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Final, cast
 
-from aiolookin import Climate, MeteoSensor
+from aiolookin import Climate, MeteoSensor, Remote
 from aiolookin.models import UDPCommandType, UDPEvent
 
 from homeassistant.components.climate import (
@@ -75,7 +75,7 @@ async def async_setup_entry(
             continue
         uuid = remote["UUID"]
         coordinator = lookin_data.device_coordinators[uuid]
-        device: Climate = coordinator.data
+        device = cast(Climate, coordinator.data)
         entities.append(
             ConditionerEntity(
                 uuid=uuid,
@@ -110,7 +110,7 @@ class ConditionerEntity(LookinCoordinatorEntity, ClimateEntity):
         uuid: str,
         device: Climate,
         lookin_data: LookinData,
-        coordinator: LookinDataUpdateCoordinator,
+        coordinator: LookinDataUpdateCoordinator[Remote],
     ) -> None:
         """Init the ConditionerEntity."""
         super().__init__(coordinator, uuid, device, lookin_data)

--- a/homeassistant/components/lookin/entity.py
+++ b/homeassistant/components/lookin/entity.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 
 from abc import abstractmethod
 import logging
-from typing import cast
 
-from aiolookin import POWER_CMD, POWER_OFF_CMD, POWER_ON_CMD, Climate, Remote
+from aiolookin import (
+    POWER_CMD,
+    POWER_OFF_CMD,
+    POWER_ON_CMD,
+    Climate,
+    MeteoSensor,
+    Remote,
+)
 from aiolookin.models import Device, UDPCommandType, UDPEvent
 
 from homeassistant.helpers.entity import DeviceInfo
@@ -53,7 +59,7 @@ class LookinDeviceMixIn:
 
 
 class LookinDeviceCoordinatorEntity(
-    LookinDeviceMixIn, CoordinatorEntity[LookinDataUpdateCoordinator]
+    LookinDeviceMixIn, CoordinatorEntity[LookinDataUpdateCoordinator[MeteoSensor]]
 ):
     """A lookin device entity on the device itself that uses the coordinator."""
 
@@ -86,7 +92,9 @@ class LookinEntityMixIn:
 
 
 class LookinCoordinatorEntity(
-    LookinDeviceMixIn, LookinEntityMixIn, CoordinatorEntity[LookinDataUpdateCoordinator]
+    LookinDeviceMixIn,
+    LookinEntityMixIn,
+    CoordinatorEntity[LookinDataUpdateCoordinator[Remote]],
 ):
     """A lookin device entity for an external device that uses the coordinator."""
 
@@ -95,7 +103,7 @@ class LookinCoordinatorEntity(
 
     def __init__(
         self,
-        coordinator: LookinDataUpdateCoordinator,
+        coordinator: LookinDataUpdateCoordinator[Remote],
         uuid: str,
         device: Remote | Climate,
         lookin_data: LookinData,
@@ -122,7 +130,7 @@ class LookinPowerEntity(LookinCoordinatorEntity):
 
     def __init__(
         self,
-        coordinator: LookinDataUpdateCoordinator,
+        coordinator: LookinDataUpdateCoordinator[Remote],
         uuid: str,
         device: Remote | Climate,
         lookin_data: LookinData,
@@ -142,7 +150,7 @@ class LookinPowerPushRemoteEntity(LookinPowerEntity):
 
     def __init__(
         self,
-        coordinator: LookinDataUpdateCoordinator,
+        coordinator: LookinDataUpdateCoordinator[Remote],
         uuid: str,
         device: Remote,
         lookin_data: LookinData,
@@ -154,7 +162,7 @@ class LookinPowerPushRemoteEntity(LookinPowerEntity):
 
     @property
     def _remote(self) -> Remote:
-        return cast(Remote, self.coordinator.data)
+        return self.coordinator.data
 
     @abstractmethod
     def _update_from_status(self, status: str) -> None:

--- a/homeassistant/components/lookin/light.py
+++ b/homeassistant/components/lookin/light.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from aiolookin import Remote
-
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -33,7 +31,7 @@ async def async_setup_entry(
             continue
         uuid = remote["UUID"]
         coordinator = lookin_data.device_coordinators[uuid]
-        device: Remote = coordinator.data
+        device = coordinator.data
         entities.append(
             LookinLightEntity(
                 coordinator=coordinator,

--- a/homeassistant/components/lookin/models.py
+++ b/homeassistant/components/lookin/models.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from aiolookin import Device, LookInHttpProtocol, LookinUDPSubscriptions
+from aiolookin import (
+    Device,
+    LookInHttpProtocol,
+    LookinUDPSubscriptions,
+    MeteoSensor,
+    Remote,
+)
 
 from .coordinator import LookinDataUpdateCoordinator
 
@@ -16,7 +22,7 @@ class LookinData:
     host: str
     lookin_udp_subs: LookinUDPSubscriptions
     lookin_device: Device
-    meteo_coordinator: LookinDataUpdateCoordinator | None
+    meteo_coordinator: LookinDataUpdateCoordinator[MeteoSensor] | None
     devices: list[dict[str, Any]]
     lookin_protocol: LookInHttpProtocol
-    device_coordinators: dict[str, LookinDataUpdateCoordinator]
+    device_coordinators: dict[str, LookinDataUpdateCoordinator[Remote]]


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
