### PR TITLE
Mark required fields in FlowResult typedict

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -10,6 +10,7 @@ import logging
 from types import MappingProxyType
 from typing import Any, TypedDict
 
+from typing_extensions import Required
 import voluptuous as vol
 
 from .backports.enum import StrEnum
@@ -91,8 +92,8 @@ class FlowResult(TypedDict, total=False):
     description: str | None
     errors: dict[str, str] | None
     extra: str
-    flow_id: str
-    handler: str
+    flow_id: Required[str]
+    handler: Required[str]
     last_step: bool | None
     menu_options: list[str] | dict[str, str]
     options: Mapping[str, Any]

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -32,7 +32,6 @@ async def test_full_user_flow_implementation(
 
     assert result.get("type") == RESULT_TYPE_FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/cpuspeed/test_config_flow.py
+++ b/tests/components/cpuspeed/test_config_flow.py
@@ -22,7 +22,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -69,7 +68,6 @@ async def test_not_compatible(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_cpuinfo_config_flow.return_value = {}
     result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/elgato/test_config_flow.py
+++ b/tests/components/elgato/test_config_flow.py
@@ -26,7 +26,6 @@ async def test_full_user_flow_implementation(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "127.0.0.1", CONF_PORT: 9123}
@@ -69,7 +68,6 @@ async def test_full_zeroconf_flow_implementation(
     assert result.get("description_placeholders") == {"serial_number": "CN11A1A00001"}
     assert result.get("step_id") == "zeroconf_confirm"
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
 
     progress = hass.config_entries.flow.async_progress()
     assert len(progress) == 1

--- a/tests/components/filesize/test_config_flow.py
+++ b/tests/components/filesize/test_config_flow.py
@@ -22,7 +22,6 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/forecast_solar/test_config_flow.py
+++ b/tests/components/forecast_solar/test_config_flow.py
@@ -25,7 +25,6 @@ async def test_user_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -68,7 +67,6 @@ async def test_options_flow_invalid_api(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -101,7 +99,6 @@ async def test_options_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
-    assert "flow_id" in result
 
     # With the API key
     result2 = await hass.config_entries.options.async_configure(
@@ -142,7 +139,6 @@ async def test_options_flow_without_key(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
-    assert "flow_id" in result
 
     # Without the API key
     result2 = await hass.config_entries.options.async_configure(

--- a/tests/components/fully_kiosk/test_config_flow.py
+++ b/tests/components/fully_kiosk/test_config_flow.py
@@ -28,7 +28,6 @@ async def test_full_flow(
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -72,7 +71,6 @@ async def test_errors(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     mock_fully_kiosk_config_flow.getDeviceInfo.side_effect = side_effect
@@ -119,7 +117,6 @@ async def test_duplicate_updates_existing_entry(
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/garages_amsterdam/test_config_flow.py
+++ b/tests/components/garages_amsterdam/test_config_flow.py
@@ -18,7 +18,6 @@ async def test_full_flow(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.garages_amsterdam.async_setup_entry",

--- a/tests/components/geocaching/test_config_flow.py
+++ b/tests/components/geocaching/test_config_flow.py
@@ -52,7 +52,6 @@ async def test_full_flow(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
 
     # pylint: disable=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
@@ -110,7 +109,6 @@ async def test_existing_entry(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
     # pylint: disable=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -151,7 +149,6 @@ async def test_oauth_error(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
 
     # pylint: disable=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
@@ -209,7 +206,6 @@ async def test_reauthentication(
     assert "flow_id" in flows[0]
 
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
-    assert "flow_id" in result
 
     # pylint: disable=protected-access
     state = config_entry_oauth2_flow._encode_jwt(

--- a/tests/components/github/test_config_flow.py
+++ b/tests/components/github/test_config_flow.py
@@ -59,7 +59,6 @@ async def test_full_user_flow_implementation(
 
     assert result["step_id"] == "device"
     assert result["type"] == FlowResultType.SHOW_PROGRESS
-    assert "flow_id" in result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 

--- a/tests/components/justnimbus/test_config_flow.py
+++ b/tests/components/justnimbus/test_config_flow.py
@@ -83,7 +83,6 @@ async def test_abort_already_configured(hass: HomeAssistant) -> None:
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") is None
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         flow_id=result["flow_id"],

--- a/tests/components/lametric/test_config_flow.py
+++ b/tests/components/lametric/test_config_flow.py
@@ -60,7 +60,6 @@ async def test_full_cloud_import_flow_multiple_devices(
     assert result.get("type") == FlowResultType.MENU
     assert result.get("step_id") == "choice_enter_manual_or_fetch_cloud"
     assert result.get("menu_options") == ["pick_implementation", "manual_entry"]
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -142,7 +141,6 @@ async def test_full_cloud_import_flow_single_device(
     assert result.get("type") == FlowResultType.MENU
     assert result.get("step_id") == "choice_enter_manual_or_fetch_cloud"
     assert result.get("menu_options") == ["pick_implementation", "manual_entry"]
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -218,7 +216,6 @@ async def test_full_manual(
     assert result.get("type") == FlowResultType.MENU
     assert result.get("step_id") == "choice_enter_manual_or_fetch_cloud"
     assert result.get("menu_options") == ["pick_implementation", "manual_entry"]
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -264,7 +261,6 @@ async def test_full_ssdp_with_cloud_import(
     assert result.get("type") == FlowResultType.MENU
     assert result.get("step_id") == "choice_enter_manual_or_fetch_cloud"
     assert result.get("menu_options") == ["pick_implementation", "manual_entry"]
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -335,7 +331,6 @@ async def test_full_ssdp_manual_entry(
     assert result.get("type") == FlowResultType.MENU
     assert result.get("step_id") == "choice_enter_manual_or_fetch_cloud"
     assert result.get("menu_options") == ["pick_implementation", "manual_entry"]
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -410,7 +405,6 @@ async def test_cloud_import_updates_existing_entry(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     await hass.config_entries.flow.async_configure(
@@ -466,7 +460,6 @@ async def test_manual_updates_existing_entry(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     await hass.config_entries.flow.async_configure(
@@ -519,7 +512,6 @@ async def test_cloud_abort_no_devices(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     await hass.config_entries.flow.async_configure(
@@ -576,7 +568,6 @@ async def test_manual_errors(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     await hass.config_entries.flow.async_configure(
@@ -640,7 +631,6 @@ async def test_cloud_errors(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     await hass.config_entries.flow.async_configure(
@@ -773,7 +763,6 @@ async def test_reauth_cloud_import(
         data=mock_config_entry.data,
     )
 
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     await hass.config_entries.flow.async_configure(
@@ -840,7 +829,6 @@ async def test_reauth_cloud_abort_device_not_found(
         data=mock_config_entry.data,
     )
 
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     await hass.config_entries.flow.async_configure(
@@ -897,7 +885,6 @@ async def test_reauth_manual(
         data=mock_config_entry.data,
     )
 
-    assert "flow_id" in result
     flow_id = result["flow_id"]
 
     await hass.config_entries.flow.async_configure(

--- a/tests/components/luftdaten/test_config_flow.py
+++ b/tests/components/luftdaten/test_config_flow.py
@@ -25,7 +25,6 @@ async def test_duplicate_error(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -46,7 +45,6 @@ async def test_communication_error(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_luftdaten_config_flow.get_data.side_effect = LuftdatenConnectionError
     result2 = await hass.config_entries.flow.async_configure(
@@ -57,7 +55,6 @@ async def test_communication_error(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {CONF_SENSOR_ID: "cannot_connect"}
-    assert "flow_id" in result2
 
     mock_luftdaten_config_flow.get_data.side_effect = None
     result3 = await hass.config_entries.flow.async_configure(
@@ -83,7 +80,6 @@ async def test_invalid_sensor(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_luftdaten_config_flow.validate_sensor.return_value = False
     result2 = await hass.config_entries.flow.async_configure(
@@ -94,7 +90,6 @@ async def test_invalid_sensor(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {CONF_SENSOR_ID: "invalid_sensor"}
-    assert "flow_id" in result2
 
     mock_luftdaten_config_flow.validate_sensor.return_value = True
     result3 = await hass.config_entries.flow.async_configure(
@@ -122,7 +117,6 @@ async def test_step_user(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/mjpeg/test_config_flow.py
+++ b/tests/components/mjpeg/test_config_flow.py
@@ -37,7 +37,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -83,7 +82,6 @@ async def test_full_flow_with_authentication_error(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_mjpeg_requests.get(
         "https://example.com/mjpeg", text="Access Denied!", status_code=401
@@ -101,7 +99,6 @@ async def test_full_flow_with_authentication_error(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {"username": "invalid_auth"}
-    assert "flow_id" in result2
 
     assert len(mock_setup_entry.mock_calls) == 0
     assert mock_mjpeg_requests.call_count == 2
@@ -145,7 +142,6 @@ async def test_connection_error(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     # Test connectione error on MJPEG url
     mock_mjpeg_requests.get(
@@ -163,7 +159,6 @@ async def test_connection_error(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {"mjpeg_url": "cannot_connect"}
-    assert "flow_id" in result2
 
     assert len(mock_setup_entry.mock_calls) == 0
     assert mock_mjpeg_requests.call_count == 1
@@ -187,7 +182,6 @@ async def test_connection_error(
     assert result3.get("type") == FlowResultType.FORM
     assert result3.get("step_id") == SOURCE_USER
     assert result3.get("errors") == {"still_image_url": "cannot_connect"}
-    assert "flow_id" in result3
 
     assert len(mock_setup_entry.mock_calls) == 0
     assert mock_mjpeg_requests.call_count == 3
@@ -233,7 +227,6 @@ async def test_already_configured(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -257,7 +250,6 @@ async def test_options_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
-    assert "flow_id" in result
 
     # Register a second camera
     mock_mjpeg_requests.get("https://example.com/second_camera", text="resp")
@@ -287,7 +279,6 @@ async def test_options_flow(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == "init"
     assert result2.get("errors") == {"mjpeg_url": "already_configured"}
-    assert "flow_id" in result2
 
     assert mock_mjpeg_requests.call_count == 1
 
@@ -306,7 +297,6 @@ async def test_options_flow(
     assert result3.get("type") == FlowResultType.FORM
     assert result3.get("step_id") == "init"
     assert result3.get("errors") == {"mjpeg_url": "cannot_connect"}
-    assert "flow_id" in result3
 
     assert mock_mjpeg_requests.call_count == 2
 
@@ -325,7 +315,6 @@ async def test_options_flow(
     assert result4.get("type") == FlowResultType.FORM
     assert result4.get("step_id") == "init"
     assert result4.get("errors") == {"still_image_url": "cannot_connect"}
-    assert "flow_id" in result4
 
     assert mock_mjpeg_requests.call_count == 4
 
@@ -345,7 +334,6 @@ async def test_options_flow(
     assert result5.get("type") == FlowResultType.FORM
     assert result5.get("step_id") == "init"
     assert result5.get("errors") == {"username": "invalid_auth"}
-    assert "flow_id" in result5
 
     assert mock_mjpeg_requests.call_count == 6
 

--- a/tests/components/modern_forms/test_config_flow.py
+++ b/tests/components/modern_forms/test_config_flow.py
@@ -34,7 +34,6 @@ async def test_full_user_flow_implementation(
 
     assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.modern_forms.async_setup_entry",
@@ -82,7 +81,6 @@ async def test_full_zeroconf_flow_implementation(
     assert result.get("description_placeholders") == {CONF_NAME: "example"}
     assert result.get("step_id") == "zeroconf_confirm"
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
 
     flow = flows[0]
     assert "context" in flow

--- a/tests/components/moon/test_config_flow.py
+++ b/tests/components/moon/test_config_flow.py
@@ -23,7 +23,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/motioneye/test_config_flow.py
+++ b/tests/components/motioneye/test_config_flow.py
@@ -86,12 +86,10 @@ async def test_hassio_success(hass: HomeAssistant) -> None:
     assert result.get("type") == data_entry_flow.FlowResultType.FORM
     assert result.get("step_id") == "hassio_confirm"
     assert result.get("description_placeholders") == {"addon": "motionEye"}
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
     assert result2.get("type") == data_entry_flow.FlowResultType.FORM
     assert result2.get("step_id") == "user"
-    assert "flow_id" in result2
 
     mock_client = create_mock_motioneye_client()
 
@@ -423,7 +421,6 @@ async def test_hassio_clean_up_on_user_flow(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result2.get("type") == data_entry_flow.FlowResultType.FORM
-    assert "flow_id" in result2
 
     mock_client = create_mock_motioneye_client()
 

--- a/tests/components/open_meteo/test_config_flow.py
+++ b/tests/components/open_meteo/test_config_flow.py
@@ -21,7 +21,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/p1_monitor/test_config_flow.py
+++ b/tests/components/p1_monitor/test_config_flow.py
@@ -18,7 +18,6 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.p1_monitor.config_flow.P1Monitor.smartmeter"

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -121,7 +121,6 @@ async def test_form(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
     assert result.get("step_id") == "user"
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -169,7 +168,6 @@ async def test_zeroconf_flow(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
     assert result.get("step_id") == "user"
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -205,7 +203,6 @@ async def test_zeroconf_flow_stretch(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
     assert result.get("step_id") == "user"
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -297,7 +294,6 @@ async def test_flow_errors(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
     assert result.get("step_id") == "user"
-    assert "flow_id" in result
 
     mock_smile_config_flow.connect.side_effect = side_effect
     result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/pure_energie/test_config_flow.py
+++ b/tests/components/pure_energie/test_config_flow.py
@@ -24,7 +24,6 @@ async def test_full_user_flow_implementation(
 
     assert result.get("step_id") == SOURCE_USER
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "192.168.1.123"}
@@ -64,7 +63,6 @@ async def test_full_zeroconf_flow_implementationn(
     }
     assert result.get("step_id") == "zeroconf_confirm"
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}

--- a/tests/components/pvoutput/test_config_flow.py
+++ b/tests/components/pvoutput/test_config_flow.py
@@ -25,7 +25,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -62,7 +61,6 @@ async def test_full_flow_with_authentication_error(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_pvoutput_config_flow.system.side_effect = PVOutputAuthenticationError
     result2 = await hass.config_entries.flow.async_configure(
@@ -76,7 +74,6 @@ async def test_full_flow_with_authentication_error(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {"base": "invalid_auth"}
-    assert "flow_id" in result2
 
     assert len(mock_setup_entry.mock_calls) == 0
     assert len(mock_pvoutput_config_flow.system.mock_calls) == 1
@@ -133,7 +130,6 @@ async def test_already_configured(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -167,7 +163,6 @@ async def test_reauth_flow(
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "reauth_confirm"
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -210,7 +205,6 @@ async def test_reauth_with_authentication_error(
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "reauth_confirm"
-    assert "flow_id" in result
 
     mock_pvoutput_config_flow.system.side_effect = PVOutputAuthenticationError
     result2 = await hass.config_entries.flow.async_configure(
@@ -222,7 +216,6 @@ async def test_reauth_with_authentication_error(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == "reauth_confirm"
     assert result2.get("errors") == {"base": "invalid_auth"}
-    assert "flow_id" in result2
 
     assert len(mock_setup_entry.mock_calls) == 0
     assert len(mock_pvoutput_config_flow.system.mock_calls) == 1
@@ -264,7 +257,6 @@ async def test_reauth_api_error(
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "reauth_confirm"
-    assert "flow_id" in result
 
     mock_pvoutput_config_flow.system.side_effect = PVOutputConnectionError
     result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/radio_browser/test_config_flow.py
+++ b/tests/components/radio_browser/test_config_flow.py
@@ -16,7 +16,6 @@ async def test_full_user_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) 
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") is None
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/rdw/test_config_flow.py
+++ b/tests/components/rdw/test_config_flow.py
@@ -20,7 +20,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -48,7 +47,6 @@ async def test_full_flow_with_authentication_error(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_rdw_config_flow.vehicle.side_effect = RDWUnknownLicensePlateError
     result2 = await hass.config_entries.flow.async_configure(
@@ -61,7 +59,6 @@ async def test_full_flow_with_authentication_error(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {"base": "unknown_license_plate"}
-    assert "flow_id" in result2
 
     mock_rdw_config_flow.vehicle.side_effect = None
     result3 = await hass.config_entries.flow.async_configure(

--- a/tests/components/rtsp_to_webrtc/test_config_flow.py
+++ b/tests/components/rtsp_to_webrtc/test_config_flow.py
@@ -26,7 +26,6 @@ async def test_web_full_flow(hass: HomeAssistant) -> None:
     assert result.get("step_id") == "user"
     assert result.get("data_schema").schema.get("server_url") == str
     assert not result.get("errors")
-    assert "flow_id" in result
     with patch("rtsp_to_webrtc.client.Client.heartbeat"), patch(
         "homeassistant.components.rtsp_to_webrtc.async_setup_entry",
         return_value=True,
@@ -63,7 +62,6 @@ async def test_invalid_url(hass: HomeAssistant) -> None:
     assert result.get("step_id") == "user"
     assert result.get("data_schema").schema.get("server_url") == str
     assert not result.get("errors")
-    assert "flow_id" in result
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"server_url": "not-a-url"}
     )
@@ -81,7 +79,6 @@ async def test_server_unreachable(hass: HomeAssistant) -> None:
     assert result.get("type") == "form"
     assert result.get("step_id") == "user"
     assert not result.get("errors")
-    assert "flow_id" in result
     with patch(
         "rtsp_to_webrtc.client.Client.heartbeat",
         side_effect=rtsp_to_webrtc.exceptions.ClientError(),
@@ -102,7 +99,6 @@ async def test_server_failure(hass: HomeAssistant) -> None:
     assert result.get("type") == "form"
     assert result.get("step_id") == "user"
     assert not result.get("errors")
-    assert "flow_id" in result
     with patch(
         "rtsp_to_webrtc.client.Client.heartbeat",
         side_effect=rtsp_to_webrtc.exceptions.ResponseError(),
@@ -214,7 +210,6 @@ async def test_hassio_discovery_server_failure(hass: HomeAssistant) -> None:
     assert result.get("type") == "form"
     assert result.get("step_id") == "hassio_confirm"
     assert not result.get("errors")
-    assert "flow_id" in result
 
     with patch(
         "rtsp_to_webrtc.client.Client.heartbeat",

--- a/tests/components/season/test_config_flow.py
+++ b/tests/components/season/test_config_flow.py
@@ -27,7 +27,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/sentry/test_config_flow.py
+++ b/tests/components/sentry/test_config_flow.py
@@ -30,7 +30,6 @@ async def test_full_user_flow_implementation(hass: HomeAssistant) -> None:
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
-    assert "flow_id" in result
 
     with patch("homeassistant.components.sentry.config_flow.Dsn"), patch(
         "homeassistant.components.sentry.async_setup_entry",
@@ -67,7 +66,6 @@ async def test_user_flow_bad_dsn(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.sentry.config_flow.Dsn",
@@ -87,7 +85,6 @@ async def test_user_flow_unknown_exception(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.sentry.config_flow.Dsn",
@@ -118,7 +115,6 @@ async def test_options_flow(hass: HomeAssistant) -> None:
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
-    assert "flow_id" in result
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],

--- a/tests/components/soundtouch/test_config_flow.py
+++ b/tests/components/soundtouch/test_config_flow.py
@@ -25,7 +25,6 @@ async def test_user_flow_create_entry(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
-    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.soundtouch.async_setup_entry", return_value=True

--- a/tests/components/stookalert/test_config_flow.py
+++ b/tests/components/stookalert/test_config_flow.py
@@ -17,7 +17,6 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.stookalert.async_setup_entry", return_value=True
@@ -47,8 +46,6 @@ async def test_already_configured(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/sun/test_config_flow.py
+++ b/tests/components/sun/test_config_flow.py
@@ -19,7 +19,6 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.sun.async_setup_entry",

--- a/tests/components/tailscale/test_config_flow.py
+++ b/tests/components/tailscale/test_config_flow.py
@@ -25,7 +25,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -62,7 +61,6 @@ async def test_full_flow_with_authentication_error(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_tailscale_config_flow.devices.side_effect = TailscaleAuthenticationError
     result2 = await hass.config_entries.flow.async_configure(
@@ -76,7 +74,6 @@ async def test_full_flow_with_authentication_error(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {"base": "invalid_auth"}
-    assert "flow_id" in result2
 
     assert len(mock_setup_entry.mock_calls) == 0
     assert len(mock_tailscale_config_flow.devices.mock_calls) == 1
@@ -142,7 +139,6 @@ async def test_reauth_flow(
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "reauth_confirm"
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -185,7 +181,6 @@ async def test_reauth_with_authentication_error(
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "reauth_confirm"
-    assert "flow_id" in result
 
     mock_tailscale_config_flow.devices.side_effect = TailscaleAuthenticationError
     result2 = await hass.config_entries.flow.async_configure(
@@ -197,7 +192,6 @@ async def test_reauth_with_authentication_error(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == "reauth_confirm"
     assert result2.get("errors") == {"base": "invalid_auth"}
-    assert "flow_id" in result2
 
     assert len(mock_setup_entry.mock_calls) == 0
     assert len(mock_tailscale_config_flow.devices.mock_calls) == 1
@@ -239,7 +233,6 @@ async def test_reauth_api_error(
     )
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "reauth_confirm"
-    assert "flow_id" in result
 
     mock_tailscale_config_flow.devices.side_effect = TailscaleConnectionError
     result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/tolo/test_config_flow.py
+++ b/tests/components/tolo/test_config_flow.py
@@ -46,7 +46,6 @@ async def test_user_walkthrough(hass: HomeAssistant, toloclient: Mock):
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
-    assert "flow_id" in result
 
     toloclient().get_status_info.side_effect = lambda *args, **kwargs: None
 
@@ -58,7 +57,6 @@ async def test_user_walkthrough(hass: HomeAssistant, toloclient: Mock):
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == SOURCE_USER
     assert result2["errors"] == {"base": "cannot_connect"}
-    assert "flow_id" in result2
 
     toloclient().get_status_info.side_effect = lambda *args, **kwargs: object()
 

--- a/tests/components/twentemilieu/test_config_flow.py
+++ b/tests/components/twentemilieu/test_config_flow.py
@@ -31,7 +31,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -68,7 +67,6 @@ async def test_invalid_address(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_twentemilieu_config_flow.unique_id.side_effect = TwenteMilieuAddressError
     result2 = await hass.config_entries.flow.async_configure(
@@ -82,7 +80,6 @@ async def test_invalid_address(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {"base": "invalid_address"}
-    assert "flow_id" in result2
 
     mock_twentemilieu_config_flow.unique_id.side_effect = None
     result3 = await hass.config_entries.flow.async_configure(

--- a/tests/components/uptime/test_config_flow.py
+++ b/tests/components/uptime/test_config_flow.py
@@ -23,7 +23,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -34,7 +34,6 @@ async def test_full_user_flow_single_installation(
     assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
-    assert "flow_id" in result
 
     mock_verisure_config_flow.installations = [
         mock_verisure_config_flow.installations[0]
@@ -73,7 +72,6 @@ async def test_full_user_flow_multiple_installations(
     assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -87,7 +85,6 @@ async def test_full_user_flow_multiple_installations(
     assert result2.get("step_id") == "installation"
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("errors") is None
-    assert "flow_id" in result2
 
     result3 = await hass.config_entries.flow.async_configure(
         result2["flow_id"], {"giid": "54321"}
@@ -118,7 +115,6 @@ async def test_full_user_flow_single_installation_with_mfa(
     assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
-    assert "flow_id" in result
 
     mock_verisure_config_flow.login.side_effect = VerisureLoginError(
         "Multifactor authentication enabled, disable or create MFA cookie"
@@ -135,7 +131,6 @@ async def test_full_user_flow_single_installation_with_mfa(
 
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == "mfa"
-    assert "flow_id" in result2
 
     mock_verisure_config_flow.login.side_effect = None
     mock_verisure_config_flow.installations = [
@@ -176,7 +171,6 @@ async def test_full_user_flow_multiple_installations_with_mfa(
     assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
-    assert "flow_id" in result
 
     mock_verisure_config_flow.login.side_effect = VerisureLoginError(
         "Multifactor authentication enabled, disable or create MFA cookie"
@@ -193,7 +187,6 @@ async def test_full_user_flow_multiple_installations_with_mfa(
 
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == "mfa"
-    assert "flow_id" in result2
 
     mock_verisure_config_flow.login.side_effect = None
 
@@ -208,7 +201,6 @@ async def test_full_user_flow_multiple_installations_with_mfa(
     assert result3.get("step_id") == "installation"
     assert result3.get("type") == FlowResultType.FORM
     assert result3.get("errors") is None
-    assert "flow_id" in result2
 
     result4 = await hass.config_entries.flow.async_configure(
         result3["flow_id"], {"giid": "54321"}
@@ -248,8 +240,6 @@ async def test_verisure_errors(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert "flow_id" in result
-
     mock_verisure_config_flow.login.side_effect = side_effect
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -263,7 +253,6 @@ async def test_verisure_errors(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == "user"
     assert result2.get("errors") == {"base": error}
-    assert "flow_id" in result2
 
     mock_verisure_config_flow.login.side_effect = VerisureLoginError(
         "Multifactor authentication enabled, disable or create MFA cookie"
@@ -284,7 +273,6 @@ async def test_verisure_errors(
     assert result3.get("type") == FlowResultType.FORM
     assert result3.get("step_id") == "user"
     assert result3.get("errors") == {"base": "unknown_mfa"}
-    assert "flow_id" in result3
 
     result4 = await hass.config_entries.flow.async_configure(
         result3["flow_id"],
@@ -297,7 +285,6 @@ async def test_verisure_errors(
 
     assert result4.get("type") == FlowResultType.FORM
     assert result4.get("step_id") == "mfa"
-    assert "flow_id" in result4
 
     mock_verisure_config_flow.mfa_validate.side_effect = side_effect
 
@@ -310,7 +297,6 @@ async def test_verisure_errors(
     assert result5.get("type") == FlowResultType.FORM
     assert result5.get("step_id") == "mfa"
     assert result5.get("errors") == {"base": error}
-    assert "flow_id" in result5
 
     mock_verisure_config_flow.installations = [
         mock_verisure_config_flow.installations[0]
@@ -376,7 +362,6 @@ async def test_reauth_flow(
     assert result.get("step_id") == "reauth_confirm"
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -420,7 +405,6 @@ async def test_reauth_flow_with_mfa(
     assert result.get("step_id") == "reauth_confirm"
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
-    assert "flow_id" in result
 
     mock_verisure_config_flow.login.side_effect = VerisureLoginError(
         "Multifactor authentication enabled, disable or create MFA cookie"
@@ -437,7 +421,6 @@ async def test_reauth_flow_with_mfa(
 
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == "reauth_mfa"
-    assert "flow_id" in result2
 
     mock_verisure_config_flow.login.side_effect = None
 
@@ -491,8 +474,6 @@ async def test_reauth_flow_errors(
         data=mock_config_entry.data,
     )
 
-    assert "flow_id" in result
-
     mock_verisure_config_flow.login.side_effect = side_effect
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -506,7 +487,6 @@ async def test_reauth_flow_errors(
     assert result2.get("step_id") == "reauth_confirm"
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("errors") == {"base": error}
-    assert "flow_id" in result2
 
     mock_verisure_config_flow.login.side_effect = VerisureLoginError(
         "Multifactor authentication enabled, disable or create MFA cookie"
@@ -525,7 +505,6 @@ async def test_reauth_flow_errors(
     assert result3.get("type") == FlowResultType.FORM
     assert result3.get("step_id") == "reauth_confirm"
     assert result3.get("errors") == {"base": "unknown_mfa"}
-    assert "flow_id" in result3
 
     mock_verisure_config_flow.login_mfa.side_effect = None
 
@@ -540,7 +519,6 @@ async def test_reauth_flow_errors(
 
     assert result4.get("type") == FlowResultType.FORM
     assert result4.get("step_id") == "reauth_mfa"
-    assert "flow_id" in result4
 
     mock_verisure_config_flow.mfa_validate.side_effect = side_effect
 
@@ -553,7 +531,6 @@ async def test_reauth_flow_errors(
     assert result5.get("type") == FlowResultType.FORM
     assert result5.get("step_id") == "reauth_mfa"
     assert result5.get("errors") == {"base": error}
-    assert "flow_id" in result5
 
     mock_verisure_config_flow.mfa_validate.side_effect = None
     mock_verisure_config_flow.login.side_effect = None
@@ -627,7 +604,6 @@ async def test_options_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
-    assert "flow_id" in result
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -659,7 +635,6 @@ async def test_options_flow_code_format_mismatch(hass: HomeAssistant) -> None:
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
     assert result.get("errors") == {}
-    assert "flow_id" in result
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],

--- a/tests/components/whois/test_config_flow.py
+++ b/tests/components/whois/test_config_flow.py
@@ -30,7 +30,6 @@ async def test_full_user_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -71,7 +70,6 @@ async def test_full_flow_with_error(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_whois_config_flow.side_effect = throw
     result2 = await hass.config_entries.flow.async_configure(
@@ -82,7 +80,6 @@ async def test_full_flow_with_error(
     assert result2.get("type") == FlowResultType.FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {"base": reason}
-    assert "flow_id" in result2
 
     assert len(mock_setup_entry.mock_calls) == 0
     assert len(mock_whois_config_flow.mock_calls) == 1

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -24,7 +24,6 @@ async def test_full_user_flow_implementation(
 
     assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "192.168.1.123"}
@@ -65,7 +64,6 @@ async def test_full_zeroconf_flow_implementation(
     assert result.get("description_placeholders") == {CONF_NAME: "WLED RGB Light"}
     assert result.get("step_id") == "zeroconf_confirm"
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
@@ -271,7 +269,6 @@ async def test_options_flow(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "init"
-    assert "flow_id" in result
 
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],

--- a/tests/components/youless/test_config_flows.py
+++ b/tests/components/youless/test_config_flows.py
@@ -28,7 +28,6 @@ async def test_full_flow(hass: HomeAssistant) -> None:
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_youless = _get_mock_youless_api(
         initialize={"homes": [{"id": 1, "name": "myhome"}]}
@@ -56,7 +55,6 @@ async def test_not_found(hass: HomeAssistant) -> None:
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
     assert result.get("step_id") == SOURCE_USER
-    assert "flow_id" in result
 
     mock_youless = _get_mock_youless_api(initialize=URLError(""))
     with patch(

--- a/tests/components/zamg/test_config_flow.py
+++ b/tests/components/zamg/test_config_flow.py
@@ -26,7 +26,6 @@ async def test_full_user_flow_implementation(
     assert result.get("type") == FlowResultType.FORM
     LOGGER.debug(result)
     assert result.get("data_schema") != ""
-    assert "flow_id" in result
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_STATION_ID: TEST_STATION_ID},
@@ -68,7 +67,6 @@ async def test_error_update(
     LOGGER.debug(result)
     assert result.get("data_schema") != ""
     mock_zamg.update.side_effect = ZamgApiError
-    assert "flow_id" in result
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_STATION_ID: TEST_STATION_ID},
@@ -105,7 +103,6 @@ async def test_user_flow_duplicate(
 
     assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_STATION_ID: TEST_STATION_ID},
@@ -143,7 +140,6 @@ async def test_import_flow_duplicate(
 
     assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_STATION_ID: TEST_STATION_ID},
@@ -176,7 +172,6 @@ async def test_import_flow_duplicate_after_position(
 
     assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
-    assert "flow_id" in result
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_STATION_ID: TEST_STATION_ID},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improves the typing of the FlowResult TypeDict, by marking the handler and flow_id fields Required. This removes the need to assert them in e.g., tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
