### PR TITLE
Renovate PurpleAir tests

### DIFF
--- a/tests/components/purpleair/conftest.py
+++ b/tests/components/purpleair/conftest.py
@@ -6,24 +6,27 @@ from aiopurpleair.models.sensors import GetSensorsResponse
 import pytest
 
 from homeassistant.components.purpleair import DOMAIN
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, load_fixture
 
+TEST_API_KEY = "abcde12345"
+
 
 @pytest.fixture(name="api")
-def api_fixture(check_api_key, get_nearby_sensors, get_sensors):
+def api_fixture(get_sensors_response):
     """Define a fixture to return a mocked aiopurple API object."""
-    api = Mock(async_check_api_key=check_api_key)
-    api.sensors.async_get_nearby_sensors = get_nearby_sensors
-    api.sensors.async_get_sensors = get_sensors
-    return api
-
-
-@pytest.fixture(name="check_api_key")
-def check_api_key_fixture():
-    """Define a fixture to mock the method to check an API key's validity."""
-    return AsyncMock()
+    return Mock(
+        async_check_api_key=AsyncMock(),
+        sensors=Mock(
+            async_get_nearby_sensors=AsyncMock(
+                return_value=[
+                    NearbySensorResult(sensor=sensor, distance=1.0)
+                    for sensor in get_sensors_response.data.values()
+                ]
+            ),
+            async_get_sensors=AsyncMock(return_value=get_sensors_response),
+        ),
+    )
 
 
 @pytest.fixture(name="config_entry")
@@ -32,7 +35,7 @@ def config_entry_fixture(hass, config_entry_data, config_entry_options):
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="abcde",
-        unique_id="abcde12345",
+        unique_id=TEST_API_KEY,
         data=config_entry_data,
         options=config_entry_options,
     )
@@ -44,7 +47,7 @@ def config_entry_fixture(hass, config_entry_data, config_entry_options):
 def config_entry_data_fixture():
     """Define a config entry data fixture."""
     return {
-        "api_key": "abcde12345",
+        "api_key": TEST_API_KEY,
     }
 
 
@@ -56,23 +59,6 @@ def config_entry_options_fixture():
     }
 
 
-@pytest.fixture(name="get_nearby_sensors")
-def get_nearby_sensors_fixture(get_sensors_response):
-    """Define a mocked API.sensors.async_get_nearby_sensors."""
-    return AsyncMock(
-        return_value=[
-            NearbySensorResult(sensor=sensor, distance=1.0)
-            for sensor in get_sensors_response.data.values()
-        ]
-    )
-
-
-@pytest.fixture(name="get_sensors")
-def get_sensors_fixture(get_sensors_response):
-    """Define a mocked API.sensors.async_get_sensors."""
-    return AsyncMock(return_value=get_sensors_response)
-
-
 @pytest.fixture(name="get_sensors_response", scope="package")
 def get_sensors_response_fixture():
     """Define a fixture to mock an aiopurpleair GetSensorsResponse object."""
@@ -81,12 +67,18 @@ def get_sensors_response_fixture():
     )
 
 
-@pytest.fixture(name="setup_purpleair")
-async def setup_purpleair_fixture(hass, api, config_entry_data):
-    """Define a fixture to set up PurpleAir."""
+@pytest.fixture(name="mock_aiopurpleair")
+async def mock_aiopurpleair_fixture(api):
+    """Define a fixture to patch aiopurpleair."""
     with patch(
         "homeassistant.components.purpleair.config_flow.API", return_value=api
     ), patch("homeassistant.components.purpleair.coordinator.API", return_value=api):
-        assert await async_setup_component(hass, DOMAIN, config_entry_data)
-        await hass.async_block_till_done()
         yield
+
+
+@pytest.fixture(name="setup_config_entry")
+async def setup_config_entry_fixture(hass, config_entry, mock_aiopurpleair):
+    """Define a fixture to set up purpleair."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    yield

--- a/tests/components/purpleair/conftest.py
+++ b/tests/components/purpleair/conftest.py
@@ -10,6 +10,8 @@ from homeassistant.components.purpleair import DOMAIN
 from tests.common import MockConfigEntry, load_fixture
 
 TEST_API_KEY = "abcde12345"
+TEST_SENSOR_INDEX1 = 123456
+TEST_SENSOR_INDEX2 = 567890
 
 
 @pytest.fixture(name="api")
@@ -55,7 +57,7 @@ def config_entry_data_fixture():
 def config_entry_options_fixture():
     """Define a config entry options fixture."""
     return {
-        "sensor_indices": [123456],
+        "sensor_indices": [TEST_SENSOR_INDEX1],
     }
 
 

--- a/tests/components/purpleair/test_config_flow.py
+++ b/tests/components/purpleair/test_config_flow.py
@@ -9,7 +9,10 @@ from homeassistant.components.purpleair import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import TEST_API_KEY
+from .conftest import TEST_API_KEY, TEST_SENSOR_INDEX1, TEST_SENSOR_INDEX2
+
+TEST_LATITUDE = 51.5285582
+TEST_LONGITUDE = -0.2416796
 
 
 @pytest.mark.parametrize(
@@ -63,8 +66,8 @@ async def test_create_entry_by_coordinates(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
-                "latitude": 51.5285582,
-                "longitude": -0.2416796,
+                "latitude": TEST_LATITUDE,
+                "longitude": TEST_LONGITUDE,
                 "distance": 5,
             },
         )
@@ -74,8 +77,8 @@ async def test_create_entry_by_coordinates(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            "latitude": 51.5285582,
-            "longitude": -0.2416796,
+            "latitude": TEST_LATITUDE,
+            "longitude": TEST_LONGITUDE,
             "distance": 5,
         },
     )
@@ -85,7 +88,7 @@ async def test_create_entry_by_coordinates(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            "sensor_index": "123456",
+            "sensor_index": str(TEST_SENSOR_INDEX1),
         },
     )
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
@@ -94,7 +97,7 @@ async def test_create_entry_by_coordinates(
         "api_key": TEST_API_KEY,
     }
     assert result["options"] == {
-        "sensor_indices": [123456],
+        "sensor_indices": [TEST_SENSOR_INDEX1],
     }
 
 
@@ -185,8 +188,8 @@ async def test_options_add_sensor(
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
-                "latitude": 51.5285582,
-                "longitude": -0.2416796,
+                "latitude": TEST_LATITUDE,
+                "longitude": TEST_LONGITUDE,
                 "distance": 5,
             },
         )
@@ -196,8 +199,8 @@ async def test_options_add_sensor(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "latitude": 51.5285582,
-            "longitude": -0.2416796,
+            "latitude": TEST_LATITUDE,
+            "longitude": TEST_LONGITUDE,
             "distance": 5,
         },
     )
@@ -207,16 +210,19 @@ async def test_options_add_sensor(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "sensor_index": "567890",
+            "sensor_index": str(TEST_SENSOR_INDEX2),
         },
     )
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "last_update_sensor_add": True,
-        "sensor_indices": [123456, 567890],
+        "sensor_indices": [TEST_SENSOR_INDEX1, TEST_SENSOR_INDEX2],
     }
 
-    assert config_entry.options["sensor_indices"] == [123456, 567890]
+    assert config_entry.options["sensor_indices"] == [
+        TEST_SENSOR_INDEX1,
+        TEST_SENSOR_INDEX2,
+    ]
 
 
 async def test_options_add_sensor_duplicate(hass, config_entry, setup_config_entry):
@@ -234,8 +240,8 @@ async def test_options_add_sensor_duplicate(hass, config_entry, setup_config_ent
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "latitude": 51.5285582,
-            "longitude": -0.2416796,
+            "latitude": TEST_LATITUDE,
+            "longitude": TEST_LONGITUDE,
             "distance": 5,
         },
     )
@@ -245,7 +251,7 @@ async def test_options_add_sensor_duplicate(hass, config_entry, setup_config_ent
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "sensor_index": "123456",
+            "sensor_index": str(TEST_SENSOR_INDEX1),
         },
     )
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
@@ -265,7 +271,7 @@ async def test_options_remove_sensor(hass, config_entry, setup_config_entry):
     assert result["step_id"] == "remove_sensor"
 
     device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device({(DOMAIN, "123456")})
+    device_entry = device_registry.async_get_device({(DOMAIN, str(TEST_SENSOR_INDEX1))})
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={"sensor_device_id": device_entry.id},

--- a/tests/components/purpleair/test_diagnostics.py
+++ b/tests/components/purpleair/test_diagnostics.py
@@ -4,7 +4,7 @@ from homeassistant.components.diagnostics import REDACTED
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_purpleair):
+async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up the PurpleAir tests in a few ways:

1. We now set up the config entry directly (vs. indirectly via `async_setup_component`).
2. We rename some fixtures for maximum clarity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
