### PR TITLE
Improve DataUpdateCoordinator typing in integrations (1)

### DIFF
--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -21,7 +21,7 @@ SCAN_INTERVAL = timedelta(seconds=DEFAULT_SCAN_INTERVAL_SECONDS)
 _LOGGER = logging.getLogger(__name__)
 
 
-class BMWDataUpdateCoordinator(DataUpdateCoordinator):
+class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Class to manage fetching BMW data."""
 
     account: MyBMWAccount

--- a/homeassistant/components/flux_led/coordinator.py
+++ b/homeassistant/components/flux_led/coordinator.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 REQUEST_REFRESH_DELAY: Final = 2.0
 
 
-class FluxLedUpdateCoordinator(DataUpdateCoordinator):
+class FluxLedUpdateCoordinator(DataUpdateCoordinator[None]):
     """DataUpdateCoordinator to gather data for a specific flux_led device."""
 
     def __init__(

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -136,7 +136,7 @@ class HostInfo(TypedDict):
     status: bool
 
 
-class FritzBoxTools(update_coordinator.DataUpdateCoordinator):
+class FritzBoxTools(update_coordinator.DataUpdateCoordinator[None]):
     """FritzBoxTools class."""
 
     def __init__(

--- a/homeassistant/components/ialarm/__init__.py
+++ b/homeassistant/components/ialarm/__init__.py
@@ -54,7 +54,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class IAlarmDataUpdateCoordinator(DataUpdateCoordinator):
+class IAlarmDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Class to manage fetching iAlarm data."""
 
     def __init__(self, hass: HomeAssistant, ialarm: IAlarm, mac: str) -> None:

--- a/homeassistant/components/lifx/coordinator.py
+++ b/homeassistant/components/lifx/coordinator.py
@@ -64,7 +64,7 @@ class FirmwareEffect(IntEnum):
     FLAME = 3
 
 
-class LIFXUpdateCoordinator(DataUpdateCoordinator):
+class LIFXUpdateCoordinator(DataUpdateCoordinator[None]):
     """DataUpdateCoordinator to gather data for a specific lifx device."""
 
     def __init__(

--- a/homeassistant/components/nexia/coordinator.py
+++ b/homeassistant/components/nexia/coordinator.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_UPDATE_RATE = 120
 
 
-class NexiaDataUpdateCoordinator(DataUpdateCoordinator):
+class NexiaDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """DataUpdateCoordinator for nexia homes."""
 
     def __init__(

--- a/homeassistant/components/rituals_perfume_genie/__init__.py
+++ b/homeassistant/components/rituals_perfume_genie/__init__.py
@@ -65,7 +65,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class RitualsDataUpdateCoordinator(DataUpdateCoordinator):
+class RitualsDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Class to manage fetching Rituals Perfume Genie device data from single endpoint."""
 
     def __init__(self, hass: HomeAssistant, device: Diffuser) -> None:

--- a/homeassistant/components/skybell/coordinator.py
+++ b/homeassistant/components/skybell/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import LOGGER
 
 
-class SkybellDataUpdateCoordinator(DataUpdateCoordinator):
+class SkybellDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Data update coordinator for the Skybell integration."""
 
     config_entry: ConfigEntry

--- a/homeassistant/components/tautulli/coordinator.py
+++ b/homeassistant/components/tautulli/coordinator.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DOMAIN, LOGGER
 
 
-class TautulliDataUpdateCoordinator(DataUpdateCoordinator):
+class TautulliDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Data update coordinator for the Tautulli integration."""
 
     config_entry: ConfigEntry

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -553,7 +553,7 @@ class TibberRtDataCoordinator(DataUpdateCoordinator):
         return self.data.get("data", {}).get("liveMeasurement")
 
 
-class TibberDataCoordinator(DataUpdateCoordinator):
+class TibberDataCoordinator(DataUpdateCoordinator[None]):
     """Handle Tibber data and insert statistics."""
 
     def __init__(self, hass: HomeAssistant, tibber_connection: tibber.Tibber) -> None:

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 REQUEST_REFRESH_DELAY = 0.35
 
 
-class TPLinkDataUpdateCoordinator(DataUpdateCoordinator):
+class TPLinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """DataUpdateCoordinator to gather data for a specific TPLink device."""
 
     def __init__(

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -239,7 +239,7 @@ class VolvoData:
             raise InvalidAuth from exc
 
 
-class VolvoUpdateCoordinator(DataUpdateCoordinator):
+class VolvoUpdateCoordinator(DataUpdateCoordinator[None]):
     """Volvo coordinator."""
 
     def __init__(self, hass: HomeAssistant, volvo_data: VolvoData) -> None:
@@ -254,14 +254,14 @@ class VolvoUpdateCoordinator(DataUpdateCoordinator):
 
         self.volvo_data = volvo_data
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> None:
         """Fetch data from API endpoint."""
 
         async with async_timeout.timeout(10):
             await self.volvo_data.update()
 
 
-class VolvoEntity(CoordinatorEntity):
+class VolvoEntity(CoordinatorEntity[VolvoUpdateCoordinator]):
     """Base class for all VOC entities."""
 
     def __init__(

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -30,7 +30,7 @@ from .const import DOMAIN, WEMO_SUBSCRIPTION_EVENT
 _LOGGER = logging.getLogger(__name__)
 
 
-class DeviceCoordinator(DataUpdateCoordinator):
+class DeviceCoordinator(DataUpdateCoordinator[None]):
     """Home Assistant wrapper for a pyWeMo device."""
 
     def __init__(self, hass: HomeAssistant, wemo: WeMoDevice, device_id: str) -> None:


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
