### PR TITLE
Renovate Ambient PWS config flow tests

### DIFF
--- a/tests/components/ambient_station/conftest.py
+++ b/tests/components/ambient_station/conftest.py
@@ -57,7 +57,7 @@ async def mock_aioambient_fixture(api):
 
 @pytest.fixture(name="mock_get_devices")
 def mock_get_devices_fixture(data_devices):
-    """Define a mock API object."""
+    """Define a mock get_devices method."""
     return AsyncMock(return_value=data_devices)
 
 

--- a/tests/components/ambient_station/conftest.py
+++ b/tests/components/ambient_station/conftest.py
@@ -1,14 +1,19 @@
 """Define test fixtures for Ambient PWS."""
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from homeassistant.components.ambient_station.const import CONF_APP_KEY, DOMAIN
 from homeassistant.const import CONF_API_KEY
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, load_fixture
+
+
+@pytest.fixture(name="api")
+def api_fixture(hass, get_devices):
+    """Define a mock API object."""
+    return Mock(get_devices=get_devices)
 
 
 @pytest.fixture(name="config")
@@ -28,27 +33,37 @@ def config_entry_fixture(hass, config):
     return entry
 
 
-@pytest.fixture(name="devices", scope="package")
-def devices_fixture():
+@pytest.fixture(name="data_devices", scope="package")
+def data_devices_fixture():
     """Define devices data."""
     return json.loads(load_fixture("devices.json", "ambient_station"))
 
 
-@pytest.fixture(name="setup_ambient_station")
-async def setup_ambient_station_fixture(hass, config, devices):
-    """Define a fixture to set up AirVisual."""
-    with patch("homeassistant.components.ambient_station.PLATFORMS", []), patch(
-        "homeassistant.components.ambient_station.config_flow.API.get_devices",
-        side_effect=devices,
-    ), patch("aioambient.api.API.get_devices", side_effect=devices), patch(
-        "aioambient.websocket.Websocket.connect"
-    ):
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
+@pytest.fixture(name="data_station", scope="package")
+def data_station_fixture():
+    """Define station data."""
+    return json.loads(load_fixture("station_data.json", "ambient_station"))
+
+
+@pytest.fixture(name="get_devices")
+def get_devices_fixture(hass, data_devices):
+    """Define a mock API object."""
+    return AsyncMock(return_value=data_devices)
+
+
+@pytest.fixture(name="mock_aioambient")
+async def mock_aioambient_fixture(api):
+    """Define a fixture to patch aioambient."""
+    with patch(
+        "homeassistant.components.ambient_station.config_flow.API",
+        return_value=api,
+    ), patch("aioambient.websocket.Websocket.connect"):
         yield
 
 
-@pytest.fixture(name="station_data", scope="package")
-def station_data_fixture():
-    """Define devices data."""
-    return json.loads(load_fixture("station_data.json", "ambient_station"))
+@pytest.fixture(name="setup_config_entry")
+async def setup_config_entry_fixture(hass, config_entry, mock_aioambient):
+    """Define a fixture to set up ambient_station."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    yield

--- a/tests/components/ambient_station/conftest.py
+++ b/tests/components/ambient_station/conftest.py
@@ -11,9 +11,9 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture(name="api")
-def api_fixture(hass, get_devices):
+def api_fixture(hass, mock_get_devices):
     """Define a mock API object."""
-    return Mock(get_devices=get_devices)
+    return Mock(get_devices=mock_get_devices)
 
 
 @pytest.fixture(name="config")
@@ -45,12 +45,6 @@ def data_station_fixture():
     return json.loads(load_fixture("station_data.json", "ambient_station"))
 
 
-@pytest.fixture(name="get_devices")
-def get_devices_fixture(hass, data_devices):
-    """Define a mock API object."""
-    return AsyncMock(return_value=data_devices)
-
-
 @pytest.fixture(name="mock_aioambient")
 async def mock_aioambient_fixture(api):
     """Define a fixture to patch aioambient."""
@@ -59,6 +53,12 @@ async def mock_aioambient_fixture(api):
         return_value=api,
     ), patch("aioambient.websocket.Websocket.connect"):
         yield
+
+
+@pytest.fixture(name="mock_get_devices")
+def mock_get_devices_fixture(hass, data_devices):
+    """Define a mock API object."""
+    return AsyncMock(return_value=data_devices)
 
 
 @pytest.fixture(name="setup_config_entry")

--- a/tests/components/ambient_station/conftest.py
+++ b/tests/components/ambient_station/conftest.py
@@ -11,9 +11,9 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture(name="api")
-def api_fixture(hass, mock_get_devices):
+def api_fixture(hass, data_devices):
     """Define a mock API object."""
-    return Mock(get_devices=mock_get_devices)
+    return Mock(get_devices=AsyncMock(return_value=data_devices))
 
 
 @pytest.fixture(name="config")
@@ -53,12 +53,6 @@ async def mock_aioambient_fixture(api):
         return_value=api,
     ), patch("aioambient.websocket.Websocket.connect"):
         yield
-
-
-@pytest.fixture(name="mock_get_devices")
-def mock_get_devices_fixture(data_devices):
-    """Define a mock get_devices method."""
-    return AsyncMock(return_value=data_devices)
 
 
 @pytest.fixture(name="setup_config_entry")

--- a/tests/components/ambient_station/conftest.py
+++ b/tests/components/ambient_station/conftest.py
@@ -56,7 +56,7 @@ async def mock_aioambient_fixture(api):
 
 
 @pytest.fixture(name="mock_get_devices")
-def mock_get_devices_fixture(hass, data_devices):
+def mock_get_devices_fixture(data_devices):
     """Define a mock API object."""
     return AsyncMock(return_value=data_devices)
 

--- a/tests/components/ambient_station/test_config_flow.py
+++ b/tests/components/ambient_station/test_config_flow.py
@@ -1,5 +1,5 @@
 """Define tests for the Ambient PWS config flow."""
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aioambient.errors import AmbientError
 import pytest
@@ -10,44 +10,34 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_API_KEY
 
 
-async def test_duplicate_error(hass, config, config_entry, setup_ambient_station):
-    """Test that errors are shown when duplicates are added."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=config
-    )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-
 @pytest.mark.parametrize(
-    "devices,error",
+    "devices_response,errors",
     [
-        (AmbientError, "invalid_key"),
-        (AsyncMock(return_value=[]), "no_devices"),
+        (AsyncMock(side_effect=AmbientError), {"base": "invalid_key"}),
+        (AsyncMock(return_value=[]), {"base": "no_devices"}),
     ],
 )
-async def test_errors(hass, config, devices, error, setup_ambient_station):
-    """Test that various issues show the correct error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=config
-    )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["errors"] == {"base": error}
-
-
-async def test_show_form(hass):
-    """Test that the form is served with no input."""
+async def test_create_entry(
+    hass, api, config, devices_response, errors, mock_aioambient
+):
+    """Test creating an entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
+    # Test errors that can arise:
+    with patch.object(api, "get_devices", devices_response):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=config
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["errors"] == errors
 
-async def test_step_user(hass, config, setup_ambient_station):
-    """Test that the user step works."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=config
+    # Test that we can recover and finish the flow after errors occur:
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=config
     )
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "67890fghij67"
@@ -55,3 +45,12 @@ async def test_step_user(hass, config, setup_ambient_station):
         CONF_API_KEY: "12345abcde12345abcde",
         CONF_APP_KEY: "67890fghij67890fghij",
     }
+
+
+async def test_duplicate_error(hass, config, config_entry, setup_config_entry):
+    """Test that errors are shown when duplicates are added."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=config
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/ambient_station/test_diagnostics.py
+++ b/tests/components/ambient_station/test_diagnostics.py
@@ -6,11 +6,11 @@ from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
 async def test_entry_diagnostics(
-    hass, config_entry, hass_client, setup_ambient_station, station_data
+    hass, config_entry, hass_client, data_station, setup_config_entry
 ):
     """Test config entry diagnostics."""
     ambient = hass.data[DOMAIN][config_entry.entry_id]
-    ambient.stations = station_data
+    ambient.stations = data_station
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {
             "entry_id": config_entry.entry_id,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up the Ambient PWS config flow tests in a few ways:

1. We now set up the config entry directly (vs. indirectly via `async_setup_component`).
2. We ensure all tests finish with either `data_entry_flow.FlowResultType.CREATE_ENTRY` or `data_entry_flow.FlowResultType.ABORT`.
3. We rename some fixtures for maximum clarity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
