### PR TITLE
Use built in polling for litterrobot update entity

### DIFF
--- a/homeassistant/components/litterrobot/update.py
+++ b/homeassistant/components/litterrobot/update.py
@@ -1,6 +1,7 @@
 """Support for Litter-Robot updates."""
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Any
 
 from pylitterbot import LitterRobot4
@@ -18,6 +19,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .entity import LitterRobotEntity, LitterRobotHub
+
+SCAN_INTERVAL = timedelta(days=1)
 
 FIRMWARE_UPDATE_ENTITY = UpdateEntityDescription(
     key="firmware",

--- a/homeassistant/components/litterrobot/update.py
+++ b/homeassistant/components/litterrobot/update.py
@@ -1,8 +1,6 @@
 """Support for Litter-Robot updates."""
 from __future__ import annotations
 
-from collections.abc import Callable
-from datetime import datetime, timedelta
 from typing import Any
 
 from pylitterbot import LitterRobot4
@@ -17,8 +15,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.start import async_at_start
 
 from .const import DOMAIN
 from .entity import LitterRobotEntity, LitterRobotHub
@@ -43,7 +39,7 @@ async def async_setup_entry(
         for robot in robots
         if isinstance(robot, LitterRobot4)
     ]
-    async_add_entities(entities)
+    async_add_entities(entities, True)
 
 
 class RobotUpdateEntity(LitterRobotEntity[LitterRobot4], UpdateEntity):
@@ -52,16 +48,6 @@ class RobotUpdateEntity(LitterRobotEntity[LitterRobot4], UpdateEntity):
     _attr_supported_features = (
         UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
     )
-
-    def __init__(
-        self,
-        robot: LitterRobot4,
-        hub: LitterRobotHub,
-        description: UpdateEntityDescription,
-    ) -> None:
-        """Initialize a Litter-Robot update entity."""
-        super().__init__(robot, hub, description)
-        self._poll_unsub: Callable[[], None] | None = None
 
     @property
     def installed_version(self) -> str:
@@ -73,10 +59,13 @@ class RobotUpdateEntity(LitterRobotEntity[LitterRobot4], UpdateEntity):
         """Update installation progress."""
         return self.robot.firmware_update_triggered
 
-    async def _async_update(self, _: HomeAssistant | datetime | None = None) -> None:
-        """Update the entity."""
-        self._poll_unsub = None
+    @property
+    def should_poll(self) -> bool:
+        """Set polling to True."""
+        return True
 
+    async def async_update(self) -> None:
+        """Update the entity."""
         if await self.robot.has_firmware_update():
             latest_version = await self.robot.get_latest_firmware()
         else:
@@ -84,16 +73,6 @@ class RobotUpdateEntity(LitterRobotEntity[LitterRobot4], UpdateEntity):
 
         if self._attr_latest_version != self.installed_version:
             self._attr_latest_version = latest_version
-            self.async_write_ha_state()
-
-        self._poll_unsub = async_call_later(
-            self.hass, timedelta(days=1), self._async_update
-        )
-
-    async def async_added_to_hass(self) -> None:
-        """Set up a listener for the entity."""
-        await super().async_added_to_hass()
-        self.async_on_remove(async_at_start(self.hass, self._async_update))
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
@@ -103,9 +82,3 @@ class RobotUpdateEntity(LitterRobotEntity[LitterRobot4], UpdateEntity):
             if not await self.robot.update_firmware():
                 message = f"Unable to start firmware update on {self.robot.name}"
                 raise HomeAssistantError(message)
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Call when entity will be removed."""
-        if self._poll_unsub:
-            self._poll_unsub()
-            self._poll_unsub = None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the built in polling per previous PR review https://github.com/home-assistant/core/pull/83590#pullrequestreview-1228934962

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
