### PR TITLE
Add door, opening and motion sensors to Xiaomi-ble

### DIFF
--- a/homeassistant/components/xiaomi_ble/binary_sensor.py
+++ b/homeassistant/components/xiaomi_ble/binary_sensor.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from xiaomi_ble.parser import (
     BinarySensorDeviceClass as XiaomiBinarySensorDeviceClass,
+    ExtendedBinarySensorDeviceClass,
     SensorUpdate,
 )
 
@@ -52,23 +53,23 @@ BINARY_SENSOR_DESCRIPTIONS = {
         key=XiaomiBinarySensorDeviceClass.SMOKE,
         device_class=BinarySensorDeviceClass.SMOKE,
     ),
-    "device_forcibly_removed": BinarySensorEntityDescription(
-        key="device_forcibly_removed",
+    ExtendedBinarySensorDeviceClass.DEVICE_FORCIBLY_REMOVED: BinarySensorEntityDescription(
+        key=ExtendedBinarySensorDeviceClass.DEVICE_FORCIBLY_REMOVED,
         device_class=BinarySensorDeviceClass.PROBLEM,
     ),
-    "door_left_open": BinarySensorEntityDescription(
-        key="door_left_open",
+    ExtendedBinarySensorDeviceClass.DOOR_LEFT_OPEN: BinarySensorEntityDescription(
+        key=ExtendedBinarySensorDeviceClass.DOOR_LEFT_OPEN,
         device_class=BinarySensorDeviceClass.PROBLEM,
     ),
-    "door_stuck": BinarySensorEntityDescription(
-        key="door_stuck",
+    ExtendedBinarySensorDeviceClass.DOOR_STUCK: BinarySensorEntityDescription(
+        key=ExtendedBinarySensorDeviceClass.DOOR_STUCK,
         device_class=BinarySensorDeviceClass.PROBLEM,
     ),
-    "knock_on_the_door": BinarySensorEntityDescription(
-        key="knock_on_the_door",
+    ExtendedBinarySensorDeviceClass.KNOCK_ON_THE_DOOR: BinarySensorEntityDescription(
+        key=ExtendedBinarySensorDeviceClass.KNOCK_ON_THE_DOOR,
     ),
-    "pry_the_door": BinarySensorEntityDescription(
-        key="pry_the_door",
+    ExtendedBinarySensorDeviceClass.PRY_THE_DOOR: BinarySensorEntityDescription(
+        key=ExtendedBinarySensorDeviceClass.PRY_THE_DOOR,
         device_class=BinarySensorDeviceClass.TAMPER,
     ),
 }
@@ -85,7 +86,7 @@ def sensor_update_to_bluetooth_data_update(
         },
         entity_descriptions={
             device_key_to_bluetooth_entity_key(device_key): BINARY_SENSOR_DESCRIPTIONS[
-                device_key.key
+                description.device_class
             ]
             for device_key, description in sensor_update.binary_entity_descriptions.items()
             if description.device_class

--- a/homeassistant/components/xiaomi_ble/binary_sensor.py
+++ b/homeassistant/components/xiaomi_ble/binary_sensor.py
@@ -28,20 +28,48 @@ from .const import DOMAIN
 from .device import device_key_to_bluetooth_entity_key
 
 BINARY_SENSOR_DESCRIPTIONS = {
-    XiaomiBinarySensorDeviceClass.MOTION: BinarySensorEntityDescription(
-        key=XiaomiBinarySensorDeviceClass.MOTION,
-        device_class=BinarySensorDeviceClass.MOTION,
+    XiaomiBinarySensorDeviceClass.DOOR: BinarySensorEntityDescription(
+        key=XiaomiBinarySensorDeviceClass.DOOR,
+        device_class=BinarySensorDeviceClass.DOOR,
     ),
     XiaomiBinarySensorDeviceClass.LIGHT: BinarySensorEntityDescription(
         key=XiaomiBinarySensorDeviceClass.LIGHT,
         device_class=BinarySensorDeviceClass.LIGHT,
     ),
+    XiaomiBinarySensorDeviceClass.MOISTURE: BinarySensorEntityDescription(
+        key=XiaomiBinarySensorDeviceClass.MOISTURE,
+        device_class=BinarySensorDeviceClass.MOISTURE,
+    ),
+    XiaomiBinarySensorDeviceClass.MOTION: BinarySensorEntityDescription(
+        key=XiaomiBinarySensorDeviceClass.MOTION,
+        device_class=BinarySensorDeviceClass.MOTION,
+    ),
+    XiaomiBinarySensorDeviceClass.OPENING: BinarySensorEntityDescription(
+        key=XiaomiBinarySensorDeviceClass.OPENING,
+        device_class=BinarySensorDeviceClass.OPENING,
+    ),
     XiaomiBinarySensorDeviceClass.SMOKE: BinarySensorEntityDescription(
         key=XiaomiBinarySensorDeviceClass.SMOKE,
         device_class=BinarySensorDeviceClass.SMOKE,
     ),
-    XiaomiBinarySensorDeviceClass.MOISTURE: BinarySensorEntityDescription(
-        key=XiaomiBinarySensorDeviceClass.MOISTURE,
+    "device_forcibly_removed": BinarySensorEntityDescription(
+        key="device_forcibly_removed",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    "door_left_open": BinarySensorEntityDescription(
+        key="door_left_open",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    "door_stuck": BinarySensorEntityDescription(
+        key="door_stuck",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    "knock_on_the_door": BinarySensorEntityDescription(
+        key="knock_on_the_door",
+    ),
+    "pry_the_door": BinarySensorEntityDescription(
+        key="pry_the_door",
+        device_class=BinarySensorDeviceClass.TAMPER,
     ),
 }
 
@@ -57,7 +85,7 @@ def sensor_update_to_bluetooth_data_update(
         },
         entity_descriptions={
             device_key_to_bluetooth_entity_key(device_key): BINARY_SENSOR_DESCRIPTIONS[
-                description.device_class
+                device_key.key
             ]
             for device_key, description in sensor_update.binary_entity_descriptions.items()
             if description.device_class

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -13,7 +13,7 @@
       "service_data_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.12.2"],
+  "requirements": ["xiaomi-ble==0.14.0"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -13,7 +13,7 @@
       "service_data_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.14.0"],
+  "requirements": ["xiaomi-ble==0.14.1"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -13,7 +13,7 @@
       "service_data_uuid": "0000fe95-0000-1000-8000-00805f9b34fb"
     }
   ],
-  "requirements": ["xiaomi-ble==0.14.1"],
+  "requirements": ["xiaomi-ble==0.14.3"],
   "dependencies": ["bluetooth"],
   "codeowners": ["@Jc2k", "@Ernst79"],
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2597,7 +2597,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.14.0
+xiaomi-ble==0.14.1
 
 # homeassistant.components.knx
 xknx==2.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2597,7 +2597,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.14.1
+xiaomi-ble==0.14.3
 
 # homeassistant.components.knx
 xknx==2.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2597,7 +2597,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.12.2
+xiaomi-ble==0.14.0
 
 # homeassistant.components.knx
 xknx==2.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1816,7 +1816,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.12.2
+xiaomi-ble==0.14.0
 
 # homeassistant.components.knx
 xknx==2.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1816,7 +1816,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.14.0
+xiaomi-ble==0.14.1
 
 # homeassistant.components.knx
 xknx==2.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1816,7 +1816,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.14.1
+xiaomi-ble==0.14.3
 
 # homeassistant.components.knx
 xknx==2.2.0

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -9,12 +9,12 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info_bleak
 
 
-async def test_smoke_sensor(hass):
-    """Test setting up a smoke sensor."""
+async def test_door_problem_sensors(hass):
+    """Test setting up a door binary sensor with additional problem sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="54:EF:44:E3:9C:BC",
-        data={"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"},
+        unique_id="EE:89:73:44:BE:98",
+        data={"bindkey": "2c3795afa33019a8afdc17ba99e6f217"},
     )
     entry.add_to_hass(hass)
 
@@ -25,24 +25,72 @@ async def test_smoke_sensor(hass):
     inject_bluetooth_service_info_bleak(
         hass,
         make_advertisement(
-            "54:EF:44:E3:9C:BC",
-            b"XY\x97\tf\xbc\x9c\xe3D\xefT\x01" b"\x08\x12\x05\x00\x00\x00q^\xbe\x90",
+            "EE:89:73:44:BE:98",
+            b"HU9\x0e3\x9cq\xc0$\x1f\xff\xee\x80S\x00\x00\x02\xb4\xc59",
         ),
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 3
 
-    smoke_sensor = hass.states.get("binary_sensor.thermometer_9cbc_smoke")
-    smoke_sensor_attribtes = smoke_sensor.attributes
-    assert smoke_sensor.state == "on"
-    assert smoke_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Thermometer 9CBC Smoke"
+    door_sensor = hass.states.get("binary_sensor.door_lock_be98_door")
+    door_sensor_attribtes = door_sensor.attributes
+    assert door_sensor.state == "off"
+    assert door_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Door Lock BE98 Door"
+
+    door_left_open = hass.states.get("binary_sensor.door_lock_be98_door_left_open")
+    door_left_open_attribtes = door_left_open.attributes
+    assert door_left_open.state == "off"
+    assert (
+        door_left_open_attribtes[ATTR_FRIENDLY_NAME] == "Door Lock BE98 Door left open"
+    )
+
+    pry_the_door = hass.states.get("binary_sensor.door_lock_be98_pry_the_door")
+    pry_the_door_attribtes = pry_the_door.attributes
+    assert pry_the_door.state == "off"
+    assert pry_the_door_attribtes[ATTR_FRIENDLY_NAME] == "Door Lock BE98 Pry the door"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_light_motion(hass):
+    """Test setting up a light and motion binary sensor."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="58:2D:34:35:93:21",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_advertisement(
+            "58:2D:34:35:93:21",
+            b"P \xf6\x07\xda!\x9354-X\x0f\x00\x03\x01\x00\x00",
+        ),
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 2
+
+    motion_sensor = hass.states.get("binary_sensor.nightlight_9321_motion")
+    motion_sensor_attribtes = motion_sensor.attributes
+    assert motion_sensor.state == "on"
+    assert motion_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Nightlight 9321 Motion"
+
+    light_sensor = hass.states.get("binary_sensor.nightlight_9321_light")
+    light_sensor_attribtes = light_sensor.attributes
+    assert light_sensor.state == "off"
+    assert light_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Nightlight 9321 Light"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
 
 async def test_moisture(hass):
-    """Make sure that formldehyde sensors are correctly mapped."""
+    """Test setting up a moisture binary sensor."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="C4:7C:8D:6A:3E:7A",
@@ -70,6 +118,128 @@ async def test_moisture(hass):
     sensor_attr = sensor.attributes
     assert sensor.state == "on"
     assert sensor_attr[ATTR_FRIENDLY_NAME] == "Smart Flower Pot 3E7A Moisture"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_opening(hass):
+    """Test setting up a opening binary sensor."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="A4:C1:38:66:E5:67",
+        data={"bindkey": "0fdcc30fe9289254876b5ef7c11ef1f0"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_advertisement(
+            "A4:C1:38:66:E5:67",
+            b"XY\x89\x18\x9ag\xe5f8\xc1\xa4\x9d\xd9z\xf3&\x00\x00\xc8\xa6\x0b\xd5",
+        ),
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 1
+
+    opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
+    opening_sensor_attribtes = opening_sensor.attributes
+    assert opening_sensor.state == "on"
+    assert (
+        opening_sensor_attribtes[ATTR_FRIENDLY_NAME]
+        == "Door/Window Sensor E567 Opening"
+    )
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_opening_problem_sensors(hass):
+    """Test setting up a opening binary sensor with additional problem sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="A4:C1:38:66:E5:67",
+        data={"bindkey": "0fdcc30fe9289254876b5ef7c11ef1f0"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_advertisement(
+            "A4:C1:38:66:E5:67",
+            b"XY\x89\x18ug\xe5f8\xc1\xa4i\xdd\xf3\xa1&\x00\x00\xa2J\x1bE",
+        ),
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 3
+
+    opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
+    opening_sensor_attribtes = opening_sensor.attributes
+    assert opening_sensor.state == "off"
+    assert (
+        opening_sensor_attribtes[ATTR_FRIENDLY_NAME]
+        == "Door/Window Sensor E567 Opening"
+    )
+
+    door_left_open = hass.states.get(
+        "binary_sensor.door_window_sensor_e567_door_left_open"
+    )
+    door_left_open_attribtes = door_left_open.attributes
+    assert door_left_open.state == "off"
+    assert (
+        door_left_open_attribtes[ATTR_FRIENDLY_NAME]
+        == "Door/Window Sensor E567 Door left open"
+    )
+
+    device_forcibly_removed = hass.states.get(
+        "binary_sensor.door_window_sensor_e567_device_forcibly_removed"
+    )
+    device_forcibly_removed_attribtes = device_forcibly_removed.attributes
+    assert device_forcibly_removed.state == "off"
+    assert (
+        device_forcibly_removed_attribtes[ATTR_FRIENDLY_NAME]
+        == "Door/Window Sensor E567 Device forcibly removed"
+    )
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_smoke(hass):
+    """Test setting up a smoke binary sensor."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="54:EF:44:E3:9C:BC",
+        data={"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_advertisement(
+            "54:EF:44:E3:9C:BC",
+            b"XY\x97\tf\xbc\x9c\xe3D\xefT\x01" b"\x08\x12\x05\x00\x00\x00q^\xbe\x90",
+        ),
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 1
+
+    smoke_sensor = hass.states.get("binary_sensor.thermometer_9cbc_smoke")
+    smoke_sensor_attribtes = smoke_sensor.attributes
+    assert smoke_sensor.state == "on"
+    assert smoke_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Thermometer 9CBC Smoke"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Adding `door`, `opening` and `motion` binary sensors to Xiaomi-ble, along with some additional binary sensors for `door stuck`, `door left open`, `device forcibly removed`, etc., which is also reported by these sensors. 
- The following sensors are using these sensors
  - Door: XMZNMS08LM, ZNMS16LM, ZNMS17LM
  - Opening: MS1BB(MI), MCCGQ02HL and Qingping CGH1
  - Motion: MJYD02YL, RTCGQ02LM, CGPR1, HS1BB(MI)
- Adding support for Xiaomi Mijia Smart Temperature and Humidity Monitor 3 (MJWSD05MMC)

Note that the motion sensor of MUE4094RT is not included in this PR, as it doesn't send `motion clear`. We will need some motion reset timer for that one, which is not included in this PR. 

Release notes of xiaomi-ble
https://github.com/Bluetooth-Devices/xiaomi-ble/releases/tag/v0.13.0
https://github.com/Bluetooth-Devices/xiaomi-ble/releases/tag/v0.14.0
https://github.com/Bluetooth-Devices/xiaomi-ble/compare/v0.14.0...v0.14.3

 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
