### PR TITLE
Improve DataUpdateCoordinator typing in integrations (7)

### DIFF
--- a/homeassistant/components/deluge/coordinator.py
+++ b/homeassistant/components/deluge/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 import socket
 from ssl import SSLError
+from typing import Any
 
 from deluge_client.client import DelugeRPCClient, FailedToReconnectException
 
@@ -16,7 +17,9 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DATA_KEYS, LOGGER
 
 
-class DelugeDataUpdateCoordinator(DataUpdateCoordinator):
+class DelugeDataUpdateCoordinator(
+    DataUpdateCoordinator[dict[Platform, dict[str, Any]]]
+):
     """Data update coordinator for the Deluge integration."""
 
     config_entry: ConfigEntry
@@ -34,7 +37,7 @@ class DelugeDataUpdateCoordinator(DataUpdateCoordinator):
         self.api = api
         self.config_entry = entry
 
-    async def _async_update_data(self) -> dict[Platform, dict[str, int | str]]:
+    async def _async_update_data(self) -> dict[Platform, dict[str, Any]]:
         """Get the latest data from Deluge and updates the state."""
         data = {}
         try:

--- a/homeassistant/components/deluge/switch.py
+++ b/homeassistant/components/deluge/switch.py
@@ -45,7 +45,7 @@ class DelugeSwitch(DelugeEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return state of the switch."""
         if self.coordinator.data:
-            data: dict = self.coordinator.data[Platform.SWITCH]
+            data = self.coordinator.data[Platform.SWITCH]
             for torrent in data.values():
                 item = torrent.popitem()
                 if not item[1]:

--- a/homeassistant/components/goalzero/coordinator.py
+++ b/homeassistant/components/goalzero/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DOMAIN, LOGGER
 
 
-class GoalZeroDataUpdateCoordinator(DataUpdateCoordinator):
+class GoalZeroDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Data update coordinator for the Goal zero integration."""
 
     config_entry: ConfigEntry

--- a/homeassistant/components/goalzero/switch.py
+++ b/homeassistant/components/goalzero/switch.py
@@ -52,10 +52,10 @@ class GoalZeroSwitch(GoalZeroEntity, SwitchEntity):
         """Turn off the switch."""
         payload = {self.entity_description.key: 0}
         await self._api.post_state(payload=payload)
-        self.coordinator.async_set_updated_data(data=payload)
+        self.coordinator.async_set_updated_data(None)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         payload = {self.entity_description.key: 1}
         await self._api.post_state(payload=payload)
-        self.coordinator.async_set_updated_data(data=payload)
+        self.coordinator.async_set_updated_data(None)

--- a/homeassistant/components/lifx/coordinator.py
+++ b/homeassistant/components/lifx/coordinator.py
@@ -358,7 +358,7 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator[None]):
         return self.active_effect.value
 
 
-class LIFXSensorUpdateCoordinator(DataUpdateCoordinator):
+class LIFXSensorUpdateCoordinator(DataUpdateCoordinator[None]):
     """DataUpdateCoordinator to gather data for a specific lifx device."""
 
     def __init__(

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -101,7 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except RequestException as err:
         raise exceptions.ConfigEntryNotReady from err
 
-    async def async_update_data():
+    async def async_update_data() -> None:
         """Fetch data from Nuki bridge."""
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
@@ -161,7 +161,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class NukiEntity(CoordinatorEntity):
+class NukiEntity(CoordinatorEntity[DataUpdateCoordinator[None]]):
     """An entity using CoordinatorEntity.
 
     The CoordinatorEntity class provides:

--- a/homeassistant/components/nuki/binary_sensor.py
+++ b/homeassistant/components/nuki/binary_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import NukiEntity
 from .const import ATTR_NUKI_ID, DATA_COORDINATOR, DATA_LOCKS, DOMAIN as NUKI_DOMAIN
@@ -19,7 +20,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Nuki lock binary sensor."""
     data = hass.data[NUKI_DOMAIN][entry.entry_id]
-    coordinator = data[DATA_COORDINATOR]
+    coordinator: DataUpdateCoordinator[None] = data[DATA_COORDINATOR]
 
     entities = []
 

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import NukiEntity
 from .const import (
@@ -35,7 +36,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Nuki lock platform."""
     data = hass.data[NUKI_DOMAIN][entry.entry_id]
-    coordinator = data[DATA_COORDINATOR]
+    coordinator: DataUpdateCoordinator[None] = data[DATA_COORDINATOR]
 
     entities: list[NukiDeviceEntity] = [
         NukiLockEntity(coordinator, lock) for lock in data[DATA_LOCKS]

--- a/homeassistant/components/tomorrowio/__init__.py
+++ b/homeassistant/components/tomorrowio/__init__.py
@@ -162,7 +162,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     return unload_ok
 
 
-class TomorrowioDataUpdateCoordinator(DataUpdateCoordinator):
+class TomorrowioDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Define an object to hold Tomorrow.io data."""
 
     def __init__(self, hass: HomeAssistant, api: TomorrowioV4) -> None:
@@ -235,7 +235,7 @@ class TomorrowioDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
-        data = {}
+        data: dict[str, Any] = {}
         # If we are refreshing because of a new config entry that's not already in our
         # data, we do a partial refresh to avoid wasted API calls.
         if self.data and any(


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
