### PR TITLE
Add hs_command_template and xy_command_template to mqtt light default schema

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -78,6 +78,7 @@ ABBREVIATIONS = {
     "hold_stat_tpl": "hold_state_template",
     "hold_stat_t": "hold_state_topic",
     "hs_cmd_t": "hs_command_topic",
+    "hs_cmd_tpl": "hs_command_template",
     "hs_stat_t": "hs_state_topic",
     "hs_val_tpl": "hs_value_template",
     "ic": "icon",

--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -251,6 +251,7 @@ ABBREVIATIONS = {
     "whit_val_stat_t": "white_value_state_topic",
     "whit_val_tpl": "white_value_template",
     "xy_cmd_t": "xy_command_topic",
+    "xy_cmd_tpl": "xy_command_template",
     "xy_stat_t": "xy_state_topic",
     "xy_val_tpl": "xy_value_template",
     "l_ver_t": "latest_version_topic",

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -106,6 +106,7 @@ CONF_RGBWW_COMMAND_TEMPLATE = "rgbww_command_template"
 CONF_RGBWW_COMMAND_TOPIC = "rgbww_command_topic"
 CONF_RGBWW_STATE_TOPIC = "rgbww_state_topic"
 CONF_RGBWW_VALUE_TEMPLATE = "rgbww_value_template"
+CONF_XY_COMMAND_TEMPLATE = "xy_command_template"
 CONF_XY_COMMAND_TOPIC = "xy_command_topic"
 CONF_XY_STATE_TOPIC = "xy_state_topic"
 CONF_XY_VALUE_TEMPLATE = "xy_value_template"
@@ -152,6 +153,7 @@ COMMAND_TEMPLATE_KEYS = [
     CONF_RGB_COMMAND_TEMPLATE,
     CONF_RGBW_COMMAND_TEMPLATE,
     CONF_RGBWW_COMMAND_TEMPLATE,
+    CONF_XY_COMMAND_TEMPLATE,
 ]
 VALUE_TEMPLATE_KEYS = [
     CONF_BRIGHTNESS_VALUE_TEMPLATE,
@@ -216,6 +218,7 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_WHITE_SCALE, default=DEFAULT_WHITE_SCALE): vol.All(
                 vol.Coerce(int), vol.Range(min=1)
             ),
+            vol.Optional(CONF_XY_COMMAND_TEMPLATE): cv.template,
             vol.Optional(CONF_XY_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_XY_STATE_TOPIC): valid_subscribe_topic,
             vol.Optional(CONF_XY_VALUE_TEMPLATE): cv.template,
@@ -804,7 +807,11 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         if (xy_color := kwargs.get(ATTR_XY_COLOR)) and self._topic[
             CONF_XY_COMMAND_TOPIC
         ] is not None:
-            await publish(CONF_XY_COMMAND_TOPIC, f"{xy_color[0]},{xy_color[1]}")
+            device_xy_payload = self._command_templates[CONF_XY_COMMAND_TEMPLATE](
+                f"{xy_color[0]},{xy_color[1]}",
+                {"x": xy_color[0], "y": xy_color[1]},
+            )
+            await publish(CONF_XY_COMMAND_TOPIC, device_xy_payload)
             should_update |= set_optimistic(ATTR_XY_COLOR, xy_color, ColorMode.XY)
 
         if (

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -88,6 +88,7 @@ CONF_EFFECT_COMMAND_TOPIC = "effect_command_topic"
 CONF_EFFECT_LIST = "effect_list"
 CONF_EFFECT_STATE_TOPIC = "effect_state_topic"
 CONF_EFFECT_VALUE_TEMPLATE = "effect_value_template"
+CONF_HS_COMMAND_TEMPLATE = "hs_command_template"
 CONF_HS_COMMAND_TOPIC = "hs_command_topic"
 CONF_HS_STATE_TOPIC = "hs_state_topic"
 CONF_HS_VALUE_TEMPLATE = "hs_value_template"
@@ -147,6 +148,7 @@ COMMAND_TEMPLATE_KEYS = [
     CONF_BRIGHTNESS_COMMAND_TEMPLATE,
     CONF_COLOR_TEMP_COMMAND_TEMPLATE,
     CONF_EFFECT_COMMAND_TEMPLATE,
+    CONF_HS_COMMAND_TEMPLATE,
     CONF_RGB_COMMAND_TEMPLATE,
     CONF_RGBW_COMMAND_TEMPLATE,
     CONF_RGBWW_COMMAND_TEMPLATE,
@@ -185,6 +187,7 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_EFFECT_LIST): vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_EFFECT_STATE_TOPIC): valid_subscribe_topic,
             vol.Optional(CONF_EFFECT_VALUE_TEMPLATE): cv.template,
+            vol.Optional(CONF_HS_COMMAND_TEMPLATE): cv.template,
             vol.Optional(CONF_HS_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_HS_STATE_TOPIC): valid_subscribe_topic,
             vol.Optional(CONF_HS_VALUE_TEMPLATE): cv.template,
@@ -763,7 +766,11 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         hs_color: str | None = kwargs.get(ATTR_HS_COLOR)
 
         if hs_color and self._topic[CONF_HS_COMMAND_TOPIC] is not None:
-            await publish(CONF_HS_COMMAND_TOPIC, f"{hs_color[0]},{hs_color[1]}")
+            device_hs_payload = self._command_templates[CONF_HS_COMMAND_TEMPLATE](
+                f"{hs_color[0]},{hs_color[1]}",
+                {"hue": hs_color[0], "sat": hs_color[1]},
+            )
+            await publish(CONF_HS_COMMAND_TOPIC, device_hs_payload)
             should_update |= set_optimistic(ATTR_HS_COLOR, hs_color, ColorMode.HS)
 
         rgb: tuple[int, int, int] | None

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -2870,9 +2870,9 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
             "xy_command_topic",
             {"hs_color": [30.118, 100.0]},
             "0.611,0.375",
-            None,
-            None,
-            None,
+            "xy_command_template",
+            "x * 10",
+            b"6",
         ),
         (
             light.SERVICE_TURN_OFF,
@@ -3147,6 +3147,42 @@ async def test_sending_mqtt_hs_command_with_template(
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
     assert state.attributes["hs_color"] == (30, 100)
+
+
+async def test_sending_mqtt_xy_command_with_template(
+    hass, mqtt_mock_entry_with_yaml_config
+):
+    """Test the sending of XY Color command with template."""
+    config = {
+        light.DOMAIN: {
+            "name": "test",
+            "command_topic": "test_light_xy/set",
+            "xy_command_topic": "test_light_xy/xy_color/set",
+            "xy_command_template": '{"Color": "{{ (x * 65536) | round | int }},{{ (y * 65536) | round | int }}"}',
+            "qos": 0,
+        }
+    }
+
+    assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
+    await hass.async_block_till_done()
+    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_UNKNOWN
+
+    await common.async_turn_on(hass, "light.test", xy_color=(0.151, 0.343))
+
+    mqtt_mock.async_publish.assert_has_calls(
+        [
+            call("test_light_xy/set", "ON", 0, False),
+            call("test_light_xy/xy_color/set", '{"Color": "9896,22479"}', 0, False),
+        ],
+        any_order=True,
+    )
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_ON
+    assert state.attributes["xy_color"] == (0.151, 0.343)
 
 
 async def test_setup_manual_entity_from_yaml(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Zigbee lights connected to a tasmotized zbbridge need a specially formatted JSON message sent to a general command topic, where the color can only be set by either its XY value, or by its hue and saturation. 

For example, to set the light color to fully saturated cyan, the following message has to be sent to `cmnd/myzbbridge/ZbSend`:
`{ "Device": "My_Light", "Send": {"HueSat": "127,254" } }`

This PR adds the missing command templates for XY Color and HS Color to the MQTT light basic schema to allow controlling the color for these lights.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io/pull/25504

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
