### PR TITLE
Improve DataUpdateCoordinator typing in integrations (5)

### DIFF
--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -63,7 +63,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add cert-expiry entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: CertExpiryDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     sensors = [
         SSLCertificateTimestamp(coordinator),
@@ -72,7 +72,7 @@ async def async_setup_entry(
     async_add_entities(sensors, True)
 
 
-class CertExpiryEntity(CoordinatorEntity):
+class CertExpiryEntity(CoordinatorEntity[CertExpiryDataUpdateCoordinator]):
     """Defines a base Cert Expiry entity."""
 
     _attr_icon = "mdi:certificate"

--- a/homeassistant/components/huisbaasje/__init__.py
+++ b/homeassistant/components/huisbaasje/__init__.py
@@ -1,6 +1,7 @@
 """The Huisbaasje integration."""
 from datetime import timedelta
 import logging
+from typing import Any
 
 import async_timeout
 from energyflip import EnergyFlip, EnergyFlipException
@@ -45,7 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Authentication failed: %s", str(exception))
         return False
 
-    async def async_update_data():
+    async def async_update_data() -> dict[str, dict[str, Any]]:
         return await async_update_huisbaasje(energyflip)
 
     # Create a coordinator for polling updates
@@ -80,7 +81,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def async_update_huisbaasje(energyflip):
+async def async_update_huisbaasje(energyflip: EnergyFlip) -> dict[str, dict[str, Any]]:
     """Update the data by performing a request to Huisbaasje."""
     try:
         # Note: asyncio.TimeoutError and aiohttp.ClientError are already

--- a/homeassistant/components/huisbaasje/sensor.py
+++ b/homeassistant/components/huisbaasje/sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+from typing import Any
 
 from energyflip.const import (
     SOURCE_TYPE_ELECTRICITY,
@@ -234,7 +235,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]] = hass.data[DOMAIN][
+        config_entry.entry_id
+    ][DATA_COORDINATOR]
     user_id = config_entry.data[CONF_ID]
 
     async_add_entities(
@@ -243,14 +246,16 @@ async def async_setup_entry(
     )
 
 
-class HuisbaasjeSensor(CoordinatorEntity, SensorEntity):
+class HuisbaasjeSensor(
+    CoordinatorEntity[DataUpdateCoordinator[dict[str, dict[str, Any]]]], SensorEntity
+):
     """Defines a Huisbaasje sensor."""
 
     entity_description: HuisbaasjeSensorEntityDescription
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
         user_id: str,
         description: HuisbaasjeSensorEntityDescription,
     ) -> None:
@@ -278,7 +283,7 @@ class HuisbaasjeSensor(CoordinatorEntity, SensorEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return (
+        return bool(
             super().available
             and self.coordinator.data
             and self._source_type in self.coordinator.data

--- a/homeassistant/components/landisgyr_heat_meter/__init__.py
+++ b/homeassistant/components/landisgyr_heat_meter/__init__.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 import logging
 
 import ultraheat_api
+from ultraheat_api.response import HeatMeterResponse
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, Platform
@@ -26,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     reader = ultraheat_api.UltraheatReader(entry.data[CONF_DEVICE])
     api = ultraheat_api.HeatMeterService(reader)
 
-    async def async_update_data():
+    async def async_update_data() -> HeatMeterResponse:
         """Fetch data from the API."""
         _LOGGER.debug("Polling on %s", entry.data[CONF_DEVICE])
         return await hass.async_add_executor_job(api.read)

--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 from dataclasses import asdict
 import logging
 
-from homeassistant.components.sensor import RestoreSensor, SensorDeviceClass
+from ultraheat_api.response import HeatMeterResponse
+
+from homeassistant.components.sensor import (
+    RestoreSensor,
+    SensorDeviceClass,
+    SensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 from homeassistant.util import dt as dt_util
 
 from . import DOMAIN
@@ -23,7 +32,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up the sensor platform."""
     unique_id = entry.entry_id
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: DataUpdateCoordinator[HeatMeterResponse] = hass.data[DOMAIN][
+        entry.entry_id
+    ]
 
     model = entry.data["model"]
 
@@ -42,16 +53,21 @@ async def async_setup_entry(
     async_add_entities(sensors)
 
 
-class HeatMeterSensor(CoordinatorEntity, RestoreSensor):
+class HeatMeterSensor(
+    CoordinatorEntity[DataUpdateCoordinator[HeatMeterResponse]], RestoreSensor
+):
     """Representation of a Sensor."""
 
-    def __init__(self, coordinator, description, device):
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[HeatMeterResponse],
+        description: SensorEntityDescription,
+        device: DeviceInfo,
+    ) -> None:
         """Set up the sensor with the initial values."""
         super().__init__(coordinator)
         self.key = description.key
-        self._attr_unique_id = (
-            f"{coordinator.config_entry.data['device_number']}_{description.key}"
-        )
+        self._attr_unique_id = f"{coordinator.config_entry.data['device_number']}_{description.key}"  # type: ignore[union-attr]
         self._attr_name = f"Heat Meter {description.name}"
         self.entity_description = description
 


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
