### PR TITLE
Renovate ReCollect Waste config flow tests

### DIFF
--- a/tests/components/recollect_waste/conftest.py
+++ b/tests/components/recollect_waste/conftest.py
@@ -1,6 +1,6 @@
 """Define test fixtures for ReCollect Waste."""
 from datetime import date
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from aiorecollect.client import PickupEvent, PickupType
 import pytest
@@ -10,48 +10,64 @@ from homeassistant.components.recollect_waste.const import (
     CONF_SERVICE_ID,
     DOMAIN,
 )
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+
+TEST_PLACE_ID = "12345"
+TEST_SERVICE_ID = "67890"
+
+
+@pytest.fixture(name="client")
+def client_fixture(pickup_events):
+    """Define a fixture to return a mocked aiopurple API object."""
+    return Mock(async_get_pickup_events=AsyncMock(return_value=pickup_events))
 
 
 @pytest.fixture(name="config_entry")
 def config_entry_fixture(hass, config):
     """Define a config entry fixture."""
     entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id=f"{config[CONF_PLACE_ID]}, {config[CONF_SERVICE_ID]}",
-        data=config,
+        domain=DOMAIN, unique_id=f"{TEST_PLACE_ID}, {TEST_SERVICE_ID}", data=config
     )
     entry.add_to_hass(hass)
     return entry
 
 
 @pytest.fixture(name="config")
-def config_fixture(hass):
+def config_fixture():
     """Define a config entry data fixture."""
     return {
-        CONF_PLACE_ID: "12345",
-        CONF_SERVICE_ID: "12345",
+        CONF_PLACE_ID: TEST_PLACE_ID,
+        CONF_SERVICE_ID: TEST_SERVICE_ID,
     }
 
 
-@pytest.fixture(name="setup_recollect_waste")
-async def setup_recollect_waste_fixture(hass, config):
-    """Define a fixture to set up ReCollect Waste."""
-    pickup_event = PickupEvent(
-        date(2022, 1, 23), [PickupType("garbage", "Trash Collection")], "The Sun"
-    )
+@pytest.fixture(name="pickup_events")
+def pickup_events_fixture():
+    """Define a list of pickup events."""
+    return [
+        PickupEvent(
+            date(2022, 1, 23), [PickupType("garbage", "Trash Collection")], "The Sun"
+        )
+    ]
 
+
+@pytest.fixture(name="mock_aiorecollect")
+async def mock_aiorecollect_fixture(client):
+    """Define a fixture to patch aiorecollect."""
     with patch(
-        "homeassistant.components.recollect_waste.Client.async_get_pickup_events",
-        return_value=[pickup_event],
+        "homeassistant.components.recollect_waste.Client",
+        return_value=client,
     ), patch(
-        "homeassistant.components.recollect_waste.config_flow.Client.async_get_pickup_events",
-        return_value=[pickup_event],
-    ), patch(
-        "homeassistant.components.recollect_waste.PLATFORMS", []
+        "homeassistant.components.recollect_waste.config_flow.Client",
+        return_value=client,
     ):
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
         yield
+
+
+@pytest.fixture(name="setup_config_entry")
+async def setup_config_entry_fixture(hass, config_entry, mock_aiorecollect):
+    """Define a fixture to set up recollect_waste."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    yield

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -1,7 +1,8 @@
 """Define tests for the ReCollect Waste config flow."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from aiorecollect.errors import RecollectError
+import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.recollect_waste import (
@@ -12,8 +13,53 @@ from homeassistant.components.recollect_waste import (
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_FRIENDLY_NAME
 
+from .conftest import TEST_PLACE_ID, TEST_SERVICE_ID
 
-async def test_duplicate_error(hass, config, config_entry):
+
+@pytest.mark.parametrize(
+    "get_pickup_events_mock,get_pickup_events_errors",
+    [
+        (
+            AsyncMock(side_effect=RecollectError),
+            {"base": "invalid_place_or_service_id"},
+        ),
+    ],
+)
+async def test_create_entry(
+    hass,
+    client,
+    config,
+    get_pickup_events_errors,
+    get_pickup_events_mock,
+    mock_aiorecollect,
+):
+    """Test creating an entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Test errors that can arise when checking the API key:
+    with patch.object(client, "async_get_pickup_events", get_pickup_events_mock):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=config
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["errors"] == get_pickup_events_errors
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=config
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"{TEST_PLACE_ID}, {TEST_SERVICE_ID}"
+    assert result["data"] == {
+        CONF_PLACE_ID: TEST_PLACE_ID,
+        CONF_SERVICE_ID: TEST_SERVICE_ID,
+    }
+
+
+async def test_duplicate_error(hass, config, setup_config_entry):
     """Test that errors are shown when duplicates are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
@@ -22,51 +68,14 @@ async def test_duplicate_error(hass, config, config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_invalid_place_or_service_id(hass, config):
-    """Test that an invalid Place or Service ID throws an error."""
-    with patch(
-        "homeassistant.components.recollect_waste.config_flow.Client.async_get_pickup_events",
-        side_effect=RecollectError,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=config
-        )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["errors"] == {"base": "invalid_place_or_service_id"}
-
-
-async def test_options_flow(hass, config, config_entry):
+async def test_options_flow(hass, config, config_entry, setup_config_entry):
     """Test config flow options."""
-    with patch(
-        "homeassistant.components.recollect_waste.async_setup_entry", return_value=True
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == "init"
-
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_FRIENDLY_NAME: True}
-        )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-        assert config_entry.options == {CONF_FRIENDLY_NAME: True}
-
-
-async def test_show_form(hass):
-    """Test that the form is served with no input."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "init"
 
-
-async def test_step_user(hass, config, setup_recollect_waste):
-    """Test that the user step works."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=config
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_FRIENDLY_NAME: True}
     )
-    await hass.async_block_till_done()
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result["title"] == "12345, 12345"
-    assert result["data"] == {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}
+    assert config_entry.options == {CONF_FRIENDLY_NAME: True}

--- a/tests/components/recollect_waste/test_diagnostics.py
+++ b/tests/components/recollect_waste/test_diagnostics.py
@@ -1,12 +1,12 @@
 """Test ReCollect Waste diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
 
+from .conftest import TEST_SERVICE_ID
+
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
-async def test_entry_diagnostics(
-    hass, config_entry, hass_client, setup_recollect_waste
-):
+async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {
@@ -14,7 +14,7 @@ async def test_entry_diagnostics(
             "version": 2,
             "domain": "recollect_waste",
             "title": REDACTED,
-            "data": {"place_id": REDACTED, "service_id": "12345"},
+            "data": {"place_id": REDACTED, "service_id": TEST_SERVICE_ID},
             "options": {},
             "pref_disable_new_entities": False,
             "pref_disable_polling": False,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up the ReCollect Waste config flow tests in a few ways:

1. We now set up the config entry directly (vs. indirectly via `async_setup_component`).
2. We ensure all tests finish with either `data_entry_flow.FlowResultType.CREATE_ENTRY` or `data_entry_flow.FlowResultType.ABORT`.
3. We reorganize some fixtures for maximum clarity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
