### PR TITLE
Implement Area Units `UnitOfArea` and respective converter

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -206,6 +206,14 @@ class SensorDeviceClass(StrEnum):
     - USCS / imperial: `in`, `ft`, `yd`, `mi`
     """
 
+    AREA = "area"
+    """Generic area.
+
+    Unit of measurement: `AREA_*` units
+    - SI /metric: `mm²`, `cm²`, `m²`, `km²`
+    - USCS / imperial: `in²`, `ft²`, `yd²`, `mi²`
+    """
+
     ENERGY = "energy"
     """Energy.
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -765,9 +765,22 @@ VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR: Final = "m³/h"
 VOLUME_FLOW_RATE_CUBIC_FEET_PER_MINUTE: Final = "ft³/m"
 """Deprecated: please use UnitOfVolumeFlowRate.CUBIC_FEET_PER_MINUTE"""
 
-# Area units
-AREA_SQUARE_METERS: Final = "m²"
 
+# Area units
+class UnitOfArea(StrEnum):
+    """Area units."""
+
+    SQUARE_MILLIMETERS = "mm²"
+    SQUARE_CENTIMETERS = "cm²"
+    SQUARE_METERS = "m²"
+    SQUARE_KILOMETERS = "km²"
+    SQUARE_INCHES = "in²"
+    SQUARE_FEET = "ft²"
+    SQUARE_YARDS = "yd²"
+    SQUARE_MILES = "mi²"
+
+"""Deprecated: please use UnitOfArea.SQUARE_METERS."""
+AREA_SQUARE_METERS: Final = "m²"
 
 # Mass units
 class UnitOfMass(StrEnum):
@@ -1116,6 +1129,7 @@ RESTART_EXIT_CODE: Final = 100
 UNIT_NOT_RECOGNIZED_TEMPLATE: Final = "{} is not a recognized {} unit."
 
 LENGTH: Final = "length"
+AREA: Final = "area"
 MASS: Final = "mass"
 PRESSURE: Final = "pressure"
 VOLUME: Final = "volume"

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from homeassistant.const import (
     UNIT_NOT_RECOGNIZED_TEMPLATE,
+    UnitOfArea,
     UnitOfEnergy,
     UnitOfLength,
     UnitOfMass,
@@ -110,6 +111,33 @@ class DistanceConverter(BaseUnitConverter):
         UnitOfLength.MILLIMETERS,
         UnitOfLength.INCHES,
         UnitOfLength.YARDS,
+    }
+
+
+class AreaConverter(BaseUnitConverter):
+    """Utility to convert area values."""
+
+    UNIT_CLASS = "area"
+    NORMALIZED_UNIT = UnitOfArea.SQUARE_METERS
+    _UNIT_CONVERSION: dict[str, float] = {
+        UnitOfArea.SQUARE_METERS: 1,
+        UnitOfArea.SQUARE_MILLIMETERS: 1 / _MM_TO_M**2,
+        UnitOfArea.SQUARE_CENTIMETERS: 1 / _CM_TO_M**2,
+        UnitOfArea.SQUARE_KILOMETERS: 1 / _KM_TO_M**2,
+        UnitOfArea.SQUARE_INCHES: 1 / _IN_TO_M**2,
+        UnitOfArea.SQUARE_FEET: 1 / _FOOT_TO_M**2,
+        UnitOfArea.SQUARE_YARDS: 1 / _YARD_TO_M**2,
+        UnitOfArea.SQUARE_MILES: 1 / _MILE_TO_M**2,
+    }
+    VALID_UNITS = {
+        UnitOfArea.SQUARE_KILOMETERS,
+        UnitOfArea.SQUARE_MILES,
+        UnitOfArea.SQUARE_FEET,
+        UnitOfArea.SQUARE_METERS,
+        UnitOfArea.SQUARE_CENTIMETERS,
+        UnitOfArea.SQUARE_MILLIMETERS,
+        UnitOfArea.SQUARE_INCHES,
+        UnitOfArea.SQUARE_YARDS,
     }
 
 

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     ACCUMULATED_PRECIPITATION,
+    AREA,
     LENGTH,
     MASS,
     PRESSURE,
@@ -15,6 +16,7 @@ from homeassistant.const import (
     UNIT_NOT_RECOGNIZED_TEMPLATE,
     VOLUME,
     WIND_SPEED,
+    UnitOfArea,
     UnitOfLength,
     UnitOfMass,
     UnitOfPrecipitationDepth,
@@ -26,6 +28,7 @@ from homeassistant.const import (
 from homeassistant.helpers.frame import report
 
 from .unit_conversion import (
+    AreaConverter,
     DistanceConverter,
     PressureConverter,
     SpeedConverter,
@@ -41,6 +44,8 @@ _CONF_UNIT_SYSTEM_METRIC: Final = "metric"
 _CONF_UNIT_SYSTEM_US_CUSTOMARY: Final = "us_customary"
 
 LENGTH_UNITS = DistanceConverter.VALID_UNITS
+
+AREA_UNITS = AreaConverter.VALID_UNITS
 
 MASS_UNITS: set[str] = {
     UnitOfMass.POUNDS,
@@ -62,6 +67,8 @@ def _is_valid_unit(unit: str, unit_type: str) -> bool:
     """Check if the unit is valid for it's type."""
     if unit_type == LENGTH:
         return unit in LENGTH_UNITS
+    if unit_type == AREA:
+        return unit in AREA_UNITS
     if unit_type == ACCUMULATED_PRECIPITATION:
         return unit in LENGTH_UNITS
     if unit_type == WIND_SPEED:
@@ -87,6 +94,7 @@ class UnitSystem:
         accumulated_precipitation: UnitOfPrecipitationDepth,
         conversions: dict[tuple[SensorDeviceClass | str | None, str | None], str],
         length: UnitOfLength,
+        area: UnitOfArea,
         mass: UnitOfMass,
         pressure: UnitOfPressure,
         temperature: UnitOfTemperature,
@@ -100,6 +108,7 @@ class UnitSystem:
                 (accumulated_precipitation, ACCUMULATED_PRECIPITATION),
                 (temperature, TEMPERATURE),
                 (length, LENGTH),
+                (area, AREA),
                 (wind_speed, WIND_SPEED),
                 (volume, VOLUME),
                 (mass, MASS),
@@ -115,6 +124,7 @@ class UnitSystem:
         self.accumulated_precipitation_unit = accumulated_precipitation
         self.temperature_unit = temperature
         self.length_unit = length
+        self.area_unit = area
         self.mass_unit = mass
         self.pressure_unit = pressure
         self.volume_unit = volume
@@ -209,6 +219,7 @@ class UnitSystem:
         """Convert the unit system to a dictionary."""
         return {
             LENGTH: self.length_unit,
+            AREA: self.area_unit,
             ACCUMULATED_PRECIPITATION: self.accumulated_precipitation_unit,
             MASS: self.mass_unit,
             PRESSURE: self.pressure_unit,
@@ -265,6 +276,11 @@ METRIC_SYSTEM = UnitSystem(
         ("distance", UnitOfLength.INCHES): UnitOfLength.MILLIMETERS,
         ("distance", UnitOfLength.MILES): UnitOfLength.KILOMETERS,
         ("distance", UnitOfLength.YARDS): UnitOfLength.METERS,
+        # Convert non-metric areas
+        ("area", UnitOfArea.SQUARE_FEET): UnitOfArea.SQUARE_METERS,
+        ("area", UnitOfArea.SQUARE_INCHES): UnitOfArea.SQUARE_MILLIMETERS,
+        ("area", UnitOfArea.SQUARE_MILES): UnitOfArea.SQUARE_KILOMETERS,
+        ("area", UnitOfArea.SQUARE_YARDS): UnitOfArea.SQUARE_METERS,
         # Convert non-metric volumes of gas meters
         ("gas", UnitOfVolume.CUBIC_FEET): UnitOfVolume.CUBIC_METERS,
         # Convert non-metric precipitation
@@ -284,6 +300,7 @@ METRIC_SYSTEM = UnitSystem(
         ("water", UnitOfVolume.GALLONS): UnitOfVolume.LITERS,
     },
     length=UnitOfLength.KILOMETERS,
+    area=UnitOfArea.SQUARE_KILOMETERS,
     mass=UnitOfMass.GRAMS,
     pressure=UnitOfPressure.PA,
     temperature=UnitOfTemperature.CELSIUS,
@@ -306,6 +323,11 @@ US_CUSTOMARY_SYSTEM = UnitSystem(
         ("distance", UnitOfLength.KILOMETERS): UnitOfLength.MILES,
         ("distance", UnitOfLength.METERS): UnitOfLength.FEET,
         ("distance", UnitOfLength.MILLIMETERS): UnitOfLength.INCHES,
+        # Convert non-USCS areas
+        ("area", UnitOfArea.SQUARE_CENTIMETERS): UnitOfArea.SQUARE_INCHES,
+        ("area", UnitOfArea.SQUARE_KILOMETERS): UnitOfArea.SQUARE_MILES,
+        ("area", UnitOfArea.SQUARE_METERS): UnitOfArea.SQUARE_FEET,
+        ("area", UnitOfArea.SQUARE_MILLIMETERS): UnitOfArea.SQUARE_INCHES,
         # Convert non-USCS volumes of gas meters
         ("gas", UnitOfVolume.CUBIC_METERS): UnitOfVolume.CUBIC_FEET,
         # Convert non-USCS precipitation
@@ -330,6 +352,7 @@ US_CUSTOMARY_SYSTEM = UnitSystem(
         ("water", UnitOfVolume.LITERS): UnitOfVolume.GALLONS,
     },
     length=UnitOfLength.MILES,
+    area=UnitOfArea.SQUARE_MILES,
     mass=UnitOfMass.POUNDS,
     pressure=UnitOfPressure.PSI,
     temperature=UnitOfTemperature.FAHRENHEIT,

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1099,6 +1099,7 @@ async def test_non_numeric_device_class_with_unit_of_measurement(
         SensorDeviceClass.DATA_RATE,
         SensorDeviceClass.DATA_SIZE,
         SensorDeviceClass.DISTANCE,
+        SensorDeviceClass.AREA,
         SensorDeviceClass.DURATION,
         SensorDeviceClass.ENERGY,
         SensorDeviceClass.FREQUENCY,

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -2,6 +2,7 @@
 import pytest
 
 from homeassistant.const import (
+    UnitOfArea,
     UnitOfEnergy,
     UnitOfLength,
     UnitOfMass,
@@ -14,6 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.unit_conversion import (
+    AreaConverter,
     BaseUnitConverter,
     DistanceConverter,
     EnergyConverter,
@@ -39,6 +41,14 @@ INVALID_SYMBOL = "bob"
         (DistanceConverter, UnitOfLength.YARDS),
         (DistanceConverter, UnitOfLength.FEET),
         (DistanceConverter, UnitOfLength.INCHES),
+        (AreaConverter, UnitOfArea.SQUARE_KILOMETERS),
+        (AreaConverter, UnitOfArea.SQUARE_METERS),
+        (AreaConverter, UnitOfArea.SQUARE_CENTIMETERS),
+        (AreaConverter, UnitOfArea.SQUARE_MILLIMETERS),
+        (AreaConverter, UnitOfArea.SQUARE_MILES),
+        (AreaConverter, UnitOfArea.SQUARE_YARDS),
+        (AreaConverter, UnitOfArea.SQUARE_FEET),
+        (AreaConverter, UnitOfArea.SQUARE_INCHES),
         (EnergyConverter, UnitOfEnergy.WATT_HOUR),
         (EnergyConverter, UnitOfEnergy.KILO_WATT_HOUR),
         (EnergyConverter, UnitOfEnergy.MEGA_WATT_HOUR),
@@ -86,6 +96,7 @@ def test_convert_same_unit(converter: type[BaseUnitConverter], valid_unit: str) 
     "converter,valid_unit",
     [
         (DistanceConverter, UnitOfLength.KILOMETERS),
+        (AreaConverter, UnitOfArea.SQUARE_KILOMETERS),
         (EnergyConverter, UnitOfEnergy.KILO_WATT_HOUR),
         (MassConverter, UnitOfMass.GRAMS),
         (PowerConverter, UnitOfPower.WATT),
@@ -112,6 +123,7 @@ def test_convert_invalid_unit(
     "converter,from_unit,to_unit",
     [
         (DistanceConverter, UnitOfLength.KILOMETERS, UnitOfLength.METERS),
+        (AreaConverter, UnitOfArea.SQUARE_KILOMETERS, UnitOfArea.SQUARE_METERS),
         (EnergyConverter, UnitOfEnergy.WATT_HOUR, UnitOfEnergy.KILO_WATT_HOUR),
         (MassConverter, UnitOfMass.GRAMS, UnitOfMass.KILOGRAMS),
         (PowerConverter, UnitOfPower.WATT, UnitOfPower.KILO_WATT),
@@ -133,6 +145,12 @@ def test_convert_nonnumeric_value(
     "converter,from_unit,to_unit,expected",
     [
         (DistanceConverter, UnitOfLength.KILOMETERS, UnitOfLength.METERS, 1 / 1000),
+        (
+            AreaConverter,
+            UnitOfArea.SQUARE_KILOMETERS,
+            UnitOfArea.SQUARE_METERS,
+            1 / 1000**2,
+        ),
         (EnergyConverter, UnitOfEnergy.WATT_HOUR, UnitOfEnergy.KILO_WATT_HOUR, 1000),
         (PowerConverter, UnitOfPower.WATT, UnitOfPower.KILO_WATT, 1000),
         (
@@ -282,6 +300,337 @@ def test_distance_convert(
 ) -> None:
     """Test conversion to other units."""
     assert DistanceConverter.convert(value, from_unit, to_unit) == expected
+
+
+@pytest.mark.parametrize(
+    "value,from_unit,expected,to_unit",
+    [
+        (
+            5,
+            UnitOfArea.SQUARE_MILES,
+            pytest.approx(8.04672),
+            UnitOfArea.SQUARE_KILOMETERS,
+        ),
+        (5, UnitOfArea.SQUARE_MILES, pytest.approx(8046.72), UnitOfArea.SQUARE_METERS),
+        (
+            5,
+            UnitOfArea.SQUARE_MILES,
+            pytest.approx(804672.0),
+            UnitOfArea.SQUARE_CENTIMETERS,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_MILES,
+            pytest.approx(8046720.0),
+            UnitOfArea.SQUARE_MILLIMETERS,
+        ),
+        (5, UnitOfArea.SQUARE_MILES, pytest.approx(8800.0), UnitOfArea.SQUARE_YARDS),
+        (
+            5,
+            UnitOfArea.SQUARE_MILES,
+            pytest.approx(26400.0008448),
+            UnitOfArea.SQUARE_FEET,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_MILES,
+            pytest.approx(316800.171072),
+            UnitOfArea.SQUARE_INCHES,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_YARDS,
+            pytest.approx(0.0045720000000000005),
+            UnitOfArea.SQUARE_KILOMETERS,
+        ),
+        (5, UnitOfArea.SQUARE_YARDS, pytest.approx(4.572), UnitOfArea.SQUARE_METERS),
+        (
+            5,
+            UnitOfArea.SQUARE_YARDS,
+            pytest.approx(457.2),
+            UnitOfArea.SQUARE_CENTIMETERS,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_YARDS,
+            pytest.approx(4572),
+            UnitOfArea.SQUARE_MILLIMETERS,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_YARDS,
+            pytest.approx(0.002840908212),
+            UnitOfArea.SQUARE_MILES,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_YARDS,
+            pytest.approx(15.00000048),
+            UnitOfArea.SQUARE_FEET,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_YARDS,
+            pytest.approx(180.0000972),
+            UnitOfArea.SQUARE_INCHES,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_FEET,
+            pytest.approx(1.524),
+            UnitOfArea.SQUARE_KILOMETERS,
+        ),
+        (5000, UnitOfArea.SQUARE_FEET, pytest.approx(1524), UnitOfArea.SQUARE_METERS),
+        (
+            5000,
+            UnitOfArea.SQUARE_FEET,
+            pytest.approx(152400.0),
+            UnitOfArea.SQUARE_CENTIMETERS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_FEET,
+            pytest.approx(1524000.0),
+            UnitOfArea.SQUARE_MILLIMETERS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_FEET,
+            pytest.approx(0.9469694040000001),
+            UnitOfArea.SQUARE_MILES,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_FEET,
+            pytest.approx(1666.66667),
+            UnitOfArea.SQUARE_YARDS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_FEET,
+            pytest.approx(60000.032400000004),
+            UnitOfArea.SQUARE_INCHES,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_INCHES,
+            pytest.approx(0.127),
+            UnitOfArea.SQUARE_KILOMETERS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_INCHES,
+            pytest.approx(127.0),
+            UnitOfArea.SQUARE_METERS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_INCHES,
+            pytest.approx(12700.0),
+            UnitOfArea.SQUARE_CENTIMETERS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_INCHES,
+            pytest.approx(127000.0),
+            UnitOfArea.SQUARE_MILLIMETERS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_INCHES,
+            pytest.approx(0.078914117),
+            UnitOfArea.SQUARE_MILES,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_INCHES,
+            pytest.approx(138.88889),
+            UnitOfArea.SQUARE_YARDS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_INCHES,
+            pytest.approx(416.66668),
+            UnitOfArea.SQUARE_FEET,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_KILOMETERS,
+            pytest.approx(5000),
+            UnitOfArea.SQUARE_METERS,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_KILOMETERS,
+            pytest.approx(500000),
+            UnitOfArea.SQUARE_CENTIMETERS,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_KILOMETERS,
+            pytest.approx(5000000),
+            UnitOfArea.SQUARE_MILLIMETERS,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_KILOMETERS,
+            pytest.approx(3.106855),
+            UnitOfArea.SQUARE_MILES,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_KILOMETERS,
+            pytest.approx(5468.066),
+            UnitOfArea.SQUARE_YARDS,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_KILOMETERS,
+            pytest.approx(16404.2),
+            UnitOfArea.SQUARE_FEET,
+        ),
+        (
+            5,
+            UnitOfArea.SQUARE_KILOMETERS,
+            pytest.approx(196850.5),
+            UnitOfArea.SQUARE_INCHES,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_METERS,
+            pytest.approx(5),
+            UnitOfArea.SQUARE_KILOMETERS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_METERS,
+            pytest.approx(500000),
+            UnitOfArea.SQUARE_CENTIMETERS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_METERS,
+            pytest.approx(5000000),
+            UnitOfArea.SQUARE_MILLIMETERS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_METERS,
+            pytest.approx(3.106855),
+            UnitOfArea.SQUARE_MILES,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_METERS,
+            pytest.approx(5468.066),
+            UnitOfArea.SQUARE_YARDS,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_METERS,
+            pytest.approx(16404.2),
+            UnitOfArea.SQUARE_FEET,
+        ),
+        (
+            5000,
+            UnitOfArea.SQUARE_METERS,
+            pytest.approx(196850.5),
+            UnitOfArea.SQUARE_INCHES,
+        ),
+        (
+            500000,
+            UnitOfArea.SQUARE_CENTIMETERS,
+            pytest.approx(5),
+            UnitOfArea.SQUARE_KILOMETERS,
+        ),
+        (
+            500000,
+            UnitOfArea.SQUARE_CENTIMETERS,
+            pytest.approx(5000),
+            UnitOfArea.SQUARE_METERS,
+        ),
+        (
+            500000,
+            UnitOfArea.SQUARE_CENTIMETERS,
+            pytest.approx(5000000),
+            UnitOfArea.SQUARE_MILLIMETERS,
+        ),
+        (
+            500000,
+            UnitOfArea.SQUARE_CENTIMETERS,
+            pytest.approx(3.106855),
+            UnitOfArea.SQUARE_MILES,
+        ),
+        (
+            500000,
+            UnitOfArea.SQUARE_CENTIMETERS,
+            pytest.approx(5468.066),
+            UnitOfArea.SQUARE_YARDS,
+        ),
+        (
+            500000,
+            UnitOfArea.SQUARE_CENTIMETERS,
+            pytest.approx(16404.2),
+            UnitOfArea.SQUARE_FEET,
+        ),
+        (
+            500000,
+            UnitOfArea.SQUARE_CENTIMETERS,
+            pytest.approx(196850.5),
+            UnitOfArea.SQUARE_INCHES,
+        ),
+        (
+            5000000,
+            UnitOfArea.SQUARE_MILLIMETERS,
+            pytest.approx(5),
+            UnitOfArea.SQUARE_KILOMETERS,
+        ),
+        (
+            5000000,
+            UnitOfArea.SQUARE_MILLIMETERS,
+            pytest.approx(5000),
+            UnitOfArea.SQUARE_METERS,
+        ),
+        (
+            5000000,
+            UnitOfArea.SQUARE_MILLIMETERS,
+            pytest.approx(500000),
+            UnitOfArea.SQUARE_CENTIMETERS,
+        ),
+        (
+            5000000,
+            UnitOfArea.SQUARE_MILLIMETERS,
+            pytest.approx(3.106855),
+            UnitOfArea.SQUARE_MILES,
+        ),
+        (
+            5000000,
+            UnitOfArea.SQUARE_MILLIMETERS,
+            pytest.approx(5468.066),
+            UnitOfArea.SQUARE_YARDS,
+        ),
+        (
+            5000000,
+            UnitOfArea.SQUARE_MILLIMETERS,
+            pytest.approx(16404.2),
+            UnitOfArea.SQUARE_FEET,
+        ),
+        (
+            5000000,
+            UnitOfArea.SQUARE_MILLIMETERS,
+            pytest.approx(196850.5),
+            UnitOfArea.SQUARE_INCHES,
+        ),
+    ],
+)
+def test_area_convert(
+    value: float,
+    from_unit: str,
+    expected: float,
+    to_unit: str,
+) -> None:
+    """Test conversion to other units."""
+    assert AreaConverter.convert(value, from_unit, to_unit) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -6,14 +6,17 @@ import pytest
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     ACCUMULATED_PRECIPITATION,
+    AREA,
     LENGTH,
     MASS,
     PRESSURE,
     TEMPERATURE,
     VOLUME,
     WIND_SPEED,
+    UnitOfArea,
     UnitOfLength,
     UnitOfMass,
+    UnitOfPrecipitationDepth,
     UnitOfPressure,
     UnitOfSpeed,
     UnitOfTemperature,
@@ -40,9 +43,10 @@ def test_invalid_units():
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            accumulated_precipitation=UnitOfLength.MILLIMETERS,
+            accumulated_precipitation=UnitOfPrecipitationDepth.MILLIMETERS,
             conversions={},
             length=UnitOfLength.METERS,
+            area=UnitOfArea.SQUARE_METERS,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
             temperature=INVALID_UNIT,
@@ -53,9 +57,10 @@ def test_invalid_units():
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            accumulated_precipitation=UnitOfLength.MILLIMETERS,
+            accumulated_precipitation=UnitOfPrecipitationDepth.MILLIMETERS,
             conversions={},
             length=INVALID_UNIT,
+            area=UnitOfArea.SQUARE_METERS,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
             temperature=UnitOfTemperature.CELSIUS,
@@ -66,9 +71,10 @@ def test_invalid_units():
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            accumulated_precipitation=UnitOfLength.MILLIMETERS,
+            accumulated_precipitation=UnitOfPrecipitationDepth.MILLIMETERS,
             conversions={},
             length=UnitOfLength.METERS,
+            area=UnitOfArea.SQUARE_METERS,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
             temperature=UnitOfTemperature.CELSIUS,
@@ -79,9 +85,10 @@ def test_invalid_units():
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            accumulated_precipitation=UnitOfLength.MILLIMETERS,
+            accumulated_precipitation=UnitOfPrecipitationDepth.MILLIMETERS,
             conversions={},
             length=UnitOfLength.METERS,
+            area=UnitOfArea.SQUARE_METERS,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
             temperature=UnitOfTemperature.CELSIUS,
@@ -92,9 +99,10 @@ def test_invalid_units():
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            accumulated_precipitation=UnitOfLength.MILLIMETERS,
+            accumulated_precipitation=UnitOfPrecipitationDepth.MILLIMETERS,
             conversions={},
             length=UnitOfLength.METERS,
+            area=UnitOfArea.SQUARE_METERS,
             mass=INVALID_UNIT,
             pressure=UnitOfPressure.PA,
             temperature=UnitOfTemperature.CELSIUS,
@@ -105,9 +113,10 @@ def test_invalid_units():
     with pytest.raises(ValueError):
         UnitSystem(
             SYSTEM_NAME,
-            accumulated_precipitation=UnitOfLength.MILLIMETERS,
+            accumulated_precipitation=UnitOfPrecipitationDepth.MILLIMETERS,
             conversions={},
             length=UnitOfLength.METERS,
+            area=UnitOfArea.SQUARE_METERS,
             mass=UnitOfMass.GRAMS,
             pressure=INVALID_UNIT,
             temperature=UnitOfTemperature.CELSIUS,
@@ -121,6 +130,21 @@ def test_invalid_units():
             accumulated_precipitation=INVALID_UNIT,
             conversions={},
             length=UnitOfLength.METERS,
+            area=UnitOfArea.SQUARE_METERS,
+            mass=UnitOfMass.GRAMS,
+            pressure=UnitOfPressure.PA,
+            temperature=UnitOfTemperature.CELSIUS,
+            volume=UnitOfVolume.LITERS,
+            wind_speed=UnitOfSpeed.METERS_PER_SECOND,
+        )
+
+    with pytest.raises(ValueError):
+        UnitSystem(
+            SYSTEM_NAME,
+            accumulated_precipitation=UnitOfPrecipitationDepth.MILLIMETERS,
+            conversions={},
+            length=UnitOfLength.METERS,
+            area=INVALID_UNIT,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
             temperature=UnitOfTemperature.CELSIUS,
@@ -133,6 +157,8 @@ def test_invalid_value():
     """Test no conversion happens if value is non-numeric."""
     with pytest.raises(TypeError):
         METRIC_SYSTEM.length("25a", UnitOfLength.KILOMETERS)
+    with pytest.raises(TypeError):
+        METRIC_SYSTEM.length("25x", UnitOfArea.SQUARE_KILOMETERS)
     with pytest.raises(TypeError):
         METRIC_SYSTEM.temperature("50K", UnitOfTemperature.CELSIUS)
     with pytest.raises(TypeError):
@@ -149,6 +175,7 @@ def test_as_dict():
     """Test that the as_dict() method returns the expected dictionary."""
     expected = {
         LENGTH: UnitOfLength.KILOMETERS,
+        AREA: UnitOfLength.KILOMETERS,
         WIND_SPEED: UnitOfSpeed.METERS_PER_SECOND,
         TEMPERATURE: UnitOfTemperature.CELSIUS,
         VOLUME: UnitOfVolume.LITERS,
@@ -405,6 +432,17 @@ def test_get_unit_system_invalid(key: str) -> None:
         (SensorDeviceClass.DISTANCE, UnitOfLength.YARDS, UnitOfLength.METERS),
         (SensorDeviceClass.DISTANCE, UnitOfLength.KILOMETERS, None),
         (SensorDeviceClass.DISTANCE, "very_long", None),
+        # Test area conversion
+        (SensorDeviceClass.AREA, UnitOfArea.SQUARE_FEET, UnitOfArea.SQUARE_METERS),
+        (
+            SensorDeviceClass.AREA,
+            UnitOfArea.SQUARE_INCHES,
+            UnitOfArea.SQUARE_MILLIMETERS,
+        ),
+        (SensorDeviceClass.AREA, UnitOfArea.SQUARE_MILES, UnitOfArea.SQUARE_KILOMETERS),
+        (SensorDeviceClass.AREA, UnitOfArea.SQUARE_YARDS, UnitOfArea.SQUARE_METERS),
+        (SensorDeviceClass.AREA, UnitOfArea.SQUARE_KILOMETERS, None),
+        (SensorDeviceClass.AREA, "very_much", None),
         # Test gas meter conversion
         (SensorDeviceClass.GAS, UnitOfVolume.CUBIC_FEET, UnitOfVolume.CUBIC_METERS),
         (SensorDeviceClass.GAS, UnitOfVolume.CUBIC_METERS, None),
@@ -482,6 +520,21 @@ def test_get_metric_converted_unit_(
         (SensorDeviceClass.DISTANCE, UnitOfLength.MILLIMETERS, UnitOfLength.INCHES),
         (SensorDeviceClass.DISTANCE, UnitOfLength.MILES, None),
         (SensorDeviceClass.DISTANCE, "very_long", None),
+        # Test area conversion
+        (
+            SensorDeviceClass.AREA,
+            UnitOfArea.SQUARE_CENTIMETERS,
+            UnitOfArea.SQUARE_INCHES,
+        ),
+        (SensorDeviceClass.AREA, UnitOfArea.SQUARE_KILOMETERS, UnitOfArea.SQUARE_MILES),
+        (SensorDeviceClass.AREA, UnitOfArea.SQUARE_METERS, UnitOfArea.SQUARE_FEET),
+        (
+            SensorDeviceClass.AREA,
+            UnitOfArea.SQUARE_MILLIMETERS,
+            UnitOfArea.SQUARE_INCHES,
+        ),
+        (SensorDeviceClass.AREA, UnitOfArea.SQUARE_MILES, None),
+        (SensorDeviceClass.AREA, "very_much", None),
         # Test gas meter conversion
         (SensorDeviceClass.GAS, UnitOfVolume.CUBIC_METERS, UnitOfVolume.CUBIC_FEET),
         (SensorDeviceClass.GAS, UnitOfVolume.CUBIC_FEET, None),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
- Deprecation of `AREA_SQUARE_METERS` in favor of `UnitOfArea.SQUARE_METERS`
- Possibly braking if `area` has been used as sensor `device_class`?


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds area units as similar as possible to the `distance` units already in the code.
I noticed the need when working with an integration and sensor for a vacuum robot, representing the cleaned area (in m²).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
