### PR TITLE
Only reflect unavailable state in DSMR when disconnected

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -540,7 +540,6 @@ class DSMREntity(SensorEntity):
     entity_description: DSMRSensorEntityDescription
     _attr_has_entity_name = True
     _attr_should_poll = False
-    telegram: dict[str, DSMRObject] | None = {}
 
     def __init__(
         self, entity_description: DSMRSensorEntityDescription, entry: ConfigEntry
@@ -548,6 +547,7 @@ class DSMREntity(SensorEntity):
         """Initialize entity."""
         self.entity_description = entity_description
         self._entry = entry
+        self.telegram: dict[str, DSMRObject] | None = {}
 
         device_serial = entry.data[CONF_SERIAL_ID]
         device_name = DEVICE_NAME_ELECTRICITY

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -401,7 +401,7 @@ async def async_setup_entry(
     )
 
     @Throttle(min_time_between_updates)
-    def update_entities_telegram(telegram: dict[str, DSMRObject]) -> None:
+    def update_entities_telegram(telegram: dict[str, DSMRObject] | None) -> None:
         """Update entities with latest telegram and trigger state update."""
         # Make all device entities aware of new telegram
         for entity in entities:
@@ -445,6 +445,11 @@ async def async_setup_entry(
 
         while hass.state == CoreState.not_running or hass.is_running:
             # Start DSMR asyncio.Protocol reader
+
+            # Reflect connected state in devices state by setting an
+            # empty telegram resulting in `unknown` states
+            update_entities_telegram({})
+
             try:
                 transport, protocol = await hass.loop.create_task(reader_factory())
 
@@ -472,8 +477,8 @@ async def async_setup_entry(
                 protocol = None
 
                 # Reflect disconnect state in devices state by setting an
-                # empty telegram resulting in `unknown` states
-                update_entities_telegram({})
+                # None telegram resulting in `unavailable` states
+                update_entities_telegram(None)
 
                 # throttle reconnect attempts
                 await asyncio.sleep(
@@ -487,11 +492,19 @@ async def async_setup_entry(
                 transport = None
                 protocol = None
 
+                # Reflect disconnect state in devices state by setting an
+                # None telegram resulting in `unavailable` states
+                update_entities_telegram(None)
+
                 # throttle reconnect attempts
                 await asyncio.sleep(
                     entry.data.get(CONF_RECONNECT_INTERVAL, DEFAULT_RECONNECT_INTERVAL)
                 )
             except CancelledError:
+                # Reflect disconnect state in devices state by setting an
+                # None telegram resulting in `unavailable` states
+                update_entities_telegram(None)
+
                 if stop_listener and (
                     hass.state == CoreState.not_running or hass.is_running
                 ):
@@ -527,6 +540,7 @@ class DSMREntity(SensorEntity):
     entity_description: DSMRSensorEntityDescription
     _attr_has_entity_name = True
     _attr_should_poll = False
+    telegram: dict[str, DSMRObject] | None = {}
 
     def __init__(
         self, entity_description: DSMRSensorEntityDescription, entry: ConfigEntry
@@ -534,7 +548,6 @@ class DSMREntity(SensorEntity):
         """Initialize entity."""
         self.entity_description = entity_description
         self._entry = entry
-        self.telegram: dict[str, DSMRObject] = {}
 
         device_serial = entry.data[CONF_SERIAL_ID]
         device_name = DEVICE_NAME_ELECTRICITY
@@ -551,16 +564,21 @@ class DSMREntity(SensorEntity):
         self._attr_unique_id = f"{device_serial}_{entity_description.key}"
 
     @callback
-    def update_data(self, telegram: dict[str, DSMRObject]) -> None:
+    def update_data(self, telegram: dict[str, DSMRObject] | None) -> None:
         """Update data."""
         self.telegram = telegram
-        if self.hass and self.entity_description.obis_reference in self.telegram:
+        if self.hass and (
+            telegram is None or self.entity_description.obis_reference in telegram
+        ):
             self.async_write_ha_state()
 
     def get_dsmr_object_attr(self, attribute: str) -> str | None:
         """Read attribute from last received telegram for this DSMR object."""
         # Make sure telegram contains an object for this entities obis
-        if self.entity_description.obis_reference not in self.telegram:
+        if (
+            self.telegram is None
+            or self.entity_description.obis_reference not in self.telegram
+        ):
             return None
 
         # Get the attribute value if the object has it
@@ -571,7 +589,7 @@ class DSMREntity(SensorEntity):
     @property
     def available(self) -> bool:
         """Entity is only available if there is a telegram."""
-        return bool(self.telegram)
+        return self.telegram is not None
 
     @property
     def native_value(self) -> StateType:

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     ENERGY_KILO_WATT_HOUR,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     VOLUME_CUBIC_METERS,
     UnitOfPower,
 )
@@ -782,6 +783,10 @@ async def test_reconnect(hass, dsmr_connection_fixture):
     await hass.async_block_till_done()
 
     assert connection_factory.call_count == 1
+
+    state = hass.states.get("sensor.electricity_meter_power_consumption")
+    assert state
+    assert state.state == STATE_UNKNOWN
 
     # indicate disconnect, release wait lock and allow reconnect to happen
     closed.set()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow up of [84848](https://github.com/home-assistant/core/pull/84848) and [84860](https://github.com/home-assistant/core/pull/84860).

The state of the DSMR sensor should not reflect unavailable when the serial port is opened (connected). This PR makes the behavior more refined. When the connection is there, the state of sensor entities (including their initial state awaiting the first telegram) will be "unknown". When an actual disconnect of the serial port happens, the entities become "unavailable".


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
