### PR TITLE
Redesign and refactor Bravia TV config_flow

### DIFF
--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -44,8 +44,6 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.client: BraviaTV | None = None
         self.device_config: dict[str, Any] = {}
         self.entry: ConfigEntry | None = None
-        self.client_id: str = ""
-        self.nickname: str = ""
 
     @staticmethod
     @callback
@@ -62,8 +60,13 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         self.client = BraviaTV(host=host, session=session)
 
-    async def async_create_device(self) -> FlowResult:
-        """Initialize and create Bravia TV device from config."""
+    async def gen_instance_ids(self) -> tuple[str, str]:
+        """Generate client_id and nickname."""
+        uuid = await instance_id.async_get(self.hass)
+        return uuid, f"{NICKNAME_PREFIX} {uuid[:6]}"
+
+    async def async_connect_device(self) -> None:
+        """Connect to Bravia TV device from config."""
         assert self.client
 
         pin = self.device_config[CONF_PIN]
@@ -72,12 +75,15 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if use_psk:
             await self.client.connect(psk=pin)
         else:
-            self.device_config[CONF_CLIENT_ID] = self.client_id
-            self.device_config[CONF_NICKNAME] = self.nickname
-            await self.client.connect(
-                pin=pin, clientid=self.client_id, nickname=self.nickname
-            )
+            client_id = self.device_config[CONF_CLIENT_ID]
+            nickname = self.device_config[CONF_NICKNAME]
+            await self.client.connect(pin=pin, clientid=client_id, nickname=nickname)
         await self.client.set_wol_mode(True)
+
+    async def async_create_device(self) -> FlowResult:
+        """Create Bravia TV device from config."""
+        assert self.client
+        await self.async_connect_device()
 
         system_info = await self.client.get_system_info()
         cid = system_info[ATTR_CID].lower()
@@ -90,6 +96,16 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=title, data=self.device_config)
 
+    async def async_reauth_device(self) -> FlowResult:
+        """Reauthorize Bravia TV device from config."""
+        assert self.entry
+        assert self.client
+        await self.async_connect_device()
+
+        self.hass.config_entries.async_update_entry(self.entry, data=self.device_config)
+        await self.hass.config_entries.async_reload(self.entry.entry_id)
+        return self.async_abort(reason="reauth_successful")
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -100,7 +116,6 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             host = user_input[CONF_HOST]
             if is_host_valid(host):
                 self.device_config[CONF_HOST] = host
-                self.create_client()
                 return await self.async_step_authorize()
 
             errors[CONF_HOST] = "invalid_host"
@@ -114,14 +129,38 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_authorize(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Authorize Bravia TV device."""
+        """Handle authorize step."""
+        self.create_client()
+
+        if user_input is not None:
+            self.device_config[CONF_USE_PSK] = user_input[CONF_USE_PSK]
+            if user_input[CONF_USE_PSK]:
+                return await self.async_step_psk()
+            return await self.async_step_pin()
+
+        return self.async_show_form(
+            step_id="authorize",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USE_PSK, default=False): bool,
+                }
+            ),
+        )
+
+    async def async_step_pin(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle PIN authorize step."""
         errors: dict[str, str] = {}
-        self.client_id, self.nickname = await self.gen_instance_ids()
+        client_id, nickname = await self.gen_instance_ids()
 
         if user_input is not None:
             self.device_config[CONF_PIN] = user_input[CONF_PIN]
-            self.device_config[CONF_USE_PSK] = user_input[CONF_USE_PSK]
+            self.device_config[CONF_CLIENT_ID] = client_id
+            self.device_config[CONF_NICKNAME] = nickname
             try:
+                if self.entry:
+                    return await self.async_reauth_device()
                 return await self.async_create_device()
             except BraviaTVAuthError:
                 errors["base"] = "invalid_auth"
@@ -133,16 +172,44 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         assert self.client
 
         try:
-            await self.client.pair(self.client_id, self.nickname)
+            await self.client.pair(client_id, nickname)
         except BraviaTVError:
             return self.async_abort(reason="no_ip_control")
 
         return self.async_show_form(
-            step_id="authorize",
+            step_id="pin",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_PIN, default=""): str,
-                    vol.Required(CONF_USE_PSK, default=False): bool,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_psk(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle PSK authorize step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self.device_config[CONF_PIN] = user_input[CONF_PIN]
+            try:
+                if self.entry:
+                    return await self.async_reauth_device()
+                return await self.async_create_device()
+            except BraviaTVAuthError:
+                errors["base"] = "invalid_auth"
+            except BraviaTVNotSupported:
+                errors["base"] = "unsupported_model"
+            except BraviaTVError:
+                errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="psk",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_PIN, default=""): str,
                 }
             ),
             errors=errors,
@@ -181,7 +248,6 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Allow the user to confirm adding the device."""
         if user_input is not None:
-            self.create_client()
             return await self.async_step_authorize()
 
         return self.async_show_form(step_id="confirm")
@@ -190,59 +256,7 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle configuration by re-auth."""
         self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         self.device_config = {**entry_data}
-        return await self.async_step_reauth_confirm()
-
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Dialog that informs the user that reauth is required."""
-        self.create_client()
-        client_id, nickname = await self.gen_instance_ids()
-
-        assert self.client is not None
-        assert self.entry is not None
-
-        if user_input is not None:
-            pin = user_input[CONF_PIN]
-            use_psk = user_input[CONF_USE_PSK]
-            try:
-                if use_psk:
-                    await self.client.connect(psk=pin)
-                else:
-                    self.device_config[CONF_CLIENT_ID] = client_id
-                    self.device_config[CONF_NICKNAME] = nickname
-                    await self.client.connect(
-                        pin=pin, clientid=client_id, nickname=nickname
-                    )
-                await self.client.set_wol_mode(True)
-            except BraviaTVError:
-                return self.async_abort(reason="reauth_unsuccessful")
-            else:
-                self.hass.config_entries.async_update_entry(
-                    self.entry, data={**self.device_config, **user_input}
-                )
-                await self.hass.config_entries.async_reload(self.entry.entry_id)
-                return self.async_abort(reason="reauth_successful")
-
-        try:
-            await self.client.pair(client_id, nickname)
-        except BraviaTVError:
-            return self.async_abort(reason="reauth_unsuccessful")
-
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_PIN, default=""): str,
-                    vol.Required(CONF_USE_PSK, default=False): bool,
-                }
-            ),
-        )
-
-    async def gen_instance_ids(self) -> tuple[str, str]:
-        """Generate client_id and nickname."""
-        uuid = await instance_id.async_get(self.hass)
-        return uuid, f"{NICKNAME_PREFIX} {uuid[:6]}"
+        return await self.async_step_authorize()
 
 
 class BraviaTVOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -122,7 +122,7 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_HOST, default=""): str}),
+            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
             errors=errors,
         )
 
@@ -180,7 +180,7 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="pin",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_PIN, default=""): str,
+                    vol.Required(CONF_PIN): str,
                 }
             ),
             errors=errors,
@@ -209,7 +209,7 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="psk",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_PIN, default=""): str,
+                    vol.Required(CONF_PIN): str,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/braviatv/strings.json
+++ b/homeassistant/components/braviatv/strings.json
@@ -9,21 +9,27 @@
       },
       "authorize": {
         "title": "Authorize Sony Bravia TV",
-        "description": "Enter the PIN code shown on the Sony Bravia TV. \n\nIf the PIN code is not shown, you have to unregister Home Assistant on your TV, go to: Settings -> Network -> Remote device settings -> Deregister remote device. \n\nYou can use PSK (Pre-Shared-Key) instead of PIN. PSK is a user-defined secret key used for access control. This authentication method is recommended as more stable. To enable PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Then check «Use PSK authentication» box and enter your PSK instead of PIN.",
+        "description": "Make sure that «Control remotely» is enabled on your TV, go to: \nSettings -> Network -> Remote device settings -> Control remotely. \n\nThere are two authorization methods: PIN code or PSK (Pre-Shared Key). \nAuthorization via PSK is recommended as more stable.",
         "data": {
-          "pin": "[%key:common::config_flow::data::pin%]",
           "use_psk": "Use PSK authentication"
+        }
+      },
+      "pin": {
+        "title": "Authorize Sony Bravia TV",
+        "description": "Enter the PIN code shown on the Sony Bravia TV. \n\nIf the PIN code is not shown, you have to unregister Home Assistant on your TV, go to: Settings -> Network -> Remote device settings -> Deregister remote device.",
+        "data": {
+          "pin": "[%key:common::config_flow::data::pin%]"
+        }
+      },
+      "psk": {
+        "title": "Authorize Sony Bravia TV",
+        "description": "To set up PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Set «Authentication» to «Normal and Pre-Shared Key» or «Pre-Shared Key» and define your Pre-Shared-Key string (e.g. sony). \n\nThen enter your PSK here.",
+        "data": {
+          "pin": "PSK"
         }
       },
       "confirm": {
         "description": "[%key:common::config_flow::description::confirm_setup%]"
-      },
-      "reauth_confirm": {
-        "description": "Enter the PIN code shown on the Sony Bravia TV. \n\nIf the PIN code is not shown, you have to unregister Home Assistant on your TV, go to: Settings -> Network -> Remote device settings -> Deregister remote device. \n\nYou can use PSK (Pre-Shared-Key) instead of PIN. PSK is a user-defined secret key used for access control. This authentication method is recommended as more stable. To enable PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Then check «Use PSK authentication» box and enter your PSK instead of PIN.",
-        "data": {
-          "pin": "[%key:common::config_flow::data::pin%]",
-          "use_psk": "Use PSK authentication"
-        }
       }
     },
     "error": {
@@ -36,8 +42,7 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "no_ip_control": "IP Control is disabled on your TV or the TV is not supported.",
       "not_bravia_device": "The device is not a Bravia TV.",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again."
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {

--- a/homeassistant/components/braviatv/translations/en.json
+++ b/homeassistant/components/braviatv/translations/en.json
@@ -4,8 +4,7 @@
             "already_configured": "Device is already configured",
             "no_ip_control": "IP Control is disabled on your TV or the TV is not supported.",
             "not_bravia_device": "The device is not a Bravia TV.",
-            "reauth_successful": "Re-authentication was successful",
-            "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again."
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -16,21 +15,27 @@
         "step": {
             "authorize": {
                 "data": {
-                    "pin": "PIN Code",
                     "use_psk": "Use PSK authentication"
                 },
-                "description": "Enter the PIN code shown on the Sony Bravia TV. \n\nIf the PIN code is not shown, you have to unregister Home Assistant on your TV, go to: Settings -> Network -> Remote device settings -> Deregister remote device. \n\nYou can use PSK (Pre-Shared-Key) instead of PIN. PSK is a user-defined secret key used for access control. This authentication method is recommended as more stable. To enable PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Then check \u00abUse PSK authentication\u00bb box and enter your PSK instead of PIN.",
+                "description": "Make sure that \u00abControl remotely\u00bb is enabled on your TV, go to: \nSettings -> Network -> Remote device settings -> Control remotely. \n\nThere are two authorization methods: PIN code or PSK (Pre-Shared Key). \nAuthorization via PSK is recommended as more stable.",
                 "title": "Authorize Sony Bravia TV"
             },
             "confirm": {
                 "description": "Do you want to start set up?"
             },
-            "reauth_confirm": {
+            "pin": {
                 "data": {
-                    "pin": "PIN Code",
-                    "use_psk": "Use PSK authentication"
+                    "pin": "PIN Code"
                 },
-                "description": "Enter the PIN code shown on the Sony Bravia TV. \n\nIf the PIN code is not shown, you have to unregister Home Assistant on your TV, go to: Settings -> Network -> Remote device settings -> Deregister remote device. \n\nYou can use PSK (Pre-Shared-Key) instead of PIN. PSK is a user-defined secret key used for access control. This authentication method is recommended as more stable. To enable PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Then check \u00abUse PSK authentication\u00bb box and enter your PSK instead of PIN."
+                "description": "Enter the PIN code shown on the Sony Bravia TV. \n\nIf the PIN code is not shown, you have to unregister Home Assistant on your TV, go to: Settings -> Network -> Remote device settings -> Deregister remote device.",
+                "title": "Authorize Sony Bravia TV"
+            },
+            "psk": {
+                "data": {
+                    "pin": "PSK"
+                },
+                "description": "To set up PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Set \u00abAuthentication\u00bb to \u00abNormal and Pre-Shared Key\u00bb or \u00abPre-Shared Key\u00bb and define your Pre-Shared-Key string (e.g. sony). \n\nThen enter your PSK here.",
+                "title": "Authorize Sony Bravia TV"
             },
             "user": {
                 "data": {

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -124,7 +124,14 @@ async def test_ssdp_discovery(hass):
         assert result["step_id"] == "authorize"
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_PIN: "1234", CONF_USE_PSK: False}
+            result["flow_id"], user_input={CONF_USE_PSK: False}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "pin"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: "1234"}
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
@@ -185,60 +192,68 @@ async def test_user_invalid_host(hass):
     assert result["errors"] == {CONF_HOST: "invalid_host"}
 
 
-async def test_authorize_invalid_auth(hass):
-    """Test that authorization errors shown on the authorization step."""
+@pytest.mark.parametrize(
+    "side_effect, error_message",
+    [
+        (BraviaTVAuthError, "invalid_auth"),
+        (BraviaTVNotSupported, "unsupported_model"),
+        (BraviaTVConnectionError, "cannot_connect"),
+    ],
+)
+async def test_pin_form_error(hass, side_effect, error_message):
+    """Test that PIN form errors are correct."""
     with patch(
         "pybravia.BraviaTV.connect",
-        side_effect=BraviaTVAuthError,
+        side_effect=side_effect,
     ), patch("pybravia.BraviaTV.pair"):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
         )
         result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_USE_PSK: False}
+        )
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PIN: "1234"}
         )
 
-        assert result["errors"] == {"base": "invalid_auth"}
+        assert result["errors"] == {"base": error_message}
 
 
-async def test_authorize_cannot_connect(hass):
-    """Test that errors are shown when cannot connect to host at the authorize step."""
+@pytest.mark.parametrize(
+    "side_effect, error_message",
+    [
+        (BraviaTVAuthError, "invalid_auth"),
+        (BraviaTVNotSupported, "unsupported_model"),
+        (BraviaTVConnectionError, "cannot_connect"),
+    ],
+)
+async def test_psk_form_error(hass, side_effect, error_message):
+    """Test that PSK form errors are correct."""
     with patch(
         "pybravia.BraviaTV.connect",
-        side_effect=BraviaTVConnectionError,
-    ), patch("pybravia.BraviaTV.pair"):
+        side_effect=side_effect,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
         )
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_PIN: "1234"}
+            result["flow_id"], user_input={CONF_USE_PSK: True}
         )
-
-        assert result["errors"] == {"base": "cannot_connect"}
-
-
-async def test_authorize_model_unsupported(hass):
-    """Test that errors are shown when the TV is not supported at the authorize step."""
-    with patch(
-        "pybravia.BraviaTV.connect",
-        side_effect=BraviaTVNotSupported,
-    ), patch("pybravia.BraviaTV.pair"):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "10.10.10.12"}
-        )
-
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_PIN: "1234"}
+            result["flow_id"], user_input={CONF_PIN: "mypsk"}
         )
 
-        assert result["errors"] == {"base": "unsupported_model"}
+        assert result["errors"] == {"base": error_message}
 
 
-async def test_authorize_no_ip_control(hass):
-    """Test that errors are shown when IP Control is disabled on the TV."""
+async def test_no_ip_control(hass):
+    """Test that error are shown when IP Control is disabled on the TV."""
     with patch("pybravia.BraviaTV.pair", side_effect=BraviaTVError):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_USE_PSK: False}
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.ABORT
@@ -246,7 +261,7 @@ async def test_authorize_no_ip_control(hass):
 
 
 async def test_duplicate_error(hass):
-    """Test that errors are shown when duplicates are added."""
+    """Test that error are shown when duplicates are added."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="very_unique_string",
@@ -269,6 +284,9 @@ async def test_duplicate_error(hass):
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
         )
         result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_USE_PSK: False}
+        )
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PIN: "1234"}
         )
 
@@ -277,7 +295,7 @@ async def test_duplicate_error(hass):
 
 
 async def test_create_entry(hass):
-    """Test that the user step works."""
+    """Test that entry is added correctly with PIN auth."""
     uuid = await instance_id.async_get(hass)
 
     with patch("pybravia.BraviaTV.connect"), patch("pybravia.BraviaTV.pair"), patch(
@@ -296,7 +314,14 @@ async def test_create_entry(hass):
         assert result["step_id"] == "authorize"
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_PIN: "1234", CONF_USE_PSK: False}
+            result["flow_id"], user_input={CONF_USE_PSK: False}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "pin"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: "1234"}
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
@@ -312,47 +337,9 @@ async def test_create_entry(hass):
         }
 
 
-async def test_create_entry_with_ipv6_address(hass):
-    """Test that the user step works with device IPv6 address."""
-    uuid = await instance_id.async_get(hass)
-
-    with patch("pybravia.BraviaTV.connect"), patch("pybravia.BraviaTV.pair"), patch(
-        "pybravia.BraviaTV.set_wol_mode"
-    ), patch(
-        "pybravia.BraviaTV.get_system_info",
-        return_value=BRAVIA_SYSTEM_INFO,
-    ), patch(
-        "homeassistant.components.braviatv.async_setup_entry", return_value=True
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-            data={CONF_HOST: "2001:db8::1428:57ab"},
-        )
-
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == "authorize"
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_PIN: "1234", CONF_USE_PSK: False}
-        )
-
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-        assert result["result"].unique_id == "very_unique_string"
-        assert result["title"] == "TV-Model"
-        assert result["data"] == {
-            CONF_HOST: "2001:db8::1428:57ab",
-            CONF_PIN: "1234",
-            CONF_USE_PSK: False,
-            CONF_MAC: "AA:BB:CC:DD:EE:FF",
-            CONF_CLIENT_ID: uuid,
-            CONF_NICKNAME: f"{NICKNAME_PREFIX} {uuid[:6]}",
-        }
-
-
 async def test_create_entry_psk(hass):
-    """Test that the user step works with PSK auth."""
-    with patch("pybravia.BraviaTV.connect"), patch("pybravia.BraviaTV.pair"), patch(
+    """Test that entry is added correctly with PSK auth."""
+    with patch("pybravia.BraviaTV.connect"), patch(
         "pybravia.BraviaTV.set_wol_mode"
     ), patch(
         "pybravia.BraviaTV.get_system_info",
@@ -368,7 +355,14 @@ async def test_create_entry_psk(hass):
         assert result["step_id"] == "authorize"
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_PIN: "mypsk", CONF_USE_PSK: True}
+            result["flow_id"], user_input={CONF_USE_PSK: True}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "psk"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: "mypsk"}
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
@@ -461,11 +455,14 @@ async def test_options_flow_error(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "user_input",
-    [{CONF_PIN: "mypsk", CONF_USE_PSK: True}, {CONF_PIN: "1234", CONF_USE_PSK: False}],
+    "use_psk, new_pin",
+    [
+        (True, "7777"),
+        (False, "newpsk"),
+    ],
 )
-async def test_reauth_successful(hass, user_input):
-    """Test starting a reauthentication flow."""
+async def test_reauth_successful(hass, use_psk, new_pin):
+    """Test that the reauthorization is successful."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="very_unique_string",
@@ -495,73 +492,15 @@ async def test_reauth_successful(hass, user_input):
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == "reauth_confirm"
+        assert result["step_id"] == "authorize"
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input=user_input,
+            result["flow_id"], user_input={CONF_USE_PSK: use_psk}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: new_pin}
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
-
-
-async def test_reauth_unsuccessful(hass):
-    """Test reauthentication flow failed."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="very_unique_string",
-        data={
-            CONF_HOST: "bravia-host",
-            CONF_PIN: "1234",
-            CONF_MAC: "AA:BB:CC:DD:EE:FF",
-        },
-        title="TV-Model",
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "pybravia.BraviaTV.connect",
-        side_effect=BraviaTVAuthError,
-    ), patch("pybravia.BraviaTV.pair"):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_REAUTH, "entry_id": config_entry.entry_id},
-            data=config_entry.data,
-        )
-
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == "reauth_confirm"
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={CONF_PIN: "mypsk", CONF_USE_PSK: True},
-        )
-
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
-        assert result["reason"] == "reauth_unsuccessful"
-
-
-async def test_reauth_unsuccessful_during_pairing(hass):
-    """Test reauthentication flow failed because of pairing error."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="very_unique_string",
-        data={
-            CONF_HOST: "bravia-host",
-            CONF_PIN: "1234",
-            CONF_MAC: "AA:BB:CC:DD:EE:FF",
-        },
-        title="TV-Model",
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch("pybravia.BraviaTV.pair", side_effect=BraviaTVError):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_REAUTH, "entry_id": config_entry.entry_id},
-            data=config_entry.data,
-        )
-
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
-        assert result["reason"] == "reauth_unsuccessful"
+        assert config_entry.data[CONF_PIN] == new_pin


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR changes the structure of the config flow to separate the connection process for different types of authorization. This is necessary primarily in order to be able to authorize via PSK authorization when PIN authorization is disabled (see [#84557](https://github.com/home-assistant/core/issues/84557#issuecomment-1366717542)). In addition, hints for each type of authorization have been added to improve the user experience. 

This change entailed refactoring entire config flow, since it has discovery and reauthorization mechanisms. I also refactored and clean up the tests.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #84557
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io