### PR TITLE
Add distance sensor device class to Mazda integration

### DIFF
--- a/homeassistant/components/mazda/sensor.py
+++ b/homeassistant/components/mazda/sensor.py
@@ -16,7 +16,6 @@ from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfPressure
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM, UnitSystem
 
 from . import MazdaEntity
 from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
@@ -27,7 +26,7 @@ class MazdaSensorRequiredKeysMixin:
     """Mixin for required keys."""
 
     # Function to determine the value for this sensor, given the coordinator data and the configured unit system
-    value: Callable[[dict[str, Any], UnitSystem], StateType]
+    value: Callable[[dict[str, Any]], StateType]
 
 
 @dataclass
@@ -38,17 +37,6 @@ class MazdaSensorEntityDescription(
 
     # Function to determine whether the vehicle supports this sensor, given the coordinator data
     is_supported: Callable[[dict[str, Any]], bool] = lambda data: True
-
-    # Function to determine the unit of measurement for this sensor, given the configured unit system
-    # Falls back to description.native_unit_of_measurement if it is not provided
-    unit: Callable[[UnitSystem], str | None] | None = None
-
-
-def _get_distance_unit(unit_system: UnitSystem) -> str:
-    """Return the distance unit for the given unit system."""
-    if unit_system is US_CUSTOMARY_SYSTEM:
-        return UnitOfLength.MILES
-    return UnitOfLength.KILOMETERS
 
 
 def _fuel_remaining_percentage_supported(data):
@@ -101,55 +89,45 @@ def _ev_remaining_range_supported(data):
     )
 
 
-def _fuel_distance_remaining_value(data, unit_system):
+def _fuel_distance_remaining_value(data):
     """Get the fuel distance remaining value."""
-    return round(
-        unit_system.length(
-            data["status"]["fuelDistanceRemainingKm"], UnitOfLength.KILOMETERS
-        )
-    )
+    return round(data["status"]["fuelDistanceRemainingKm"])
 
 
-def _odometer_value(data, unit_system):
+def _odometer_value(data):
     """Get the odometer value."""
     # In order to match the behavior of the Mazda mobile app, we always round down
-    return int(
-        unit_system.length(data["status"]["odometerKm"], UnitOfLength.KILOMETERS)
-    )
+    return int(data["status"]["odometerKm"])
 
 
-def _front_left_tire_pressure_value(data, unit_system):
+def _front_left_tire_pressure_value(data):
     """Get the front left tire pressure value."""
     return round(data["status"]["tirePressure"]["frontLeftTirePressurePsi"])
 
 
-def _front_right_tire_pressure_value(data, unit_system):
+def _front_right_tire_pressure_value(data):
     """Get the front right tire pressure value."""
     return round(data["status"]["tirePressure"]["frontRightTirePressurePsi"])
 
 
-def _rear_left_tire_pressure_value(data, unit_system):
+def _rear_left_tire_pressure_value(data):
     """Get the rear left tire pressure value."""
     return round(data["status"]["tirePressure"]["rearLeftTirePressurePsi"])
 
 
-def _rear_right_tire_pressure_value(data, unit_system):
+def _rear_right_tire_pressure_value(data):
     """Get the rear right tire pressure value."""
     return round(data["status"]["tirePressure"]["rearRightTirePressurePsi"])
 
 
-def _ev_charge_level_value(data, unit_system):
+def _ev_charge_level_value(data):
     """Get the charge level value."""
     return round(data["evStatus"]["chargeInfo"]["batteryLevelPercentage"])
 
 
-def _ev_remaining_range_value(data, unit_system):
+def _ev_remaining_range_value(data):
     """Get the remaining range value."""
-    return round(
-        unit_system.length(
-            data["evStatus"]["chargeInfo"]["drivingRangeKm"], UnitOfLength.KILOMETERS
-        )
-    )
+    return round(data["evStatus"]["chargeInfo"]["drivingRangeKm"])
 
 
 SENSOR_ENTITIES = [
@@ -160,13 +138,14 @@ SENSOR_ENTITIES = [
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         is_supported=_fuel_remaining_percentage_supported,
-        value=lambda data, unit_system: data["status"]["fuelRemainingPercent"],
+        value=lambda data: data["status"]["fuelRemainingPercent"],
     ),
     MazdaSensorEntityDescription(
         key="fuel_distance_remaining",
         name="Fuel distance remaining",
         icon="mdi:gas-station",
-        unit=_get_distance_unit,
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
         state_class=SensorStateClass.MEASUREMENT,
         is_supported=_fuel_distance_remaining_supported,
         value=_fuel_distance_remaining_value,
@@ -175,7 +154,8 @@ SENSOR_ENTITIES = [
         key="odometer",
         name="Odometer",
         icon="mdi:speedometer",
-        unit=_get_distance_unit,
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
         state_class=SensorStateClass.TOTAL_INCREASING,
         is_supported=lambda data: data["status"]["odometerKm"] is not None,
         value=_odometer_value,
@@ -233,7 +213,8 @@ SENSOR_ENTITIES = [
         key="ev_remaining_range",
         name="Remaining range",
         icon="mdi:ev-station",
-        unit=_get_distance_unit,
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
         state_class=SensorStateClass.MEASUREMENT,
         is_supported=_ev_remaining_range_supported,
         value=_ev_remaining_range_value,
@@ -275,13 +256,6 @@ class MazdaSensorEntity(MazdaEntity, SensorEntity):
         self._attr_unique_id = f"{self.vin}_{description.key}"
 
     @property
-    def native_unit_of_measurement(self):
-        """Return the unit of measurement for the sensor, according to the configured unit system."""
-        if unit_fn := self.entity_description.unit:
-            return unit_fn(self.hass.config.units)
-        return self.entity_description.native_unit_of_measurement
-
-    @property
-    def native_value(self):
+    def native_value(self) -> StateType:
         """Return the state of the sensor."""
-        return self.entity_description.value(self.data, self.hass.config.units)
+        return self.entity_description.value(self.data)

--- a/tests/components/mazda/test_sensor.py
+++ b/tests/components/mazda/test_sensor.py
@@ -130,11 +130,15 @@ async def test_sensors(hass):
     assert entry.unique_id == "JM000000000000000_rear_right_tire_pressure"
 
 
-async def test_sensors_imperial_units(hass):
-    """Test that the sensors work properly with imperial units."""
+async def test_sensors_us_customary_units(hass):
+    """Test that the sensors work properly with US customary units."""
     hass.config.units = US_CUSTOMARY_SYSTEM
 
     await init_integration(hass)
+
+    # In the US, miles are used for vehicle odometers.
+    # These tests verify that the unit conversion logic for the distance
+    # sensor device class automatically converts the unit to miles.
 
     # Fuel Distance Remaining
     state = hass.states.get("sensor.my_mazda3_fuel_distance_remaining")

--- a/tests/components/mazda/test_sensor.py
+++ b/tests/components/mazda/test_sensor.py
@@ -49,6 +49,7 @@ async def test_sensors(hass):
         state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Fuel distance remaining"
     )
     assert state.attributes.get(ATTR_ICON) == "mdi:gas-station"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.DISTANCE
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == LENGTH_KILOMETERS
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert state.state == "381"
@@ -61,6 +62,7 @@ async def test_sensors(hass):
     assert state
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Odometer"
     assert state.attributes.get(ATTR_ICON) == "mdi:speedometer"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.DISTANCE
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == LENGTH_KILOMETERS
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL_INCREASING
     assert state.state == "2795"
@@ -185,6 +187,7 @@ async def test_electric_vehicle_sensors(hass):
     assert state
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Remaining range"
     assert state.attributes.get(ATTR_ICON) == "mdi:ev-station"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.DISTANCE
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == LENGTH_KILOMETERS
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert state.state == "218"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the distance device class to the Mazda distance sensor entities so that users can choose between miles and kilometers.

Since this device class has automatic unit conversion, I was able to remove the custom unit conversion logic that had been implemented in this integration.

I would appreciate if someone (possibly @emontnemery or @epenet) could review this change to make sure it is aligned with https://github.com/home-assistant/core/pull/83228 and will avoid a breaking change for users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
