### PR TITLE
Change cast.show_lovelace_view to cast.dashboard

### DIFF
--- a/tests/components/cast/test_home_assistant_cast.py
+++ b/tests/components/cast/test_home_assistant_cast.py
@@ -20,7 +20,7 @@ async def test_service_show_view(hass, mock_zeroconf):
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             "cast",
-            "show_lovelace_view",
+            "show_dashboard",
             {"entity_id": "media_player.kitchen", "view_path": "mock_path"},
             blocking=True,
         )
@@ -32,7 +32,7 @@ async def test_service_show_view(hass, mock_zeroconf):
     )
     await hass.services.async_call(
         "cast",
-        "show_lovelace_view",
+        "show_dashboard",
         {"entity_id": "media_player.kitchen", "view_path": "mock_path"},
         blocking=True,
     )
@@ -59,7 +59,7 @@ async def test_service_show_view_dashboard(hass, mock_zeroconf):
 
     await hass.services.async_call(
         "cast",
-        "show_lovelace_view",
+        "show_dashboard",
         {
             "entity_id": "media_player.kitchen",
             "view_path": "mock_path",
@@ -92,7 +92,7 @@ async def test_use_cloud_url(hass, mock_zeroconf):
     ):
         await hass.services.async_call(
             "cast",
-            "show_lovelace_view",
+            "show_dashboard",
             {"entity_id": "media_player.kitchen", "view_path": "mock_path"},
             blocking=True,
         )

--- a/tests/components/lovelace/test_cast.py
+++ b/tests/components/lovelace/test_cast.py
@@ -162,7 +162,7 @@ async def test_browse_media(hass, mock_yaml_dashboard, mock_https_url):
 
 async def test_play_media(hass, mock_yaml_dashboard):
     """Test playing media."""
-    calls = async_mock_service(hass, "cast", "show_lovelace_view")
+    calls = async_mock_service(hass, "cast", "show_dashboard")
 
     await lovelace_cast.async_play_media(
         hass, "media_player.my_cast", None, "lovelace", lovelace_cast.DEFAULT_DASHBOARD


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Since Lovelace has been renamed to Dashboards, I believe we should also change the cast.show_lovelace_view service to cast.show_dashboard. This change renames the service.
All users should rename their automations to use the new service name.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Renaming cast.show_lovelace_view to cast.show_dashboard


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: _Will add later and edit PR when finished documentation_

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->


This is my very first PR and I'm not sure how HA core coding works, so please be gentle with me. If this is not how changing a service name should be done, then please close this PR.