### PR TITLE
Fix some typos in ZHA comments

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -99,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if config.get(CONF_ENABLE_QUIRKS, True):
         setup_quirks(config)
 
-    # temporary code to remove the zha storage file from disk. this will be removed in 2022.10.0
+    # temporary code to remove the ZHA storage file from disk. this will be removed in 2022.10.0
     storage_path = hass.config.path(STORAGE_DIR, "zha.storage")
     if os.path.isfile(storage_path):
         _LOGGER.debug("removing ZHA storage file")

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -800,7 +800,7 @@ async def websocket_device_cluster_commands(
 async def websocket_read_zigbee_cluster_attributes(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    """Read zigbee attribute for cluster on zha entity."""
+    """Read zigbee attribute for cluster on ZHA entity."""
     zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     ieee: EUI64 = msg[ATTR_IEEE]
     endpoint_id: int = msg[ATTR_ENDPOINT_ID]
@@ -1318,7 +1318,7 @@ def async_load_api(hass: HomeAssistant) -> None:
     )
 
     async def issue_zigbee_cluster_command(service: ServiceCall) -> None:
-        """Issue command on zigbee cluster on zha entity."""
+        """Issue command on zigbee cluster on ZHA entity."""
         ieee: EUI64 = service.data[ATTR_IEEE]
         endpoint_id: int = service.data[ATTR_ENDPOINT_ID]
         cluster_id: int = service.data[ATTR_CLUSTER_ID]

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -422,7 +422,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle a zha config flow start."""
+        """Handle a ZHA config flow start."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -286,7 +286,7 @@ class BaseZhaFlow(FlowHandler):
     async def async_step_form_new_network(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Form a brand new network."""
+        """Form a brand-new network."""
         await self._radio_mgr.async_form_network()
         return await self._async_create_radio_entry()
 

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -87,7 +87,7 @@ class Channels:
 
     @property
     def zha_device(self) -> ZHADevice:
-        """Return parent zha device."""
+        """Return parent ZHA device."""
         return self._zha_device
 
     @property

--- a/homeassistant/components/zha/core/channels/lightlink.py
+++ b/homeassistant/components/zha/core/channels/lightlink.py
@@ -17,7 +17,7 @@ class LightLink(ZigbeeChannel):
     BIND: bool = False
 
     async def async_configure(self) -> None:
-        """Add Coordinator to LightLink group ."""
+        """Add Coordinator to LightLink group."""
 
         if self._ch_pool.skip_configuration:
             self._status = ChannelStatus.CONFIGURED

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -76,7 +76,7 @@ class IasAce(ZigbeeChannel):
         self.armed_state: AceCluster.PanelStatus = AceCluster.PanelStatus.Panel_Disarmed
         self.invalid_tries: int = 0
 
-        # These will all be setup by the entity from zha configuration
+        # These will all be setup by the entity from ZHA configuration
         self.panel_code: str = "1234"
         self.code_required_arm_actions = False
         self.max_invalid_tries: int = 3

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -129,7 +129,7 @@ class ProbeEndpoint:
 
             self.probe_single_cluster(component, channel, channel_pool)
 
-        # until we can get rid off registries
+        # until we can get rid of registries
         self.handle_on_off_output_cluster_exception(channel_pool)
 
     @staticmethod

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -254,7 +254,7 @@ class GroupProbe:
         )
 
     def cleanup(self) -> None:
-        """Clean up on when zha shuts down."""
+        """Clean up on when ZHA shuts down."""
         for unsub in self._unsubs[:]:
             unsub()
             self._unsubs.remove(unsub)

--- a/homeassistant/components/zha/core/group.py
+++ b/homeassistant/components/zha/core/group.py
@@ -65,7 +65,7 @@ class ZHAGroupMember(LogMixin):
 
     @property
     def device(self) -> ZHADevice:
-        """Return the zha device for this group member."""
+        """Return the ZHA device for this group member."""
         return self._zha_device
 
     @property

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -213,7 +213,7 @@ def async_is_bindable_target(source_zha_device, target_zha_device):
 def async_get_zha_config_value(
     config_entry: ConfigEntry, section: str, config_key: str, default: _T
 ) -> _T:
-    """Get the value for the specified configuration from the zha config entry."""
+    """Get the value for the specified configuration from the ZHA config entry."""
     return (
         config_entry.options.get(CUSTOM_CONFIGURATION, {})
         .get(section, {})

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -151,11 +151,11 @@ class MatchRule:
 
         Most specific matches should be preferred over less specific. Model matching
         rules have a priority over manufacturer matching rules and rules matching a
-        single model/manufacturer get a better priority overrules matching multiple
+        single model/manufacturer get a better priority over rules matching multiple
         models/manufacturers. And any model or manufacturers matching rules get better
-        priority overrules matching only channels.
+        priority over rules matching only channels.
         But in case of a channel name/channel id matching, we give rules matching
-        multiple channels a better priority overrules matching a single channel.
+        multiple channels a better priority over rules matching a single channel.
         """
         weight = 0
         if self.models:

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -151,11 +151,11 @@ class MatchRule:
 
         Most specific matches should be preferred over less specific. Model matching
         rules have a priority over manufacturer matching rules and rules matching a
-        single model/manufacturer get a better priority over rules matching multiple
+        single model/manufacturer get a better priority overrules matching multiple
         models/manufacturers. And any model or manufacturers matching rules get better
-        priority over rules matching only channels.
+        priority overrules matching only channels.
         But in case of a channel name/channel id matching, we give rules matching
-        multiple channels a better priority over rules matching a single channel.
+        multiple channels a better priority overrules matching a single channel.
         """
         weight = 0
         if self.models:
@@ -343,7 +343,7 @@ class ZHAEntityRegistry:
         def decorator(zha_ent: _ZhaEntityT) -> _ZhaEntityT:
             """Register a strict match rule.
 
-            All non empty fields of a match rule must match.
+            All non-empty fields of a match rule must match.
             """
             self._strict_registry[component][rule] = zha_ent
             return zha_ent
@@ -406,7 +406,7 @@ class ZHAEntityRegistry:
         def decorator(zha_entity: _ZhaEntityT) -> _ZhaEntityT:
             """Register a loose match rule.
 
-            All non empty fields of a match rule must match.
+            All non-empty fields of a match rule must match.
             """
             # group the rules by channels
             self._config_diagnostic_entity_registry[component][stop_on_match_group][

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -149,7 +149,7 @@ class MatchRule:
     def weight(self) -> int:
         """Return the weight of the matching rule.
 
-        Most specific matches should be preferred over less specific. Model matching
+        More specific matches should be preferred over less specific. Model matching
         rules have a priority over manufacturer matching rules and rules matching a
         single model/manufacturer get a better priority over rules matching multiple
         models/manufacturers. And any model or manufacturers matching rules get better

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -77,7 +77,7 @@ class BaseZhaEntity(LogMixin, entity.Entity):
 
     @property
     def zha_device(self) -> ZHADevice:
-        """Return the zha device this entity is attached to."""
+        """Return the ZHA device this entity is attached to."""
         return self._zha_device
 
     @property

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -258,7 +258,7 @@ class ZhaGroupEntity(BaseZhaEntity):
         zha_device: ZHADevice,
         **kwargs: Any,
     ) -> None:
-        """Initialize a light group."""
+        """Initialize a ZHA group."""
         super().__init__(unique_id, zha_device, **kwargs)
         self._available = False
         self._group = zha_device.gateway.groups.get(group_id)

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -105,7 +105,7 @@ class BaseFan(FanEntity):
         await self.async_set_percentage(0)
 
     async def async_set_percentage(self, percentage: int) -> None:
-        """Set the speed percenage of the fan."""
+        """Set the speed percentage of the fan."""
         fan_mode = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
         await self._async_set_fan_mode(fan_mode)
 

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -119,7 +119,7 @@ class BaseLight(LogMixin, light.LightEntity):
         super().__init__(*args, **kwargs)
         self._attr_min_mireds: int | None = 153
         self._attr_max_mireds: int | None = 500
-        self._attr_color_mode = ColorMode.UNKNOWN  # Set by sub classes
+        self._attr_color_mode = ColorMode.UNKNOWN  # Set by subclasses
         self._attr_supported_features: int = 0
         self._attr_state: bool | None
         self._off_with_transition: bool = False

--- a/homeassistant/components/zha/logbook.py
+++ b/homeassistant/components/zha/logbook.py
@@ -26,7 +26,7 @@ def async_describe_events(
 
     @callback
     def async_describe_zha_event(event: Event) -> dict[str, str]:
-        """Describe zha logbook event."""
+        """Describe ZHA logbook event."""
         device: dr.DeviceEntry | None = None
         device_name: str = "Unknown device"
         zha_device: ZHADevice | None = None

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -454,7 +454,7 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
 class AqaraMotionDetectionInterval(
     ZHANumberConfigurationEntity, id_suffix="detection_interval"
 ):
-    """Representation of a ZHA on off transition time configuration entity."""
+    """Representation of a ZHA motion detection interval configuration entity."""
 
     _attr_native_min_value: float = 2
     _attr_native_max_value: float = 65535
@@ -577,7 +577,7 @@ class TimerDurationMinutes(ZHANumberConfigurationEntity, id_suffix="timer_durati
 
 @CONFIG_DIAGNOSTIC_MATCH(channel_names="ikea_airpurifier")
 class FilterLifeTime(ZHANumberConfigurationEntity, id_suffix="filter_life_time"):
-    """Representation of a ZHA timer duration configuration entity."""
+    """Representation of a ZHA filter lifetime configuration entity."""
 
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon: str = ICONS[14]

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -210,7 +210,7 @@ class ZhaRadioManager:
         return backup
 
     async def async_form_network(self) -> None:
-        """Form a brand new network."""
+        """Form a brand-new network."""
         async with self._connect_zigpy_app() as app:
             await app.form_network()
 
@@ -273,7 +273,7 @@ class ZhaMultiPANMigrationHelper:
     """Helper class for automatic migration when upgrading the firmware of a radio.
 
     This class is currently only intended to be used when changing the firmware on the
-    radio used in the Home Assistant Sky Connect USB stick and the Home Asssistant Yellow
+    radio used in the Home Assistant Sky Connect USB stick and the Home Assistant Yellow
     from Zigbee only firmware to firmware supporting both Zigbee and Thread.
     """
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -871,7 +871,7 @@ class AqaraPetFeederPortionsDispensed(Sensor, id_suffix="portions_dispensed"):
 
 @MULTI_MATCH(channel_names="opple_cluster", models={"aqara.feeder.acn001"})
 class AqaraPetFeederWeightDispensed(Sensor, id_suffix="weight_dispensed"):
-    """Sensor that displays the weight weight dispensed by the pet feeder."""
+    """Sensor that displays the weight dispensed by the pet feeder."""
 
     SENSOR_ATTR = "weight_dispensed"
     _attr_name: str = "Weight dispensed today"

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -160,7 +160,7 @@ class SwitchGroup(ZhaGroupEntity, SwitchEntity):
         self.async_write_ha_state()
 
     async def async_update(self) -> None:
-        """Query all members and determine the light group state."""
+        """Query all members and determine the switch group state."""
         all_states = [self.hass.states.get(x) for x in self._entity_ids]
         states: list[State] = list(filter(None, all_states))
         on_states = [state for state in states if state.state == STATE_ON]

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -179,7 +179,7 @@ def async_find_group_entity_id(hass, domain, group):
 
 
 async def async_enable_traffic(hass, zha_devices, enabled=True):
-    """Allow traffic to flow through the gateway and the zha device."""
+    """Allow traffic to flow through the gateway and the ZHA device."""
     for zha_device in zha_devices:
         zha_device.update_available(enabled)
     await hass.async_block_till_done()

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -228,7 +228,7 @@ def zha_device_joined_restored(request):
 
 @pytest.fixture
 def zha_device_mock(hass, zigpy_device_mock):
-    """Return a zha Device factory."""
+    """Return a ZHA Device factory."""
 
     def _zha_device(
         endpoints=None,

--- a/tests/components/zha/test_alarm_control_panel.py
+++ b/tests/components/zha/test_alarm_control_panel.py
@@ -1,4 +1,4 @@
-"""Test zha alarm control panel."""
+"""Test ZHA alarm control panel."""
 from unittest.mock import AsyncMock, call, patch, sentinel
 
 import pytest
@@ -58,7 +58,7 @@ def zigpy_device(zigpy_device_mock):
     new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )
 async def test_alarm_control_panel(hass, zha_device_joined_restored, zigpy_device):
-    """Test zha alarm control panel platform."""
+    """Test ZHA alarm control panel platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device)
     cluster = zigpy_device.endpoints.get(1).ias_ace

--- a/tests/components/zha/test_alarm_control_panel.py
+++ b/tests/components/zha/test_alarm_control_panel.py
@@ -24,7 +24,7 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 @pytest.fixture(autouse=True)
 def alarm_control_panel_platform_only():
-    """Only setup the alarm_control_panel and required base platforms to speed up tests."""
+    """Only set up the alarm_control_panel and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -60,7 +60,7 @@ IEEE_GROUPABLE_DEVICE = "01:2d:6f:00:0a:90:69:e8"
 
 @pytest.fixture(autouse=True)
 def required_platform_only():
-    """Only setup the required and required base platforms to speed up tests."""
+    """Only set up the required and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -138,7 +138,7 @@ async def device_groupable(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def zha_client(hass, hass_ws_client, device_switch, device_groupable):
-    """Get zha websocket client."""
+    """Get ZHA WebSocket client."""
 
     # load the ZHA API
     async_load_api(hass)

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -138,7 +138,7 @@ async def device_groupable(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def zha_client(hass, hass_ws_client, device_switch, device_groupable):
-    """Test zha switch platform."""
+    """Get zha websocket client."""
 
     # load the ZHA API
     async_load_api(hass)

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -75,7 +75,7 @@ def required_platform_only():
 
 @pytest.fixture
 async def device_switch(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha switch platform."""
+    """Test ZHA switch platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -114,7 +114,7 @@ async def device_ias_ace(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_groupable(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -216,7 +216,7 @@ async def test_device_cluster_commands(zha_client):
 
 
 async def test_list_devices(zha_client):
-    """Test getting zha devices."""
+    """Test getting ZHA devices."""
     await zha_client.send_json({ID: 5, TYPE: "zha/devices"})
 
     msg = await zha_client.receive_json()
@@ -249,7 +249,7 @@ async def test_list_devices(zha_client):
 
 
 async def test_get_zha_config(zha_client):
-    """Test getting zha custom configuration."""
+    """Test getting ZHA custom configuration."""
     await zha_client.send_json({ID: 5, TYPE: "zha/configuration"})
 
     msg = await zha_client.receive_json()
@@ -259,7 +259,7 @@ async def test_get_zha_config(zha_client):
 
 
 async def test_get_zha_config_with_alarm(hass, zha_client, device_ias_ace):
-    """Test getting zha custom configuration."""
+    """Test getting ZHA custom configuration."""
     await zha_client.send_json({ID: 5, TYPE: "zha/configuration"})
 
     msg = await zha_client.receive_json()
@@ -279,7 +279,7 @@ async def test_get_zha_config_with_alarm(hass, zha_client, device_ias_ace):
 
 
 async def test_update_zha_config(zha_client, zigpy_app_controller):
-    """Test updating zha custom configuration."""
+    """Test updating ZHA custom configuration."""
 
     configuration = deepcopy(CONFIG_WITH_ALARM_OPTIONS)
     configuration["data"]["zha_options"]["default_light_transition"] = 10
@@ -313,7 +313,7 @@ async def test_device_not_found(zha_client):
 
 
 async def test_list_groups(zha_client):
-    """Test getting zha zigbee groups."""
+    """Test getting ZHA zigbee groups."""
     await zha_client.send_json({ID: 7, TYPE: "zha/groups"})
 
     msg = await zha_client.receive_json()
@@ -330,7 +330,7 @@ async def test_list_groups(zha_client):
 
 
 async def test_get_group(zha_client):
-    """Test getting a specific zha zigbee group."""
+    """Test getting a specific ZHA zigbee group."""
     await zha_client.send_json({ID: 8, TYPE: "zha/group", GROUP_ID: FIXTURE_GRP_ID})
 
     msg = await zha_client.receive_json()
@@ -357,7 +357,7 @@ async def test_get_group_not_found(zha_client):
 
 
 async def test_list_groupable_devices(zha_client, device_groupable):
-    """Test getting zha devices that have a group cluster."""
+    """Test getting ZHA devices that have a group cluster."""
 
     await zha_client.send_json({ID: 10, TYPE: "zha/devices/groupable"})
 
@@ -400,7 +400,7 @@ async def test_list_groupable_devices(zha_client, device_groupable):
 
 
 async def test_add_group(zha_client):
-    """Test adding and getting a new zha zigbee group."""
+    """Test adding and getting a new ZHA zigbee group."""
     await zha_client.send_json({ID: 12, TYPE: "zha/group/add", GROUP_NAME: "new_group"})
 
     msg = await zha_client.receive_json()
@@ -426,7 +426,7 @@ async def test_add_group(zha_client):
 
 
 async def test_remove_group(zha_client):
-    """Test removing a new zha zigbee group."""
+    """Test removing a new ZHA zigbee group."""
 
     await zha_client.send_json({ID: 14, TYPE: "zha/groups"})
 

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -1,4 +1,4 @@
-"""Test zha binary sensor."""
+"""Test ZHA binary sensor."""
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -38,7 +38,7 @@ DEVICE_OCCUPANCY = {
 
 @pytest.fixture(autouse=True)
 def binary_sensor_platform_only():
-    """Only setup the binary_sensor and required base platforms to speed up tests."""
+    """Only set up the binary_sensor and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -121,7 +121,7 @@ async def tuya_water_valve(hass, zigpy_device_mock, zha_device_joined_restored):
 
 @freeze_time("2021-11-04 17:37:00", tz_offset=-1)
 async def test_button(hass, contact_sensor):
-    """Test zha button platform."""
+    """Test ZHA button platform."""
 
     entity_registry = er.async_get(hass)
     zha_device, cluster = contact_sensor
@@ -161,7 +161,7 @@ async def test_button(hass, contact_sensor):
 
 
 async def test_frost_unlock(hass, tuya_water_valve):
-    """Test custom frost unlock zha button."""
+    """Test custom frost unlock ZHA button."""
 
     entity_registry = er.async_get(hass)
     zha_device, cluster = tuya_water_valve

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -38,7 +38,7 @@ from tests.common import mock_coro
 
 @pytest.fixture(autouse=True)
 def button_platform_only():
-    """Only setup the button and required base platforms to speed up tests."""
+    """Only set up the button and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -173,7 +173,7 @@ ZCL_ATTR_PLUG = {
 
 @pytest.fixture(autouse=True)
 def climate_platform_only():
-    """Only setup the climate and required base platforms to speed up tests."""
+    """Only set up the climate and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -1,4 +1,4 @@
-"""Test zha climate."""
+"""Test ZHA climate."""
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -41,7 +41,7 @@ from tests.common import async_capture_events, mock_coro, mock_restore_cache
 
 @pytest.fixture(autouse=True)
 def cover_platform_only():
-    """Only setup the cover and required base platforms to speed up tests."""
+    """Only set up the cover and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -1,4 +1,4 @@
-"""Test zha cover."""
+"""Test ZHA cover."""
 import asyncio
 from unittest.mock import AsyncMock, patch
 
@@ -121,7 +121,7 @@ def zigpy_keen_vent(zigpy_device_mock):
 
 
 async def test_cover(hass, zha_device_joined_restored, zigpy_cover_device):
-    """Test zha cover platform."""
+    """Test ZHA cover platform."""
 
     # load up cover domain
     cluster = zigpy_cover_device.endpoints.get(1).window_covering
@@ -212,7 +212,7 @@ async def test_cover(hass, zha_device_joined_restored, zigpy_cover_device):
 
 
 async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
-    """Test zha cover platform for shade device type."""
+    """Test ZHA cover platform for shade device type."""
 
     # load up cover domain
     zha_device = await zha_device_joined_restored(zigpy_shade_device)
@@ -418,7 +418,7 @@ async def test_keen_vent(hass, zha_device_joined_restored, zigpy_keen_vent):
 
 
 async def test_cover_remote(hass, zha_device_joined_restored, zigpy_cover_remote):
-    """Test zha cover remote."""
+    """Test ZHA cover remote."""
 
     # load up cover domain
     await zha_device_joined_restored(zigpy_cover_remote)

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -197,7 +197,7 @@ async def test_check_available_unsuccessful(
         time.time() - zha_device.consider_unavailable_time - 2
     )
 
-    # unsuccessfuly ping zigpy device, but zha_device is still available
+    # unsuccessfully ping zigpy device, but zha_device is still available
     _send_time_changed(hass, 91)
     await hass.async_block_till_done()
     assert basic_ch.read_attributes.await_count == 1

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -1,4 +1,4 @@
-"""Test zha device switch."""
+"""Test ZHA device switch."""
 from datetime import timedelta
 import time
 from unittest import mock
@@ -86,13 +86,13 @@ def zigpy_device_mains(zigpy_device_mock):
 
 @pytest.fixture
 def device_with_basic_channel(zigpy_device_mains):
-    """Return a zha device with a basic channel present."""
+    """Return a ZHA device with a basic channel present."""
     return zigpy_device_mains(with_basic_channel=True)
 
 
 @pytest.fixture
 def device_without_basic_channel(zigpy_device):
-    """Return a zha device with a basic channel present."""
+    """Return a ZHA device with a basic channel present."""
     return zigpy_device(with_basic_channel=False)
 
 

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -26,7 +26,7 @@ from tests.common import async_fire_time_changed
 
 @pytest.fixture(autouse=True)
 def required_platforms_only():
-    """Only setup the required platform and required base platforms to speed up tests."""
+    """Only set up the required platform and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -1,4 +1,4 @@
-"""The test for zha device automation actions."""
+"""The test for ZHA device automation actions."""
 from unittest.mock import call, patch
 
 import pytest
@@ -102,7 +102,7 @@ async def device_inovelli(hass, zigpy_device_mock, zha_device_joined):
 
 
 async def test_get_actions(hass, device_ias):
-    """Test we get the expected actions from a zha device."""
+    """Test we get the expected actions from a ZHA device."""
 
     ieee_address = str(device_ias[0].ieee)
 
@@ -155,7 +155,7 @@ async def test_get_actions(hass, device_ias):
 
 
 async def test_get_inovelli_actions(hass, device_inovelli):
-    """Test we get the expected actions from a zha device."""
+    """Test we get the expected actions from a ZHA device."""
 
     inovelli_ieee_address = str(device_inovelli[0].ieee)
     ha_device_registry = dr.async_get(hass)
@@ -235,7 +235,7 @@ async def test_get_inovelli_actions(hass, device_inovelli):
 
 
 async def test_action(hass, device_ias, device_inovelli):
-    """Test for executing a zha device action."""
+    """Test for executing a ZHA device action."""
     zigpy_device, zha_device = device_ias
     inovelli_zigpy_device, inovelli_zha_device = device_inovelli
 

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -32,7 +32,7 @@ COMMAND_SINGLE = "single"
 
 @pytest.fixture(autouse=True)
 def required_platforms_only():
-    """Only setup the required platforms and required base platforms to speed up tests."""
+    """Only set up the required platforms and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -63,7 +63,7 @@ def zigpy_device_dt(zigpy_device_mock):
 
 
 async def test_device_tracker(hass, zha_device_joined_restored, zigpy_device_dt):
-    """Test zha device tracker platform."""
+    """Test ZHA device tracker platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device_dt)
     cluster = zigpy_device_dt.endpoints.get(1).power

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -27,7 +27,7 @@ from tests.common import async_fire_time_changed
 
 @pytest.fixture(autouse=True)
 def device_tracker_platforms_only():
-    """Only setup the device_tracker platforms and required base platforms to speed up tests."""
+    """Only set up the device_tracker platforms and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -40,7 +40,7 @@ LONG_RELEASE = "remote_button_long_release"
 
 @pytest.fixture(autouse=True)
 def sensor_platforms_only():
-    """Only setup the sensor platform and required base platforms to speed up tests."""
+    """Only set up the sensor platform and required base platforms to speed up tests."""
     with patch("homeassistant.components.zha.PLATFORMS", (Platform.SENSOR,)):
         yield
 

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -83,7 +83,7 @@ async def mock_devices(hass, zigpy_device_mock, zha_device_joined_restored):
 
 
 async def test_triggers(hass, mock_devices):
-    """Test zha device triggers."""
+    """Test ZHA device triggers."""
 
     zigpy_device, zha_device = mock_devices
 
@@ -158,7 +158,7 @@ async def test_triggers(hass, mock_devices):
 
 
 async def test_no_triggers(hass, mock_devices):
-    """Test zha device with no triggers."""
+    """Test ZHA device with no triggers."""
 
     _, zha_device = mock_devices
     ieee_address = str(zha_device.ieee)

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -31,7 +31,7 @@ CONFIG_ENTRY_DIAGNOSTICS_KEYS = [
 
 @pytest.fixture(autouse=True)
 def required_platforms_only():
-    """Only setup the required platform and required base platforms to speed up tests."""
+    """Only set up the required platform and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS", (Platform.ALARM_CONTROL_PANEL,)
     ):

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -1,4 +1,4 @@
-"""Test zha device discovery."""
+"""Test ZHA device discovery."""
 
 import re
 from unittest import mock
@@ -480,7 +480,7 @@ async def test_device_override(
 async def test_group_probe_cleanup_called(
     hass_disable_services, setup_zha, config_entry
 ):
-    """Test cleanup happens when zha is unloaded."""
+    """Test cleanup happens when ZHA is unloaded."""
     await setup_zha()
     disc.GROUP_PROBE.cleanup = mock.Mock(wraps=disc.GROUP_PROBE.cleanup)
     await config_entry.async_unload(hass_disable_services)

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -52,7 +52,7 @@ IEEE_GROUPABLE_DEVICE2 = "02:2d:6f:00:0a:90:69:e8"
 
 @pytest.fixture(autouse=True)
 def fan_platform_only():
-    """Only setup the fan and required base platforms to speed up tests."""
+    """Only set up the fan and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -1,4 +1,4 @@
-"""Test zha fan."""
+"""Test ZHA fan."""
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
@@ -88,7 +88,7 @@ def zigpy_device(zigpy_device_mock):
 
 @pytest.fixture
 async def coordinator(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha fan platform."""
+    """Test ZHA fan platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -110,7 +110,7 @@ async def coordinator(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_fan_1(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha fan platform."""
+    """Test ZHA fan platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -135,7 +135,7 @@ async def device_fan_1(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_fan_2(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha fan platform."""
+    """Test ZHA fan platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -160,7 +160,7 @@ async def device_fan_2(hass, zigpy_device_mock, zha_device_joined):
 
 
 async def test_fan(hass, zha_device_joined_restored, zigpy_device):
-    """Test zha fan platform."""
+    """Test ZHA fan platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device)
     cluster = zigpy_device.endpoints.get(1).fan
@@ -460,7 +460,7 @@ async def test_fan_init(
     expected_state,
     expected_percentage,
 ):
-    """Test zha fan platform."""
+    """Test ZHA fan platform."""
 
     cluster = zigpy_device.endpoints.get(1).fan
     cluster.PLUGGED_ATTR_READS = plug_read
@@ -478,7 +478,7 @@ async def test_fan_update_entity(
     zha_device_joined_restored,
     zigpy_device,
 ):
-    """Test zha fan platform."""
+    """Test ZHA fan platform."""
 
     cluster = zigpy_device.endpoints.get(1).fan
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 0}
@@ -548,7 +548,7 @@ def zigpy_device_ikea(zigpy_device_mock):
 
 
 async def test_fan_ikea(hass, zha_device_joined_restored, zigpy_device_ikea):
-    """Test zha fan Ikea platform."""
+    """Test ZHA fan Ikea platform."""
     zha_device = await zha_device_joined_restored(zigpy_device_ikea)
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
     entity_id = await find_entity_id(Platform.FAN, zha_device, hass)
@@ -635,7 +635,7 @@ async def test_fan_ikea_init(
     ikea_expected_percentage,
     ikea_preset_mode,
 ):
-    """Test zha fan platform."""
+    """Test ZHA fan platform."""
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
     cluster.PLUGGED_ATTR_READS = ikea_plug_read
 
@@ -655,7 +655,7 @@ async def test_fan_ikea_update_entity(
     zha_device_joined_restored,
     zigpy_device_ikea,
 ):
-    """Test zha fan platform."""
+    """Test ZHA fan platform."""
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 0}
 

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -58,7 +58,7 @@ async def zha_dev_basic(hass, zha_device_restored, zigpy_dev_basic):
 
 @pytest.fixture
 async def coordinator(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -80,7 +80,7 @@ async def coordinator(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_light_1(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -105,7 +105,7 @@ async def device_light_1(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_light_2(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     zigpy_device = zigpy_device_mock(
         {

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -34,7 +34,7 @@ def zigpy_dev_basic(zigpy_device_mock):
 
 @pytest.fixture(autouse=True)
 def required_platform_only():
-    """Only setup the required and required base platforms to speed up tests."""
+    """Only set up the required and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @pytest.fixture(autouse=True)
 def light_platform_only():
-    """Only setup the light and required base platforms to speed up tests."""
+    """Only set up the light and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -1,4 +1,4 @@
-"""Test zha light."""
+"""Test ZHA light."""
 from datetime import timedelta
 from unittest.mock import AsyncMock, call, patch, sentinel
 
@@ -104,7 +104,7 @@ def light_platform_only():
 
 @pytest.fixture
 async def coordinator(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -126,7 +126,7 @@ async def coordinator(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_light_1(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -158,7 +158,7 @@ async def device_light_1(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_light_2(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -191,7 +191,7 @@ async def device_light_2(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_light_3(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -252,7 +252,7 @@ async def eWeLink_light(hass, zigpy_device_mock, zha_device_joined):
 
 
 async def test_light_refresh(hass, zigpy_device_mock, zha_device_joined_restored):
-    """Test zha light platform refresh."""
+    """Test ZHA light platform refresh."""
 
     # create zigpy devices
     zigpy_device = zigpy_device_mock(LIGHT_ON_OFF)
@@ -312,7 +312,7 @@ async def test_light_refresh(hass, zigpy_device_mock, zha_device_joined_restored
 async def test_light(
     hass, zigpy_device_mock, zha_device_joined_restored, device, reporting
 ):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     # create zigpy devices
     zigpy_device = zigpy_device_mock(device)
@@ -427,7 +427,7 @@ async def test_light_initialization(
     config_override,
     expected_state,
 ):
-    """Test zha light initialization with cached attributes and color modes."""
+    """Test ZHA light initialization with cached attributes and color modes."""
 
     # create zigpy devices
     zigpy_device = zigpy_device_mock(LIGHT_COLOR)

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -86,7 +86,7 @@ LIGHT_COLOR = {
 
 @pytest.fixture(autouse=True)
 def light_platform_only():
-    """Only setup the light and required base platforms to speed up tests."""
+    """Only set up the light and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -1,4 +1,4 @@
-"""Test zha lock."""
+"""Test ZHA lock."""
 from unittest.mock import patch
 
 import pytest
@@ -60,7 +60,7 @@ async def lock(hass, zigpy_device_mock, zha_device_joined_restored):
 
 
 async def test_lock(hass, lock):
-    """Test zha lock platform."""
+    """Test ZHA lock platform."""
 
     zha_device, cluster = lock
     entity_id = await find_entity_id(Platform.LOCK, zha_device, hass)

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -29,7 +29,7 @@ SET_USER_STATUS = 9
 
 @pytest.fixture(autouse=True)
 def lock_platform_only():
-    """Only setup the lock and required base platforms to speed up tests."""
+    """Only set up the lock and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -33,7 +33,7 @@ DOWN = "down"
 
 @pytest.fixture(autouse=True)
 def sensor_platform_only():
-    """Only setup the sensor and required base platforms to speed up tests."""
+    """Only set up the sensor and required base platforms to speed up tests."""
     with patch("homeassistant.components.zha.PLATFORMS", (Platform.SENSOR,)):
         yield
 

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -60,7 +60,7 @@ async def mock_devices(hass, zigpy_device_mock, zha_device_joined):
 
 
 async def test_zha_logbook_event_device_with_triggers(hass, mock_devices):
-    """Test zha logbook events with device and triggers."""
+    """Test ZHA logbook events with device and triggers."""
 
     zigpy_device, zha_device = mock_devices
 
@@ -145,7 +145,7 @@ async def test_zha_logbook_event_device_with_triggers(hass, mock_devices):
 
 
 async def test_zha_logbook_event_device_no_triggers(hass, mock_devices):
-    """Test zha logbook events with device and without triggers."""
+    """Test ZHA logbook events with device and without triggers."""
 
     zigpy_device, zha_device = mock_devices
     ieee_address = str(zha_device.ieee)
@@ -232,7 +232,7 @@ async def test_zha_logbook_event_device_no_triggers(hass, mock_devices):
 
 
 async def test_zha_logbook_event_device_no_device(hass, mock_devices):
-    """Test zha logbook events without device and without triggers."""
+    """Test ZHA logbook events without device and without triggers."""
 
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -1,4 +1,4 @@
-"""Test zha analog output."""
+"""Test ZHA analog output."""
 from unittest.mock import call, patch
 
 import pytest
@@ -83,7 +83,7 @@ async def light(zigpy_device_mock):
 
 
 async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_device):
-    """Test zha number platform."""
+    """Test ZHA number platform."""
 
     cluster = zigpy_analog_output_device.endpoints.get(1).analog_output
     cluster.PLUGGED_ATTR_READS = {
@@ -200,7 +200,7 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
 async def test_level_control_number(
     hass, light, zha_device_joined, attr, initial_value, new_value
 ):
-    """Test zha level control number entities - new join."""
+    """Test ZHA level control number entities - new join."""
 
     entity_registry = er.async_get(hass)
     level_control_cluster = light.endpoints[1].level
@@ -333,7 +333,7 @@ async def test_level_control_number(
 async def test_color_number(
     hass, light, zha_device_joined, attr, initial_value, new_value
 ):
-    """Test zha color number entities - new join."""
+    """Test ZHA color number entities - new join."""
 
     entity_registry = er.async_get(hass)
     color_cluster = light.endpoints[1].light_color

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -28,7 +28,7 @@ from tests.common import mock_coro
 
 @pytest.fixture(autouse=True)
 def number_platform_only():
-    """Only setup the number and required base platforms to speed up tests."""
+    """Only set up the number and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -105,7 +105,7 @@ async def test_migrate_matching_port(
     mock_connect_zigpy_app,
 ) -> None:
     """Test automatic migration."""
-    # Setup the config entry
+    # Set up the config entry
     config_entry = MockConfigEntry(
         data={"device": {"path": "/dev/ttyTEST123"}, "radio_type": "ezsp"},
         domain=DOMAIN,
@@ -165,7 +165,7 @@ async def test_migrate_matching_port_usb(
     mock_connect_zigpy_app,
 ) -> None:
     """Test automatic migration."""
-    # Setup the config entry
+    # Set up the config entry
     config_entry = MockConfigEntry(
         data={"device": {"path": "/dev/ttyTEST123"}, "radio_type": "ezsp"},
         domain=DOMAIN,
@@ -212,7 +212,7 @@ async def test_migrate_matching_port_config_entry_not_loaded(
     mock_connect_zigpy_app,
 ) -> None:
     """Test automatic migration."""
-    # Setup the config entry
+    # Set up the config entry
     config_entry = MockConfigEntry(
         data={"device": {"path": "/dev/ttyTEST123"}, "radio_type": "ezsp"},
         domain=DOMAIN,
@@ -272,7 +272,7 @@ async def test_migrate_matching_port_retry(
     mock_connect_zigpy_app,
 ) -> None:
     """Test automatic migration."""
-    # Setup the config entry
+    # Set up the config entry
     config_entry = MockConfigEntry(
         data={"device": {"path": "/dev/ttyTEST123"}, "radio_type": "ezsp"},
         domain=DOMAIN,
@@ -329,7 +329,7 @@ async def test_migrate_non_matching_port(
     mock_connect_zigpy_app,
 ) -> None:
     """Test automatic migration."""
-    # Setup the config entry
+    # Set up the config entry
     config_entry = MockConfigEntry(
         data={"device": {"path": "/dev/ttyTEST123"}, "radio_type": "ezsp"},
         domain=DOMAIN,

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -109,7 +109,7 @@ def core_rs(hass_storage):
 
 
 async def test_select(hass, siren):
-    """Test zha select platform."""
+    """Test ZHA select platform."""
 
     entity_registry = er.async_get(hass)
     zha_device, cluster = siren
@@ -161,7 +161,7 @@ async def test_select_restore_state(
     core_rs,
     zha_device_restored,
 ):
-    """Test zha select entity restore state."""
+    """Test ZHA select entity restore state."""
 
     entity_id = "select.fakemanufacturer_fakemodel_default_siren_tone"
     core_rs(entity_id, state="Burglar")
@@ -194,7 +194,7 @@ async def test_select_restore_state(
 
 
 async def test_on_off_select_new_join(hass, light, zha_device_joined):
-    """Test zha on off select - new join."""
+    """Test ZHA on off select - new join."""
 
     entity_registry = er.async_get(hass)
     on_off_cluster = light.endpoints[1].on_off
@@ -253,7 +253,7 @@ async def test_on_off_select_new_join(hass, light, zha_device_joined):
 
 
 async def test_on_off_select_restored(hass, light, zha_device_restored):
-    """Test zha on off select - restored."""
+    """Test ZHA on off select - restored."""
 
     entity_registry = er.async_get(hass)
     on_off_cluster = light.endpoints[1].on_off
@@ -305,7 +305,7 @@ async def test_on_off_select_restored(hass, light, zha_device_restored):
 
 
 async def test_on_off_select_unsupported(hass, light, zha_device_joined_restored):
-    """Test zha on off select unsupported."""
+    """Test ZHA on off select unsupported."""
 
     on_off_cluster = light.endpoints[1].on_off
     on_off_cluster.add_unsupported_attribute("start_up_on_off")

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -19,7 +19,7 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 
 @pytest.fixture(autouse=True)
 def select_select_only():
-    """Only setup the select and required base platforms to speed up tests."""
+    """Only set up the select and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -53,7 +53,7 @@ ENTITY_ID_PREFIX = "sensor.fakemanufacturer_fakemodel_{}"
 
 @pytest.fixture(autouse=True)
 def sensor_platform_only():
-    """Only setup the sensor and required base platforms to speed up tests."""
+    """Only set up the sensor and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -1,4 +1,4 @@
-"""Test zha sensor."""
+"""Test ZHA sensor."""
 import math
 from unittest.mock import patch
 
@@ -414,7 +414,7 @@ async def test_sensor(
     read_plug,
     unsupported_attrs,
 ):
-    """Test zha sensor platform."""
+    """Test ZHA sensor platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -533,7 +533,7 @@ async def test_temp_uom(
     zigpy_device_mock,
     zha_device_restored,
 ):
-    """Test zha temperature sensor unit of measurement."""
+    """Test ZHA temperature sensor unit of measurement."""
 
     entity_id = "sensor.fake1026_fakemodel1026_004f3202_temperature"
     if restore:
@@ -717,7 +717,7 @@ async def test_unsupported_attributes_sensor(
     entity_ids,
     missing_entity_ids,
 ):
-    """Test zha sensor platform."""
+    """Test ZHA sensor platform."""
 
     entity_ids = {ENTITY_ID_PREFIX.format(e) for e in entity_ids}
     missing_entity_ids = {ENTITY_ID_PREFIX.format(e) for e in missing_entity_ids}
@@ -832,7 +832,7 @@ async def test_se_summation_uom(
     expected_state,
     expected_uom,
 ):
-    """Test zha smart energy summation."""
+    """Test ZHA smart energy summation."""
 
     entity_id = ENTITY_ID_PREFIX.format("summation_delivered")
     zigpy_device = zigpy_device_mock(
@@ -886,7 +886,7 @@ async def test_elec_measurement_sensor_type(
     expected_type,
     zha_device_joined,
 ):
-    """Test zha electrical measurement sensor type."""
+    """Test ZHA electrical measurement sensor type."""
 
     entity_id = ENTITY_ID_PREFIX.format("active_power")
     zigpy_dev = elec_measurement_zigpy_dev
@@ -935,7 +935,7 @@ async def test_elec_measurement_skip_unsupported_attribute(
     elec_measurement_zha_dev,
     supported_attributes,
 ):
-    """Test zha electrical measurement skipping update of unsupported attributes."""
+    """Test ZHA electrical measurement skipping update of unsupported attributes."""
 
     entity_id = ENTITY_ID_PREFIX.format("active_power")
     zha_dev = elec_measurement_zha_dev

--- a/tests/components/zha/test_siren.py
+++ b/tests/components/zha/test_siren.py
@@ -30,7 +30,7 @@ from tests.common import async_fire_time_changed, mock_coro
 
 @pytest.fixture(autouse=True)
 def siren_platform_only():
-    """Only setup the siren and required base platforms to speed up tests."""
+    """Only set up the siren and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -297,14 +297,14 @@ async def test_zha_group_switch_entity(
     await async_enable_traffic(hass, [device_switch_1, device_switch_2], enabled=False)
     await async_wait_for_updates(hass)
 
-    # test that the lights were created and that they are off
+    # test that the switches were created and that they are off
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # allow traffic to flow through the gateway and device
     await async_enable_traffic(hass, [device_switch_1, device_switch_2])
     await async_wait_for_updates(hass)
 
-    # test that the lights were created and are off
+    # test that the switches were created and are off
     assert hass.states.get(entity_id).state == STATE_OFF
 
     # turn on from HA
@@ -354,25 +354,25 @@ async def test_zha_group_switch_entity(
     await send_attributes_report(hass, dev2_cluster_on_off, {0: 1})
     await async_wait_for_updates(hass)
 
-    # test that group light is on
+    # test that group switch is on
     assert hass.states.get(entity_id).state == STATE_ON
 
     await send_attributes_report(hass, dev1_cluster_on_off, {0: 0})
     await async_wait_for_updates(hass)
 
-    # test that group light is still on
+    # test that group switch is still on
     assert hass.states.get(entity_id).state == STATE_ON
 
     await send_attributes_report(hass, dev2_cluster_on_off, {0: 0})
     await async_wait_for_updates(hass)
 
-    # test that group light is now off
+    # test that group switch is now off
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await send_attributes_report(hass, dev1_cluster_on_off, {0: 1})
     await async_wait_for_updates(hass)
 
-    # test that group light is now back on
+    # test that group switch is now back on
     assert hass.states.get(entity_id).state == STATE_ON
 
 

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -1,4 +1,4 @@
-"""Test zha switch."""
+"""Test ZHA switch."""
 from unittest.mock import call, patch
 
 import pytest
@@ -71,7 +71,7 @@ def zigpy_device(zigpy_device_mock):
 
 @pytest.fixture
 async def coordinator(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha light platform."""
+    """Test ZHA light platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -92,7 +92,7 @@ async def coordinator(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_switch_1(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha switch platform."""
+    """Test ZHA switch platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -112,7 +112,7 @@ async def device_switch_1(hass, zigpy_device_mock, zha_device_joined):
 
 @pytest.fixture
 async def device_switch_2(hass, zigpy_device_mock, zha_device_joined):
-    """Test zha switch platform."""
+    """Test ZHA switch platform."""
 
     zigpy_device = zigpy_device_mock(
         {
@@ -131,7 +131,7 @@ async def device_switch_2(hass, zigpy_device_mock, zha_device_joined):
 
 
 async def test_switch(hass, zha_device_joined_restored, zigpy_device):
-    """Test zha switch platform."""
+    """Test ZHA switch platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device)
     cluster = zigpy_device.endpoints.get(1).on_off
@@ -377,7 +377,7 @@ async def test_zha_group_switch_entity(
 
 
 async def test_switch_configurable(hass, zha_device_joined_restored, zigpy_device_tuya):
-    """Test zha configurable switch platform."""
+    """Test ZHA configurable switch platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device_tuya)
     cluster = zigpy_device_tuya.endpoints.get(1).tuya_manufacturer

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -43,7 +43,7 @@ IEEE_GROUPABLE_DEVICE2 = "02:2d:6f:00:0a:90:69:e8"
 
 @pytest.fixture(autouse=True)
 def switch_platform_only():
-    """Only setup the switch and required base platforms to speed up tests."""
+    """Only set up the switch and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
         (


### PR DESCRIPTION
## Proposed change
This just fixes a couple of small typos/copy paste errors in ZHA comments.
(Regarding "setup" vs "set up": https://github.com/home-assistant/core/pull/83774)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] ~~Code~~ quality improvements to existing ~~code~~ comments or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
