### PR TITLE
Improve `brunt` generic typing

### DIFF
--- a/homeassistant/components/brunt/__init__.py
+++ b/homeassistant/components/brunt/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 from aiohttp.client_exceptions import ClientResponseError, ServerDisconnectedError
 import async_timeout
-from brunt import BruntClientAsync
+from brunt import BruntClientAsync, Thing
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -36,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"Brunt could not connect with username: {entry.data[CONF_USERNAME]}."
         ) from exc
 
-    async def async_update_data():
+    async def async_update_data() -> dict[str | None, Thing]:
         """Fetch data from the Brunt endpoint for all Things.
 
         Error 403 is the API response for any kind of authentication error (failed password or email)
@@ -54,6 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if err.status == 401:
                 _LOGGER.warning("Device not found, will reload Brunt integration")
                 await hass.config_entries.async_reload(entry.entry_id)
+            raise UpdateFailed from err
 
     coordinator = DataUpdateCoordinator(
         hass,

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -1,7 +1,7 @@
 """Support for Brunt Blind Engine covers."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from aiohttp.client_exceptions import ClientResponseError
 from brunt import BruntClientAsync, Thing
@@ -42,7 +42,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up the brunt platform."""
     bapi: BruntClientAsync = hass.data[DOMAIN][entry.entry_id][DATA_BAPI]
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][DATA_COOR]
+    coordinator: DataUpdateCoordinator[dict[str | None, Thing]] = hass.data[DOMAIN][
+        entry.entry_id
+    ][DATA_COOR]
 
     async_add_entities(
         BruntDevice(coordinator, serial, thing, bapi, entry.entry_id)
@@ -50,7 +52,9 @@ async def async_setup_entry(
     )
 
 
-class BruntDevice(CoordinatorEntity, CoverEntity):
+class BruntDevice(
+    CoordinatorEntity[DataUpdateCoordinator[dict[Optional[str], Thing]]], CoverEntity
+):
     """
     Representation of a Brunt cover device.
 
@@ -65,8 +69,8 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
-        serial: str,
+        coordinator: DataUpdateCoordinator[dict[str | None, Thing]],
+        serial: str | None,
         thing: Thing,
         bapi: BruntClientAsync,
         entry_id: str,
@@ -84,7 +88,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         self._attr_device_class = CoverDeviceClass.BLIND
         self._attr_attribution = ATTRIBUTION
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._attr_unique_id)},
+            identifiers={(DOMAIN, self._attr_unique_id)},  # type: ignore[arg-type]
             name=self._attr_name,
             via_device=(DOMAIN, self._entry_id),
             manufacturer="Brunt",


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
