### PR TITLE
Schluter DITRA-HEAT integration forgets to renew session IDs

### DIFF
--- a/homeassistant/components/schluter/__init__.py
+++ b/homeassistant/components/schluter/__init__.py
@@ -12,13 +12,24 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
+from datetime import datetime, timedelta
+
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 DATA_SCHLUTER_SESSION = "schluter_session"
 DATA_SCHLUTER_API = "schluter_api"
-SCHLUTER_CONFIG_FILE = ".schluter.conf"
+DATA_SCHLUTER_USER = "schluter_user"
+DATA_SCHLUTER_PASS = "schluter_pass"
+DATA_SCHLUTER_EXPIRES = "schluter_expires"
+#DATA_SCHLUTER_SESSIONFILE = "schluter_file"
+#SCHLUTER_CONFIG_FILE = ".schluter.conf"
 API_TIMEOUT = 10
+
+#
+# Period for session renewal in hours
+#
+SCHLUTER_UPDATE_HOURS=1
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -32,44 +43,78 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+def schluter_auth_update(hass_domain: dict[str,any]) -> bool:
+    ''' 
+    schluter_auth_update() updates session_id and expires inside the hass.data[DOMAIN].
+    returns None on error and session id on success
+
+    Note: we are reimplementing the code from Schluter's library Authenticator, because
+    that code dumps error message upon token expiration and this pollutes the logs. '''
+
+    api = hass_domain[DATA_SCHLUTER_API];
+    session = hass_domain[DATA_SCHLUTER_SESSION];
+    expires = hass_domain[DATA_SCHLUTER_EXPIRES];
+
+    if expires > datetime.utcnow():
+        return session;
+
+    _LOGGER.debug("schluter: reacquiring new session ID.");
+
+    try:
+        ## 
+        ## As of 2022, one http session to Schluter cloud can last for months.
+        ## Thus we could reuse it between the session id updates,
+        ## but it seems to be safer to reestablish it periodically. 
+        ##
+        ## HACK: This is probably not a good idea because _http_session is not exposed by the API.
+        api._http_session.close();
+
+        response = api.get_session(hass_domain[DATA_SCHLUTER_USER],hass_domain[DATA_SCHLUTER_PASS]);
+        data = response.json()
+    except RequestException as ex:
+        _LOGGER.error("Unable to connect to Schluter service: %s", ex);
+        return None;
+        
+    if data["ErrorCode"] == 2:
+        _LOGGER.error("Unable to auth to Schluter service: bad password");
+        return None;
+    elif data["ErrorCode"] == 1:
+        _LOGGER.error("Unable to auth to Schluter service: bad email");
+        return None;
+
+    session_id = data["SessionId"];
+
+    hass_domain[DATA_SCHLUTER_EXPIRES] = datetime.utcnow() + timedelta(hours=SCHLUTER_UPDATE_HOURS);
+    hass_domain[DATA_SCHLUTER_SESSION] = session_id;
+
+    return session_id;
+
 
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Schluter component."""
     _LOGGER.debug("Starting setup of schluter")
 
     conf = config[DOMAIN]
+        
+    user = conf.get(CONF_USERNAME);
+    password = conf.get(CONF_PASSWORD);
+
     api_http_session = Session()
     api = Api(timeout=API_TIMEOUT, http_session=api_http_session)
-
-    authenticator = Authenticator(
-        api,
-        conf.get(CONF_USERNAME),
-        conf.get(CONF_PASSWORD),
-        session_id_cache_file=hass.config.path(SCHLUTER_CONFIG_FILE),
-    )
-
-    authentication = None
-    try:
-        authentication = authenticator.authenticate()
-    except RequestException as ex:
-        _LOGGER.error("Unable to connect to Schluter service: %s", ex)
-        return False
-
-    state = authentication.state
-
-    if state == AuthenticationState.AUTHENTICATED:
-        hass.data[DOMAIN] = {
+    
+    hass_domain = {
             DATA_SCHLUTER_API: api,
-            DATA_SCHLUTER_SESSION: authentication.session_id,
-        }
+            DATA_SCHLUTER_USER: user,
+            DATA_SCHLUTER_PASS: password,
+            DATA_SCHLUTER_SESSION: None,
+            DATA_SCHLUTER_EXPIRES: datetime.utcnow() - timedelta(hours=1),
+    }
+
+    sid = schluter_auth_update(hass_domain);
+
+    if (sid is None):
+        return False
+    else:
+        hass.data[DOMAIN] = hass_domain;
         discovery.load_platform(hass, Platform.CLIMATE, DOMAIN, {}, config)
         return True
-    if state == AuthenticationState.BAD_PASSWORD:
-        _LOGGER.error("Invalid password provided")
-        return False
-    if state == AuthenticationState.BAD_EMAIL:
-        _LOGGER.error("Invalid email provided")
-        return False
-
-    _LOGGER.error("Unknown set up error: %s", state)
-    return False

--- a/homeassistant/components/schluter/manifest.json
+++ b/homeassistant/components/schluter/manifest.json
@@ -5,5 +5,6 @@
   "requirements": ["py-schluter==0.1.7"],
   "codeowners": ["@prairieapps"],
   "iot_class": "cloud_polling",
-  "loggers": ["schluter"]
+  "loggers": ["schluter"],
+  "version": "2023.01.02"
 }


### PR DESCRIPTION
Version in the mainline uses schluter python library. That library is called once during the setup to establish the session id (by sending email and password). After that all communication with the cloud only requires a session id. However, Schluter's cloud server invalidates the session ID after a certain interval (appears to be a few days). This commit ensures that the session ID is renewed every hour (configurable). That this is needed is also indicated in the schluter python library, however, the way session id renewal is implemented there results in a _LOGGER.error() message each time the session ID gets renewed. Thus, we have chosen to reimplement the library's logic inside the Home Assistant component code.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
