### PR TITLE
Move add Device tracker entities to UniFi controller

### DIFF
--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -206,7 +206,7 @@ class UniFiController:
                 """Create UniFi entity."""
                 if not description.allowed_fn(
                     self, obj_id
-                ) or not description.supported_fn(self.api, obj_id):
+                ) or not description.supported_fn(self, obj_id):
                     return
 
                 entity = unifi_platform_entity(obj_id, self, description)

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -136,6 +136,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up device tracker for UniFi Network integration."""
     controller: UniFiController = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+    controller.register_platform_add_entities(
+        UnifiScannerEntity, ENTITY_DESCRIPTIONS, async_add_entities
+    )
+
     controller.entities[DOMAIN] = {CLIENT_TRACKER: set(), DEVICE_TRACKER: set()}
 
     @callback
@@ -152,35 +156,6 @@ async def async_setup_entry(
         )
 
     items_added()
-
-    @callback
-    def async_load_entities(description: UnifiEntityDescription) -> None:
-        """Load and subscribe to UniFi devices."""
-        entities: list[ScannerEntity] = []
-        api_handler = description.api_handler_fn(controller.api)
-
-        @callback
-        def async_create_entity(event: ItemEvent, obj_id: str) -> None:
-            """Create UniFi entity."""
-            if not description.allowed_fn(
-                controller, obj_id
-            ) or not description.supported_fn(controller.api, obj_id):
-                return
-
-            entity = UnifiScannerEntity(obj_id, controller, description)
-            if event == ItemEvent.ADDED:
-                async_add_entities([entity])
-                return
-            entities.append(entity)
-
-        for obj_id in api_handler:
-            async_create_entity(ItemEvent.CHANGED, obj_id)
-        async_add_entities(entities)
-
-        api_handler.subscribe(async_create_entity, ItemEvent.ADDED)
-
-    for description in ENTITY_DESCRIPTIONS:
-        async_load_entities(description)
 
 
 @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Centralise creation of entities based on UnifiEntity to the controller.
Next step can then be to allow creating entities when enabled through config options which currently doesn't work during the rewrite.

Related PRs
- https://github.com/home-assistant/core/pull/84262
- https://github.com/home-assistant/core/pull/84458
- https://github.com/home-assistant/core/pull/84786
- https://github.com/home-assistant/core/pull/84818
- https://github.com/home-assistant/core/pull/84477
- https://github.com/home-assistant/core/pull/84883
- #84942

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
