### PR TITLE
Remove attributes from Twinkly lights

### DIFF
--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -23,11 +23,5 @@ DEV_PROFILE_RGBW = "RGBW"
 DATA_CLIENT = "client"
 DATA_DEVICE_INFO = "device_info"
 
-HIDDEN_DEV_VALUES = (
-    "code",  # This is the internal status code of the API response
-    "copyright",  # We should not display a copyright "LEDWORKS 2018" in the Home-Assistant UI
-    "mac",  # Does not report the actual device mac address
-)
-
 # Minimum version required to support effects
 MIN_EFFECT_VERSION = "2.7.1"

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -38,7 +38,6 @@ from .const import (
     DEV_PROFILE_RGB,
     DEV_PROFILE_RGBW,
     DOMAIN,
-    HIDDEN_DEV_VALUES,
     MIN_EFFECT_VERSION,
 )
 
@@ -296,10 +295,6 @@ class TwinklyLight(LightEntity):
                         CONF_MODEL: self._model,
                     },
                 )
-
-            for key, value in device_info.items():
-                if key not in HIDDEN_DEV_VALUES:
-                    self._attributes[key] = value
 
             if LightEntityFeature.EFFECT & self.supported_features:
                 await self.async_update_movies()

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -34,9 +34,6 @@ async def test_initial_state(hass: HomeAssistant):
     assert state.attributes["friendly_name"] == entity.unique_id
     assert state.attributes["icon"] == "mdi:string-lights"
 
-    # Validates that custom properties of the API device_info are propagated through attributes
-    assert state.attributes["uuid"] == entity.unique_id
-
     assert entity.original_name == entity.unique_id
     assert entity.original_icon == "mdi:string-lights"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

All state attributes from Twinkly lights have been removed. They mostly added information about the device and not about the actual state itself.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes the state attributes from Twinkly lights. They are excessive and not something we generally accept as state attributes. Additionally, they have been just pulled in from the library and are not controlled by Home Assistant either.

See screenshot below of all the current state attributes provided:

![image](https://user-images.githubusercontent.com/195327/210245968-bea99211-1679-4392-bdf2-9e09c9f02e1a.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
