### PR TITLE
Handle not available add-on in hassio add-on manager

### DIFF
--- a/tests/components/homeassistant_hardware/conftest.py
+++ b/tests/components/homeassistant_hardware/conftest.py
@@ -67,6 +67,7 @@ def addon_store_info_fixture():
         "homeassistant.components.hassio.addon_manager.async_get_addon_store_info"
     ) as addon_store_info:
         addon_store_info.return_value = {
+            "available": True,
             "installed": None,
             "state": None,
             "version": "1.0.0",
@@ -81,6 +82,7 @@ def addon_info_fixture():
         "homeassistant.components.hassio.addon_manager.async_get_addon_info",
     ) as addon_info:
         addon_info.return_value = {
+            "available": True,
             "hostname": None,
             "options": {},
             "state": None,

--- a/tests/components/homeassistant_sky_connect/conftest.py
+++ b/tests/components/homeassistant_sky_connect/conftest.py
@@ -69,6 +69,7 @@ def addon_store_info_fixture():
         "homeassistant.components.hassio.addon_manager.async_get_addon_store_info"
     ) as addon_store_info:
         addon_store_info.return_value = {
+            "available": True,
             "installed": None,
             "state": None,
             "version": "1.0.0",
@@ -83,6 +84,7 @@ def addon_info_fixture():
         "homeassistant.components.hassio.addon_manager.async_get_addon_info",
     ) as addon_info:
         addon_info.return_value = {
+            "available": True,
             "hostname": None,
             "options": {},
             "state": None,

--- a/tests/components/homeassistant_yellow/conftest.py
+++ b/tests/components/homeassistant_yellow/conftest.py
@@ -67,6 +67,7 @@ def addon_store_info_fixture():
         "homeassistant.components.hassio.addon_manager.async_get_addon_store_info"
     ) as addon_store_info:
         addon_store_info.return_value = {
+            "available": True,
             "installed": None,
             "state": None,
             "version": "1.0.0",
@@ -81,6 +82,7 @@ def addon_info_fixture():
         "homeassistant.components.hassio.addon_manager.async_get_addon_info",
     ) as addon_info:
         addon_info.return_value = {
+            "available": True,
             "hostname": None,
             "options": {},
             "state": None,

--- a/tests/components/matter/conftest.py
+++ b/tests/components/matter/conftest.py
@@ -80,6 +80,7 @@ def addon_store_info_fixture() -> Generator[AsyncMock, None, None]:
         "homeassistant.components.hassio.addon_manager.async_get_addon_store_info"
     ) as addon_store_info:
         addon_store_info.return_value = {
+            "available": False,
             "installed": None,
             "state": None,
             "version": "1.0.0",
@@ -94,6 +95,7 @@ def addon_info_fixture() -> Generator[AsyncMock, None, None]:
         "homeassistant.components.hassio.addon_manager.async_get_addon_info",
     ) as addon_info:
         addon_info.return_value = {
+            "available": False,
             "hostname": None,
             "options": {},
             "state": None,
@@ -108,6 +110,7 @@ def addon_not_installed_fixture(
     addon_store_info: AsyncMock, addon_info: AsyncMock
 ) -> AsyncMock:
     """Mock add-on not installed."""
+    addon_store_info.return_value["available"] = True
     return addon_info
 
 
@@ -117,10 +120,12 @@ def addon_installed_fixture(
 ) -> AsyncMock:
     """Mock add-on already installed but not running."""
     addon_store_info.return_value = {
+        "available": True,
         "installed": "1.0.0",
         "state": "stopped",
         "version": "1.0.0",
     }
+    addon_info.return_value["available"] = True
     addon_info.return_value["hostname"] = "core-matter-server"
     addon_info.return_value["state"] = "stopped"
     addon_info.return_value["version"] = "1.0.0"
@@ -133,10 +138,12 @@ def addon_running_fixture(
 ) -> AsyncMock:
     """Mock add-on already running."""
     addon_store_info.return_value = {
+        "available": True,
         "installed": "1.0.0",
         "state": "started",
         "version": "1.0.0",
     }
+    addon_info.return_value["available"] = True
     addon_info.return_value["hostname"] = "core-matter-server"
     addon_info.return_value["state"] = "started"
     addon_info.return_value["version"] = "1.0.0"
@@ -152,10 +159,12 @@ def install_addon_fixture(
     async def install_addon_side_effect(hass: HomeAssistant, slug: str) -> None:
         """Mock install add-on."""
         addon_store_info.return_value = {
+            "available": True,
             "installed": "1.0.0",
             "state": "stopped",
             "version": "1.0.0",
         }
+        addon_info.return_value["available"] = True
         addon_info.return_value["state"] = "stopped"
         addon_info.return_value["version"] = "1.0.0"
 

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -307,7 +307,7 @@ async def test_install_addon(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
-    assert addon_store_info.call_count == 2
+    assert addon_store_info.call_count == 3
     assert install_addon.call_count == 1
     assert install_addon.call_args == call(hass, "core_matter_server")
     assert start_addon.call_count == 1

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -30,6 +30,7 @@ def mock_addon_info(addon_info_side_effect):
         side_effect=addon_info_side_effect,
     ) as addon_info:
         addon_info.return_value = {
+            "available": False,
             "hostname": None,
             "options": {},
             "state": None,
@@ -53,6 +54,7 @@ def mock_addon_store_info(addon_store_info_side_effect):
         side_effect=addon_store_info_side_effect,
     ) as addon_store_info:
         addon_store_info.return_value = {
+            "available": False,
             "installed": None,
             "state": None,
             "version": "1.0.0",
@@ -64,10 +66,12 @@ def mock_addon_store_info(addon_store_info_side_effect):
 def mock_addon_running(addon_store_info, addon_info):
     """Mock add-on already running."""
     addon_store_info.return_value = {
+        "available": True,
         "installed": "1.0.0",
         "state": "started",
         "version": "1.0.0",
     }
+    addon_info.return_value["available"] = True
     addon_info.return_value["state"] = "started"
     addon_info.return_value["version"] = "1.0.0"
     return addon_info
@@ -77,10 +81,12 @@ def mock_addon_running(addon_store_info, addon_info):
 def mock_addon_installed(addon_store_info, addon_info):
     """Mock add-on already installed but not running."""
     addon_store_info.return_value = {
+        "available": True,
         "installed": "1.0.0",
         "state": "stopped",
         "version": "1.0.0",
     }
+    addon_info.return_value["available"] = True
     addon_info.return_value["state"] = "stopped"
     addon_info.return_value["version"] = "1.0.0"
     return addon_info
@@ -89,6 +95,7 @@ def mock_addon_installed(addon_store_info, addon_info):
 @pytest.fixture(name="addon_not_installed")
 def mock_addon_not_installed(addon_store_info, addon_info):
     """Mock add-on not installed."""
+    addon_store_info.return_value["available"] = True
     return addon_info
 
 
@@ -126,10 +133,12 @@ def install_addon_side_effect_fixture(addon_store_info, addon_info):
     async def install_addon(hass, slug):
         """Mock install add-on."""
         addon_store_info.return_value = {
+            "available": True,
             "installed": "1.0.0",
             "state": "stopped",
             "version": "1.0.0",
         }
+        addon_info.return_value["available"] = True
         addon_info.return_value["state"] = "stopped"
         addon_info.return_value["version"] = "1.0.0"
 
@@ -162,10 +171,12 @@ def start_addon_side_effect_fixture(addon_store_info, addon_info):
     async def start_addon(hass, slug):
         """Mock start add-on."""
         addon_store_info.return_value = {
+            "available": True,
             "installed": "1.0.0",
             "state": "started",
             "version": "1.0.0",
         }
+        addon_info.return_value["available"] = True
         addon_info.return_value["state"] = "started"
 
     return start_addon

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -536,6 +536,7 @@ async def test_abort_hassio_discovery_for_other_addon(
 async def test_usb_discovery(
     hass,
     supervisor,
+    addon_not_installed,
     install_addon,
     addon_options,
     get_addon_discovery_info,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Background: We upgraded the chip SDK in Matter Server add-on 1.2.0 but the client in the core integration wasn't upgraded to the same chip SDK until beta 1. This will cause a version mismatch for affected users and if the integration manages the add-on the integration will try to update the add-on. In Matter Server add-on 2.0.0 we added the requirement to run Home Assistant 2023.1.0b1 to install or update the add-on to guard more users getting into the chip SDK mismatch situation. This caused backup spamming for users already in the mismatch situation, when the integration tries to update the add-on and first creates a backup of the add-on.
- If the add-on is not available we want to raise an error to the caller as install and update of add-on do not work.
- If backported to 2022.12.x, this would fix backup spamming after chip SDK mismatch in client and server in the Matter integration for users that have already ugraded the Matter Server add-on to 1.2.0 but not running the 2023.1.x beta. Users running the latest beta are not affected by the chip SDK mismatch so are not affected by the backup spam either.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
