### PR TITLE
Improve DataUpdateCoordinator typing in integrations (4)

### DIFF
--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -73,7 +73,7 @@ def get_entry_data(hass: HomeAssistant) -> dict[str, ShellyEntryData]:
     return cast(dict[str, ShellyEntryData], hass.data[DOMAIN][DATA_CONFIG_ENTRY])
 
 
-class ShellyBlockCoordinator(DataUpdateCoordinator):
+class ShellyBlockCoordinator(DataUpdateCoordinator[None]):
     """Coordinator for a Shelly block based device."""
 
     def __init__(
@@ -318,7 +318,7 @@ class ShellyRestCoordinator(DataUpdateCoordinator):
         return cast(str, self.device.settings["device"]["mac"])
 
 
-class ShellyRpcCoordinator(DataUpdateCoordinator):
+class ShellyRpcCoordinator(DataUpdateCoordinator[None]):
     """Coordinator for a Shelly RPC based device."""
 
     def __init__(
@@ -543,7 +543,7 @@ class ShellyRpcCoordinator(DataUpdateCoordinator):
         elif update_type is UpdateType.DISCONNECTED:
             self.hass.async_create_task(self._async_disconnected())
         elif update_type is UpdateType.STATUS:
-            self.async_set_updated_data(self.device)
+            self.async_set_updated_data(None)
         elif update_type is UpdateType.EVENT and (event := self.device.event):
             self._async_device_event_handler(event)
 

--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -53,10 +53,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator):
+class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator[list[UptimeRobotMonitor]]):
     """Data update coordinator for UptimeRobot."""
 
-    data: list[UptimeRobotMonitor]
     config_entry: ConfigEntry
 
     def __init__(
@@ -77,7 +76,7 @@ class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator):
         self._device_registry = dev_reg
         self.api = api
 
-    async def _async_update_data(self) -> list[UptimeRobotMonitor] | None:
+    async def _async_update_data(self) -> list[UptimeRobotMonitor]:
         """Update data."""
         try:
             response = await self.api.async_get_monitors()
@@ -111,6 +110,5 @@ class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator):
             self.hass.async_create_task(
                 self.hass.config_entries.async_reload(self._config_entry_id)
             )
-            return None
 
         return monitors

--- a/homeassistant/components/version/coordinator.py
+++ b/homeassistant/components/version/coordinator.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DOMAIN, LOGGER, UPDATE_COORDINATOR_UPDATE_INTERVAL
 
 
-class VersionDataUpdateCoordinator(DataUpdateCoordinator):
+class VersionDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Data update coordinator for Version entities."""
 
     config_entry: ConfigEntry

--- a/homeassistant/components/version/diagnostics.py
+++ b/homeassistant/components/version/diagnostics.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import DOMAIN
+from .coordinator import VersionDataUpdateCoordinator
 
 
 async def async_get_config_entry_diagnostics(
@@ -17,7 +18,7 @@ async def async_get_config_entry_diagnostics(
     config_entry: ConfigEntry,
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: VersionDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
 


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
