### PR TITLE
Improve renault tests

### DIFF
--- a/tests/components/renault/test_binary_sensor.py
+++ b/tests/components/renault/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for Renault binary sensors."""
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -21,7 +22,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms():
+def override_platforms() -> Generator[None, None, None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.BINARY_SENSOR]):
         yield
@@ -30,7 +31,7 @@ def override_platforms():
 @pytest.mark.usefixtures("fixtures_with_data")
 async def test_binary_sensors(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault binary sensors."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -50,7 +51,7 @@ async def test_binary_sensors(
 @pytest.mark.usefixtures("fixtures_with_no_data")
 async def test_binary_sensor_empty(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault binary sensors with empty data from Renault."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -69,7 +70,7 @@ async def test_binary_sensor_empty(
 @pytest.mark.usefixtures("fixtures_with_invalid_upstream_exception")
 async def test_binary_sensor_errors(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault binary sensors with temporary failure."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -90,7 +91,7 @@ async def test_binary_sensor_errors(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_binary_sensor_access_denied(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault binary sensors with access denied failure."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -108,7 +109,7 @@ async def test_binary_sensor_access_denied(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_binary_sensor_not_supported(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault binary sensors with not supported failure."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)

--- a/tests/components/renault/test_button.py
+++ b/tests/components/renault/test_button.py
@@ -1,4 +1,5 @@
 """Tests for Renault sensors."""
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -18,7 +19,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms():
+def override_platforms() -> Generator[None, None, None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.BUTTON]):
         yield
@@ -27,7 +28,7 @@ def override_platforms():
 @pytest.mark.usefixtures("fixtures_with_data")
 async def test_buttons(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers."""
 
     entity_registry = mock_registry(hass)
@@ -48,7 +49,7 @@ async def test_buttons(
 @pytest.mark.usefixtures("fixtures_with_no_data")
 async def test_button_empty(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers with empty data from Renault."""
 
     entity_registry = mock_registry(hass)
@@ -68,7 +69,7 @@ async def test_button_empty(
 @pytest.mark.usefixtures("fixtures_with_invalid_upstream_exception")
 async def test_button_errors(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers with temporary failure."""
 
     entity_registry = mock_registry(hass)
@@ -90,7 +91,7 @@ async def test_button_errors(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_button_access_denied(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers with access denied failure."""
 
     entity_registry = mock_registry(hass)
@@ -112,7 +113,7 @@ async def test_button_access_denied(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_button_not_supported(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers with not supported failure."""
 
     entity_registry = mock_registry(hass)
@@ -132,7 +133,9 @@ async def test_button_not_supported(
 
 @pytest.mark.usefixtures("fixtures_with_data")
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
-async def test_button_start_charge(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_button_start_charge(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test that button invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -160,7 +163,7 @@ async def test_button_start_charge(hass: HomeAssistant, config_entry: ConfigEntr
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_button_start_air_conditioner(
     hass: HomeAssistant, config_entry: ConfigEntry
-):
+) -> None:
     """Test that button invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/renault/test_device_tracker.py
+++ b/tests/components/renault/test_device_tracker.py
@@ -1,4 +1,5 @@
 """Tests for Renault sensors."""
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -21,7 +22,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms():
+def override_platforms() -> Generator[None, None, None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.DEVICE_TRACKER]):
         yield
@@ -30,7 +31,7 @@ def override_platforms():
 @pytest.mark.usefixtures("fixtures_with_data")
 async def test_device_trackers(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers."""
 
     entity_registry = mock_registry(hass)
@@ -51,7 +52,7 @@ async def test_device_trackers(
 @pytest.mark.usefixtures("fixtures_with_no_data")
 async def test_device_tracker_empty(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers with empty data from Renault."""
 
     entity_registry = mock_registry(hass)
@@ -71,7 +72,7 @@ async def test_device_tracker_empty(
 @pytest.mark.usefixtures("fixtures_with_invalid_upstream_exception")
 async def test_device_tracker_errors(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers with temporary failure."""
 
     entity_registry = mock_registry(hass)
@@ -93,7 +94,7 @@ async def test_device_tracker_errors(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_device_tracker_access_denied(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers with access denied failure."""
 
     entity_registry = mock_registry(hass)
@@ -112,7 +113,7 @@ async def test_device_tracker_access_denied(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_device_tracker_not_supported(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault device trackers with not supported failure."""
 
     entity_registry = mock_registry(hass)

--- a/tests/components/renault/test_init.py
+++ b/tests/components/renault/test_init.py
@@ -1,4 +1,5 @@
 """Tests for Renault setup process."""
+from collections.abc import Generator
 from unittest.mock import patch
 
 import aiohttp
@@ -11,7 +12,7 @@ from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture(autouse=True)
-def override_platforms():
+def override_platforms() -> Generator[None, None, None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", []):
         yield
@@ -24,23 +25,25 @@ def override_vehicle_type(request) -> str:
 
 
 @pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicles")
-async def test_setup_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_setup_unload_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test entry setup and unload."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert config_entry.state is ConfigEntryState.LOADED
-    assert config_entry.entry_id in hass.data[DOMAIN]
 
     # Unload the entry and verify that the data has been removed
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.NOT_LOADED
-    assert config_entry.entry_id not in hass.data[DOMAIN]
 
 
-async def test_setup_entry_bad_password(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_setup_entry_bad_password(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test entry setup and unload."""
     # Create a mock entry so we don't have to go through config flow
     with patch(
@@ -55,7 +58,9 @@ async def test_setup_entry_bad_password(hass: HomeAssistant, config_entry: Confi
     assert not hass.data.get(DOMAIN)
 
 
-async def test_setup_entry_exception(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_setup_entry_exception(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test ConfigEntryNotReady when API raises an exception during entry setup."""
     # In this case we are testing the condition where async_setup_entry raises
     # ConfigEntryNotReady.

--- a/tests/components/renault/test_select.py
+++ b/tests/components/renault/test_select.py
@@ -1,4 +1,5 @@
 """Tests for Renault selects."""
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -27,7 +28,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms():
+def override_platforms() -> Generator[None, None, None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.SELECT]):
         yield
@@ -36,7 +37,7 @@ def override_platforms():
 @pytest.mark.usefixtures("fixtures_with_data")
 async def test_selects(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault selects."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -56,7 +57,7 @@ async def test_selects(
 @pytest.mark.usefixtures("fixtures_with_no_data")
 async def test_select_empty(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault selects with empty data from Renault."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -75,7 +76,7 @@ async def test_select_empty(
 @pytest.mark.usefixtures("fixtures_with_invalid_upstream_exception")
 async def test_select_errors(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault selects with temporary failure."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -96,7 +97,7 @@ async def test_select_errors(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_select_access_denied(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault selects with access denied failure."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -114,7 +115,7 @@ async def test_select_access_denied(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_select_not_supported(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault selects with access denied failure."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -130,7 +131,9 @@ async def test_select_not_supported(
 
 @pytest.mark.usefixtures("fixtures_with_data")
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
-async def test_select_charge_mode(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_select_charge_mode(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test that service invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/renault/test_sensor.py
+++ b/tests/components/renault/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for Renault sensors."""
+from collections.abc import Generator
 from types import MappingProxyType
 from unittest.mock import patch
 
@@ -23,7 +24,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms():
+def override_platforms() -> Generator[None, None, None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.SENSOR]):
         yield
@@ -45,7 +46,7 @@ def _check_and_enable_disabled_entities(
 @pytest.mark.usefixtures("fixtures_with_data")
 async def test_sensors(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault sensors."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -69,7 +70,7 @@ async def test_sensors(
 @pytest.mark.usefixtures("fixtures_with_no_data")
 async def test_sensor_empty(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault sensors with empty data from Renault."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -93,7 +94,7 @@ async def test_sensor_empty(
 @pytest.mark.usefixtures("fixtures_with_invalid_upstream_exception")
 async def test_sensor_errors(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault sensors with temporary failure."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -118,7 +119,7 @@ async def test_sensor_errors(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_sensor_access_denied(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault sensors with access denied failure."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -136,7 +137,7 @@ async def test_sensor_access_denied(
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_sensor_not_supported(
     hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
-):
+) -> None:
     """Test for Renault sensors with access denied failure."""
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -1,4 +1,5 @@
 """Tests for Renault sensors."""
+from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import patch
 
@@ -37,7 +38,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms():
+def override_platforms() -> Generator[None, None, None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", []):
         yield
@@ -57,7 +58,9 @@ def get_device_id(hass: HomeAssistant) -> str:
     return device.id
 
 
-async def test_service_registration(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_service_registration(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test entry setup and unload."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -74,7 +77,9 @@ async def test_service_registration(hass: HomeAssistant, config_entry: ConfigEnt
         assert not hass.services.has_service(DOMAIN, service)
 
 
-async def test_service_set_ac_cancel(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_service_set_ac_cancel(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test that service invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -100,7 +105,7 @@ async def test_service_set_ac_cancel(hass: HomeAssistant, config_entry: ConfigEn
 
 async def test_service_set_ac_start_simple(
     hass: HomeAssistant, config_entry: ConfigEntry
-):
+) -> None:
     """Test that service invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -128,7 +133,7 @@ async def test_service_set_ac_start_simple(
 
 async def test_service_set_ac_start_with_date(
     hass: HomeAssistant, config_entry: ConfigEntry
-):
+) -> None:
     """Test that service invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -158,7 +163,7 @@ async def test_service_set_ac_start_with_date(
 
 async def test_service_set_charge_schedule(
     hass: HomeAssistant, config_entry: ConfigEntry
-):
+) -> None:
     """Test that service invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -192,7 +197,7 @@ async def test_service_set_charge_schedule(
 
 async def test_service_set_charge_schedule_multi(
     hass: HomeAssistant, config_entry: ConfigEntry
-):
+) -> None:
     """Test that service invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -239,7 +244,7 @@ async def test_service_set_charge_schedule_multi(
 
 async def test_service_set_charge_start(
     hass: HomeAssistant, config_entry: ConfigEntry, caplog: pytest.LogCaptureFixture
-):
+) -> None:
     """Test that service invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -266,7 +271,7 @@ async def test_service_set_charge_start(
 
 async def test_service_invalid_device_id(
     hass: HomeAssistant, config_entry: ConfigEntry
-):
+) -> None:
     """Test that service fails with ValueError if device_id not found in registry."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -281,7 +286,7 @@ async def test_service_invalid_device_id(
 
 async def test_service_invalid_device_id2(
     hass: HomeAssistant, config_entry: ConfigEntry
-):
+) -> None:
     """Test that service fails with ValueError if device_id not found in vehicles."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on code review from #85054

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
