### PR TITLE
airzone: update aioairzone to v0.5.2

### DIFF
--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -3,7 +3,7 @@
   "name": "Airzone",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/airzone",
-  "requirements": ["aioairzone==0.5.1"],
+  "requirements": ["aioairzone==0.5.2"],
   "codeowners": ["@Noltari"],
   "iot_class": "local_polling",
   "loggers": ["aioairzone"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -119,7 +119,7 @@ aio_georss_gdacs==0.7
 aioairq==0.2.4
 
 # homeassistant.components.airzone
-aioairzone==0.5.1
+aioairzone==0.5.2
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -106,7 +106,7 @@ aio_georss_gdacs==0.7
 aioairq==0.2.4
 
 # homeassistant.components.airzone
-aioairzone==0.5.1
+aioairzone==0.5.2
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0

--- a/tests/components/airzone/test_binary_sensor.py
+++ b/tests/components/airzone/test_binary_sensor.py
@@ -78,3 +78,9 @@ async def test_airzone_create_binary_sensors(hass: HomeAssistant) -> None:
 
     state = hass.states.get("binary_sensor.salon_problem")
     assert state.state == STATE_OFF
+
+    state = hass.states.get("binary_sensor.airzone_2_1_battery_low")
+    assert state is None
+
+    state = hass.states.get("binary_sensor.airzone_2_1_problem")
+    assert state.state == STATE_OFF

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -131,6 +131,20 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_TARGET_TEMP_STEP) == API_TEMPERATURE_STEP
     assert state.attributes.get(ATTR_TEMPERATURE) == 19.1
 
+    state = hass.states.get("climate.airzone_2_1")
+    assert state.state == HVACMode.OFF
+    assert state.attributes.get(ATTR_CURRENT_HUMIDITY) == 62
+    assert state.attributes.get(ATTR_CURRENT_TEMPERATURE) == 22.3
+    assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.OFF
+    assert state.attributes.get(ATTR_HVAC_MODES) == [
+        HVACMode.HEAT_COOL,
+        HVACMode.OFF,
+    ]
+    assert state.attributes.get(ATTR_MAX_TEMP) == 30
+    assert state.attributes.get(ATTR_MIN_TEMP) == 15
+    assert state.attributes.get(ATTR_TARGET_TEMP_STEP) == API_TEMPERATURE_STEP
+    assert state.attributes.get(ATTR_TEMPERATURE) == 19.0
+
 
 async def test_airzone_climate_turn_on_off(hass: HomeAssistant) -> None:
     """Test turning on."""
@@ -186,6 +200,31 @@ async def test_airzone_climate_turn_on_off(hass: HomeAssistant) -> None:
 
     state = hass.states.get("climate.salon")
     assert state.state == HVACMode.OFF
+
+    HVAC_MOCK = {
+        API_DATA: [
+            {
+                API_SYSTEM_ID: 2,
+                API_ZONE_ID: 1,
+                API_ON: 1,
+            }
+        ]
+    }
+    with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.put_hvac",
+        return_value=HVAC_MOCK,
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: "climate.airzone_2_1",
+            },
+            blocking=True,
+        )
+
+    state = hass.states.get("climate.airzone_2_1")
+    assert state.state == HVACMode.HEAT_COOL
 
 
 async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant) -> None:
@@ -245,6 +284,32 @@ async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant) -> None:
 
     state = hass.states.get("climate.salon")
     assert state.state == HVACMode.OFF
+
+    HVAC_MOCK_3 = {
+        API_DATA: [
+            {
+                API_SYSTEM_ID: 2,
+                API_ZONE_ID: 1,
+                API_ON: 1,
+            }
+        ]
+    }
+    with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.put_hvac",
+        return_value=HVAC_MOCK_3,
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {
+                ATTR_ENTITY_ID: "climate.airzone_2_1",
+                ATTR_HVAC_MODE: HVACMode.HEAT_COOL,
+            },
+            blocking=True,
+        )
+
+    state = hass.states.get("climate.airzone_2_1")
+    assert state.state == HVACMode.HEAT_COOL
 
 
 async def test_airzone_climate_set_hvac_slave_error(hass: HomeAssistant) -> None:

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -48,3 +48,9 @@ async def test_airzone_create_sensors(
 
     state = hass.states.get("sensor.salon_humidity")
     assert state.state == "34"
+
+    state = hass.states.get("sensor.airzone_2_1_temperature")
+    assert state.state == "22.3"
+
+    state = hass.states.get("sensor.airzone_2_1_humidity")
+    assert state.state == "62"

--- a/tests/components/airzone/util.py
+++ b/tests/components/airzone/util.py
@@ -177,7 +177,27 @@ HVAC_MOCK = {
                     API_FLOOR_DEMAND: 0,
                 },
             ]
-        }
+        },
+        {
+            API_DATA: [
+                {
+                    API_SYSTEM_ID: 2,
+                    API_ZONE_ID: 1,
+                    API_ON: 0,
+                    API_MAX_TEMP: 30,
+                    API_MIN_TEMP: 15,
+                    API_SET_POINT: 19,
+                    API_ROOM_TEMP: 22.299999,
+                    API_COLD_STAGES: 1,
+                    API_COLD_STAGE: 1,
+                    API_HEAT_STAGES: 1,
+                    API_HEAT_STAGE: 1,
+                    API_HUMIDITY: 62,
+                    API_UNITS: 0,
+                    API_ERRORS: [],
+                },
+            ]
+        },
     ]
 }
 


### PR DESCRIPTION
## Proposed change
Update aioairzone to [v0.5.2](https://github.com/Noltari/aioairzone/compare/0.5.1...0.5.2) which adds compatibility with older devices that lack `name`, `mode`, `modes`, `air_demand` and `floor_demand` parameters.
This was reported by @jorisnavarro https://github.com/home-assistant/core/issues/82137#issuecomment-1364227298.

Releases:
- https://github.com/Noltari/aioairzone/releases/tag/0.5.2

Git compare: https://github.com/Noltari/aioairzone/compare/0.5.1...0.5.2

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
