### PR TITLE
Ruuvi Gateway integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1082,6 +1082,9 @@ omit =
     homeassistant/components/rova/sensor.py
     homeassistant/components/rpi_camera/*
     homeassistant/components/rtorrent/sensor.py
+    homeassistant/components/ruuvi_gateway/__init__.py
+    homeassistant/components/ruuvi_gateway/bluetooth.py
+    homeassistant/components/ruuvi_gateway/coordinator.py
     homeassistant/components/russound_rio/media_player.py
     homeassistant/components/russound_rnet/media_player.py
     homeassistant/components/sabnzbd/__init__.py

--- a/.strict-typing
+++ b/.strict-typing
@@ -247,6 +247,7 @@ homeassistant.components.rituals_perfume_genie.*
 homeassistant.components.roku.*
 homeassistant.components.rpi_power.*
 homeassistant.components.rtsp_to_webrtc.*
+homeassistant.components.ruuvi_gateway.*
 homeassistant.components.ruuvitag_ble.*
 homeassistant.components.samsungtv.*
 homeassistant.components.scene.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -979,6 +979,8 @@ build.json @home-assistant/supervisor
 /tests/components/rtsp_to_webrtc/ @allenporter
 /homeassistant/components/ruckus_unleashed/ @gabe565
 /tests/components/ruckus_unleashed/ @gabe565
+/homeassistant/components/ruuvi_gateway/ @akx
+/tests/components/ruuvi_gateway/ @akx
 /homeassistant/components/ruuvitag_ble/ @akx
 /tests/components/ruuvitag_ble/ @akx
 /homeassistant/components/sabnzbd/ @shaiu

--- a/homeassistant/components/ruuvi_gateway/__init__.py
+++ b/homeassistant/components/ruuvi_gateway/__init__.py
@@ -1,0 +1,45 @@
+"""The Ruuvi Gateway integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
+from homeassistant.core import HomeAssistant
+
+from .bluetooth import async_connect_scanner
+from .const import DOMAIN
+from .coordinator import RuuviGatewayUpdateCoordinator
+from .models import RuuviGatewayRuntimeData
+
+PLATFORMS: list[Platform] = []
+
+_LOGGER = logging.getLogger(DOMAIN)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Ruuvi Gateway from a config entry."""
+    coordinator = RuuviGatewayUpdateCoordinator(
+        hass,
+        logger=_LOGGER,
+        name=entry.title,
+        update_interval=timedelta(seconds=10),
+        host=entry.data[CONF_HOST],
+        token=entry.data[CONF_TOKEN],
+    )
+    scanner, unload_scanner = async_connect_scanner(hass, entry, coordinator)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = RuuviGatewayRuntimeData(
+        update_coordinator=coordinator,
+        scanner=scanner,
+    )
+    entry.async_on_unload(unload_scanner)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/ruuvi_gateway/__init__.py
+++ b/homeassistant/components/ruuvi_gateway/__init__.py
@@ -1,19 +1,16 @@
 """The Ruuvi Gateway integration."""
 from __future__ import annotations
 
-from datetime import timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
+from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 
 from .bluetooth import async_connect_scanner
-from .const import DOMAIN
+from .const import DOMAIN, SCAN_INTERVAL
 from .coordinator import RuuviGatewayUpdateCoordinator
 from .models import RuuviGatewayRuntimeData
-
-PLATFORMS: list[Platform] = []
 
 _LOGGER = logging.getLogger(DOMAIN)
 
@@ -24,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         logger=_LOGGER,
         name=entry.title,
-        update_interval=timedelta(seconds=10),
+        update_interval=SCAN_INTERVAL,
         host=entry.data[CONF_HOST],
         token=entry.data[CONF_TOKEN],
     )
@@ -39,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, []):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/ruuvi_gateway/bluetooth.py
+++ b/homeassistant/components/ruuvi_gateway/bluetooth.py
@@ -1,0 +1,102 @@
+"""Bluetooth support for Ruuvi Gateway."""
+from __future__ import annotations
+
+from collections.abc import Callable
+import datetime
+import logging
+
+from home_assistant_bluetooth import BluetoothServiceInfoBleak
+
+from homeassistant.components.bluetooth import (
+    BaseHaRemoteScanner,
+    async_get_advertisement_callback,
+    async_register_scanner,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+
+from .coordinator import RuuviGatewayUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RuuviGatewayScanner(BaseHaRemoteScanner):
+    """Scanner for Ruuvi Gateway."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        scanner_id: str,
+        name: str,
+        new_info_callback: Callable[[BluetoothServiceInfoBleak], None],
+        *,
+        coordinator: RuuviGatewayUpdateCoordinator,
+    ) -> None:
+        """Initialize the scanner, using the given update coordinator as data source."""
+        super().__init__(
+            hass,
+            scanner_id,
+            name,
+            new_info_callback,
+            connector=None,
+            connectable=False,
+        )
+        self.coordinator = coordinator
+
+    @callback
+    def _async_handle_new_data(self) -> None:
+        now = datetime.datetime.now()
+        for tag_data in self.coordinator.data:
+            if now - tag_data.datetime > datetime.timedelta(minutes=10):
+                # Don't process data that is older than 10 minutes
+                continue
+            anno = tag_data.parse_announcement()
+            self._async_on_advertisement(
+                address=tag_data.mac,
+                rssi=tag_data.rssi,
+                local_name=anno.local_name,
+                service_data=anno.service_data,
+                service_uuids=anno.service_uuids,
+                manufacturer_data=anno.manufacturer_data,
+                tx_power=anno.tx_power,
+                details={},
+            )
+
+    @callback
+    def start_polling(self) -> CALLBACK_TYPE:
+        """Start polling; return a callback to stop polling."""
+        return self.coordinator.async_add_listener(self._async_handle_new_data)
+
+
+def async_connect_scanner(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: RuuviGatewayUpdateCoordinator,
+) -> tuple[RuuviGatewayScanner, CALLBACK_TYPE]:
+    """Connect scanner and start polling."""
+    assert entry.unique_id is not None
+    source = str(entry.unique_id)
+    _LOGGER.debug(
+        "%s [%s]: Connecting scanner",
+        entry.title,
+        source,
+    )
+    scanner = RuuviGatewayScanner(
+        hass=hass,
+        scanner_id=source,
+        name=entry.title,
+        new_info_callback=async_get_advertisement_callback(hass),
+        coordinator=coordinator,
+    )
+    unload_callbacks = [
+        async_register_scanner(hass, scanner, connectable=False),
+        scanner.async_setup(),
+        scanner.start_polling(),
+    ]
+
+    @callback
+    def _async_unload() -> None:
+        for unloader in unload_callbacks:
+            unloader()
+
+    return (scanner, _async_unload)

--- a/homeassistant/components/ruuvi_gateway/bluetooth.py
+++ b/homeassistant/components/ruuvi_gateway/bluetooth.py
@@ -15,6 +15,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 
+from .const import OLD_ADVERTISEMENT_CUTOFF
 from .coordinator import RuuviGatewayUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ class RuuviGatewayScanner(BaseHaRemoteScanner):
     def _async_handle_new_data(self) -> None:
         now = datetime.datetime.now()
         for tag_data in self.coordinator.data:
-            if now - tag_data.datetime > datetime.timedelta(minutes=10):
+            if now - tag_data.datetime > OLD_ADVERTISEMENT_CUTOFF:
                 # Don't process data that is older than 10 minutes
                 continue
             anno = tag_data.parse_announcement()

--- a/homeassistant/components/ruuvi_gateway/config_flow.py
+++ b/homeassistant/components/ruuvi_gateway/config_flow.py
@@ -44,7 +44,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     bearer_token=user_input[CONF_TOKEN],
                 )
             await self.async_set_unique_id(resp.gw_mac, raise_on_progress=False)
-            self._abort_if_unique_id_configured()
+            self._abort_if_unique_id_configured(
+                updates={CONF_HOST: user_input[CONF_HOST]}
+            )
             info = {"title": f"Ruuvi Gateway {resp.gw_mac_suffix}"}
             return (
                 self.async_create_entry(title=info["title"], data=user_input),

--- a/homeassistant/components/ruuvi_gateway/config_flow.py
+++ b/homeassistant/components/ruuvi_gateway/config_flow.py
@@ -43,7 +43,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     host=user_input[CONF_HOST],
                     bearer_token=user_input[CONF_TOKEN],
                 )
-            await self.async_set_unique_id(resp.gw_mac, raise_on_progress=False)
+            await self.async_set_unique_id(format_mac(resp.gw_mac), raise_on_progress=False)
             self._abort_if_unique_id_configured(
                 updates={CONF_HOST: user_input[CONF_HOST]}
             )
@@ -80,5 +80,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Prepare configuration for a DHCP discovered Ruuvi Gateway."""
+        await self.async_set_unique_id(format_mac(discovery_info.macaddress))
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
         self.config_schema = get_config_schema_with_default_host(host=discovery_info.ip)
         return await self.async_step_user()

--- a/homeassistant/components/ruuvi_gateway/config_flow.py
+++ b/homeassistant/components/ruuvi_gateway/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.httpx_client import get_async_client
 
 from . import DOMAIN
@@ -43,7 +44,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     host=user_input[CONF_HOST],
                     bearer_token=user_input[CONF_TOKEN],
                 )
-            await self.async_set_unique_id(format_mac(resp.gw_mac), raise_on_progress=False)
+            await self.async_set_unique_id(
+                format_mac(resp.gw_mac), raise_on_progress=False
+            )
             self._abort_if_unique_id_configured(
                 updates={CONF_HOST: user_input[CONF_HOST]}
             )

--- a/homeassistant/components/ruuvi_gateway/config_flow.py
+++ b/homeassistant/components/ruuvi_gateway/config_flow.py
@@ -1,0 +1,82 @@
+"""Config flow for Ruuvi Gateway integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import aioruuvigateway.api as gw_api
+from aioruuvigateway.excs import CannotConnect, InvalidAuth
+
+from homeassistant import config_entries
+from homeassistant.components import dhcp
+from homeassistant.const import CONF_HOST, CONF_TOKEN
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.httpx_client import get_async_client
+
+from . import DOMAIN
+from .schemata import CONFIG_SCHEMA, get_config_schema_with_default_host
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Ruuvi Gateway."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        super().__init__()
+        self.config_schema = CONFIG_SCHEMA
+
+    async def _async_validate(
+        self,
+        user_input: dict[str, Any],
+    ) -> tuple[FlowResult | None, dict[str, str]]:
+        """Validate configuration (either discovered or user input)."""
+        errors: dict[str, str] = {}
+
+        try:
+            async with get_async_client(self.hass) as client:
+                resp = await gw_api.get_gateway_history_data(
+                    client,
+                    host=user_input[CONF_HOST],
+                    bearer_token=user_input[CONF_TOKEN],
+                )
+            await self.async_set_unique_id(resp.gw_mac, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            info = {"title": f"Ruuvi Gateway {resp.gw_mac_suffix}"}
+            return (
+                self.async_create_entry(title=info["title"], data=user_input),
+                errors,
+            )
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        return (None, errors)
+
+    async def async_step_user(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Handle requesting or validating user input."""
+        if user_input is not None:
+            result, errors = await self._async_validate(user_input)
+        else:
+            result, errors = None, {}
+        if result is not None:
+            return result
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.config_schema,
+            errors=(errors or None),
+        )
+
+    async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
+        """Prepare configuration for a DHCP discovered Ruuvi Gateway."""
+        self.config_schema = get_config_schema_with_default_host(host=discovery_info.ip)
+        return await self.async_step_user()

--- a/homeassistant/components/ruuvi_gateway/const.py
+++ b/homeassistant/components/ruuvi_gateway/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Ruuvi Gateway integration."""
+
+DOMAIN = "ruuvi_gateway"

--- a/homeassistant/components/ruuvi_gateway/const.py
+++ b/homeassistant/components/ruuvi_gateway/const.py
@@ -1,3 +1,12 @@
 """Constants for the Ruuvi Gateway integration."""
+from datetime import timedelta
+
+from homeassistant.components.bluetooth import (
+    FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
+)
 
 DOMAIN = "ruuvi_gateway"
+SCAN_INTERVAL = timedelta(seconds=5)
+OLD_ADVERTISEMENT_CUTOFF = timedelta(
+    seconds=FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
+)

--- a/homeassistant/components/ruuvi_gateway/coordinator.py
+++ b/homeassistant/components/ruuvi_gateway/coordinator.py
@@ -1,0 +1,49 @@
+"""Update coordinator for Ruuvi Gateway."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from aioruuvigateway.api import get_gateway_history_data
+from aioruuvigateway.models import TagData
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+
+class RuuviGatewayUpdateCoordinator(DataUpdateCoordinator[list[TagData]]):
+    """Polls the gateway for data and returns a list of TagData objects that have changed since the last poll."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: logging.Logger,
+        *,
+        name: str,
+        update_interval: timedelta | None = None,
+        host: str,
+        token: str,
+    ) -> None:
+        """Initialize the coordinator using the given configuration (host, token)."""
+        super().__init__(hass, logger, name=name, update_interval=update_interval)
+        self.host = host
+        self.token = token
+        self.last_tag_datas: dict[str, TagData] = {}
+
+    async def _async_update_data(self) -> list[TagData]:
+        changed_tag_datas: list[TagData] = []
+        async with get_async_client(self.hass) as client:
+            data = await get_gateway_history_data(
+                client,
+                host=self.host,
+                bearer_token=self.token,
+            )
+        for tag in data.tags:
+            if (
+                tag.mac not in self.last_tag_datas
+                or self.last_tag_datas[tag.mac].data != tag.data
+            ):
+                changed_tag_datas.append(tag)
+                self.last_tag_datas[tag.mac] = tag
+        return changed_tag_datas

--- a/homeassistant/components/ruuvi_gateway/manifest.json
+++ b/homeassistant/components/ruuvi_gateway/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "ruuvi_gateway",
+  "name": "Ruuvi Gateway",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/ruuvi_gateway",
+  "codeowners": ["@akx"],
+  "requirements": ["aioruuvigateway==0.0.2"],
+  "iot_class": "local_polling",
+  "dhcp": [
+    {
+      "hostname": "ruuvigateway*"
+    }
+  ]
+}

--- a/homeassistant/components/ruuvi_gateway/models.py
+++ b/homeassistant/components/ruuvi_gateway/models.py
@@ -1,0 +1,15 @@
+"""Models for Ruuvi Gateway integration."""
+from __future__ import annotations
+
+import dataclasses
+
+from .bluetooth import RuuviGatewayScanner
+from .coordinator import RuuviGatewayUpdateCoordinator
+
+
+@dataclasses.dataclass(frozen=True)
+class RuuviGatewayRuntimeData:
+    """Runtime data for Ruuvi Gateway integration."""
+
+    update_coordinator: RuuviGatewayUpdateCoordinator
+    scanner: RuuviGatewayScanner

--- a/homeassistant/components/ruuvi_gateway/schemata.py
+++ b/homeassistant/components/ruuvi_gateway/schemata.py
@@ -1,0 +1,18 @@
+"""Schemata for ruuvi_gateway."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_HOST, CONF_TOKEN
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_TOKEN): str,
+    }
+)
+
+
+def get_config_schema_with_default_host(host: str) -> vol.Schema:
+    """Return a config schema with a default host."""
+    return CONFIG_SCHEMA.extend({vol.Required(CONF_HOST, default=host): str})

--- a/homeassistant/components/ruuvi_gateway/strings.json
+++ b/homeassistant/components/ruuvi_gateway/strings.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "Host (IP address or DNS name)",
+          "token": "Bearer token (configured during gateway setup)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+    }
+  }
+}

--- a/homeassistant/components/ruuvi_gateway/translations/en.json
+++ b/homeassistant/components/ruuvi_gateway/translations/en.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Account is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host (IP address or DNS name)",
+                    "token": "Bearer token (configured during gateway setup)"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -349,6 +349,7 @@ FLOWS = {
         "rpi_power",
         "rtsp_to_webrtc",
         "ruckus_unleashed",
+        "ruuvi_gateway",
         "ruuvitag_ble",
         "sabnzbd",
         "samsungtv",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -401,6 +401,10 @@ DHCP: list[dict[str, str | bool]] = [
         "macaddress": "204EF6*",
     },
     {
+        "domain": "ruuvi_gateway",
+        "hostname": "ruuvigateway*",
+    },
+    {
         "domain": "samsungtv",
         "registered_devices": True,
     },

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4569,6 +4569,12 @@
         }
       }
     },
+    "ruuvi_gateway": {
+      "name": "Ruuvi Gateway",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "ruuvitag_ble": {
       "name": "RuuviTag BLE",
       "integration_type": "hub",

--- a/mypy.ini
+++ b/mypy.ini
@@ -2224,6 +2224,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.ruuvi_gateway.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.ruuvitag_ble.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -260,6 +260,9 @@ aiorecollect==1.0.8
 # homeassistant.components.ridwell
 aioridwell==2022.11.0
 
+# homeassistant.components.ruuvi_gateway
+aioruuvigateway==0.0.2
+
 # homeassistant.components.senseme
 aiosenseme==0.6.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -235,6 +235,9 @@ aiorecollect==1.0.8
 # homeassistant.components.ridwell
 aioridwell==2022.11.0
 
+# homeassistant.components.ruuvi_gateway
+aioruuvigateway==0.0.2
+
 # homeassistant.components.senseme
 aiosenseme==0.6.1
 

--- a/tests/components/ruuvi_gateway/__init__.py
+++ b/tests/components/ruuvi_gateway/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Ruuvi Gateway integration."""

--- a/tests/components/ruuvi_gateway/consts.py
+++ b/tests/components/ruuvi_gateway/consts.py
@@ -1,0 +1,11 @@
+"""Constants for ruuvi_gateway tests."""
+from __future__ import annotations
+
+ASYNC_SETUP_ENTRY = "homeassistant.components.ruuvi_gateway.async_setup_entry"
+GET_GATEWAY_HISTORY_DATA = "aioruuvigateway.api.get_gateway_history_data"
+EXPECTED_TITLE = "Ruuvi Gateway EE:FF"
+BASE_DATA = {
+    "host": "1.1.1.1",
+    "token": "toktok",
+}
+GATEWAY_MAC = "AA:BB:CC:DD:EE:FF"

--- a/tests/components/ruuvi_gateway/consts.py
+++ b/tests/components/ruuvi_gateway/consts.py
@@ -9,3 +9,4 @@ BASE_DATA = {
     "token": "toktok",
 }
 GATEWAY_MAC = "AA:BB:CC:DD:EE:FF"
+GATEWAY_MAC_LOWER = GATEWAY_MAC.lower()

--- a/tests/components/ruuvi_gateway/test_config_flow.py
+++ b/tests/components/ruuvi_gateway/test_config_flow.py
@@ -39,72 +39,72 @@ DHCP_DATA = {**BASE_DATA, "host": DHCP_IP}
 )
 async def test_ok_setup(hass: HomeAssistant, init_data, init_context, entry) -> None:
     """Test we get the form."""
-    result = await hass.config_entries.flow.async_init(
+    init_result = await hass.config_entries.flow.async_init(
         DOMAIN,
         data=init_data,
         context=init_context,
     )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == config_entries.SOURCE_USER
-    assert result["errors"] is None
+    assert init_result["type"] == FlowResultType.FORM
+    assert init_result["step_id"] == config_entries.SOURCE_USER
+    assert init_result["errors"] is None
 
     with patch_gateway_ok(), patch_setup_entry_ok() as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        config_result = await hass.config_entries.flow.async_configure(
+            init_result["flow_id"],
             entry,
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == EXPECTED_TITLE
-    assert result2["data"] == entry
-    assert result2["context"]["unique_id"] == GATEWAY_MAC
+    assert config_result["type"] == FlowResultType.CREATE_ENTRY
+    assert config_result["title"] == EXPECTED_TITLE
+    assert config_result["data"] == entry
+    assert config_result["context"]["unique_id"] == GATEWAY_MAC
     assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
-    result = await hass.config_entries.flow.async_init(
+    init_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(GET_GATEWAY_HISTORY_DATA, side_effect=InvalidAuth):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        config_result = await hass.config_entries.flow.async_configure(
+            init_result["flow_id"],
             BASE_DATA,
         )
 
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_auth"}
+    assert config_result["type"] == FlowResultType.FORM
+    assert config_result["errors"] == {"base": "invalid_auth"}
 
 
 async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
+    init_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(GET_GATEWAY_HISTORY_DATA, side_effect=CannotConnect):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        config_result = await hass.config_entries.flow.async_configure(
+            init_result["flow_id"],
             BASE_DATA,
         )
 
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert config_result["type"] == FlowResultType.FORM
+    assert config_result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_form_unexpected(hass: HomeAssistant) -> None:
     """Test we handle unexpected errors."""
-    result = await hass.config_entries.flow.async_init(
+    init_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(GET_GATEWAY_HISTORY_DATA, side_effect=MemoryError):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        config_result = await hass.config_entries.flow.async_configure(
+            init_result["flow_id"],
             BASE_DATA,
         )
 
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "unknown"}
+    assert config_result["type"] == FlowResultType.FORM
+    assert config_result["errors"] == {"base": "unknown"}

--- a/tests/components/ruuvi_gateway/test_config_flow.py
+++ b/tests/components/ruuvi_gateway/test_config_flow.py
@@ -1,0 +1,103 @@
+"""Test the Ruuvi Gateway config flow."""
+from unittest.mock import patch
+
+from aioruuvigateway.excs import CannotConnect, InvalidAuth
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components import dhcp
+from homeassistant.components.ruuvi_gateway.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .consts import BASE_DATA, EXPECTED_TITLE, GATEWAY_MAC, GET_GATEWAY_HISTORY_DATA
+from .utils import patch_gateway_ok, patch_setup_entry_ok
+
+
+@pytest.mark.parametrize("method", ["user", "dhcp"])
+async def test_ok_setup(hass: HomeAssistant, method: str) -> None:
+    """Test we get the form."""
+    if method == "user":
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        data = entry = BASE_DATA
+    elif method == "dhcp":
+        dhcp_ip = "1.2.3.4"
+        data = entry = {**BASE_DATA, "host": dhcp_ip}
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=dhcp.DhcpServiceInfo(
+                hostname="RuuviGateway1234",
+                ip=dhcp_ip,
+                macaddress="12:34:56:78:90:ab",
+            ),
+            context={"source": config_entries.SOURCE_DHCP},
+        )
+    else:
+        raise NotImplementedError("...")
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == config_entries.SOURCE_USER
+    assert result["errors"] is None
+
+    with patch_gateway_ok(), patch_setup_entry_ok() as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            entry,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == EXPECTED_TITLE
+    assert result2["data"] == data
+    assert result2["context"]["unique_id"] == GATEWAY_MAC
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(GET_GATEWAY_HISTORY_DATA, side_effect=InvalidAuth):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            BASE_DATA,
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(GET_GATEWAY_HISTORY_DATA, side_effect=CannotConnect):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            BASE_DATA,
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_unexpected(hass: HomeAssistant) -> None:
+    """Test we handle unexpected errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(GET_GATEWAY_HISTORY_DATA, side_effect=MemoryError):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            BASE_DATA,
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "unknown"}

--- a/tests/components/ruuvi_gateway/utils.py
+++ b/tests/components/ruuvi_gateway/utils.py
@@ -1,0 +1,30 @@
+"""Utilities for ruuvi_gateway tests."""
+from __future__ import annotations
+
+import time
+from unittest.mock import _patch, patch
+
+from aioruuvigateway.models import HistoryResponse
+
+from tests.components.ruuvi_gateway.consts import (
+    ASYNC_SETUP_ENTRY,
+    GATEWAY_MAC,
+    GET_GATEWAY_HISTORY_DATA,
+)
+
+
+def patch_gateway_ok() -> _patch:
+    """Patch gateway function to return valid data."""
+    return patch(
+        GET_GATEWAY_HISTORY_DATA,
+        return_value=HistoryResponse(
+            timestamp=int(time.time()),
+            gw_mac=GATEWAY_MAC,
+            tags=[],
+        ),
+    )
+
+
+def patch_setup_entry_ok() -> _patch:
+    """Patch setup entry to return True."""
+    return patch(ASYNC_SETUP_ENTRY, return_value=True)


### PR DESCRIPTION
## Proposed change

This PR adds a new `ruuvi_gateway` integration that supports reading BLE advertisements from a [Ruuvi Gateway](https://ruuvi.com/gateway/) on the local network, acting as a Remote Bluetooth Scanner (like ESPhome and Shelly).

By default, the Ruuvi Gateway is configured to only relay advertisements with the RuuviTag manufacturer identifier, but it can be configured to relay all the things. (This is documented.)

Communication with the gateway is handled by https://github.com/akx/aioruuvigateway.

## Screenshots

### DHCP Autodiscovery!

![Screen Shot 2022-12-31 at 17 02 09](https://user-images.githubusercontent.com/58669/210148731-d82d047c-52d4-4b43-9a1f-04b7631f5de2.png)

### ... with a pre-filled IP (wow!)

![Screen Shot 2022-12-31 at 17 02 06](https://user-images.githubusercontent.com/58669/210148730-2d816bba-7fd4-477a-b430-8f33bc1731db.png)


## Open questions

- Should there be some sort of test for the bluetooth/coordinator bits here? They empirically work, and e.g. `esphome` doesn't seem to have explicit tests for that either..?

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
  - Setting up a Ruuvi Gateway in the UI spawns BLE sensors from around my house even if no other BT adapter is set up.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
  - Partially. 

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated: https://github.com/home-assistant/home-assistant.io/pull/25480
- [x] Brand PR: https://github.com/home-assistant/brands/pull/3984

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other PRs
