### PR TITLE
Fix incorrectly return type on bad_identifier in UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from datetime import date, datetime, timedelta
 from enum import Enum
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 
 from pyunifiprotect.data import (
     Camera,
@@ -107,7 +107,7 @@ def _get_month_start_end(start: datetime) -> tuple[datetime, datetime]:
 
 
 @callback
-def _bad_identifier(identifier: str, err: Exception | None = None) -> BrowseMediaSource:
+def _bad_identifier(identifier: str, err: Exception | None = None) -> NoReturn:
     msg = f"Unexpected identifier: {identifier}"
     if err is None:
         raise BrowseError(msg)

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -115,11 +115,6 @@ def _bad_identifier(identifier: str, err: Exception | None = None) -> NoReturn:
 
 
 @callback
-def _bad_identifier_media(identifier: str, err: Exception | None = None) -> PlayMedia:
-    return cast(PlayMedia, _bad_identifier(identifier, err))
-
-
-@callback
 def _format_duration(duration: timedelta) -> str:
     formatted = ""
     seconds = int(duration.total_seconds())
@@ -164,20 +159,20 @@ class ProtectMediaSource(MediaSource):
 
         parts = item.identifier.split(":")
         if len(parts) != 3 or parts[1] not in ("event", "eventthumb"):
-            return _bad_identifier_media(item.identifier)
+            _bad_identifier(item.identifier)
 
         thumbnail_only = parts[1] == "eventthumb"
         try:
             data = self.data_sources[parts[0]]
         except (KeyError, IndexError) as err:
-            return _bad_identifier_media(item.identifier, err)
+            _bad_identifier(item.identifier, err)
 
         event = data.api.bootstrap.events.get(parts[2])
         if event is None:
             try:
                 event = await data.api.get_event(parts[2])
             except NvrError as err:
-                return _bad_identifier_media(item.identifier, err)
+                _bad_identifier(item.identifier, err)
             else:
                 # cache the event for later
                 data.api.bootstrap.events[event.id] = event
@@ -241,15 +236,15 @@ class ProtectMediaSource(MediaSource):
         try:
             data = self.data_sources[parts[0]]
         except (KeyError, IndexError) as err:
-            return _bad_identifier(item.identifier, err)
+            _bad_identifier(item.identifier, err)
 
         if len(parts) < 2:
-            return _bad_identifier(item.identifier)
+            _bad_identifier(item.identifier)
 
         try:
             identifier_type = IdentifierType(parts[1])
         except ValueError as err:
-            return _bad_identifier(item.identifier, err)
+            _bad_identifier(item.identifier, err)
 
         if identifier_type in (IdentifierType.EVENT, IdentifierType.EVENT_THUMB):
             thumbnail_only = identifier_type == IdentifierType.EVENT_THUMB
@@ -271,7 +266,7 @@ class ProtectMediaSource(MediaSource):
         try:
             event_type = SimpleEventType(parts.pop(0).lower())
         except (IndexError, ValueError) as err:
-            return _bad_identifier(item.identifier, err)
+            _bad_identifier(item.identifier, err)
 
         if len(parts) == 0:
             return await self._build_events_type(
@@ -281,17 +276,17 @@ class ProtectMediaSource(MediaSource):
         try:
             time_type = IdentifierTimeType(parts.pop(0))
         except ValueError as err:
-            return _bad_identifier(item.identifier, err)
+            _bad_identifier(item.identifier, err)
 
         if len(parts) == 0:
-            return _bad_identifier(item.identifier)
+            _bad_identifier(item.identifier)
 
         # {nvr_id}:browse:all|{camera_id}:all|{event_type}:recent:{day_count}
         if time_type == IdentifierTimeType.RECENT:
             try:
                 days = int(parts.pop(0))
             except (IndexError, ValueError) as err:
-                return _bad_identifier(item.identifier, err)
+                _bad_identifier(item.identifier, err)
 
             return await self._build_recent(
                 data, camera_id, event_type, days, build_children=True
@@ -302,7 +297,7 @@ class ProtectMediaSource(MediaSource):
         try:
             start, is_month, is_all = self._parse_range(parts)
         except (IndexError, ValueError) as err:
-            return _bad_identifier(item.identifier, err)
+            _bad_identifier(item.identifier, err)
 
         if is_month:
             return await self._build_month(
@@ -336,9 +331,7 @@ class ProtectMediaSource(MediaSource):
         try:
             event = await data.api.get_event(event_id)
         except NvrError as err:
-            return _bad_identifier(
-                f"{data.api.bootstrap.nvr.id}:{subtype}:{event_id}", err
-            )
+            _bad_identifier(f"{data.api.bootstrap.nvr.id}:{subtype}:{event_id}", err)
 
         if event.start is None or event.end is None:
             raise BrowseError("Event is still ongoing")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix an incorrect return type in UniFi Protect. 

In this specific case, the method always raises and thus does never return.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
