### PR TITLE
Improve `totalconnect` generic typing

### DIFF
--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -78,10 +78,12 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
         client.locations[location_id].auto_bypass_low_battery = bypass
 
 
-class TotalConnectDataUpdateCoordinator(DataUpdateCoordinator):
+class TotalConnectDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Class to fetch data from TotalConnect."""
 
-    def __init__(self, hass: HomeAssistant, client):
+    config_entry: ConfigEntry
+
+    def __init__(self, hass: HomeAssistant, client: TotalConnectClient) -> None:
         """Initialize."""
         self.hass = hass
         self.client = client
@@ -89,11 +91,11 @@ class TotalConnectDataUpdateCoordinator(DataUpdateCoordinator):
             hass, logger=_LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL
         )
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> None:
         """Update data."""
         await self.hass.async_add_executor_job(self.sync_update_data)
 
-    def sync_update_data(self):
+    def sync_update_data(self) -> None:
         """Fetch synchronous data from TotalConnect."""
         try:
             for location_id in self.client.locations:

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import TotalConnectDataUpdateCoordinator
 from .const import DOMAIN
 
 SERVICE_ALARM_ARM_AWAY_INSTANT = "arm_away_instant"
@@ -36,7 +37,7 @@ async def async_setup_entry(
     """Set up TotalConnect alarm panels based on a config entry."""
     alarms = []
 
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: TotalConnectDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     for location_id, location in coordinator.client.locations.items():
         location_name = location.location_name
@@ -68,7 +69,9 @@ async def async_setup_entry(
     )
 
 
-class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
+class TotalConnectAlarm(
+    CoordinatorEntity[TotalConnectDataUpdateCoordinator], alarm.AlarmControlPanelEntity
+):
     """Represent an TotalConnect status."""
 
     _attr_supported_features = (
@@ -77,7 +80,13 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         | AlarmControlPanelEntityFeature.ARM_NIGHT
     )
 
-    def __init__(self, coordinator, name, location_id, partition_id):
+    def __init__(
+        self,
+        coordinator: TotalConnectDataUpdateCoordinator,
+        name,
+        location_id,
+        partition_id,
+    ):
         """Initialize the TotalConnect status."""
         super().__init__(coordinator)
         self._location_id = location_id
@@ -85,7 +94,7 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
         self._partition_id = partition_id
         self._partition = self._location.partitions[partition_id]
         self._device = self._location.devices[self._location.security_device_id]
-        self._state = None
+        self._state: str | None = None
         self._attr_extra_state_attributes = {}
 
         """
@@ -122,7 +131,7 @@ class TotalConnectAlarm(CoordinatorEntity, alarm.AlarmControlPanelEntity):
             "triggered_zone": None,
         }
 
-        state = None
+        state: str | None = None
         if self._partition.arming_state.is_disarmed():
             state = STATE_ALARM_DISARMED
         elif self._partition.arming_state.is_armed_night():


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
