### PR TITLE
Remove deprecated PI-Hole YAML config

### DIFF
--- a/homeassistant/components/pi_hole/config_flow.py
+++ b/homeassistant/components/pi_hole/config_flow.py
@@ -49,12 +49,6 @@ class PiHoleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initiated by the user."""
         return await self.async_step_init(user_input)
 
-    async def async_step_import(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle a flow initiated by import."""
-        return await self.async_step_init(user_input, is_import=True)
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None, is_import: bool = False
     ) -> FlowResult:

--- a/homeassistant/components/pi_hole/strings.json
+++ b/homeassistant/components/pi_hole/strings.json
@@ -25,11 +25,5 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     }
-  },
-  "issues": {
-    "deprecated_yaml": {
-      "title": "The PI-Hole YAML configuration is being removed",
-      "description": "Configuring PI-Hole using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the PI-Hole YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
-    }
   }
 }

--- a/homeassistant/components/pi_hole/translations/de.json
+++ b/homeassistant/components/pi_hole/translations/de.json
@@ -25,11 +25,5 @@
                 }
             }
         }
-    },
-    "issues": {
-        "deprecated_yaml": {
-            "description": "Die Konfiguration von PI-Hole mittels YAML wird entfernt.\n\nDeine bestehende YAML-Konfiguration wurde automatisch in die Benutzeroberfl\u00e4che importiert.\n\nEntferne die PI-Hole YAML-Konfiguration aus deiner configuration.yaml-Datei und starte den Home Assistant neu, um dieses Problem zu beheben.",
-            "title": "Die PI-Hole YAML-Konfiguration wird entfernt"
-        }
     }
 }

--- a/homeassistant/components/pi_hole/translations/en.json
+++ b/homeassistant/components/pi_hole/translations/en.json
@@ -25,11 +25,5 @@
                 }
             }
         }
-    },
-    "issues": {
-        "deprecated_yaml": {
-            "description": "Configuring PI-Hole using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the PI-Hole YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue.",
-            "title": "The PI-Hole YAML configuration is being removed"
-        }
     }
 }

--- a/tests/components/pi_hole/__init__.py
+++ b/tests/components/pi_hole/__init__.py
@@ -3,7 +3,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from hole.exceptions import HoleError
 
-from homeassistant.components.pi_hole.const import CONF_STATISTICS_ONLY
+from homeassistant.components.pi_hole.const import (
+    CONF_STATISTICS_ONLY,
+    DEFAULT_LOCATION,
+    DEFAULT_NAME,
+    DEFAULT_SSL,
+    DEFAULT_STATISTICS_ONLY,
+    DEFAULT_VERIFY_SSL,
+)
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_HOST,
@@ -46,6 +53,15 @@ NAME = "Pi hole"
 API_KEY = "apikey"
 SSL = False
 VERIFY_SSL = True
+
+CONF_DATA_DEFAULTS = {
+    CONF_HOST: f"{HOST}:{PORT}",
+    CONF_LOCATION: DEFAULT_LOCATION,
+    CONF_NAME: DEFAULT_NAME,
+    CONF_STATISTICS_ONLY: DEFAULT_STATISTICS_ONLY,
+    CONF_SSL: DEFAULT_SSL,
+    CONF_VERIFY_SSL: DEFAULT_VERIFY_SSL,
+}
 
 CONF_DATA = {
     CONF_HOST: f"{HOST}:{PORT}",

--- a/tests/components/pi_hole/test_config_flow.py
+++ b/tests/components/pi_hole/test_config_flow.py
@@ -1,24 +1,21 @@
 """Test pi_hole config flow."""
-import logging
-from unittest.mock import patch
-
 from homeassistant.components.pi_hole.const import CONF_STATISTICS_ONLY, DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
     CONF_CONFIG_ENTRY,
     CONF_CONFIG_FLOW_API_KEY,
     CONF_CONFIG_FLOW_USER,
-    CONF_DATA,
     NAME,
     _create_mocked_hole,
     _patch_config_flow_hole,
 )
 
 
-def _flow_next(hass, flow_id):
+def _flow_next(hass: HomeAssistant, flow_id: str):
     return next(
         flow
         for flow in hass.config_entries.flow.async_progress()
@@ -26,48 +23,10 @@ def _flow_next(hass, flow_id):
     )
 
 
-def _patch_setup():
-    return patch(
-        "homeassistant.components.pi_hole.async_setup_entry",
-        return_value=True,
-    )
-
-
-async def test_flow_import(hass, caplog):
-    """Test import flow."""
-    mocked_hole = _create_mocked_hole()
-    with _patch_config_flow_hole(mocked_hole), _patch_setup():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=CONF_DATA
-        )
-        assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == NAME
-        assert result["data"] == CONF_CONFIG_ENTRY
-
-        # duplicated server
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=CONF_DATA
-        )
-        assert result["type"] == FlowResultType.ABORT
-        assert result["reason"] == "already_configured"
-
-
-async def test_flow_import_invalid(hass, caplog):
-    """Test import flow with invalid server."""
-    mocked_hole = _create_mocked_hole(True)
-    with _patch_config_flow_hole(mocked_hole), _patch_setup():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=CONF_DATA
-        )
-        assert result["type"] == FlowResultType.ABORT
-        assert result["reason"] == "cannot_connect"
-        assert len([x for x in caplog.records if x.levelno == logging.ERROR]) == 1
-
-
-async def test_flow_user(hass):
+async def test_flow_user(hass: HomeAssistant):
     """Test user initialized flow."""
     mocked_hole = _create_mocked_hole()
-    with _patch_config_flow_hole(mocked_hole), _patch_setup():
+    with _patch_config_flow_hole(mocked_hole):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -104,10 +63,10 @@ async def test_flow_user(hass):
         assert result["reason"] == "already_configured"
 
 
-async def test_flow_statistics_only(hass):
+async def test_flow_statistics_only(hass: HomeAssistant):
     """Test user initialized flow with statistics only."""
     mocked_hole = _create_mocked_hole()
-    with _patch_config_flow_hole(mocked_hole), _patch_setup():
+    with _patch_config_flow_hole(mocked_hole):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -131,10 +90,10 @@ async def test_flow_statistics_only(hass):
         assert result["data"] == config_entry_data
 
 
-async def test_flow_user_invalid(hass):
+async def test_flow_user_invalid(hass: HomeAssistant):
     """Test user initialized flow with invalid server."""
     mocked_hole = _create_mocked_hole(True)
-    with _patch_config_flow_hole(mocked_hole), _patch_setup():
+    with _patch_config_flow_hole(mocked_hole):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_CONFIG_FLOW_USER
         )

--- a/tests/components/pi_hole/test_update.py
+++ b/tests/components/pi_hole/test_update.py
@@ -2,18 +2,20 @@
 
 from homeassistant.components import pi_hole
 from homeassistant.const import STATE_ON, STATE_UNKNOWN
-from homeassistant.setup import async_setup_component
+from homeassistant.core import HomeAssistant
 
-from . import _create_mocked_hole, _patch_config_flow_hole, _patch_init_hole
+from . import CONF_DATA_DEFAULTS, _create_mocked_hole, _patch_init_hole
+
+from tests.common import MockConfigEntry
 
 
-async def test_update(hass):
+async def test_update(hass: HomeAssistant):
     """Tests update entity."""
     mocked_hole = _create_mocked_hole()
-    with _patch_config_flow_hole(mocked_hole), _patch_init_hole(mocked_hole):
-        assert await async_setup_component(
-            hass, pi_hole.DOMAIN, {pi_hole.DOMAIN: [{"host": "pi.hole"}]}
-        )
+    entry = MockConfigEntry(domain=pi_hole.DOMAIN, data=CONF_DATA_DEFAULTS)
+    entry.add_to_hass(hass)
+    with _patch_init_hole(mocked_hole):
+        assert await hass.config_entries.async_setup(entry.entry_id)
 
     await hass.async_block_till_done()
 
@@ -48,13 +50,13 @@ async def test_update(hass):
     )
 
 
-async def test_update_no_versions(hass):
+async def test_update_no_versions(hass: HomeAssistant):
     """Tests update entity when no version data available."""
     mocked_hole = _create_mocked_hole(has_versions=False)
-    with _patch_config_flow_hole(mocked_hole), _patch_init_hole(mocked_hole):
-        assert await async_setup_component(
-            hass, pi_hole.DOMAIN, {pi_hole.DOMAIN: [{"host": "pi.hole"}]}
-        )
+    entry = MockConfigEntry(domain=pi_hole.DOMAIN, data=CONF_DATA_DEFAULTS)
+    entry.add_to_hass(hass)
+    with _patch_init_hole(mocked_hole):
+        assert await hass.config_entries.async_setup(entry.entry_id)
 
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated YAML configuration of the PI-Hole integration has been removed.

PI-Hole is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

deprecated with #84797

~~need rebase after #84797 is merged~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
