### PR TITLE
Add option to retrieve SwitchBot Lock encryption key through config flow

### DIFF
--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -39,16 +39,6 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SWITCHBOT_INTERNAL_API_BASE_URL = (
-    "https://l9ren7efdj.execute-api.us-east-1.amazonaws.com"
-)
-SWITCHBOT_COGNITO_POOL = {
-    "PoolId": "us-east-1_x1fixo5LC",
-    "AppClientId": "66r90hdllaj4nnlne4qna0muls",
-    "AppClientSecret": "1v3v7vfjsiggiupkeuqvsovg084e3msbefpj9rgh611u30uug6t8",
-    "Region": "us-east-1",
-}
-
 
 def format_unique_id(address: str) -> str:
     """Format the unique ID for a switchbot."""

--- a/homeassistant/components/switchbot/lock.py
+++ b/homeassistant/components/switchbot/lock.py
@@ -31,6 +31,7 @@ class SwitchBotLock(SwitchbotEntity, LockEntity):
     def __init__(self, coordinator: SwitchbotDataUpdateCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.base_unique_id}-lock"
         self._async_update_attrs()
 
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/switchbot/lock.py
+++ b/homeassistant/components/switchbot/lock.py
@@ -31,7 +31,6 @@ class SwitchBotLock(SwitchbotEntity, LockEntity):
     def __init__(self, coordinator: SwitchbotDataUpdateCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.base_unique_id}-lock"
         self._async_update_attrs()
 
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.33.0"],
+  "requirements": ["PySwitchbot==0.34.1"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "codeowners": [

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -31,7 +31,7 @@
         }
       },
       "lock_chose_method": {
-        "description": "Chose configuration method, details can be found in the documentation.",
+        "description": "Choose configuration method, details can be found in the documentation.",
         "menu_options": {
           "lock_auth": "SwitchBot app login and password",
           "lock_key": "Lock encryption key"

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -22,11 +22,25 @@
           "key_id": "Key ID",
           "encryption_key": "Encryption key"
         }
+      },
+      "lock_auth": {
+        "description": "Please provide your SwitchBot app username and password. This data won't be saved and only used to retrieve your locks encryption key.",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
+      "lock_chose_method": {
+        "description": "Chose configuration method, details can be found in the documentation.",
+        "menu_options": {
+          "lock_auth": "SwitchBot app login and password",
+          "lock_key": "Lock encryption key"
+        }
       }
     },
     "error": {
-      "key_id_invalid": "Key ID or Encryption key is invalid",
-      "encryption_key_invalid": "Key ID or Encryption key is invalid"
+      "encryption_key_invalid": "Key ID or Encryption key is invalid",
+      "auth_failed": "Authentication failed"
     },
     "abort": {
       "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/switchbot/translations/en.json
+++ b/homeassistant/components/switchbot/translations/en.json
@@ -24,7 +24,7 @@
                 "description": "Please provide your SwitchBot app username and password. This data won't be saved and only used to retrieve your locks encryption key."
             },
             "lock_chose_method": {
-                "description": "Chose configuration method, details can be found in the documentation.",
+                "description": "Choose configuration method, details can be found in the documentation.",
                 "menu_options": {
                     "lock_auth": "SwitchBot app login and password",
                     "lock_key": "Lock encryption key"

--- a/homeassistant/components/switchbot/translations/en.json
+++ b/homeassistant/components/switchbot/translations/en.json
@@ -8,13 +8,27 @@
             "unknown": "Unexpected error"
         },
         "error": {
-            "encryption_key_invalid": "Key ID or Encryption key is invalid",
-            "key_id_invalid": "Key ID or Encryption key is invalid"
+            "auth_failed": "Authentication failed",
+            "encryption_key_invalid": "Key ID or Encryption key is invalid"
         },
         "flow_title": "{name} ({address})",
         "step": {
             "confirm": {
                 "description": "Do you want to set up {name}?"
+            },
+            "lock_auth": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username"
+                },
+                "description": "Please provide your SwitchBot app username and password. This data won't be saved and only used to retrieve your locks encryption key."
+            },
+            "lock_chose_method": {
+                "description": "Chose configuration method, details can be found in the documentation.",
+                "menu_options": {
+                    "lock_auth": "SwitchBot app login and password",
+                    "lock_key": "Lock encryption key"
+                }
             },
             "lock_key": {
                 "data": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,7 +40,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.33.0
+PySwitchbot==0.34.1
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -36,7 +36,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.33.0
+PySwitchbot==0.34.1
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/tests/components/switchbot/__init__.py
+++ b/tests/components/switchbot/__init__.py
@@ -180,7 +180,7 @@ WOLOCK_SERVICE_INFO = BluetoothServiceInfoBleak(
     advertisement=generate_advertisement_data(
         local_name="WoLock",
         manufacturer_data={2409: b"\xf1\t\x9fE\x1a]\xda\x83\x00 "},
-        service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"o\x80d"},
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"o\x80d"},
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
     device=BLEDevice("aa:bb:cc:dd:ee:ff", "WoLock"),

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -8,7 +8,13 @@ from homeassistant.components.switchbot.const import (
     CONF_RETRY_COUNT,
 )
 from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PASSWORD, CONF_SENSOR_TYPE
+from homeassistant.const import (
+    CONF_ADDRESS,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_SENSOR_TYPE,
+    CONF_USERNAME,
+)
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -80,6 +86,62 @@ async def test_bluetooth_discovery_requires_password(hass):
         CONF_ADDRESS: "798A8547-2A3D-C609-55FF-73FA824B923B",
         CONF_SENSOR_TYPE: "bot",
         CONF_PASSWORD: "abc123",
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_bluetooth_discovery_lock_key(hass):
+    """Test discovery via bluetooth with a lock."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_BLUETOOTH},
+        data=WOLOCK_SERVICE_INFO,
+    )
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "lock_chose_method"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "lock_key"}
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_key"
+    assert result["errors"] == {}
+
+    with patch("switchbot.SwitchbotLock.verify_encryption_key", return_value=False):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KEY_ID: "",
+                CONF_ENCRYPTION_KEY: "",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_key"
+    assert result["errors"] == {"base": "encryption_key_invalid"}
+
+    with patch_async_setup_entry() as mock_setup_entry, patch(
+        "switchbot.SwitchbotLock.verify_encryption_key", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KEY_ID: "ff",
+                CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Lock EEFF"
+    assert result["data"] == {
+        CONF_ADDRESS: "aa:bb:cc:dd:ee:ff",
+        CONF_KEY_ID: "ff",
+        CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
+        CONF_SENSOR_TYPE: "lock",
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
@@ -327,7 +389,7 @@ async def test_user_setup_single_bot_with_password(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_wolock(hass):
+async def test_user_setup_wolock_key(hass):
     """Test the user initiated form for a lock."""
 
     with patch(
@@ -337,14 +399,35 @@ async def test_user_setup_wolock(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "lock_chose_method"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "lock_key"}
+    )
+    await hass.async_block_till_done()
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "lock_key"
     assert result["errors"] == {}
 
+    with patch("switchbot.SwitchbotLock.verify_encryption_key", return_value=False):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KEY_ID: "",
+                CONF_ENCRYPTION_KEY: "",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_key"
+    assert result["errors"] == {"base": "encryption_key_invalid"}
+
     with patch_async_setup_entry() as mock_setup_entry, patch(
         "switchbot.SwitchbotLock.verify_encryption_key", return_value=True
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_KEY_ID: "ff",
@@ -353,9 +436,76 @@ async def test_user_setup_wolock(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Lock EEFF"
-    assert result2["data"] == {
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Lock EEFF"
+    assert result["data"] == {
+        CONF_ADDRESS: "aa:bb:cc:dd:ee:ff",
+        CONF_KEY_ID: "ff",
+        CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
+        CONF_SENSOR_TYPE: "lock",
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_setup_wolock_auth(hass):
+    """Test the user initiated form for a lock."""
+
+    with patch(
+        "homeassistant.components.switchbot.config_flow.async_discovered_service_info",
+        return_value=[WOLOCK_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "lock_chose_method"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "lock_auth"}
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_auth"
+    assert result["errors"] == {}
+
+    with patch(
+        "switchbot.SwitchbotLock.retrieve_encryption_key",
+        side_effect=RuntimeError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+            },
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "lock_auth"
+    assert result["errors"] == {"base": "auth_failed"}
+
+    with patch_async_setup_entry() as mock_setup_entry, patch(
+        "switchbot.SwitchbotLock.verify_encryption_key", return_value=True
+    ), patch(
+        "switchbot.SwitchbotLock.retrieve_encryption_key",
+        return_value={
+            CONF_KEY_ID: "ff",
+            CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
+        },
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "username",
+                CONF_PASSWORD: "password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Lock EEFF"
+    assert result["data"] == {
         CONF_ADDRESS: "aa:bb:cc:dd:ee:ff",
         CONF_KEY_ID: "ff",
         CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
@@ -387,6 +537,13 @@ async def test_user_setup_wolock_or_bot(hass):
         USER_INPUT,
     )
     await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "lock_chose_method"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "lock_key"}
+    )
+    await hass.async_block_till_done()
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "lock_key"
     assert result["errors"] == {}
@@ -413,42 +570,6 @@ async def test_user_setup_wolock_or_bot(hass):
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_user_setup_wolock_invalid_encryption_key(hass):
-    """Test the user initiated form for a lock with invalid encryption key."""
-
-    with patch(
-        "homeassistant.components.switchbot.config_flow.async_discovered_service_info",
-        return_value=[WOLOCK_SERVICE_INFO],
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}
-        )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "lock_key"
-    assert result["errors"] == {}
-
-    with patch_async_setup_entry() as mock_setup_entry, patch(
-        "switchbot.SwitchbotLock.verify_encryption_key", return_value=False
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_KEY_ID: "",
-                CONF_ENCRYPTION_KEY: "",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["step_id"] == "lock_key"
-    assert result2["errors"] == {
-        CONF_KEY_ID: "key_id_invalid",
-        CONF_ENCRYPTION_KEY: "encryption_key_invalid",
-    }
-
-    assert len(mock_setup_entry.mock_calls) == 0
 
 
 async def test_user_setup_wosensor(hass):

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -109,7 +109,10 @@ async def test_bluetooth_discovery_lock_key(hass):
     assert result["step_id"] == "lock_key"
     assert result["errors"] == {}
 
-    with patch("switchbot.SwitchbotLock.verify_encryption_key", return_value=False):
+    with patch(
+        "homeassistant.components.switchbot.config_flow.SwitchbotLock.verify_encryption_key",
+        return_value=False,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -124,7 +127,8 @@ async def test_bluetooth_discovery_lock_key(hass):
     assert result["errors"] == {"base": "encryption_key_invalid"}
 
     with patch_async_setup_entry() as mock_setup_entry, patch(
-        "switchbot.SwitchbotLock.verify_encryption_key", return_value=True
+        "homeassistant.components.switchbot.config_flow.SwitchbotLock.verify_encryption_key",
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -410,7 +414,10 @@ async def test_user_setup_wolock_key(hass):
     assert result["step_id"] == "lock_key"
     assert result["errors"] == {}
 
-    with patch("switchbot.SwitchbotLock.verify_encryption_key", return_value=False):
+    with patch(
+        "homeassistant.components.switchbot.config_flow.SwitchbotLock.verify_encryption_key",
+        return_value=False,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -425,7 +432,8 @@ async def test_user_setup_wolock_key(hass):
     assert result["errors"] == {"base": "encryption_key_invalid"}
 
     with patch_async_setup_entry() as mock_setup_entry, patch(
-        "switchbot.SwitchbotLock.verify_encryption_key", return_value=True
+        "homeassistant.components.switchbot.config_flow.SwitchbotLock.verify_encryption_key",
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -470,7 +478,7 @@ async def test_user_setup_wolock_auth(hass):
     assert result["errors"] == {}
 
     with patch(
-        "switchbot.SwitchbotLock.retrieve_encryption_key",
+        "homeassistant.components.switchbot.config_flow.SwitchbotLock.retrieve_encryption_key",
         side_effect=RuntimeError,
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -486,9 +494,10 @@ async def test_user_setup_wolock_auth(hass):
     assert result["errors"] == {"base": "auth_failed"}
 
     with patch_async_setup_entry() as mock_setup_entry, patch(
-        "switchbot.SwitchbotLock.verify_encryption_key", return_value=True
+        "homeassistant.components.switchbot.config_flow.SwitchbotLock.verify_encryption_key",
+        return_value=True,
     ), patch(
-        "switchbot.SwitchbotLock.retrieve_encryption_key",
+        "homeassistant.components.switchbot.config_flow.SwitchbotLock.retrieve_encryption_key",
         return_value={
             CONF_KEY_ID: "ff",
             CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
@@ -549,7 +558,8 @@ async def test_user_setup_wolock_or_bot(hass):
     assert result["errors"] == {}
 
     with patch_async_setup_entry() as mock_setup_entry, patch(
-        "switchbot.SwitchbotLock.verify_encryption_key", return_value=True
+        "homeassistant.components.switchbot.config_flow.SwitchbotLock.verify_encryption_key",
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION
## Proposed change
* Add option to retrieve SwitchBot Lock encryption key through config flow to address review comment https://github.com/home-assistant/core/pull/84673#issuecomment-1366562534
* Updating PySwitchbot to version 0.34.1:
https://github.com/Danielhiversen/pySwitchbot/compare/0.33.0...0.34.1

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
