### PR TITLE
Bump whirlpool-sixth-sense to 0.18.0

### DIFF
--- a/homeassistant/components/whirlpool/climate.py
+++ b/homeassistant/components/whirlpool/climate.py
@@ -107,8 +107,8 @@ class AirConEntity(ClimateEntity):
 
     def __init__(self, hass, said, name, backend_selector: BackendSelector, auth: Auth):
         """Initialize the entity."""
-        self._aircon = Aircon(backend_selector, auth, said, self.async_write_ha_state)
-
+        self._aircon = Aircon(backend_selector, auth, said)
+        self._aircon.register_attr_callback(self.async_write_ha_state)
         self.entity_id = generate_entity_id(ENTITY_ID_FORMAT, said, hass=hass)
         self._attr_name = name if name is not None else said
         self._attr_unique_id = said
@@ -116,6 +116,10 @@ class AirConEntity(ClimateEntity):
     async def async_added_to_hass(self) -> None:
         """Connect aircon to the cloud."""
         await self._aircon.connect()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Close Whrilpool Appliance sockets before removing."""
+        await self._aircon.disconnect()
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/whirlpool/manifest.json
+++ b/homeassistant/components/whirlpool/manifest.json
@@ -3,7 +3,7 @@
   "name": "Whirlpool Sixth Sense",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/whirlpool",
-  "requirements": ["whirlpool-sixth-sense==0.17.1"],
+  "requirements": ["whirlpool-sixth-sense==0.18.0"],
   "codeowners": ["@abmantis"],
   "iot_class": "cloud_push",
   "loggers": ["whirlpool"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2570,7 +2570,7 @@ waterfurnace==1.1.0
 webexteamssdk==1.1.1
 
 # homeassistant.components.whirlpool
-whirlpool-sixth-sense==0.17.1
+whirlpool-sixth-sense==0.18.0
 
 # homeassistant.components.whois
 whois==0.9.16

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1795,7 +1795,7 @@ wallbox==0.4.12
 watchdog==2.2.0
 
 # homeassistant.components.whirlpool
-whirlpool-sixth-sense==0.17.1
+whirlpool-sixth-sense==0.18.0
 
 # homeassistant.components.whois
 whois==0.9.16

--- a/tests/components/whirlpool/conftest.py
+++ b/tests/components/whirlpool/conftest.py
@@ -56,6 +56,7 @@ def get_aircon_mock(said):
     """Get a mock of an air conditioner."""
     mock_aircon = mock.Mock(said=said)
     mock_aircon.connect = AsyncMock()
+    mock_aircon.disconnect = AsyncMock()
     mock_aircon.get_online.return_value = True
     mock_aircon.get_power_on.return_value = True
     mock_aircon.get_mode.return_value = whirlpool.aircon.Mode.Cool

--- a/tests/components/whirlpool/test_climate.py
+++ b/tests/components/whirlpool/test_climate.py
@@ -51,15 +51,13 @@ from . import init_integration
 async def update_ac_state(
     hass: HomeAssistant,
     entity_id: str,
-    mock_aircon_api_instances: MagicMock,
-    mock_instance_idx: int,
+    mock_aircon_api_instance: MagicMock,
 ):
     """Simulate an update trigger from the API."""
-    update_ha_state_cb = mock_aircon_api_instances.call_args_list[
-        mock_instance_idx
-    ].args[3]
-    update_ha_state_cb()
-    await hass.async_block_till_done()
+    for call in mock_aircon_api_instance.register_attr_callback.call_args_list:
+        update_ha_state_cb = call[0][0]
+        update_ha_state_cb()
+        await hass.async_block_till_done()
     return hass.states.get(entity_id)
 
 
@@ -72,7 +70,11 @@ async def test_no_appliances(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_static_attributes(hass: HomeAssistant, mock_aircon1_api: MagicMock):
+async def test_static_attributes(
+    hass: HomeAssistant,
+    mock_aircon1_api: MagicMock,
+    mock_aircon_api_instances: MagicMock,
+):
     """Test static climate attributes."""
     await init_integration(hass)
 
@@ -137,81 +139,56 @@ async def test_dynamic_attributes(
     ):
         entity_id = clim_test_instance.entity_id
         mock_instance = clim_test_instance.mock_instance
-        mock_instance_idx = clim_test_instance.mock_instance_idx
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == HVACMode.COOL
 
         mock_instance.get_power_on.return_value = False
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.state == HVACMode.OFF
 
         mock_instance.get_online.return_value = False
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.state == STATE_UNAVAILABLE
 
         mock_instance.get_power_on.return_value = True
         mock_instance.get_online.return_value = True
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.state == HVACMode.COOL
 
         mock_instance.get_mode.return_value = whirlpool.aircon.Mode.Heat
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.state == HVACMode.HEAT
 
         mock_instance.get_mode.return_value = whirlpool.aircon.Mode.Fan
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.state == HVACMode.FAN_ONLY
 
         mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.Auto
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.attributes[ATTR_FAN_MODE] == HVACMode.AUTO
 
         mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.Low
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.attributes[ATTR_FAN_MODE] == FAN_LOW
 
         mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.Medium
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.attributes[ATTR_FAN_MODE] == FAN_MEDIUM
 
         mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.High
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.attributes[ATTR_FAN_MODE] == FAN_HIGH
 
         mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.Off
-        state = await update_ac_state(
-            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-        )
+        state = await update_ac_state(hass, entity_id, mock_instance)
         assert state.attributes[ATTR_FAN_MODE] == FAN_OFF
 
         mock_instance.get_current_temp.return_value = 15
         mock_instance.get_temp.return_value = 20
         mock_instance.get_current_humidity.return_value = 80
         mock_instance.get_h_louver_swing.return_value = True
-        attributes = (
-            await update_ac_state(
-                hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-            )
-        ).attributes
+        attributes = (await update_ac_state(hass, entity_id, mock_instance)).attributes
         assert attributes[ATTR_CURRENT_TEMPERATURE] == 15
         assert attributes[ATTR_TEMPERATURE] == 20
         assert attributes[ATTR_CURRENT_HUMIDITY] == 80
@@ -221,11 +198,7 @@ async def test_dynamic_attributes(
         mock_instance.get_temp.return_value = 21
         mock_instance.get_current_humidity.return_value = 70
         mock_instance.get_h_louver_swing.return_value = False
-        attributes = (
-            await update_ac_state(
-                hass, entity_id, mock_aircon_api_instances, mock_instance_idx
-            )
-        ).attributes
+        attributes = (await update_ac_state(hass, entity_id, mock_instance)).attributes
         assert attributes[ATTR_CURRENT_TEMPERATURE] == 16
         assert attributes[ATTR_TEMPERATURE] == 21
         assert attributes[ATTR_CURRENT_HUMIDITY] == 70
@@ -233,7 +206,10 @@ async def test_dynamic_attributes(
 
 
 async def test_service_calls(
-    hass: HomeAssistant, mock_aircon1_api: MagicMock, mock_aircon2_api: MagicMock
+    hass: HomeAssistant,
+    mock_aircon_api_instances: MagicMock,
+    mock_aircon1_api: MagicMock,
+    mock_aircon2_api: MagicMock,
 ):
     """Test controlling the entity through service calls."""
     await init_integration(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump whirlpool-sixth-sense to 0.18: https://github.com/abmantis/whirlpool-sixth-sense/compare/0.17.1...0.18
Add callback method initiated in 18.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
