### PR TITLE
Make client tracker use common UniFi entity class

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -2,18 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Generic, TypeVar
+from typing import Any, Generic
 
 import aiounifi
 from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.clients import Clients
 from aiounifi.interfaces.devices import Devices
-from aiounifi.models.api import SOURCE_DATA, SOURCE_EVENT
+from aiounifi.models.client import Client
 from aiounifi.models.device import Device
-from aiounifi.models.event import EventKey
+from aiounifi.models.event import Event, EventKey
 
 from homeassistant.components.device_tracker import DOMAIN, ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
@@ -24,8 +25,7 @@ import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN as UNIFI_DOMAIN
 from .controller import UniFiController
-from .entity import UnifiEntity, UnifiEntityDescription
-from .unifi_client import UniFiClientBase
+from .entity import DataT, HandlerT, UnifiEntity, UnifiEntityDescription
 
 LOGGER = logging.getLogger(__name__)
 
@@ -58,6 +58,7 @@ CLIENT_STATIC_ATTRIBUTES = [
 CLIENT_CONNECTED_ALL_ATTRIBUTES = CLIENT_CONNECTED_ATTRIBUTES + CLIENT_STATIC_ATTRIBUTES
 
 WIRED_CONNECTION = (EventKey.WIRED_CLIENT_CONNECTED,)
+WIRED_DISCONNECTION = (EventKey.WIRED_CLIENT_DISCONNECTED,)
 WIRELESS_CONNECTION = (
     EventKey.WIRELESS_CLIENT_CONNECTED,
     EventKey.WIRELESS_CLIENT_ROAM,
@@ -66,10 +67,63 @@ WIRELESS_CONNECTION = (
     EventKey.WIRELESS_GUEST_ROAM,
     EventKey.WIRELESS_GUEST_ROAM_RADIO,
 )
+WIRELESS_DISCONNECTION = (
+    EventKey.WIRELESS_CLIENT_DISCONNECTED,
+    EventKey.WIRELESS_GUEST_DISCONNECTED,
+)
 
 
-_DataT = TypeVar("_DataT", bound=Device)
-_HandlerT = TypeVar("_HandlerT", bound=Devices)
+@callback
+def async_client_allowed_fn(controller: UniFiController, obj_id: str) -> bool:
+    """Check if client is allowed."""
+    client = controller.api.clients[obj_id]
+    if not controller.option_track_clients:
+        return False
+
+    if client.mac not in controller.wireless_clients:
+        if not controller.option_track_wired_clients:
+            return False
+
+    elif (
+        client.essid
+        and controller.option_ssid_filter
+        and client.essid not in controller.option_ssid_filter
+    ):
+        return False
+
+    return True
+
+
+@callback
+def async_client_heartbeat_timedelta_fn(
+    controller: UniFiController, obj_id: str
+) -> timedelta:
+    """Check if device object is disabled."""
+    return controller.option_detection_time
+
+
+@callback
+def async_client_is_connected_fn(controller: UniFiController, obj_id: str) -> bool:
+    """Check if device object is disabled."""
+    client = controller.api.clients[obj_id]
+
+    if client.is_wired != (is_wired := client.mac not in controller.wireless_clients):
+        return False  # Wired bug in action
+
+    if (
+        not is_wired
+        and client.essid
+        and controller.option_ssid_filter
+        and client.essid not in controller.option_ssid_filter
+    ):
+        return False
+
+    if (
+        dt_util.utcnow() - dt_util.utc_from_timestamp(client.last_seen or 0)
+        > controller.option_detection_time
+    ):
+        return False
+    return True
 
 
 @callback
@@ -89,7 +143,7 @@ def async_device_heartbeat_timedelta_fn(
 
 
 @dataclass
-class UnifiEntityTrackerDescriptionMixin(Generic[_HandlerT, _DataT]):
+class UnifiEntityTrackerDescriptionMixin(Generic[HandlerT, DataT]):
     """Device tracker local functions."""
 
     heartbeat_timedelta_fn: Callable[[UniFiController, str], timedelta]
@@ -100,13 +154,34 @@ class UnifiEntityTrackerDescriptionMixin(Generic[_HandlerT, _DataT]):
 
 @dataclass
 class UnifiTrackerEntityDescription(
-    UnifiEntityDescription[_HandlerT, _DataT],
-    UnifiEntityTrackerDescriptionMixin[_HandlerT, _DataT],
+    UnifiEntityDescription[HandlerT, DataT],
+    UnifiEntityTrackerDescriptionMixin[HandlerT, DataT],
 ):
     """Class describing UniFi device tracker entity."""
 
 
 ENTITY_DESCRIPTIONS: tuple[UnifiTrackerEntityDescription, ...] = (
+    UnifiTrackerEntityDescription[Clients, Client](
+        key="Client device scanner",
+        has_entity_name=True,
+        allowed_fn=async_client_allowed_fn,
+        api_handler_fn=lambda api: api.clients,
+        available_fn=lambda controller, obj_id: controller.available,
+        device_info_fn=lambda api, obj_id: None,
+        event_is_on=WIRED_CONNECTION + WIRELESS_CONNECTION,
+        event_to_subscribe=WIRED_CONNECTION
+        + WIRED_DISCONNECTION
+        + WIRELESS_CONNECTION
+        + WIRELESS_DISCONNECTION,
+        heartbeat_timedelta_fn=async_client_heartbeat_timedelta_fn,
+        is_connected_fn=async_client_is_connected_fn,
+        name_fn=lambda client: client.name or client.hostname,
+        object_fn=lambda api, obj_id: api.clients[obj_id],
+        supported_fn=lambda controller, obj_id: True,
+        unique_id_fn=lambda controller, obj_id: f"{obj_id}-{controller.site}",
+        ip_address_fn=lambda api, obj_id: api.clients[obj_id].ip,
+        hostname_fn=lambda api, obj_id: None,
+    ),
     UnifiTrackerEntityDescription[Devices, Device](
         key="Device scanner",
         has_entity_name=True,
@@ -139,236 +214,10 @@ async def async_setup_entry(
     controller.register_platform_add_entities(
         UnifiScannerEntity, ENTITY_DESCRIPTIONS, async_add_entities
     )
-
     controller.entities[DOMAIN] = {CLIENT_TRACKER: set(), DEVICE_TRACKER: set()}
 
-    @callback
-    def items_added(
-        clients: set = controller.api.clients, devices: set = controller.api.devices
-    ) -> None:
-        """Update the values of the controller."""
-        if controller.option_track_clients:
-            add_client_entities(controller, async_add_entities, clients)
 
-    for signal in (controller.signal_update, controller.signal_options_update):
-        config_entry.async_on_unload(
-            async_dispatcher_connect(hass, signal, items_added)
-        )
-
-    items_added()
-
-
-@callback
-def add_client_entities(controller, async_add_entities, clients):
-    """Add new client tracker entities from the controller."""
-    trackers = []
-
-    for mac in clients:
-        if mac in controller.entities[DOMAIN][UniFiClientTracker.TYPE] or not (
-            client := controller.api.clients.get(mac)
-        ):
-            continue
-
-        if mac not in controller.wireless_clients:
-            if not controller.option_track_wired_clients:
-                continue
-        elif (
-            client.essid
-            and controller.option_ssid_filter
-            and client.essid not in controller.option_ssid_filter
-        ):
-            continue
-
-        trackers.append(UniFiClientTracker(client, controller))
-
-    async_add_entities(trackers)
-
-
-class UniFiClientTracker(UniFiClientBase, ScannerEntity):
-    """Representation of a network client."""
-
-    DOMAIN = DOMAIN
-    TYPE = CLIENT_TRACKER
-
-    def __init__(self, client, controller):
-        """Set up tracked client."""
-        super().__init__(client, controller)
-
-        self._controller_connection_state_changed = False
-
-        self._only_listen_to_data_source = False
-
-        last_seen = client.last_seen or 0
-        self.schedule_update = self._is_connected = (
-            self.is_wired == client.is_wired
-            and dt_util.utcnow() - dt_util.utc_from_timestamp(float(last_seen))
-            < controller.option_detection_time
-        )
-
-    @callback
-    def _async_log_debug_data(self, method: str) -> None:
-        """Print debug data about entity."""
-        if not LOGGER.isEnabledFor(logging.DEBUG):
-            return
-        last_seen = self.client.last_seen or 0
-        LOGGER.debug(
-            "%s [%s, %s] [%s %s] [%s] %s (%s)",
-            method,
-            self.entity_id,
-            self.client.mac,
-            self.schedule_update,
-            self._is_connected,
-            dt_util.utc_from_timestamp(float(last_seen)),
-            dt_util.utcnow() - dt_util.utc_from_timestamp(float(last_seen)),
-            last_seen,
-        )
-
-    async def async_added_to_hass(self) -> None:
-        """Watch object when added."""
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{self.controller.signal_heartbeat_missed}_{self.unique_id}",
-                self._make_disconnected,
-            )
-        )
-        await super().async_added_to_hass()
-        self._async_log_debug_data("added_to_hass")
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect object when removed."""
-        self.controller.async_heartbeat(self.unique_id)
-        await super().async_will_remove_from_hass()
-
-    @callback
-    def async_signal_reachable_callback(self) -> None:
-        """Call when controller connection state change."""
-        self._controller_connection_state_changed = True
-        super().async_signal_reachable_callback()
-
-    @callback
-    def async_update_callback(self) -> None:
-        """Update the clients state."""
-
-        if self._controller_connection_state_changed:
-            self._controller_connection_state_changed = False
-
-            if self.controller.available:
-                self.schedule_update = True
-
-            else:
-                self.controller.async_heartbeat(self.unique_id)
-                super().async_update_callback()
-
-        elif (
-            self.client.last_updated == SOURCE_DATA
-            and self.is_wired == self.client.is_wired
-        ):
-            self._is_connected = True
-            self.schedule_update = True
-            self._only_listen_to_data_source = True
-
-        elif (
-            self.client.last_updated == SOURCE_EVENT
-            and not self._only_listen_to_data_source
-        ):
-            if (self.is_wired and self.client.event.key in WIRED_CONNECTION) or (
-                not self.is_wired and self.client.event.key in WIRELESS_CONNECTION
-            ):
-                self._is_connected = True
-                self.schedule_update = False
-                self.controller.async_heartbeat(self.unique_id)
-                super().async_update_callback()
-
-            else:
-                self.schedule_update = True
-
-        self._async_log_debug_data("update_callback")
-
-        if self.schedule_update:
-            self.schedule_update = False
-            self.controller.async_heartbeat(
-                self.unique_id, dt_util.utcnow() + self.controller.option_detection_time
-            )
-
-            super().async_update_callback()
-
-    @callback
-    def _make_disconnected(self, *_):
-        """No heart beat by device."""
-        self._is_connected = False
-        self.async_write_ha_state()
-        self._async_log_debug_data("make_disconnected")
-
-    @property
-    def is_connected(self):
-        """Return true if the client is connected to the network."""
-        if (
-            not self.is_wired
-            and self.client.essid
-            and self.controller.option_ssid_filter
-            and self.client.essid not in self.controller.option_ssid_filter
-        ):
-            return False
-
-        return self._is_connected
-
-    @property
-    def source_type(self) -> SourceType:
-        """Return the source type of the client."""
-        return SourceType.ROUTER
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique identifier for this client."""
-        return f"{self.client.mac}-{self.controller.site}"
-
-    @property
-    def extra_state_attributes(self):
-        """Return the client state attributes."""
-        raw = self.client.raw
-
-        attributes_to_check = CLIENT_STATIC_ATTRIBUTES
-        if self.is_connected:
-            attributes_to_check = CLIENT_CONNECTED_ALL_ATTRIBUTES
-
-        attributes = {k: raw[k] for k in attributes_to_check if k in raw}
-        attributes["is_wired"] = self.is_wired
-
-        return attributes
-
-    @property
-    def ip_address(self) -> str:
-        """Return the primary ip address of the device."""
-        return self.client.raw.get("ip")
-
-    @property
-    def mac_address(self) -> str:
-        """Return the mac address of the device."""
-        return self.client.raw.get("mac")
-
-    @property
-    def hostname(self) -> str:
-        """Return hostname of the device."""
-        return self.client.raw.get("hostname")
-
-    async def options_updated(self) -> None:
-        """Config entry options are updated, remove entity if option is disabled."""
-        if not self.controller.option_track_clients:
-            await self.remove_item({self.client.mac})
-
-        elif self.is_wired:
-            if not self.controller.option_track_wired_clients:
-                await self.remove_item({self.client.mac})
-
-        elif (
-            self.controller.option_ssid_filter
-            and self.client.essid not in self.controller.option_ssid_filter
-        ):
-            await self.remove_item({self.client.mac})
-
-
-class UnifiScannerEntity(UnifiEntity[_HandlerT, _DataT], ScannerEntity):
+class UnifiScannerEntity(UnifiEntity[HandlerT, DataT], ScannerEntity):
     """Representation of a UniFi scanner."""
 
     entity_description: UnifiTrackerEntityDescription
@@ -452,13 +301,36 @@ class UnifiScannerEntity(UnifiEntity[_HandlerT, _DataT], ScannerEntity):
                 + description.heartbeat_timedelta_fn(self.controller, self._obj_id),
             )
 
+    @callback
+    def async_event_callback(self, event: Event) -> None:
+        """Event subscription callback."""
+        if event.mac != self._obj_id or self._ignore_events:
+            return
+
+        description = self.entity_description
+        assert isinstance(description.event_to_subscribe, tuple)
+        assert isinstance(description.event_is_on, tuple)
+
+        if event.key in description.event_is_on:
+            self.controller.async_heartbeat(self.unique_id)
+            self._is_connected = True
+            self.async_write_ha_state()
+        else:
+            self.controller.async_heartbeat(
+                self.unique_id,
+                dt_util.utcnow()
+                + self.entity_description.heartbeat_timedelta_fn(
+                    self.controller, self._obj_id
+                ),
+            )
+
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await super().async_added_to_hass()
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                f"{self.controller.signal_heartbeat_missed}_{self._obj_id}",
+                f"{self.controller.signal_heartbeat_missed}_{self.unique_id}",
                 self._make_disconnected,
             )
         )
@@ -467,3 +339,21 @@ class UnifiScannerEntity(UnifiEntity[_HandlerT, _DataT], ScannerEntity):
         """Disconnect object when removed."""
         await super().async_will_remove_from_hass()
         self.controller.async_heartbeat(self.unique_id)
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return the client state attributes."""
+        if self.entity_description.key != "Client device scanner":
+            return None
+
+        client = self.entity_description.object_fn(self.controller.api, self._obj_id)
+        raw = client.raw
+
+        attributes_to_check = CLIENT_STATIC_ATTRIBUTES
+        if self.is_connected:
+            attributes_to_check = CLIENT_CONNECTED_ALL_ATTRIBUTES
+
+        attributes = {k: raw[k] for k in attributes_to_check if k in raw}
+        attributes["is_wired"] = client.is_wired
+
+        return attributes

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -16,7 +16,7 @@ from aiounifi.models.client import Client
 from aiounifi.models.device import Device
 from aiounifi.models.event import Event, EventKey
 
-from homeassistant.components.device_tracker import DOMAIN, ScannerEntity, SourceType
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -216,7 +216,6 @@ async def async_setup_entry(
     controller.register_platform_add_entities(
         UnifiScannerEntity, ENTITY_DESCRIPTIONS, async_add_entities
     )
-    controller.entities[DOMAIN] = {CLIENT_TRACKER: set(), DEVICE_TRACKER: set()}
 
 
 class UnifiScannerEntity(UnifiEntity[HandlerT, DataT], ScannerEntity):
@@ -302,7 +301,6 @@ class UnifiScannerEntity(UnifiEntity[HandlerT, DataT], ScannerEntity):
             return
 
         if is_connected := description.is_connected_fn(self.controller, self._obj_id):
-
             self._is_connected = is_connected
             self.controller.async_heartbeat(
                 self.unique_id,

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -25,7 +25,13 @@ import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN as UNIFI_DOMAIN
 from .controller import UniFiController
-from .entity import DataT, HandlerT, UnifiEntity, UnifiEntityDescription
+from .entity import (
+    DataT,
+    HandlerT,
+    UnifiEntity,
+    UnifiEntityDescription,
+    async_device_available_fn,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -125,14 +131,8 @@ def async_client_is_connected_fn(controller: UniFiController, obj_id: str) -> bo
         > controller.option_detection_time
     ):
         return False
+
     return True
-
-
-@callback
-def async_device_available_fn(controller: UniFiController, obj_id: str) -> bool:
-    """Check if device object is disabled."""
-    device = controller.api.devices[obj_id]
-    return controller.available and not device.disabled
 
 
 @callback

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -76,10 +76,10 @@ WIRELESS_DISCONNECTION = (
 @callback
 def async_client_allowed_fn(controller: UniFiController, obj_id: str) -> bool:
     """Check if client is allowed."""
-    client = controller.api.clients[obj_id]
     if not controller.option_track_clients:
         return False
 
+    client = controller.api.clients[obj_id]
     if client.mac not in controller.wireless_clients:
         if not controller.option_track_wired_clients:
             return False

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -170,11 +170,13 @@ ENTITY_DESCRIPTIONS: tuple[UnifiTrackerEntityDescription, ...] = (
         api_handler_fn=lambda api: api.clients,
         available_fn=lambda controller, obj_id: controller.available,
         device_info_fn=lambda api, obj_id: None,
-        event_is_on=WIRED_CONNECTION + WIRELESS_CONNECTION,
-        event_to_subscribe=WIRED_CONNECTION
-        + WIRED_DISCONNECTION
-        + WIRELESS_CONNECTION
-        + WIRELESS_DISCONNECTION,
+        event_is_on=(WIRED_CONNECTION + WIRELESS_CONNECTION),
+        event_to_subscribe=(
+            WIRED_CONNECTION
+            + WIRED_DISCONNECTION
+            + WIRELESS_CONNECTION
+            + WIRELESS_DISCONNECTION
+        ),
         heartbeat_timedelta_fn=async_client_heartbeat_timedelta_fn,
         is_connected_fn=async_client_is_connected_fn,
         name_fn=lambda client: client.name or client.hostname,

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -223,6 +223,7 @@ class UnifiScannerEntity(UnifiEntity[HandlerT, DataT], ScannerEntity):
 
     entity_description: UnifiTrackerEntityDescription
 
+    _event_is_on: tuple[EventKey, ...]
     _ignore_events: bool
     _is_connected: bool
 
@@ -233,6 +234,7 @@ class UnifiScannerEntity(UnifiEntity[HandlerT, DataT], ScannerEntity):
         Initiate is_connected.
         """
         description = self.entity_description
+        self._event_is_on = description.event_is_on or ()
         self._ignore_events = False
         self._is_connected = description.is_connected_fn(self.controller, self._obj_id)
         if self.is_connected:
@@ -314,11 +316,7 @@ class UnifiScannerEntity(UnifiEntity[HandlerT, DataT], ScannerEntity):
         if event.mac != self._obj_id or self._ignore_events:
             return
 
-        description = self.entity_description
-        assert isinstance(description.event_to_subscribe, tuple)
-        assert isinstance(description.event_is_on, tuple)
-
-        if event.key in description.event_is_on:
+        if event.key in self._event_is_on:
             self.controller.async_heartbeat(self.unique_id)
             self._is_connected = True
             self.async_write_ha_state()

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -322,14 +322,15 @@ class UnifiScannerEntity(UnifiEntity[HandlerT, DataT], ScannerEntity):
             self.controller.async_heartbeat(self.unique_id)
             self._is_connected = True
             self.async_write_ha_state()
-        else:
-            self.controller.async_heartbeat(
-                self.unique_id,
-                dt_util.utcnow()
-                + self.entity_description.heartbeat_timedelta_fn(
-                    self.controller, self._obj_id
-                ),
-            )
+            return
+
+        self.controller.async_heartbeat(
+            self.unique_id,
+            dt_util.utcnow()
+            + self.entity_description.heartbeat_timedelta_fn(
+                self.controller, self._obj_id
+            ),
+        )
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -32,9 +32,6 @@ from .entity import (
 if TYPE_CHECKING:
     from .controller import UniFiController
 
-DataT = TypeVar("DataT", bound=Device)
-HandlerT = TypeVar("HandlerT", bound=Devices)
-
 LOGGER = logging.getLogger(__name__)
 
 _DataT = TypeVar("_DataT", bound=Device)

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -32,6 +32,9 @@ from .entity import (
 if TYPE_CHECKING:
     from .controller import UniFiController
 
+DataT = TypeVar("DataT", bound=Device)
+HandlerT = TypeVar("HandlerT", bound=Devices)
+
 LOGGER = logging.getLogger(__name__)
 
 _DataT = TypeVar("_DataT", bound=Device)

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -156,7 +156,7 @@ async def test_tracked_clients(
 
     # State change signalling works
 
-    client_1["last_seen"] += 1
+    client_1["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
     mock_unifi_websocket(message=MessageKey.CLIENT, data=client_1)
     await hass.async_block_till_done()
 
@@ -244,6 +244,7 @@ async def test_tracked_wireless_clients_event_source(
 
     # New data
 
+    client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
     mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
     assert hass.states.get("device_tracker.client").state == STATE_HOME


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make UniFi device tracker platform for clients also use common entity class introduced in #84262.

Related PRs
- #81680
- #81821
- #81930
- #81979
- #84262
- #84458
- #84786
- #84818
- #84477
- #84883
- #84942

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
