### PR TITLE
Set Yamaha unique_id

### DIFF
--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -193,6 +193,8 @@ class YamahaDevice(MediaPlayerEntity):
     def __init__(self, name, receiver, source_ignore, source_names, zone_names):
         """Initialize the Yamaha Receiver."""
         self.receiver = receiver
+        if name == DEFAULT_NAME and not receiver.model_name is None and not receiver.model_name == "Unknown":
+            name = 'Yamaha %s' % receiver.model_name
         self._attr_is_volume_muted = False
         self._attr_volume_level = 0
         self._attr_state = MediaPlayerState.OFF

--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -207,8 +207,8 @@ class YamahaDevice(MediaPlayerEntity):
         self._play_status = None
         self._name = name
         self._zone = receiver.zone
-        if not self.receiver.serial_number is None:
-            self._attr_unique_id = '%s_%s' % (self.receiver.serial_number, self._zone)
+        if self.receiver.serial_number is not None:
+            self._attr_unique_id = f"{self.receiver.serial_number}_{self._zone}"
 
     def update(self) -> None:
         """Get the latest details from the device."""

--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -193,8 +193,6 @@ class YamahaDevice(MediaPlayerEntity):
     def __init__(self, name, receiver, source_ignore, source_names, zone_names):
         """Initialize the Yamaha Receiver."""
         self.receiver = receiver
-        if name == DEFAULT_NAME and not receiver.model_name is None and not receiver.model_name == "Unknown":
-            name = 'Yamaha %s' % receiver.model_name
         self._attr_is_volume_muted = False
         self._attr_volume_level = 0
         self._attr_state = MediaPlayerState.OFF

--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -206,6 +206,9 @@ class YamahaDevice(MediaPlayerEntity):
         self._name = name
         self._zone = receiver.zone
         if self.receiver.serial_number is not None:
+            # Since not all receivers will have a serial number and set a unique id
+            # the default name of the integration may not be changed
+            # to avoid a breaking change.
             self._attr_unique_id = f"{self.receiver.serial_number}_{self._zone}"
 
     def update(self) -> None:

--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -207,6 +207,8 @@ class YamahaDevice(MediaPlayerEntity):
         self._play_status = None
         self._name = name
         self._zone = receiver.zone
+        if not self.receiver.serial_number is None:
+            self._attr_unique_id = '%s_%s' % (self.receiver.serial_number, self._zone)
 
     def update(self) -> None:
         """Get the latest details from the device."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Having a unique_id is a huge win for people without static IPs assigned. The id is based on the serial number reported by the underlying rxv library. This is the same serial number as reported by SSDP. I have only inspected two Yamaha devices but they seem to be unique.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

<!--
## Additional information

  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: -->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
