### PR TITLE
Improve `modbus` generic typing

### DIFF
--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.const import (
@@ -59,7 +59,7 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
     def __init__(self, hub: ModbusHub, entry: dict[str, Any], slave_count: int) -> None:
         """Initialize the Modbus binary sensor."""
         self._count = slave_count + 1
-        self._coordinator: DataUpdateCoordinator[Any] | None = None
+        self._coordinator: DataUpdateCoordinator[list | None] | None = None
         self._result: list = []
         super().__init__(hub, entry)
 
@@ -121,11 +121,18 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
             self._coordinator.async_set_updated_data(self._result)
 
 
-class SlaveSensor(CoordinatorEntity, RestoreEntity, BinarySensorEntity):
+class SlaveSensor(
+    CoordinatorEntity[DataUpdateCoordinator[Optional[list]]],
+    RestoreEntity,
+    BinarySensorEntity,
+):
     """Modbus slave binary sensor."""
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator[Any], idx: int, entry: dict[str, Any]
+        self,
+        coordinator: DataUpdateCoordinator[list | None],
+        idx: int,
+        entry: dict[str, Any],
     ) -> None:
         """Initialize the Modbus binary sensor."""
         idx += 1

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -59,8 +59,8 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
     def __init__(self, hub: ModbusHub, entry: dict[str, Any], slave_count: int) -> None:
         """Initialize the Modbus binary sensor."""
         self._count = slave_count + 1
-        self._coordinator: DataUpdateCoordinator[list | None] | None = None
-        self._result: list = []
+        self._coordinator: DataUpdateCoordinator[list[int] | None] | None = None
+        self._result: list[int] = []
         super().__init__(hub, entry)
 
     async def async_setup_slaves(
@@ -122,7 +122,7 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
 
 
 class SlaveSensor(
-    CoordinatorEntity[DataUpdateCoordinator[Optional[list]]],
+    CoordinatorEntity[DataUpdateCoordinator[Optional[list[int]]]],
     RestoreEntity,
     BinarySensorEntity,
 ):
@@ -130,7 +130,7 @@ class SlaveSensor(
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[list | None],
+        coordinator: DataUpdateCoordinator[list[int] | None],
         idx: int,
         entry: dict[str, Any],
     ) -> None:

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from homeassistant.components.sensor import CONF_STATE_CLASS, SensorEntity
 from homeassistant.const import CONF_NAME, CONF_SENSORS, CONF_UNIT_OF_MEASUREMENT
@@ -58,7 +58,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreEntity, SensorEntity):
     ) -> None:
         """Initialize the modbus register sensor."""
         super().__init__(hub, entry)
-        self._coordinator: DataUpdateCoordinator[Any] | None = None
+        self._coordinator: DataUpdateCoordinator[list[str] | None] | None = None
         self._attr_native_unit_of_measurement = entry.get(CONF_UNIT_OF_MEASUREMENT)
         self._attr_state_class = entry.get(CONF_STATE_CLASS)
 
@@ -126,11 +126,18 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreEntity, SensorEntity):
         self.async_write_ha_state()
 
 
-class SlaveSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
+class SlaveSensor(
+    CoordinatorEntity[DataUpdateCoordinator[Optional[list[str]]]],
+    RestoreEntity,
+    SensorEntity,
+):
     """Modbus slave binary sensor."""
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator[Any], idx: int, entry: dict[str, Any]
+        self,
+        coordinator: DataUpdateCoordinator[list[str] | None],
+        idx: int,
+        entry: dict[str, Any],
     ) -> None:
         """Initialize the Modbus binary sensor."""
         idx += 1

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -58,7 +58,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreEntity, SensorEntity):
     ) -> None:
         """Initialize the modbus register sensor."""
         super().__init__(hub, entry)
-        self._coordinator: DataUpdateCoordinator[list[str] | None] | None = None
+        self._coordinator: DataUpdateCoordinator[list[int] | None] | None = None
         self._attr_native_unit_of_measurement = entry.get(CONF_UNIT_OF_MEASUREMENT)
         self._attr_state_class = entry.get(CONF_STATE_CLASS)
 
@@ -110,7 +110,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreEntity, SensorEntity):
         result = self.unpack_structure_result(raw_result.registers)
         if self._coordinator:
             if result:
-                result_array = result.split(",")
+                result_array = list(map(int, result.split(",")))
                 self._attr_native_value = result_array[0]
                 self._coordinator.async_set_updated_data(result_array)
             else:
@@ -127,7 +127,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreEntity, SensorEntity):
 
 
 class SlaveSensor(
-    CoordinatorEntity[DataUpdateCoordinator[Optional[list[str]]]],
+    CoordinatorEntity[DataUpdateCoordinator[Optional[list[int]]]],
     RestoreEntity,
     SensorEntity,
 ):
@@ -135,7 +135,7 @@ class SlaveSensor(
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[list[str] | None],
+        coordinator: DataUpdateCoordinator[list[int] | None],
         idx: int,
         entry: dict[str, Any],
     ) -> None:


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
