### PR TITLE
Improve `syncthru` generic typing

### DIFF
--- a/homeassistant/components/syncthru/__init__.py
+++ b/homeassistant/components/syncthru/__init__.py
@@ -50,7 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
             return printer
 
-    coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
+    coordinator = DataUpdateCoordinator[SyncThru](
         hass,
         _LOGGER,
         name=DOMAIN,

--- a/homeassistant/components/syncthru/binary_sensor.py
+++ b/homeassistant/components/syncthru/binary_sensor.py
@@ -38,9 +38,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up from config entry."""
 
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: DataUpdateCoordinator[SyncThru] = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
 
-    name = config_entry.data[CONF_NAME]
+    name: str = config_entry.data[CONF_NAME]
     entities = [
         SyncThruOnlineSensor(coordinator, name),
         SyncThruProblemSensor(coordinator, name),
@@ -49,14 +51,16 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SyncThruBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class SyncThruBinarySensor(
+    CoordinatorEntity[DataUpdateCoordinator[SyncThru]], BinarySensorEntity
+):
     """Implementation of an abstract Samsung Printer binary sensor platform."""
 
-    def __init__(self, coordinator, name):
+    def __init__(self, coordinator: DataUpdateCoordinator[SyncThru], name: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self.syncthru: SyncThru = coordinator.data
-        self._name = name
+        self.syncthru = coordinator.data
+        self._attr_name = name
         self._id_suffix = ""
 
     @property
@@ -64,11 +68,6 @@ class SyncThruBinarySensor(CoordinatorEntity, BinarySensorEntity):
         """Return unique ID for the sensor."""
         serial = self.syncthru.serial_number()
         return f"{serial}{self._id_suffix}" if serial else None
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
 
     @property
     def device_info(self) -> DeviceInfo | None:
@@ -85,9 +84,9 @@ class SyncThruOnlineSensor(SyncThruBinarySensor):
 
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 
-    def __init__(self, syncthru, name):
+    def __init__(self, coordinator: DataUpdateCoordinator[SyncThru], name: str) -> None:
         """Initialize the sensor."""
-        super().__init__(syncthru, name)
+        super().__init__(coordinator, name)
         self._id_suffix = "_online"
 
     @property

--- a/homeassistant/components/syncthru/sensor.py
+++ b/homeassistant/components/syncthru/sensor.py
@@ -161,6 +161,8 @@ class SyncThruTonerSensor(SyncThruSensor):
 class SyncThruDrumSensor(SyncThruSensor):
     """Implementation of a Samsung Printer drum sensor platform."""
 
+    _attr_native_unit_of_measurement = PERCENTAGE
+
     def __init__(
         self, coordinator: DataUpdateCoordinator[SyncThru], name: str, color: str
     ) -> None:
@@ -168,7 +170,6 @@ class SyncThruDrumSensor(SyncThruSensor):
         super().__init__(coordinator, name)
         self._attr_name = f"{name} Drum {color}"
         self._color = color
-        self._attr_native_unit_of_measurement = PERCENTAGE
         self._id_suffix = f"_drum_{color}"
 
     @property

--- a/homeassistant/components/syncthru/sensor.py
+++ b/homeassistant/components/syncthru/sensor.py
@@ -46,7 +46,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up from config entry."""
 
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: DataUpdateCoordinator[SyncThru] = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
     printer: SyncThru = coordinator.data
 
     supp_toner = printer.toner_status(filter_supported=True)
@@ -54,7 +56,7 @@ async def async_setup_entry(
     supp_tray = printer.input_tray_status(filter_supported=True)
     supp_output_tray = printer.output_tray_status()
 
-    name = config_entry.data[CONF_NAME]
+    name: str = config_entry.data[CONF_NAME]
     entities: list[SyncThruSensor] = [
         SyncThruMainSensor(coordinator, name),
         SyncThruActiveAlertSensor(coordinator, name),
@@ -72,16 +74,16 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SyncThruSensor(CoordinatorEntity, SensorEntity):
+class SyncThruSensor(CoordinatorEntity[DataUpdateCoordinator[SyncThru]], SensorEntity):
     """Implementation of an abstract Samsung Printer sensor platform."""
 
-    def __init__(self, coordinator, name):
+    _attr_icon = "mdi:printer"
+
+    def __init__(self, coordinator: DataUpdateCoordinator[SyncThru], name: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self.syncthru: SyncThru = coordinator.data
-        self._name = name
-        self._icon = "mdi:printer"
-        self._unit_of_measurement = None
+        self.syncthru = coordinator.data
+        self._attr_name = name
         self._id_suffix = ""
 
     @property
@@ -89,21 +91,6 @@ class SyncThruSensor(CoordinatorEntity, SensorEntity):
         """Return unique ID for the sensor."""
         serial = self.syncthru.serial_number()
         return f"{serial}{self._id_suffix}" if serial else None
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def icon(self):
-        """Return the icon of the device."""
-        return self._icon
-
-    @property
-    def native_unit_of_measurement(self):
-        """Return the unit of measuremnt."""
-        return self._unit_of_measurement
 
     @property
     def device_info(self) -> DeviceInfo | None:
@@ -123,7 +110,7 @@ class SyncThruMainSensor(SyncThruSensor):
     the displayed current status message.
     """
 
-    def __init__(self, coordinator, name):
+    def __init__(self, coordinator: DataUpdateCoordinator[SyncThru], name: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, name)
         self._id_suffix = "_main"
@@ -149,12 +136,15 @@ class SyncThruMainSensor(SyncThruSensor):
 class SyncThruTonerSensor(SyncThruSensor):
     """Implementation of a Samsung Printer toner sensor platform."""
 
-    def __init__(self, coordinator, name, color):
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(
+        self, coordinator: DataUpdateCoordinator[SyncThru], name: str, color: str
+    ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, name)
-        self._name = f"{name} Toner {color}"
+        self._attr_name = f"{name} Toner {color}"
         self._color = color
-        self._unit_of_measurement = PERCENTAGE
         self._id_suffix = f"_toner_{color}"
 
     @property
@@ -171,12 +161,14 @@ class SyncThruTonerSensor(SyncThruSensor):
 class SyncThruDrumSensor(SyncThruSensor):
     """Implementation of a Samsung Printer drum sensor platform."""
 
-    def __init__(self, syncthru, name, color):
+    def __init__(
+        self, coordinator: DataUpdateCoordinator[SyncThru], name: str, color: str
+    ) -> None:
         """Initialize the sensor."""
-        super().__init__(syncthru, name)
-        self._name = f"{name} Drum {color}"
+        super().__init__(coordinator, name)
+        self._attr_name = f"{name} Drum {color}"
         self._color = color
-        self._unit_of_measurement = PERCENTAGE
+        self._attr_native_unit_of_measurement = PERCENTAGE
         self._id_suffix = f"_drum_{color}"
 
     @property
@@ -193,10 +185,12 @@ class SyncThruDrumSensor(SyncThruSensor):
 class SyncThruInputTraySensor(SyncThruSensor):
     """Implementation of a Samsung Printer input tray sensor platform."""
 
-    def __init__(self, syncthru, name, number):
+    def __init__(
+        self, coordinator: DataUpdateCoordinator[SyncThru], name: str, number: str
+    ) -> None:
         """Initialize the sensor."""
-        super().__init__(syncthru, name)
-        self._name = f"{name} Tray {number}"
+        super().__init__(coordinator, name)
+        self._attr_name = f"{name} Tray {number}"
         self._number = number
         self._id_suffix = f"_tray_{number}"
 
@@ -219,10 +213,12 @@ class SyncThruInputTraySensor(SyncThruSensor):
 class SyncThruOutputTraySensor(SyncThruSensor):
     """Implementation of a Samsung Printer output tray sensor platform."""
 
-    def __init__(self, syncthru, name, number):
+    def __init__(
+        self, coordinator: DataUpdateCoordinator[SyncThru], name: str, number: int
+    ) -> None:
         """Initialize the sensor."""
-        super().__init__(syncthru, name)
-        self._name = f"{name} Output Tray {number}"
+        super().__init__(coordinator, name)
+        self._attr_name = f"{name} Output Tray {number}"
         self._number = number
         self._id_suffix = f"_output_tray_{number}"
 
@@ -245,10 +241,10 @@ class SyncThruOutputTraySensor(SyncThruSensor):
 class SyncThruActiveAlertSensor(SyncThruSensor):
     """Implementation of a Samsung Printer active alerts sensor platform."""
 
-    def __init__(self, syncthru, name):
+    def __init__(self, coordinator: DataUpdateCoordinator[SyncThru], name: str) -> None:
         """Initialize the sensor."""
-        super().__init__(syncthru, name)
-        self._name = f"{name} Active Alerts"
+        super().__init__(coordinator, name)
+        self._attr_name = f"{name} Active Alerts"
         self._id_suffix = "_active_alerts"
 
     @property


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
