### PR TITLE
Use ExecuteIfOff on color cluster for supported bulbs with ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -167,3 +167,13 @@ class ColorChannel(ZigbeeChannel):
             self.color_capabilities is not None
             and lighting.Color.ColorCapabilities.Color_loop in self.color_capabilities
         )
+
+    @property
+    def options(self) -> lighting.Color.Options:
+        """Return ZCL options of the channel."""
+        return lighting.Color.Options(self.cluster.get("options", 0))
+
+    @property
+    def execute_if_off_supported(self) -> bool:
+        """Return True if the channel can execute commands when off."""
+        return lighting.Color.Options.Execute_if_off in self.options

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -45,6 +45,7 @@ class ColorChannel(ZigbeeChannel):
         "color_capabilities": True,
         "color_loop_active": False,
         "start_up_color_temperature": True,
+        "options": True,
     }
 
     @cached_property

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -228,7 +228,6 @@ class BaseLight(LogMixin, light.LightEntity):
         # desired color mode with the desired color or color temperature.
         new_color_provided_while_off = (
             self._zha_config_enhanced_light_transition
-            and not self._color_channel.execute_if_off_supported
             and not self._FORCE_ON
             and not self._attr_state
             and (
@@ -255,6 +254,7 @@ class BaseLight(LogMixin, light.LightEntity):
                 )
             )
             and brightness_supported(self._attr_supported_color_modes)
+            and not self._color_channel.execute_if_off_supported
         )
 
         if (
@@ -291,6 +291,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
         if (
             not isinstance(self, LightGroup)
+            and self._color_channel is not None
             and self._color_channel.execute_if_off_supported
         ):
             self.debug("handling color commands before turning on/level")
@@ -349,6 +350,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
         if (
             isinstance(self, LightGroup)
+            or self._color_channel is None
             or not self._color_channel.execute_if_off_supported
         ):
             self.debug("handling color commands after turning on/level")

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -291,7 +291,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
         if (
             not isinstance(self, LightGroup)
-            and self._color_channel is not None
+            and self._color_channel
             and self._color_channel.execute_if_off_supported
         ):
             self.debug("handling color commands before turning on/level")
@@ -350,7 +350,7 @@ class BaseLight(LogMixin, light.LightEntity):
 
         if (
             isinstance(self, LightGroup)
-            or self._color_channel is None
+            or not self._color_channel
             or not self._color_channel.execute_if_off_supported
         ):
             self.debug("handling color commands after turning on/level")

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -189,11 +189,9 @@ class BaseLight(LogMixin, light.LightEntity):
         hs_color = kwargs.get(light.ATTR_HS_COLOR)
 
         execute_if_off_supported = (
-            self._GROUP_SUPPORTS_EXECUTE_IF_OFF
-            if isinstance(self, LightGroup)
-            else self._color_channel.execute_if_off_supported
-            if self._color_channel
-            else False
+            not isinstance(self, LightGroup)
+            and self._color_channel
+            and self._color_channel.execute_if_off_supported
         )
 
         set_transition_flag = (
@@ -1051,22 +1049,6 @@ class LightGroup(BaseLight, ZhaGroupEntity):
         """Initialize a light group."""
         super().__init__(entity_ids, unique_id, group_id, zha_device, **kwargs)
         group = self.zha_device.gateway.get_group(self._group_id)
-
-        # ugly experimental code to support "execute if off" for groups
-        # Note: Can this be done in a better way?
-        # Note: Also, currently, this is only set once when the group is initialized,
-        #       so if the "options" attribute is changed, ZHA needs to be reloaded.
-        self._GROUP_SUPPORTS_EXECUTE_IF_OFF = True  # pylint: disable=invalid-name
-        for member in group.members:
-            for pool in member.device.channels.pools:
-                for channel in pool.all_channels.values():
-                    if (
-                        channel.name == CHANNEL_COLOR
-                        and not channel.execute_if_off_supported
-                    ):
-                        self._GROUP_SUPPORTS_EXECUTE_IF_OFF = False
-                        break
-
         self._DEFAULT_MIN_TRANSITION_TIME = any(  # pylint: disable=invalid-name
             member.device.manufacturer in DEFAULT_MIN_TRANSITION_MANUFACTURERS
             for member in group.members

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -34,6 +34,7 @@ from .common import (
     get_zha_gateway,
     patch_zha_config,
     send_attributes_report,
+    update_attribute_cache,
 )
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
@@ -1197,6 +1198,151 @@ async def test_transitions(
     assert eWeLink_state.attributes["color_mode"] == ColorMode.COLOR_TEMP
     assert eWeLink_state.attributes["min_mireds"] == 153
     assert eWeLink_state.attributes["max_mireds"] == 500
+
+
+@patch(
+    "zigpy.zcl.clusters.lighting.Color.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+@patch(
+    "zigpy.zcl.clusters.general.LevelControl.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+@patch(
+    "zigpy.zcl.clusters.general.OnOff.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+async def test_on_with_off_color(hass, device_light_1):
+    """Test turning on the light and sending color commands before on/level commands for supporting lights."""
+
+    device_1_entity_id = await find_entity_id(Platform.LIGHT, device_light_1, hass)
+    dev1_cluster_on_off = device_light_1.device.endpoints[1].on_off
+    dev1_cluster_level = device_light_1.device.endpoints[1].level
+    dev1_cluster_color = device_light_1.device.endpoints[1].light_color
+
+    # Execute_if_off will override the "enhanced turn on from an off-state" config option that's enabled here
+    dev1_cluster_color.PLUGGED_ATTR_READS = {
+        "options": lighting.Color.Options.Execute_if_off
+    }
+    update_attribute_cache(dev1_cluster_color)
+
+    # turn on via UI
+    dev1_cluster_on_off.request.reset_mock()
+    dev1_cluster_level.request.reset_mock()
+    dev1_cluster_color.request.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {
+            "entity_id": device_1_entity_id,
+            "color_temp": 235,
+        },
+        blocking=True,
+    )
+
+    assert dev1_cluster_on_off.request.call_count == 1
+    assert dev1_cluster_on_off.request.await_count == 1
+    assert dev1_cluster_color.request.call_count == 1
+    assert dev1_cluster_color.request.await_count == 1
+    assert dev1_cluster_level.request.call_count == 0
+    assert dev1_cluster_level.request.await_count == 0
+
+    assert dev1_cluster_on_off.request.call_args_list[0] == call(
+        False,
+        dev1_cluster_on_off.commands_by_name["on"].id,
+        dev1_cluster_on_off.commands_by_name["on"].schema,
+        expect_reply=True,
+        manufacturer=None,
+        tries=1,
+        tsn=None,
+    )
+    assert dev1_cluster_color.request.call_args == call(
+        False,
+        dev1_cluster_color.commands_by_name["move_to_color_temp"].id,
+        dev1_cluster_color.commands_by_name["move_to_color_temp"].schema,
+        color_temp_mireds=235,
+        transition_time=0,
+        expect_reply=True,
+        manufacturer=None,
+        tries=1,
+        tsn=None,
+    )
+
+    light1_state = hass.states.get(device_1_entity_id)
+    assert light1_state.state == STATE_ON
+    assert light1_state.attributes["color_temp"] == 235
+    assert light1_state.attributes["color_mode"] == ColorMode.COLOR_TEMP
+
+    # now let's turn off the Execute_if_off option and see if the old behavior is restored
+    dev1_cluster_color.PLUGGED_ATTR_READS = {"options": 0}
+    update_attribute_cache(dev1_cluster_color)
+
+    # turn off via UI, so the old "enhanced turn on from an off-state" behavior can do something
+    await async_test_off_from_hass(hass, dev1_cluster_on_off, device_1_entity_id)
+
+    # turn on via UI (with a different color temp, so the "enhanced turn on" does something)
+    dev1_cluster_on_off.request.reset_mock()
+    dev1_cluster_level.request.reset_mock()
+    dev1_cluster_color.request.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {
+            "entity_id": device_1_entity_id,
+            "color_temp": 240,
+        },
+        blocking=True,
+    )
+
+    assert dev1_cluster_on_off.request.call_count == 0
+    assert dev1_cluster_on_off.request.await_count == 0
+    assert dev1_cluster_color.request.call_count == 1
+    assert dev1_cluster_color.request.await_count == 1
+    assert dev1_cluster_level.request.call_count == 2
+    assert dev1_cluster_level.request.await_count == 2
+
+    # first it comes on with no transition at 2 brightness
+    assert dev1_cluster_level.request.call_args_list[0] == call(
+        False,
+        dev1_cluster_level.commands_by_name["move_to_level_with_on_off"].id,
+        dev1_cluster_level.commands_by_name["move_to_level_with_on_off"].schema,
+        level=2,
+        transition_time=0,
+        expect_reply=True,
+        manufacturer=None,
+        tries=1,
+        tsn=None,
+    )
+    assert dev1_cluster_color.request.call_args == call(
+        False,
+        dev1_cluster_color.commands_by_name["move_to_color_temp"].id,
+        dev1_cluster_color.commands_by_name["move_to_color_temp"].schema,
+        color_temp_mireds=240,
+        transition_time=0,
+        expect_reply=True,
+        manufacturer=None,
+        tries=1,
+        tsn=None,
+    )
+    assert dev1_cluster_level.request.call_args_list[1] == call(
+        False,
+        dev1_cluster_level.commands_by_name["move_to_level"].id,
+        dev1_cluster_level.commands_by_name["move_to_level"].schema,
+        level=254,
+        transition_time=0,
+        expect_reply=True,
+        manufacturer=None,
+        tries=1,
+        tsn=None,
+    )
+
+    light1_state = hass.states.get(device_1_entity_id)
+    assert light1_state.state == STATE_ON
+    assert light1_state.attributes["brightness"] == 254
+    assert light1_state.attributes["color_temp"] == 240
+    assert light1_state.attributes["color_mode"] == ColorMode.COLOR_TEMP
 
 
 async def async_test_on_off_from_light(hass, cluster, entity_id):

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -358,6 +358,7 @@ async def test_color_number(
                 "color_temp_physical_max",
                 "color_capabilities",
                 "start_up_color_temperature",
+                "options",
             ],
             allow_cache=True,
             only_cache=False,


### PR DESCRIPTION
## Proposed change
This implements the ``options`` -> ``ExecuteIfOff`` on the color cluster for supporting Zigbee 3.0 lights.
This option allows the light to receive various color commands while it's still off. It won't turn on when just the color commands are received, but next time it turns on, it'll turn on with the new color.

- it implements both an ``options`` and ``execute_if_off_supported`` property in the color channel
- it implements the following behavior for ``turn_on``:
  - if the user enables ``ExecuteIfOff`` (currently via setting ``options`` from ``0`` to ``1`` through the clusters UI),
  - then the color commands are always sent before the "on" or "move to level with on off" commands
  - otherwise (like before), the color commands are sent after to "on" or "level" commands

The ``transition`` parameter for the various ``move_to_color`` commands is apparently ignored by the light if it's off.
This is why we can simply re-order how the calls are sent (when ``ExecuteIfOff`` is on) without needing to check the HA state for what transition we want to use when.

(@dmulcahey previously implemented a similar behavior on some (now deleted) test branch)

Note: At the moment, this is only supported for single lights. Groups will always default to the old/standard behavior for now. I'll focus on adding group support for "execute if off" in a separate PR.

(The benefit of using that is that transitions to different colors from an off-state are done properly.)

### Previous behavior

The behavior from this PR (disabled by default) is still used for older lights which don't support ``ExecuteIfOff`` (or when it's disabled):
- https://github.com/home-assistant/core/pull/74024

So the behavior only changes if the lights supports ``ExecuteIfOff`` **and** if it's also enabled.
(Enabling it needs to be done via cluster settings right now. I'll likely add a config entity in a separate PR)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
