### PR TITLE
Bump AIOAladdinConnect to 0.1.50

### DIFF
--- a/homeassistant/components/aladdin_connect/cover.py
+++ b/homeassistant/components/aladdin_connect/cover.py
@@ -91,31 +91,27 @@ class AladdinDevice(CoverEntity):
         self._name = device["name"]
         self._serial = device["serial"]
         self._model = device["model"]
-        self._attr_unique_id = f"{self._device_id}-{self._number}"
-        self._attr_has_entity_name = True
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Device information for Aladdin Connect cover."""
-        return DeviceInfo(
+        self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{self._device_id}-{self._number}")},
             name=self._name,
             manufacturer="Overhead Door",
             model=self._model,
         )
+        self._attr_has_entity_name = True
+        self._attr_unique_id = f"{self._device_id}-{self._number}"
 
     async def async_added_to_hass(self) -> None:
         """Connect Aladdin Connect to the cloud."""
 
-        async def update_callback() -> None:
-            """Schedule a state update."""
-            self.async_write_ha_state()
-
-        self._acc.register_callback(update_callback, self._serial, self._number)
+        self._acc.register_callback(
+            self.async_write_ha_state, self._serial, self._number
+        )
         await self._acc.get_doors(self._serial)
 
     async def async_will_remove_from_hass(self) -> None:
         """Close Aladdin Connect before removing."""
+        self._acc.unregister_callback(self._serial, self._number)
         await self._acc.close()
 
     async def async_close_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/aladdin_connect/manifest.json
+++ b/homeassistant/components/aladdin_connect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "aladdin_connect",
   "name": "Aladdin Connect",
   "documentation": "https://www.home-assistant.io/integrations/aladdin_connect",
-  "requirements": ["AIOAladdinConnect==0.1.48"],
+  "requirements": ["AIOAladdinConnect==0.1.50"],
   "codeowners": ["@mkmer"],
   "iot_class": "cloud_polling",
   "loggers": ["aladdin_connect"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,7 +5,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.48
+AIOAladdinConnect==0.1.50
 
 # homeassistant.components.adax
 Adax-local==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.aladdin_connect
-AIOAladdinConnect==0.1.48
+AIOAladdinConnect==0.1.50
 
 # homeassistant.components.adax
 Adax-local==0.1.5

--- a/tests/components/aladdin_connect/test_cover.py
+++ b/tests/components/aladdin_connect/test_cover.py
@@ -231,37 +231,3 @@ async def test_yaml_import(
     config_data = hass.config_entries.async_entries(DOMAIN)[0].data
     assert config_data[CONF_USERNAME] == "test-user"
     assert config_data[CONF_PASSWORD] == "test-password"
-
-
-async def test_callback(
-    hass: HomeAssistant,
-    mock_aladdinconnect_api: MagicMock,
-):
-    """Test callback from Aladdin Connect API."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=YAML_CONFIG,
-        unique_id="test-id",
-    )
-    config_entry.add_to_hass(hass)
-    await hass.async_block_till_done()
-
-    with patch(
-        "homeassistant.components.aladdin_connect.AladdinConnectClient",
-        return_value=mock_aladdinconnect_api,
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    mock_aladdinconnect_api.async_get_door_status.return_value = STATE_CLOSING
-    mock_aladdinconnect_api.get_door_status.return_value = STATE_CLOSING
-    with patch(
-        "homeassistant.components.aladdin_connect.AladdinConnectClient",
-        return_value=mock_aladdinconnect_api,
-    ), patch(
-        "homeassistant.components.aladdin_connect.AladdinConnectClient._call_back",
-        AsyncMock(),
-    ):
-        callback = mock_aladdinconnect_api.register_callback.call_args[0][0]
-        await callback()
-    assert hass.states.get("cover.home").state == STATE_CLOSING


### PR DESCRIPTION
code cleanup
bump aioaladdinconnect to 0.1.50 - https://github.com/mkmer/AIOAladdinConnect/compare/0.1.48...0.1.50

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add unregister_callback function to properly remove cover entity.
Move DeviceInfo to static.
Remove unnecessary extra callback step

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade: https://github.com/mkmer/AIOAladdinConnect/compare/0.1.48...0.1.50
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
