### PR TITLE
Added service to delete backups

### DIFF
--- a/homeassistant/components/backup/__init__.py
+++ b/homeassistant/components/backup/__init__.py
@@ -3,7 +3,7 @@ from homeassistant.components.hassio import is_hassio
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, LOGGER
+from .const import ATTR_AMOUNT, DOMAIN, LOGGER
 from .http import async_register_http_views
 from .manager import BackupManager
 from .websocket import async_register_websocket_handlers
@@ -25,7 +25,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Service handler for creating backups."""
         await backup_manager.generate_backup()
 
+    async def async_handle_delete_service(call: ServiceCall) -> None:
+        """Service handler for deleting backups."""
+        amount = call.data[ATTR_AMOUNT] if ATTR_AMOUNT in call.data else None
+
+        await backup_manager.delete_backups(amount)
+
     hass.services.async_register(DOMAIN, "create", async_handle_create_service)
+    hass.services.async_register(DOMAIN, "delete", async_handle_delete_service)
 
     async_register_websocket_handlers(hass)
     async_register_http_views(hass)

--- a/homeassistant/components/backup/const.py
+++ b/homeassistant/components/backup/const.py
@@ -13,3 +13,5 @@ EXCLUDE_FROM_BACKUP = [
     "backups/*.tar",
     "OZW_Log.txt",
 ]
+
+ATTR_AMOUNT = "amount"

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -246,7 +246,7 @@ class BackupManager:
             tar_file.add(tmp_dir_path, arcname=".")
 
     async def delete_backups(self, amount: int) -> None:
-        """Delete backups."""
+        """Delete backups and keep the specified amount of newest backups."""
         if self.backing_up:
             raise HomeAssistantError(
                 "Backup in progress, can not delete backups right now"

--- a/homeassistant/components/backup/services.yaml
+++ b/homeassistant/components/backup/services.yaml
@@ -1,3 +1,19 @@
 create:
   name: Create backup
   description: Create a new backup.
+
+delete:
+  name: Delete backups
+  description: Delete existing backups
+  fields:
+    amount:
+      name: Amount of backups to keep
+      description: Keep a certain amount of backups. Once there are more backups than the specified amount, the oldest backups are deleted.
+      required: true
+      example: 5
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: box


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a service to delete backups with a parameter of the amount existing backups to keep.
Usage will be to automate deletion of old backups and to always keep the last ex 3 backups. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  Not done yet. Want to get opinion of this feature first.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
