### PR TITLE
Adjust stale bot action to be more performant

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
       # - PRs
       # - No PRs marked as no-stale
       # - No issues (-1)
-      - name: 90 days stale issues & PRs policy
+      - name: 90 days stale PRs policy
         uses: actions/stale@v7.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
       # - Issues
       # - No issues marked as no-stale or help-wanted
       # - No PRs (-1)
-      - name: 90 days stale issues & PRs policy
+      - name: 90 days stale issues
         uses: actions/stale@v7.0.0
         with:
           repo-token: ${{ steps.token.outputs.token }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,11 +11,11 @@ jobs:
     if: github.repository_owner == 'home-assistant'
     runs-on: ubuntu-latest
     steps:
-      # The 90 day stale policy
+      # The 90 day stale policy for PRs
       # Used for:
-      # - Issues & PRs
+      # - PRs
       # - No PRs marked as no-stale
-      # - No issues marked as no-stale or help-wanted
+      # - No issues (-1)
       - name: 90 days stale issues & PRs policy
         uses: actions/stale@v7.0.0
         with:
@@ -24,8 +24,43 @@ jobs:
           days-before-close: 7
           operations-per-run: 150
           remove-stale-when-updated: true
+          stale-pr-label: "stale"
+          exempt-pr-labels: "no-stale"
+          stale-pr-message: >
+            There hasn't been any activity on this pull request recently. This
+            pull request has been automatically marked as stale because of that
+            and will be closed if no further activity occurs within 7 days.
+
+            Thank you for your contributions.
+
+      # Generate a token for the GitHub App, we use this method to avoid
+      # hitting API limits for our GitHub actions + have a higher rate limit.
+      # This is only used for issues.
+      - name: Generate app token
+        id: token
+        # Pinned to a specific version of the action for security reasons
+        # v1.7.0
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        with:
+          app_id: ${{ secrets.ISSUE_TRIAGE_APP_ID }}
+          private_key: ${{ secrets.ISSUE_TRIAGE_APP_PEM }}
+
+      # The 90 day stale policy for issues
+      # Used for:
+      # - Issues
+      # - No issues marked as no-stale or help-wanted
+      # - No PRs (-1)
+      - name: 90 days stale issues & PRs policy
+        uses: actions/stale@v7.0.0
+        with:
+          repo-token: ${{ steps.token.outputs.token }}
+          days-before-stale: 90
+          days-before-close: 7
+          days-before-pr-close: -1
+          operations-per-run: 250
+          remove-stale-when-updated: true
           stale-issue-label: "stale"
-          exempt-issue-labels: "no-stale,help-wanted"
+          exempt-issue-labels: "no-stale,help-wanted,needs-more-information"
           stale-issue-message: >
             There hasn't been any activity on this issue recently. Due to the
             high number of incoming GitHub notifications, we have to clean some
@@ -39,40 +74,6 @@ jobs:
             This issue has now been marked as stale and will be closed if no
             further activity occurs. Thank you for your contributions.
 
-          stale-pr-label: "stale"
-          exempt-pr-labels: "no-stale"
-          stale-pr-message: >
-            There hasn't been any activity on this pull request recently. This
-            pull request has been automatically marked as stale because of that
-            and will be closed if no further activity occurs within 7 days.
-
-            Thank you for your contributions.
-
-      # The 30 day stale policy for PRS
-      # Used for:
-      # - PRs
-      # - No PRs marked as no-stale or new-integrations
-      # - No issues (-1)
-      - name: 30 days stale PRs policy
-        uses: actions/stale@v7.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 30
-          days-before-close: 7
-          days-before-issue-close: -1
-          operations-per-run: 50
-          remove-stale-when-updated: true
-          stale-pr-label: "stale"
-          # Exempt new integrations, these often take more time.
-          # They will automatically be handled by the 90 day version above.
-          exempt-pr-labels: "no-stale,new-integration"
-          stale-pr-message: >
-            There hasn't been any activity on this pull request recently. This
-            pull request has been automatically marked as stale because of that
-            and will be closed if no further activity occurs within 7 days.
-
-            Thank you for your contributions.
-
       # The 30 day stale policy for issues
       # Used for:
       # - Issues that are pending more information (incomplete issues)
@@ -81,12 +82,12 @@ jobs:
       - name: Needs more information stale issues policy
         uses: actions/stale@v7.0.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.token.outputs.token }}
           only-labels: "needs-more-information"
           days-before-stale: 14
           days-before-close: 7
           days-before-pr-close: -1
-          operations-per-run: 50
+          operations-per-run: 250
           remove-stale-when-updated: true
           stale-issue-label: "stale"
           exempt-issue-labels: "no-stale,help-wanted"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adjusted stalebot, to handle our load :) It is just lagging behind terribly right now. This is mainly caused by the amount we can process with our API rate limits.

This PR makes a few adjustments:

- Only keep a single, 90-day policy that handles PRs. It keeps using our GitHub Actions token, and is thus bound by its rate limits of it. But since it only handles PRs, it should be less of a problem. The other PR policy has been removed.

- Add a stale policy of 90 days, just for issues. It uses a dedicated app, which has triage issues rights on our repository. It can therefore handle requests that are not in the scope of our GitHub Action token rate limits (but its own).

- The existing 30-day policy on "needs-more-information" changed to use the same app token as the above.
 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
