### PR TITLE
Improve DataUpdateCoordinator typing in integrations (2)

### DIFF
--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     atag = AtagOne(
         session=async_get_clientsession(hass), **entry.data, device=entry.unique_id
     )
-    coordinator = DataUpdateCoordinator(
+    coordinator = DataUpdateCoordinator[AtagOne](
         hass,
         _LOGGER,
         name=DOMAIN.title(),
@@ -65,10 +65,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class AtagEntity(CoordinatorEntity):
+class AtagEntity(CoordinatorEntity[DataUpdateCoordinator[AtagOne]]):
     """Defines a base Atag entity."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, atag_id: str) -> None:
+    def __init__(
+        self, coordinator: DataUpdateCoordinator[AtagOne], atag_id: str
+    ) -> None:
         """Initialize the Atag entity."""
         super().__init__(coordinator)
 

--- a/homeassistant/components/awair/__init__.py
+++ b/homeassistant/components/awair/__init__.py
@@ -72,7 +72,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     return unload_ok
 
 
-class AwairDataUpdateCoordinator(DataUpdateCoordinator):
+class AwairDataUpdateCoordinator(DataUpdateCoordinator[dict[str, AwairResult]]):
     """Define a wrapper class to update Awair data."""
 
     def __init__(
@@ -107,7 +107,7 @@ class AwairCloudDataUpdateCoordinator(AwairDataUpdateCoordinator):
 
         super().__init__(hass, config_entry, UPDATE_INTERVAL_CLOUD)
 
-    async def _async_update_data(self) -> dict[str, AwairResult] | None:
+    async def _async_update_data(self) -> dict[str, AwairResult]:
         """Update data via Awair client library."""
         async with timeout(API_TIMEOUT):
             try:
@@ -139,7 +139,7 @@ class AwairLocalDataUpdateCoordinator(AwairDataUpdateCoordinator):
 
         super().__init__(hass, config_entry, UPDATE_INTERVAL_LOCAL)
 
-    async def _async_update_data(self) -> dict[str, AwairResult] | None:
+    async def _async_update_data(self) -> dict[str, AwairResult]:
         """Update data via Awair client library."""
         async with timeout(API_TIMEOUT):
             try:

--- a/homeassistant/components/awair/sensor.py
+++ b/homeassistant/components/awair/sensor.py
@@ -215,8 +215,7 @@ class AwairSensor(CoordinatorEntity[AwairDataUpdateCoordinator], SensorEntity):
     @property
     def _air_data(self) -> AirData | None:
         """Return the latest data for our device, or None."""
-        result: AwairResult | None = self.coordinator.data.get(self._device.uuid)
-        if result:
+        if result := self.coordinator.data.get(self._device.uuid):
             return result.air_data
 
         return None

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -62,7 +62,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class BrotherDataUpdateCoordinator(DataUpdateCoordinator):
+class BrotherDataUpdateCoordinator(DataUpdateCoordinator[BrotherSensors]):
     """Class to manage fetching Brother data from the printer."""
 
     def __init__(self, hass: HomeAssistant, brother: Brother) -> None:

--- a/homeassistant/components/canary/coordinator.py
+++ b/homeassistant/components/canary/coordinator.py
@@ -7,7 +7,7 @@ import logging
 
 from async_timeout import timeout
 from canary.api import Api
-from canary.model import Location
+from canary.model import Location, Reading
 from requests.exceptions import ConnectTimeout, HTTPError
 
 from homeassistant.core import HomeAssistant
@@ -19,7 +19,7 @@ from .model import CanaryData
 _LOGGER = logging.getLogger(__name__)
 
 
-class CanaryDataUpdateCoordinator(DataUpdateCoordinator):
+class CanaryDataUpdateCoordinator(DataUpdateCoordinator[CanaryData]):
     """Class to manage fetching Canary data."""
 
     def __init__(self, hass: HomeAssistant, *, api: Api) -> None:
@@ -37,7 +37,7 @@ class CanaryDataUpdateCoordinator(DataUpdateCoordinator):
     def _update_data(self) -> CanaryData:
         """Fetch data from Canary via sync functions."""
         locations_by_id: dict[str, Location] = {}
-        readings_by_device_id: dict[str, ValuesView] = {}
+        readings_by_device_id: dict[str, ValuesView[Reading]] = {}
 
         for location in self.canary.get_locations():
             location_id = location.location_id

--- a/homeassistant/components/canary/model.py
+++ b/homeassistant/components/canary/model.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 from collections.abc import ValuesView
 from typing import TypedDict
 
-from canary.model import Location
+from canary.model import Location, Reading
 
 
 class CanaryData(TypedDict):
     """TypedDict for Canary Coordinator Data."""
 
     locations: dict[str, Location]
-    readings: dict[str, ValuesView]
+    readings: dict[str, ValuesView[Reading]]

--- a/homeassistant/components/gree/climate.py
+++ b/homeassistant/components/gree/climate.py
@@ -43,6 +43,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .bridge import DeviceDataUpdateCoordinator
 from .const import (
     COORDINATORS,
     DISPATCH_DEVICE_DISCOVERED,
@@ -105,7 +106,7 @@ async def async_setup_entry(
     )
 
 
-class GreeClimateEntity(CoordinatorEntity, ClimateEntity):
+class GreeClimateEntity(CoordinatorEntity[DeviceDataUpdateCoordinator], ClimateEntity):
     """Representation of a Gree HVAC device."""
 
     _attr_precision = PRECISION_WHOLE
@@ -116,7 +117,7 @@ class GreeClimateEntity(CoordinatorEntity, ClimateEntity):
         | ClimateEntityFeature.SWING_MODE
     )
 
-    def __init__(self, coordinator):
+    def __init__(self, coordinator: DeviceDataUpdateCoordinator) -> None:
         """Initialize the Gree device."""
         super().__init__(coordinator)
         self._name = coordinator.device.device_info.name

--- a/homeassistant/components/mill/climate.py
+++ b/homeassistant/components/mill/climate.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import MillDataUpdateCoordinator
 from .const import (
     ATTR_AWAY_TEMP,
     ATTR_COMFORT_TEMP,
@@ -86,7 +87,7 @@ async def async_setup_entry(
     )
 
 
-class MillHeater(CoordinatorEntity, ClimateEntity):
+class MillHeater(CoordinatorEntity[MillDataUpdateCoordinator], ClimateEntity):
     """Representation of a Mill Thermostat device."""
 
     _attr_fan_modes = [FAN_ON, FAN_OFF]
@@ -94,7 +95,9 @@ class MillHeater(CoordinatorEntity, ClimateEntity):
     _attr_min_temp = MIN_TEMP
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator, heater):
+    def __init__(
+        self, coordinator: MillDataUpdateCoordinator, heater: mill.Heater
+    ) -> None:
         """Initialize the thermostat."""
 
         super().__init__(coordinator)
@@ -196,7 +199,7 @@ class MillHeater(CoordinatorEntity, ClimateEntity):
             self._attr_hvac_mode = HVACMode.OFF
 
 
-class LocalMillHeater(CoordinatorEntity, ClimateEntity):
+class LocalMillHeater(CoordinatorEntity[MillDataUpdateCoordinator], ClimateEntity):
     """Representation of a Mill Thermostat device."""
 
     _attr_hvac_mode = HVACMode.HEAT
@@ -207,7 +210,7 @@ class LocalMillHeater(CoordinatorEntity, ClimateEntity):
     _attr_target_temperature_step = PRECISION_HALVES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator):
+    def __init__(self, coordinator: MillDataUpdateCoordinator) -> None:
         """Initialize the thermostat."""
         super().__init__(coordinator)
         self._attr_name = coordinator.mill_data_connection.name

--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -92,7 +92,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class NAMDataUpdateCoordinator(DataUpdateCoordinator):
+class NAMDataUpdateCoordinator(DataUpdateCoordinator[NAMSensors]):
     """Class to manage fetching Nettigo Air Monitor data."""
 
     def __init__(


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
