### PR TITLE
Improve `synology_dsm` generic typing

### DIFF
--- a/homeassistant/components/synology_dsm/binary_sensor.py
+++ b/homeassistant/components/synology_dsm/binary_sensor.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 from synology_dsm.api.core.security import SynoCoreSecurity
 from synology_dsm.api.storage.storage import SynoStorage
@@ -17,10 +16,10 @@ from homeassistant.const import CONF_DISKS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import SynoApi
 from .const import DOMAIN
+from .coordinator import SynologyDSMCentralUpdateCoordinator
 from .entity import (
     SynologyDSMBaseEntity,
     SynologyDSMDeviceEntity,
@@ -89,7 +88,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SynoDSMBinarySensor(SynologyDSMBaseEntity, BinarySensorEntity):
+class SynoDSMBinarySensor(
+    SynologyDSMBaseEntity[SynologyDSMCentralUpdateCoordinator], BinarySensorEntity
+):
     """Mixin for binary sensor specific attributes."""
 
     entity_description: SynologyDSMBinarySensorEntityDescription
@@ -97,7 +98,7 @@ class SynoDSMBinarySensor(SynologyDSMBaseEntity, BinarySensorEntity):
     def __init__(
         self,
         api: SynoApi,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
+        coordinator: SynologyDSMCentralUpdateCoordinator,
         description: SynologyDSMBinarySensorEntityDescription,
     ) -> None:
         """Initialize the Synology DSM binary_sensor entity."""
@@ -131,7 +132,7 @@ class SynoDSMStorageBinarySensor(SynologyDSMDeviceEntity, SynoDSMBinarySensor):
     def __init__(
         self,
         api: SynoApi,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
+        coordinator: SynologyDSMCentralUpdateCoordinator,
         description: SynologyDSMBinarySensorEntityDescription,
         device_id: str | None = None,
     ) -> None:

--- a/homeassistant/components/synology_dsm/camera.py
+++ b/homeassistant/components/synology_dsm/camera.py
@@ -20,7 +20,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import SynoApi
 from .const import (
@@ -29,6 +28,7 @@ from .const import (
     DOMAIN,
     SIGNAL_CAMERA_SOURCE_CHANGED,
 )
+from .coordinator import SynologyDSMCameraUpdateCoordinator
 from .entity import SynologyDSMBaseEntity, SynologyDSMEntityDescription
 from .models import SynologyDSMData
 
@@ -54,17 +54,16 @@ async def async_setup_entry(
         )
 
 
-class SynoDSMCamera(SynologyDSMBaseEntity, Camera):
+class SynoDSMCamera(SynologyDSMBaseEntity[SynologyDSMCameraUpdateCoordinator], Camera):
     """Representation a Synology camera."""
 
     _attr_supported_features = CameraEntityFeature.STREAM
-    coordinator: DataUpdateCoordinator[dict[str, dict[str, SynoCamera]]]
     entity_description: SynologyDSMCameraEntityDescription
 
     def __init__(
         self,
         api: SynoApi,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, SynoCamera]]],
+        coordinator: SynologyDSMCameraUpdateCoordinator,
         camera_id: str,
     ) -> None:
         """Initialize a Synology camera."""

--- a/homeassistant/components/synology_dsm/coordinator.py
+++ b/homeassistant/components/synology_dsm/coordinator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, TypeVar
 
 import async_timeout
 from synology_dsm.api.surveillance_station.camera import SynoCamera
@@ -23,9 +23,10 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_DataT = TypeVar("_DataT")
 
 
-class SynologyDSMUpdateCoordinator(DataUpdateCoordinator):
+class SynologyDSMUpdateCoordinator(DataUpdateCoordinator[_DataT]):
     """DataUpdateCoordinator base class for synology_dsm."""
 
     def __init__(
@@ -46,7 +47,9 @@ class SynologyDSMUpdateCoordinator(DataUpdateCoordinator):
         )
 
 
-class SynologyDSMSwitchUpdateCoordinator(SynologyDSMUpdateCoordinator):
+class SynologyDSMSwitchUpdateCoordinator(
+    SynologyDSMUpdateCoordinator[dict[str, dict[str, Any]]]
+):
     """DataUpdateCoordinator to gather data for a synology_dsm switch devices."""
 
     def __init__(
@@ -78,7 +81,7 @@ class SynologyDSMSwitchUpdateCoordinator(SynologyDSMUpdateCoordinator):
         }
 
 
-class SynologyDSMCentralUpdateCoordinator(SynologyDSMUpdateCoordinator):
+class SynologyDSMCentralUpdateCoordinator(SynologyDSMUpdateCoordinator[None]):
     """DataUpdateCoordinator to gather data for a synology_dsm central device."""
 
     def __init__(
@@ -106,7 +109,9 @@ class SynologyDSMCentralUpdateCoordinator(SynologyDSMUpdateCoordinator):
         return None
 
 
-class SynologyDSMCameraUpdateCoordinator(SynologyDSMUpdateCoordinator):
+class SynologyDSMCameraUpdateCoordinator(
+    SynologyDSMUpdateCoordinator[dict[str, dict[str, SynoCamera]]]
+):
     """DataUpdateCoordinator to gather data for a synology_dsm cameras."""
 
     def __init__(

--- a/homeassistant/components/synology_dsm/entity.py
+++ b/homeassistant/components/synology_dsm/entity.py
@@ -2,16 +2,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeVar
 
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .common import SynoApi
 from .const import ATTRIBUTION, DOMAIN
+from .coordinator import (
+    SynologyDSMCentralUpdateCoordinator,
+    SynologyDSMUpdateCoordinator,
+)
+
+_CoordinatorT = TypeVar("_CoordinatorT", bound=SynologyDSMUpdateCoordinator[Any])
 
 
 @dataclass
@@ -26,9 +29,7 @@ class SynologyDSMEntityDescription(EntityDescription, SynologyDSMRequiredKeysMix
     """Generic Synology DSM entity description."""
 
 
-class SynologyDSMBaseEntity(
-    CoordinatorEntity[DataUpdateCoordinator[dict[str, dict[str, Any]]]]
-):
+class SynologyDSMBaseEntity(CoordinatorEntity[_CoordinatorT]):
     """Representation of a Synology NAS entry."""
 
     entity_description: SynologyDSMEntityDescription
@@ -38,7 +39,7 @@ class SynologyDSMBaseEntity(
     def __init__(
         self,
         api: SynoApi,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
+        coordinator: _CoordinatorT,
         description: SynologyDSMEntityDescription,
     ) -> None:
         """Initialize the Synology DSM entity."""
@@ -67,13 +68,15 @@ class SynologyDSMBaseEntity(
         await super().async_added_to_hass()
 
 
-class SynologyDSMDeviceEntity(SynologyDSMBaseEntity):
+class SynologyDSMDeviceEntity(
+    SynologyDSMBaseEntity[SynologyDSMCentralUpdateCoordinator]
+):
     """Representation of a Synology NAS disk or volume entry."""
 
     def __init__(
         self,
         api: SynoApi,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
+        coordinator: SynologyDSMCentralUpdateCoordinator,
         description: SynologyDSMEntityDescription,
         device_id: str | None = None,
     ) -> None:

--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -26,11 +26,11 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.dt import utcnow
 
 from . import SynoApi
 from .const import CONF_VOLUMES, DOMAIN, ENTITY_UNIT_LOAD
+from .coordinator import SynologyDSMCentralUpdateCoordinator
 from .entity import (
     SynologyDSMBaseEntity,
     SynologyDSMDeviceEntity,
@@ -328,7 +328,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SynoDSMSensor(SynologyDSMBaseEntity, SensorEntity):
+class SynoDSMSensor(
+    SynologyDSMBaseEntity[SynologyDSMCentralUpdateCoordinator], SensorEntity
+):
     """Mixin for sensor specific attributes."""
 
     entity_description: SynologyDSMSensorEntityDescription
@@ -336,7 +338,7 @@ class SynoDSMSensor(SynologyDSMBaseEntity, SensorEntity):
     def __init__(
         self,
         api: SynoApi,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
+        coordinator: SynologyDSMCentralUpdateCoordinator,
         description: SynologyDSMSensorEntityDescription,
     ) -> None:
         """Initialize the Synology DSM sensor entity."""
@@ -383,7 +385,7 @@ class SynoDSMStorageSensor(SynologyDSMDeviceEntity, SynoDSMSensor):
     def __init__(
         self,
         api: SynoApi,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
+        coordinator: SynologyDSMCentralUpdateCoordinator,
         description: SynologyDSMSensorEntityDescription,
         device_id: str | None = None,
     ) -> None:
@@ -410,7 +412,7 @@ class SynoDSMInfoSensor(SynoDSMSensor):
     def __init__(
         self,
         api: SynoApi,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
+        coordinator: SynologyDSMCentralUpdateCoordinator,
         description: SynologyDSMSensorEntityDescription,
     ) -> None:
         """Initialize the Synology SynoDSMInfoSensor entity."""

--- a/homeassistant/components/synology_dsm/switch.py
+++ b/homeassistant/components/synology_dsm/switch.py
@@ -12,10 +12,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import SynoApi
 from .const import DOMAIN
+from .coordinator import SynologyDSMSwitchUpdateCoordinator
 from .entity import SynologyDSMBaseEntity, SynologyDSMEntityDescription
 from .models import SynologyDSMData
 
@@ -54,17 +54,18 @@ async def async_setup_entry(
         )
 
 
-class SynoDSMSurveillanceHomeModeToggle(SynologyDSMBaseEntity, SwitchEntity):
+class SynoDSMSurveillanceHomeModeToggle(
+    SynologyDSMBaseEntity[SynologyDSMSwitchUpdateCoordinator], SwitchEntity
+):
     """Representation a Synology Surveillance Station Home Mode toggle."""
 
-    coordinator: DataUpdateCoordinator[dict[str, dict[str, bool]]]
     entity_description: SynologyDSMSwitchEntityDescription
 
     def __init__(
         self,
         api: SynoApi,
         version: str,
-        coordinator: DataUpdateCoordinator[dict[str, dict[str, bool]]],
+        coordinator: SynologyDSMSwitchUpdateCoordinator,
         description: SynologyDSMSwitchEntityDescription,
     ) -> None:
         """Initialize a Synology Surveillance Station Home Mode."""
@@ -78,7 +79,7 @@ class SynoDSMSurveillanceHomeModeToggle(SynologyDSMBaseEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the state."""
-        return self.coordinator.data["switches"][self.entity_description.key]
+        return self.coordinator.data["switches"][self.entity_description.key]  # type: ignore[no-any-return]
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on Home mode."""

--- a/homeassistant/components/synology_dsm/update.py
+++ b/homeassistant/components/synology_dsm/update.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from .coordinator import SynologyDSMCentralUpdateCoordinator
 from .entity import SynologyDSMBaseEntity, SynologyDSMEntityDescription
 from .models import SynologyDSMData
 
@@ -46,7 +47,9 @@ async def async_setup_entry(
     )
 
 
-class SynoDSMUpdateEntity(SynologyDSMBaseEntity, UpdateEntity):
+class SynoDSMUpdateEntity(
+    SynologyDSMBaseEntity[SynologyDSMCentralUpdateCoordinator], UpdateEntity
+):
     """Mixin for update entity specific attributes."""
 
     entity_description: SynologyDSMUpdateEntityEntityDescription


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
