### PR TITLE
Google Assistant SDK: Fire event with request/response for automations

### DIFF
--- a/homeassistant/components/google_assistant_sdk/helpers.py
+++ b/homeassistant/components/google_assistant_sdk/helpers.py
@@ -39,7 +39,12 @@ async def async_send_text_commands(commands: list[str], hass: HomeAssistant) -> 
     language_code = entry.options.get(CONF_LANGUAGE_CODE, default_language_code(hass))
     with TextAssistant(credentials, language_code) as assistant:
         for command in commands:
-            assistant.assist(command)
+            text_response = assistant.assist(command)[0]
+            event_data = {
+                "request": command,
+                "response": text_response,
+            }
+            hass.bus.async_fire(DOMAIN + "_event", event_data)
 
 
 def default_language_code(hass: HomeAssistant):

--- a/homeassistant/components/google_assistant_sdk/manifest.json
+++ b/homeassistant/components/google_assistant_sdk/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/google_assistant_sdk/",
-  "requirements": ["gassist-text==0.0.5"],
+  "requirements": ["gassist-text==0.0.7"],
   "codeowners": ["@tronikos"],
   "iot_class": "cloud_polling",
   "integration_type": "service"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -741,7 +741,7 @@ fritzconnection==1.10.3
 gTTS==2.2.4
 
 # homeassistant.components.google_assistant_sdk
-gassist-text==0.0.5
+gassist-text==0.0.7
 
 # homeassistant.components.google
 gcal-sync==4.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -557,7 +557,7 @@ fritzconnection==1.10.3
 gTTS==2.2.4
 
 # homeassistant.components.google_assistant_sdk
-gassist-text==0.0.5
+gassist-text==0.0.7
 
 # homeassistant.components.google
 gcal-sync==4.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fire events to allow automations to update the status of manual sensors
e.g. the following service calls
```
service: google_assistant_sdk.send_text_command
data:
  command: is nest guard armed?

service: google_assistant_sdk.send_text_command
data:
  command: set Nest Guard to home and guarding

service: google_assistant_sdk.send_text_command
data:
  command: is nest guard armed?
```
Fire the following events
```
event_type: google_assistant_sdk_event
data:
  request: is nest guard armed?
  response: Nest Guard is disarmed.

event_type: google_assistant_sdk_event
data:
  request: set Nest Guard to home and guarding
  response: >-
    Alright, there are 8 issues. Setting to Home And Guarding. Check Nest Guard
    or the app for more information.

event_type: google_assistant_sdk_event
data:
  request: is nest guard armed?
  response: Nest Guard is armed.
```

An automation can listen to such events and update the state of manual sensors.

Underlying library changes: https://github.com/tronikos/gassist_text/compare/0.0.5...0.0.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
