### PR TITLE
Improve `opengarage` generic typing

### DIFF
--- a/homeassistant/components/opengarage/__init__.py
+++ b/homeassistant/components/opengarage/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
+from typing import Any
 
 import opengarage
 
@@ -11,6 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import update_coordinator
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import CONF_DEVICE_KEY, DOMAIN
 
@@ -50,7 +52,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class OpenGarageDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
+class OpenGarageDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching Opengarage data."""
 
     def __init__(
@@ -69,7 +71,7 @@ class OpenGarageDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
             update_interval=timedelta(seconds=5),
         )
 
-    async def _async_update_data(self) -> None:
+    async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data."""
         data = await self.open_garage_connection.update_state()
         if data is None:

--- a/homeassistant/components/opengarage/binary_sensor.py
+++ b/homeassistant/components/opengarage/binary_sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -36,7 +37,7 @@ async def async_setup_entry(
         [
             OpenGarageBinarySensor(
                 open_garage_data_coordinator,
-                entry.unique_id,
+                cast(str, entry.unique_id),
                 description,
             )
             for description in SENSOR_TYPES
@@ -50,7 +51,7 @@ class OpenGarageBinarySensor(OpenGarageEntity, BinarySensorEntity):
     def __init__(
         self,
         coordinator: OpenGarageDataUpdateCoordinator,
-        device_id: str | None,
+        device_id: str,
         description: BinarySensorEntityDescription,
     ) -> None:
         """Initialize the entity."""

--- a/homeassistant/components/opengarage/binary_sensor.py
+++ b/homeassistant/components/opengarage/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import OpenGarageDataUpdateCoordinator
 from .const import DOMAIN
 from .entity import OpenGarageEntity
 
@@ -28,7 +29,9 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the OpenGarage binary sensors."""
-    open_garage_data_coordinator = hass.data[DOMAIN][entry.entry_id]
+    open_garage_data_coordinator: OpenGarageDataUpdateCoordinator = hass.data[DOMAIN][
+        entry.entry_id
+    ]
     async_add_entities(
         [
             OpenGarageBinarySensor(
@@ -44,10 +47,15 @@ async def async_setup_entry(
 class OpenGarageBinarySensor(OpenGarageEntity, BinarySensorEntity):
     """Representation of a OpenGarage binary sensor."""
 
-    def __init__(self, open_garage_data_coordinator, device_id, description):
+    def __init__(
+        self,
+        coordinator: OpenGarageDataUpdateCoordinator,
+        device_id: str | None,
+        description: BinarySensorEntityDescription,
+    ) -> None:
         """Initialize the entity."""
         self._available = False
-        super().__init__(open_garage_data_coordinator, device_id, description)
+        super().__init__(coordinator, device_id, description)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.cover import (
     CoverDeviceClass,
@@ -28,7 +28,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the OpenGarage covers."""
     async_add_entities(
-        [OpenGarageCover(hass.data[DOMAIN][entry.entry_id], entry.unique_id)]
+        [OpenGarageCover(hass.data[DOMAIN][entry.entry_id], cast(str, entry.unique_id))]
     )
 
 
@@ -39,7 +39,7 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
     def __init__(
-        self, coordinator: OpenGarageDataUpdateCoordinator, device_id: str | None
+        self, coordinator: OpenGarageDataUpdateCoordinator, device_id: str
     ) -> None:
         """Initialize the cover."""
         self._state: str | None = None

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -14,6 +14,7 @@ from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_O
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import OpenGarageDataUpdateCoordinator
 from .const import DOMAIN
 from .entity import OpenGarageEntity
 
@@ -37,12 +38,14 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
     _attr_device_class = CoverDeviceClass.GARAGE
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
-    def __init__(self, open_garage_data_coordinator, device_id):
+    def __init__(
+        self, coordinator: OpenGarageDataUpdateCoordinator, device_id: str | None
+    ) -> None:
         """Initialize the cover."""
-        self._state = None
-        self._state_before_move = None
+        self._state: str | None = None
+        self._state_before_move: str | None = None
 
-        super().__init__(open_garage_data_coordinator, device_id)
+        super().__init__(coordinator, device_id)
 
     @property
     def is_closed(self) -> bool | None:
@@ -87,7 +90,7 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
         status = self.coordinator.data
 
         self._attr_name = status["name"]
-        state = STATES_MAP.get(status.get("door"))
+        state = STATES_MAP.get(status.get("door"))  # type: ignore[arg-type]
         if self._state_before_move is not None:
             if self._state_before_move != state:
                 self._state = state

--- a/homeassistant/components/opengarage/entity.py
+++ b/homeassistant/components/opengarage/entity.py
@@ -15,7 +15,7 @@ class OpenGarageEntity(CoordinatorEntity[OpenGarageDataUpdateCoordinator]):
     def __init__(
         self,
         open_garage_data_coordinator: OpenGarageDataUpdateCoordinator,
-        device_id: str | None,
+        device_id: str,
         description: EntityDescription | None = None,
     ) -> None:
         """Initialize the entity."""
@@ -41,9 +41,9 @@ class OpenGarageEntity(CoordinatorEntity[OpenGarageDataUpdateCoordinator]):
         self.async_write_ha_state()
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
-        device_info = DeviceInfo(
+        return DeviceInfo(
             configuration_url=self.coordinator.open_garage_connection.device_url,
             connections={(CONNECTION_NETWORK_MAC, self.coordinator.data["mac"])},
             identifiers={(DOMAIN, self._device_id)},
@@ -52,4 +52,3 @@ class OpenGarageEntity(CoordinatorEntity[OpenGarageDataUpdateCoordinator]):
             suggested_area="Garage",
             sw_version=self.coordinator.data["fwv"],
         )
-        return device_info

--- a/homeassistant/components/opengarage/entity.py
+++ b/homeassistant/components/opengarage/entity.py
@@ -1,17 +1,23 @@
 """Entity for the opengarage.io component."""
+from __future__ import annotations
 
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import DOMAIN
+from . import DOMAIN, OpenGarageDataUpdateCoordinator
 
 
-class OpenGarageEntity(CoordinatorEntity):
+class OpenGarageEntity(CoordinatorEntity[OpenGarageDataUpdateCoordinator]):
     """Representation of a OpenGarage entity."""
 
-    def __init__(self, open_garage_data_coordinator, device_id, description=None):
+    def __init__(
+        self,
+        open_garage_data_coordinator: OpenGarageDataUpdateCoordinator,
+        device_id: str | None,
+        description: EntityDescription | None = None,
+    ) -> None:
         """Initialize the entity."""
         super().__init__(open_garage_data_coordinator)
 

--- a/homeassistant/components/opengarage/sensor.py
+++ b/homeassistant/components/opengarage/sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -67,7 +68,7 @@ async def async_setup_entry(
         [
             OpenGarageSensor(
                 open_garage_data_coordinator,
-                entry.unique_id,
+                cast(str, entry.unique_id),
                 description,
             )
             for description in SENSOR_TYPES

--- a/homeassistant/components/opengarage/sensor.py
+++ b/homeassistant/components/opengarage/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import OpenGarageDataUpdateCoordinator
 from .const import DOMAIN
 from .entity import OpenGarageEntity
 
@@ -59,7 +60,9 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the OpenGarage sensors."""
-    open_garage_data_coordinator = hass.data[DOMAIN][entry.entry_id]
+    open_garage_data_coordinator: OpenGarageDataUpdateCoordinator = hass.data[DOMAIN][
+        entry.entry_id
+    ]
     async_add_entities(
         [
             OpenGarageSensor(


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
