### PR TITLE
Allow specifying an icon in file sensor config

### DIFF
--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -65,7 +65,7 @@ class FileSensor(SensorEntity):
     def __init__(
         self,
         name: str,
-        icon: str,
+        icon: str | None,
         file_path: str,
         unit_of_measurement: str | None,
         value_template: Template | None,

--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import (
     CONF_FILE_PATH,
     CONF_NAME,
+    CONF_ICON,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_TEMPLATE,
 )
@@ -23,13 +24,13 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "File"
-
-ICON = "mdi:file"
+DEFAULT_ICON = "mdi:file"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_FILE_PATH): cv.isfile,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.icon,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     }
@@ -45,6 +46,7 @@ async def async_setup_platform(
     """Set up the file sensor."""
     file_path: str = config[CONF_FILE_PATH]
     name: str = config[CONF_NAME]
+    icon: str | None = config.get(CONF_ICON)
     unit: str | None = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template: Template | None = config.get(CONF_VALUE_TEMPLATE)
 
@@ -52,7 +54,7 @@ async def async_setup_platform(
         value_template.hass = hass
 
     if hass.config.is_allowed_path(file_path):
-        async_add_entities([FileSensor(name, file_path, unit, value_template)], True)
+        async_add_entities([FileSensor(name, icon, file_path, unit, value_template)], True)
     else:
         _LOGGER.error("'%s' is not an allowed directory", file_path)
 
@@ -60,17 +62,17 @@ async def async_setup_platform(
 class FileSensor(SensorEntity):
     """Implementation of a file sensor."""
 
-    _attr_icon = ICON
-
     def __init__(
         self,
         name: str,
+        icon: str,
         file_path: str,
         unit_of_measurement: str | None,
         value_template: Template | None,
     ) -> None:
         """Initialize the file sensor."""
         self._attr_name = name
+        self._attr_icon = icon
         self._file_path = file_path
         self._attr_native_unit_of_measurement = unit_of_measurement
         self._val_tpl = value_template
@@ -96,3 +98,4 @@ class FileSensor(SensorEntity):
             )
         else:
             self._attr_native_value = data
+


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `file` sensor is used to read all kinds of different values but is now always using the default `mdi:file` icon to represent it. With this change you can use any icon to better match what the sensor is representing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [home-assistant/home-assistant.io#25505](https://github.com/home-assistant/home-assistant.io/pull/25505)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`) (but it also generates many other changes)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
