### PR TITLE
Update geniushub-client to 0.7.0

### DIFF
--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -2,7 +2,7 @@
   "domain": "geniushub",
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/integrations/geniushub",
-  "requirements": ["geniushub-client==0.6.30"],
+  "requirements": ["geniushub-client==0.7.0"],
   "codeowners": ["@zxdavb"],
   "iot_class": "local_polling",
   "loggers": ["geniushubclient"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -747,7 +747,7 @@ gassist-text==0.0.7
 gcal-sync==4.1.0
 
 # homeassistant.components.geniushub
-geniushub-client==0.6.30
+geniushub-client==0.7.0
 
 # homeassistant.components.geocaching
 geocachingapi==0.2.1


### PR DESCRIPTION
## Proposed change
There is an issue running the GeniusHub integration against the latest software on GeniusHub hubs in my case version 6.0.16.

This is meant to have been fixed with the latest version of the geniushub python client.

## Type of change
## Type of change
- [x]  Dependency upgrade
- [ ]  Bugfix (non-breaking change which fixes an issue)
- [ ]  New integration (thank you!)
- [ ]  New feature (which adds functionality to an existing integration)
- [ ]  Deprecation (breaking change to happen in the future)
- [ ]  Breaking change (fix/feature causing existing functionality to break)
- [ ]  Code quality improvements to existing code or addition of tests


## Additional information
- This PR fixes or closes issue: fixes #78799
- This PR is related to issue:
- Link to documentation pull request:

Dependency being upgraded
https://github.com/manzanotti/geniushub-client/releases/tag/v0.7.0


## Checklist
- [x]  The code change is tested and works locally.
- [ ]  Local tests pass. **Your PR cannot be merged unless tests pass**
- [x]  There is no commented out code in this PR.
- [ ]  I have followed the [development checklist](https://developers.home-assistant.io/docs/en/development_checklist.html)
- [ ]  The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ]  Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ]  Documentation added/updated for [www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ]  Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ]  I have reviewed two other [open pull requests](https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure) in this repository.