### PR TITLE
Change ISY994 group device assignments

### DIFF
--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -80,9 +80,6 @@ class ISYEntity(Entity):
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return the device_info of the device."""
-        if hasattr(self._node, "protocol") and self._node.protocol == PROTO_GROUP:
-            # not a device
-            return None
         isy = self._node.isy
         uuid = isy.configuration["uuid"]
         node = self._node
@@ -90,9 +87,17 @@ class ISYEntity(Entity):
 
         basename = self._name or str(self._node.name)
 
-        if hasattr(self._node, "parent_node") and self._node.parent_node is not None:
+        if hasattr(node, "protocol") and node.protocol == PROTO_GROUP:
+            # If Group has only 1 Controller, link to that device, otherwise link to ISY Hub
+            if len(node.controllers) != 1:
+                return DeviceInfo(identifiers={(DOMAIN, uuid)})
+
+            node = isy.nodes.get_by_id(node.controllers[0])
+            basename = node.name
+
+        if hasattr(node, "parent_node") and node.parent_node is not None:
             # This is not the parent node, get the parent node.
-            node = self._node.parent_node
+            node = node.parent_node
             basename = node.name
 
         device_info = DeviceInfo(
@@ -105,7 +110,9 @@ class ISYEntity(Entity):
 
         if hasattr(node, "address"):
             assert isinstance(node.address, str)
-            device_info[ATTR_NAME] = f"{basename} ({node.address})"
+            device_info[
+                ATTR_NAME
+            ] = f"{basename} ({(node.address.rpartition(' ')[0] or node.address)})"
         if hasattr(node, "primary_node"):
             device_info[ATTR_IDENTIFIERS] = {(DOMAIN, f"{uuid}_{node.address}")}
         # ISYv5 Device Types


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Assign ISY994 Groups/Scenes to devices based on the following logic:

- If the group only has one "controller" (ISY term for triggering device), assign the group to that device (or related parent device).
- If the group does not have any controllers (ISY hub-activated only), or has multiple controllers: assign to the ISY Hub device.

In addition, the trailing sub-node numbers will be removed from the Device's Display Name so the name matches the physical device address (i.e. "Device Name (AB CD EF 1)" becomes "Device Name (AB CD EF)"). Identifiers are not changed to prevent a breaking change.

Background / Justification:

ISY994 Groups/Scenes do not currently have any device_info associated with them. When Devices were added originally and supported by this integration, these were left as unrelated entities since they were not "physically associated" with any one device.

This PR updates this logic in order to take advantage of the updates to Devices in Home Assistant over the past 18 months and to lay ground work for using Device Actions and Device Triggers in this integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # n/a
- This PR is related to issue:  n/a
- Link to documentation pull request:  n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
