### PR TITLE
Add support for SwitchBot Lock

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1256,6 +1256,7 @@ omit =
     homeassistant/components/switchbot/light.py
     homeassistant/components/switchbot/sensor.py
     homeassistant/components/switchbot/switch.py
+    homeassistant/components/switchbot/lock.py
     homeassistant/components/switchmate/switch.py
     homeassistant/components/syncthing/__init__.py
     homeassistant/components/syncthing/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1136,8 +1136,8 @@ build.json @home-assistant/supervisor
 /tests/components/switch_as_x/ @home-assistant/core
 /homeassistant/components/switchbee/ @jafar-atili
 /tests/components/switchbee/ @jafar-atili
-/homeassistant/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas @Eloston
-/tests/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas @Eloston
+/homeassistant/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas @Eloston @dsypniewski
+/tests/components/switchbot/ @bdraco @danielhiversen @RenierM26 @murtas @Eloston @dsypniewski
 /homeassistant/components/switcher_kis/ @tomerfi @thecode
 /tests/components/switcher_kis/ @tomerfi @thecode
 /homeassistant/components/switchmate/ @danielhiversen @qiz-li

--- a/homeassistant/components/switchbot/__init__.py
+++ b/homeassistant/components/switchbot/__init__.py
@@ -19,6 +19,8 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
 from .const import (
+    CONF_ENCRYPTION_KEY,
+    CONF_KEY_ID,
     CONF_RETRY_COUNT,
     CONNECTABLE_SUPPORTED_MODEL_TYPES,
     DEFAULT_RETRY_COUNT,
@@ -43,6 +45,7 @@ PLATFORMS_BY_TYPE = {
     SupportedModels.CONTACT.value: [Platform.BINARY_SENSOR, Platform.SENSOR],
     SupportedModels.MOTION.value: [Platform.BINARY_SENSOR, Platform.SENSOR],
     SupportedModels.HUMIDIFIER.value: [Platform.HUMIDIFIER, Platform.SENSOR],
+    SupportedModels.LOCK.value: [Platform.BINARY_SENSOR, Platform.LOCK],
 }
 CLASS_BY_DEVICE = {
     SupportedModels.CEILING_LIGHT.value: switchbot.SwitchbotCeilingLight,
@@ -52,6 +55,7 @@ CLASS_BY_DEVICE = {
     SupportedModels.BULB.value: switchbot.SwitchbotBulb,
     SupportedModels.LIGHT_STRIP.value: switchbot.SwitchbotLightStrip,
     SupportedModels.HUMIDIFIER.value: switchbot.SwitchbotHumidifier,
+    SupportedModels.LOCK.value: switchbot.SwitchbotLock,
 }
 
 
@@ -94,11 +98,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await switchbot.close_stale_connections(ble_device)
     cls = CLASS_BY_DEVICE.get(sensor_type, switchbot.SwitchbotDevice)
-    device = cls(
-        device=ble_device,
-        password=entry.data.get(CONF_PASSWORD),
-        retry_count=entry.options[CONF_RETRY_COUNT],
-    )
+    if cls is switchbot.SwitchbotLock:
+        try:
+            device = switchbot.SwitchbotLock(
+                device=ble_device,
+                key_id=entry.data.get(CONF_KEY_ID),
+                encryption_key=entry.data.get(CONF_ENCRYPTION_KEY),
+                retry_count=entry.options[CONF_RETRY_COUNT],
+            )
+        except ValueError as error:
+            raise ConfigEntryNotReady(
+                "Invalid encryption configuration provided"
+            ) from error
+    else:
+        device = cls(
+            device=ble_device,
+            password=entry.data.get(CONF_PASSWORD),
+            retry_count=entry.options[CONF_RETRY_COUNT],
+        )
 
     coordinator = hass.data[DOMAIN][entry.entry_id] = SwitchbotDataUpdateCoordinator(
         hass,

--- a/homeassistant/components/switchbot/binary_sensor.py
+++ b/homeassistant/components/switchbot/binary_sensor.py
@@ -44,6 +44,28 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorEntityDescription] = {
         name="Light",
         device_class=BinarySensorDeviceClass.LIGHT,
     ),
+    "door_open": BinarySensorEntityDescription(
+        key="door_status",
+        name="Door status",
+        device_class=BinarySensorDeviceClass.DOOR,
+    ),
+    "unclosed_alarm": BinarySensorEntityDescription(
+        key="unclosed_alarm",
+        name="Door unclosed alarm",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    "unlocked_alarm": BinarySensorEntityDescription(
+        key="unlocked_alarm",
+        name="Door unlocked alarm",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    "auto_lock_paused": BinarySensorEntityDescription(
+        key="auto_lock_paused",
+        name="Door auto-lock paused",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 }
 
 

--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -181,7 +181,6 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             description_placeholders={
                 "name": name_from_discovery(self._discovered_adv),
-                "url": "https://www.home-assistant.io/integrations/switchbot#lock-encryption-key",
             },
         )
 

--- a/homeassistant/components/switchbot/const.py
+++ b/homeassistant/components/switchbot/const.py
@@ -24,6 +24,7 @@ class SupportedModels(StrEnum):
     PLUG = "plug"
     MOTION = "motion"
     HUMIDIFIER = "humidifier"
+    LOCK = "lock"
 
 
 CONNECTABLE_SUPPORTED_MODEL_TYPES = {
@@ -34,6 +35,7 @@ CONNECTABLE_SUPPORTED_MODEL_TYPES = {
     SwitchbotModel.LIGHT_STRIP: SupportedModels.LIGHT_STRIP,
     SwitchbotModel.CEILING_LIGHT: SupportedModels.CEILING_LIGHT,
     SwitchbotModel.HUMIDIFIER: SupportedModels.HUMIDIFIER,
+    SwitchbotModel.LOCK: SupportedModels.LOCK,
 }
 
 NON_CONNECTABLE_SUPPORTED_MODEL_TYPES = {
@@ -56,6 +58,8 @@ DEFAULT_RETRY_COUNT = 3
 
 # Config Options
 CONF_RETRY_COUNT = "retry_count"
+CONF_KEY_ID = "key_id"
+CONF_ENCRYPTION_KEY = "encryption_key"
 
 # Deprecated config Entry Options to be removed in 2023.4
 CONF_TIME_BETWEEN_UPDATE_COMMAND = "update_time"

--- a/homeassistant/components/switchbot/lock.py
+++ b/homeassistant/components/switchbot/lock.py
@@ -1,0 +1,57 @@
+"""Support for SwitchBot lock platform."""
+from typing import Any
+
+import switchbot
+from switchbot import SwitchbotModel
+from switchbot.const import LockStatus
+
+from homeassistant.components.lock import LockEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SwitchbotDataUpdateCoordinator
+from .entity import SwitchbotEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Switchbot lock based on a config entry."""
+    coordinator: SwitchbotDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    if coordinator.model == SwitchbotModel.LOCK:
+        async_add_entities([(SwitchBotLock(coordinator))])
+
+
+# noinspection PyAbstractClass
+class SwitchBotLock(SwitchbotEntity, LockEntity):
+    """Representation of a Switchbot lock."""
+
+    _device: switchbot.SwitchbotLock
+
+    def __init__(self, coordinator: SwitchbotDataUpdateCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._async_update_attrs()
+
+    def _async_update_attrs(self) -> None:
+        """Update the entity attributes."""
+        status = self._device.get_lock_status()
+        self._attr_is_locked = status is LockStatus.LOCKED
+        self._attr_is_locking = status is LockStatus.LOCKING
+        self._attr_is_unlocking = status is LockStatus.UNLOCKING
+        self._attr_is_jammed = status in {
+            LockStatus.LOCKING_STOP,
+            LockStatus.UNLOCKING_STOP,
+        }
+
+    async def async_lock(self, **kwargs: Any) -> None:
+        """Lock the lock."""
+        self._last_run_success = await self._device.lock()
+        self.async_write_ha_state()
+
+    async def async_unlock(self, **kwargs: Any) -> None:
+        """Unlock the lock."""
+        self._last_run_success = await self._device.unlock()
+        self.async_write_ha_state()

--- a/homeassistant/components/switchbot/lock.py
+++ b/homeassistant/components/switchbot/lock.py
@@ -2,7 +2,6 @@
 from typing import Any
 
 import switchbot
-from switchbot import SwitchbotModel
 from switchbot.const import LockStatus
 
 from homeassistant.components.lock import LockEntity
@@ -20,8 +19,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Switchbot lock based on a config entry."""
     coordinator: SwitchbotDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    if coordinator.model == SwitchbotModel.LOCK:
-        async_add_entities([(SwitchBotLock(coordinator))])
+    async_add_entities([(SwitchBotLock(coordinator))])
 
 
 # noinspection PyAbstractClass

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.31.0"],
+  "requirements": ["PySwitchbot==0.32.0"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "codeowners": [

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.32.1"],
+  "requirements": ["PySwitchbot==0.33.0"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "codeowners": [

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.32.0"],
+  "requirements": ["PySwitchbot==0.32.1"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "codeowners": [

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -10,7 +10,8 @@
     "@danielhiversen",
     "@RenierM26",
     "@murtas",
-    "@Eloston"
+    "@Eloston",
+    "@dsypniewski"
   ],
   "bluetooth": [
     {

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -17,7 +17,7 @@
         }
       },
       "lock_key": {
-        "description": "The {name} device requires encryption key, details on how to obtain it can be found in the [documentation]({url}).",
+        "description": "The {name} device requires encryption key, details on how to obtain it can be found in the documentation.",
         "data": {
           "key_id": "Key ID",
           "encryption_key": "Encryption key"

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -15,9 +15,19 @@
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "lock_key": {
+        "description": "The {name} device requires encryption key, details on how to obtain it can be found in the [documentation]({url}).",
+        "data": {
+          "key_id": "Key ID",
+          "encryption_key": "Encryption key"
+        }
       }
     },
-    "error": {},
+    "error": {
+      "key_id_invalid": "Key ID or Encryption key is invalid",
+      "encryption_key_invalid": "Key ID or Encryption key is invalid"
+    },
     "abort": {
       "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",
       "no_unconfigured_devices": "No unconfigured devices found.",

--- a/homeassistant/components/switchbot/translations/en.json
+++ b/homeassistant/components/switchbot/translations/en.json
@@ -24,7 +24,7 @@
                 }
             },
             "lock_key": {
-            "description": "The {name} device requires encryption key, details on how to obtain it can be found in the [documentation]({url}).",
+            "description": "The {name} device requires encryption key, details on how to obtain it can be found in the documentation.",
             "data": {
                 "key_id": "Key ID",
                 "encryption_key": "Encryption key"

--- a/homeassistant/components/switchbot/translations/en.json
+++ b/homeassistant/components/switchbot/translations/en.json
@@ -22,7 +22,18 @@
                 "data": {
                     "address": "Device address"
                 }
+            },
+            "lock_key": {
+            "description": "The {name} device requires encryption key, details on how to obtain it can be found in the [documentation]({url}).",
+            "data": {
+                "key_id": "Key ID",
+                "encryption_key": "Encryption key"
             }
+      }
+        },
+        "error": {
+            "key_id_invalid": "Key ID or Encryption key is invalid",
+            "encryption_key_invalid": "Key ID or Encryption key is invalid"
         }
     },
     "options": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,7 +40,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.32.1
+PySwitchbot==0.33.0
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,7 +40,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.32.0
+PySwitchbot==0.32.1
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,7 +40,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.31.0
+PySwitchbot==0.32.0
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -36,7 +36,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.32.0
+PySwitchbot==0.32.1
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -36,7 +36,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.32.1
+PySwitchbot==0.33.0
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -36,7 +36,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.31.0
+PySwitchbot==0.32.0
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/tests/components/switchbot/__init__.py
+++ b/tests/components/switchbot/__init__.py
@@ -174,7 +174,7 @@ WOLOCK_SERVICE_INFO = BluetoothServiceInfoBleak(
     manufacturer_data={2409: b"\xf1\t\x9fE\x1a]\xda\x83\x00 "},
     service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"o\x80d"},
     service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
-    address="798A8547-2A3D-C609-55FF-73FA824B923B",
+    address="aa:bb:cc:dd:ee:ff",
     rssi=-60,
     source="local",
     advertisement=generate_advertisement_data(
@@ -183,7 +183,7 @@ WOLOCK_SERVICE_INFO = BluetoothServiceInfoBleak(
         service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"o\x80d"},
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
-    device=BLEDevice("798A8547-2A3D-C609-55FF-73FA824B923B", "WoLock"),
+    device=BLEDevice("aa:bb:cc:dd:ee:ff", "WoLock"),
     time=0,
     connectable=True,
 )

--- a/tests/components/switchbot/__init__.py
+++ b/tests/components/switchbot/__init__.py
@@ -168,6 +168,26 @@ WOSENSORTH_SERVICE_INFO = BluetoothServiceInfoBleak(
     connectable=False,
 )
 
+
+WOLOCK_SERVICE_INFO = BluetoothServiceInfoBleak(
+    name="WoLock",
+    manufacturer_data={2409: b"\xf1\t\x9fE\x1a]\xda\x83\x00 "},
+    service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"o\x80d"},
+    service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    address="798A8547-2A3D-C609-55FF-73FA824B923B",
+    rssi=-60,
+    source="local",
+    advertisement=generate_advertisement_data(
+        local_name="WoLock",
+        manufacturer_data={2409: b"\xf1\t\x9fE\x1a]\xda\x83\x00 "},
+        service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"o\x80d"},
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    ),
+    device=BLEDevice("798A8547-2A3D-C609-55FF-73FA824B923B", "WoLock"),
+    time=0,
+    connectable=True,
+)
+
 NOT_SWITCHBOT_INFO = BluetoothServiceInfoBleak(
     name="unknown",
     service_uuids=[],

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -354,15 +354,42 @@ async def test_user_setup_wolock(hass):
         await hass.async_block_till_done()
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Lock 923B"
+    assert result2["title"] == "Lock EEFF"
     assert result2["data"] == {
-        CONF_ADDRESS: "798A8547-2A3D-C609-55FF-73FA824B923B",
+        CONF_ADDRESS: "aa:bb:cc:dd:ee:ff",
         CONF_KEY_ID: "ff",
         CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
         CONF_SENSOR_TYPE: "lock",
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_setup_wolock_or_bot(hass):
+    """Test the user initiated form for a lock."""
+
+    with patch(
+        "homeassistant.components.switchbot.config_flow.async_discovered_service_info",
+        return_value=[
+            WOLOCK_SERVICE_INFO,
+            WOHAND_SERVICE_ALT_ADDRESS_INFO,
+        ],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        USER_INPUT,
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_key"
+    assert result["errors"] == {}
 
 
 async def test_user_setup_wolock_invalid_encryption_key(hass):

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import patch
 
-from homeassistant.components.switchbot.const import CONF_RETRY_COUNT
+from homeassistant.components.switchbot.const import (
+    CONF_ENCRYPTION_KEY,
+    CONF_KEY_ID,
+    CONF_RETRY_COUNT,
+)
 from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PASSWORD, CONF_SENSOR_TYPE
 from homeassistant.data_entry_flow import FlowResultType
@@ -15,6 +19,7 @@ from . import (
     WOHAND_SERVICE_ALT_ADDRESS_INFO,
     WOHAND_SERVICE_INFO,
     WOHAND_SERVICE_INFO_NOT_CONNECTABLE,
+    WOLOCK_SERVICE_INFO,
     WOSENSORTH_SERVICE_INFO,
     init_integration,
     patch_async_setup_entry,
@@ -320,6 +325,80 @@ async def test_user_setup_single_bot_with_password(hass):
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_setup_wolock(hass):
+    """Test the user initiated form for a lock."""
+
+    with patch(
+        "homeassistant.components.switchbot.config_flow.async_discovered_service_info",
+        return_value=[WOLOCK_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_key"
+    assert result["errors"] == {}
+
+    with patch_async_setup_entry() as mock_setup_entry, patch(
+        "switchbot.SwitchbotLock.verify_encryption_key", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KEY_ID: "ff",
+                CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Lock 923B"
+    assert result2["data"] == {
+        CONF_ADDRESS: "798A8547-2A3D-C609-55FF-73FA824B923B",
+        CONF_KEY_ID: "ff",
+        CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
+        CONF_SENSOR_TYPE: "lock",
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_setup_wolock_invalid_encryption_key(hass):
+    """Test the user initiated form for a lock with invalid encryption key."""
+
+    with patch(
+        "homeassistant.components.switchbot.config_flow.async_discovered_service_info",
+        return_value=[WOLOCK_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_key"
+    assert result["errors"] == {}
+
+    with patch_async_setup_entry() as mock_setup_entry, patch(
+        "switchbot.SwitchbotLock.verify_encryption_key", return_value=False
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KEY_ID: "",
+                CONF_ENCRYPTION_KEY: "",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "lock_key"
+    assert result2["errors"] == {
+        CONF_KEY_ID: "key_id_invalid",
+        CONF_ENCRYPTION_KEY: "encryption_key_invalid",
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 0
 
 
 async def test_user_setup_wosensor(hass):


### PR DESCRIPTION
## Proposed change

* Adding support for SwitchBot Lock
* Updating PySwitchbot to version 0.33.0:
https://github.com/Danielhiversen/pySwitchbot/compare/0.31.0...0.33.0


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25421


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
