### PR TITLE
Improve SFR Box test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1117,8 +1117,6 @@ omit =
     homeassistant/components/sesame/lock.py
     homeassistant/components/seven_segments/image_processing.py
     homeassistant/components/seventeentrack/sensor.py
-    homeassistant/components/sfr_box/__init__.py
-    homeassistant/components/sfr_box/coordinator.py
     homeassistant/components/sfr_box/sensor.py
     homeassistant/components/shiftr/*
     homeassistant/components/shodan/sensor.py

--- a/tests/components/sfr_box/conftest.py
+++ b/tests/components/sfr_box/conftest.py
@@ -1,12 +1,17 @@
 """Provide common SFR Box fixtures."""
+from collections.abc import Generator
+import json
+from unittest.mock import patch
+
 import pytest
+from sfrbox_api.models import DslInfo, SystemInfo
 
 from homeassistant.components.sfr_box.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture(name="config_entry")
@@ -22,3 +27,25 @@ def get_config_entry(hass: HomeAssistant) -> ConfigEntry:
     )
     config_entry.add_to_hass(hass)
     return config_entry
+
+
+@pytest.fixture()
+def system_get_info() -> Generator[SystemInfo, None, None]:
+    """Fixture for SFRBox.system_get_info."""
+    system_info = SystemInfo(**json.loads(load_fixture("system_getInfo.json", DOMAIN)))
+    with patch(
+        "homeassistant.components.sfr_box.coordinator.SFRBox.system_get_info",
+        return_value=system_info,
+    ):
+        yield system_info
+
+
+@pytest.fixture()
+def dsl_get_info() -> Generator[DslInfo, None, None]:
+    """Fixture for SFRBox.dsl_get_info."""
+    dsl_info = DslInfo(**json.loads(load_fixture("dsl_getInfo.json", DOMAIN)))
+    with patch(
+        "homeassistant.components.sfr_box.coordinator.SFRBox.dsl_get_info",
+        return_value=dsl_info,
+    ):
+        yield dsl_info

--- a/tests/components/sfr_box/fixtures/dsl_getInfo.json
+++ b/tests/components/sfr_box/fixtures/dsl_getInfo.json
@@ -1,0 +1,15 @@
+{
+  "linemode": "ADSL2+",
+  "uptime": 450796,
+  "counter": 16,
+  "crc": 0,
+  "status": "up",
+  "noise_down": 5.8,
+  "noise_up": 6.0,
+  "attenuation_down": 28.5,
+  "attenuation_up": 20.8,
+  "rate_down": 5549,
+  "rate_up": 187,
+  "line_status": "No Defect",
+  "training": "Showtime"
+}

--- a/tests/components/sfr_box/test_init.py
+++ b/tests/components/sfr_box/test_init.py
@@ -1,0 +1,47 @@
+"""Test the SFR Box setup process."""
+from unittest.mock import patch
+
+import pytest
+from sfrbox_api.exceptions import SFRBoxError
+
+from homeassistant.components.sfr_box.const import DOMAIN
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture(autouse=True)
+def override_platforms():
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.sfr_box.PLATFORMS", []):
+        yield
+
+
+@pytest.mark.usefixtures("system_get_info", "dsl_get_info")
+async def test_setup_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Test entry setup and unload."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.entry_id in hass.data[DOMAIN]
+
+    # Unload the entry and verify that the data has been removed
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert config_entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_setup_entry_exception(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Test ConfigEntryNotReady when API raises an exception during entry setup."""
+    with patch(
+        "homeassistant.components.sfr_box.coordinator.SFRBox.system_get_info",
+        side_effect=SFRBoxError,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert not hass.data.get(DOMAIN)

--- a/tests/components/sfr_box/test_init.py
+++ b/tests/components/sfr_box/test_init.py
@@ -1,4 +1,5 @@
 """Test the SFR Box setup process."""
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -10,30 +11,32 @@ from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture(autouse=True)
-def override_platforms():
+def override_platforms() -> Generator[None, None, None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.sfr_box.PLATFORMS", []):
         yield
 
 
 @pytest.mark.usefixtures("system_get_info", "dsl_get_info")
-async def test_setup_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_setup_unload_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test entry setup and unload."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert config_entry.state is ConfigEntryState.LOADED
-    assert config_entry.entry_id in hass.data[DOMAIN]
 
     # Unload the entry and verify that the data has been removed
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.NOT_LOADED
-    assert config_entry.entry_id not in hass.data[DOMAIN]
 
 
-async def test_setup_entry_exception(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_setup_entry_exception(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test ConfigEntryNotReady when API raises an exception during entry setup."""
     with patch(
         "homeassistant.components.sfr_box.coordinator.SFRBox.system_get_info",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve SFR Box test coverage: add tests for integration setup (loading/unloading)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
