### PR TITLE
Add Whirlpool washer and dryer to Whirlpool integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1300,8 +1300,8 @@ build.json @home-assistant/supervisor
 /tests/components/websocket_api/ @home-assistant/core
 /homeassistant/components/wemo/ @esev
 /tests/components/wemo/ @esev
-/homeassistant/components/whirlpool/ @abmantis
-/tests/components/whirlpool/ @abmantis
+/homeassistant/components/whirlpool/ @abmantis @mkmer
+/tests/components/whirlpool/ @abmantis @mkmer
 /homeassistant/components/whois/ @frenck
 /tests/components/whois/ @frenck
 /homeassistant/components/wiffi/ @mampfes

--- a/homeassistant/components/whirlpool/__init__.py
+++ b/homeassistant/components/whirlpool/__init__.py
@@ -1,4 +1,5 @@
-"""The Whirlpool Sixth Sense integration."""
+"""The Whirlpool Appliances integration."""
+import asyncio
 from dataclasses import dataclass
 import logging
 
@@ -17,7 +18,7 @@ from .util import get_brand_for_region
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.CLIMATE]
+PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -30,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     auth = Auth(backend_selector, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD])
     try:
         await auth.do_auth(store=False)
-    except aiohttp.ClientError as ex:
+    except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as ex:
         raise ConfigEntryNotReady("Cannot connect") from ex
 
     if not auth.is_access_token_valid():
@@ -49,7 +50,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     return True
 
 

--- a/homeassistant/components/whirlpool/__init__.py
+++ b/homeassistant/components/whirlpool/__init__.py
@@ -31,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     auth = Auth(backend_selector, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD])
     try:
         await auth.do_auth(store=False)
-    except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as ex:
+    except (aiohttp.ClientError, asyncio.TimeoutError) as ex:
         raise ConfigEntryNotReady("Cannot connect") from ex
 
     if not auth.is_access_token_valid():

--- a/homeassistant/components/whirlpool/climate.py
+++ b/homeassistant/components/whirlpool/climate.py
@@ -71,9 +71,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up entry."""
     whirlpool_data: WhirlpoolData = hass.data[DOMAIN][config_entry.entry_id]
-    if not (aircons := whirlpool_data.appliances_manager.aircons):
-        _LOGGER.debug("No aircons found")
-        return
 
     aircons = [
         AirConEntity(
@@ -83,7 +80,7 @@ async def async_setup_entry(
             whirlpool_data.backend_selector,
             whirlpool_data.auth,
         )
-        for ac_data in aircons
+        for ac_data in whirlpool_data.appliances_manager.aircons
     ]
     async_add_entities(aircons, True)
 

--- a/homeassistant/components/whirlpool/config_flow.py
+++ b/homeassistant/components/whirlpool/config_flow.py
@@ -46,7 +46,7 @@ async def validate_input(
     auth = Auth(backend_selector, data[CONF_USERNAME], data[CONF_PASSWORD])
     try:
         await auth.do_auth()
-    except (asyncio.TimeoutError, aiohttp.ClientConnectionError) as exc:
+    except (asyncio.TimeoutError, aiohttp.ClientError) as exc:
         raise CannotConnect from exc
 
     if not auth.is_access_token_valid():

--- a/homeassistant/components/whirlpool/config_flow.py
+++ b/homeassistant/components/whirlpool/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Whirlpool Sixth Sense integration."""
+"""Config flow for Whirlpool Appliances integration."""
 from __future__ import annotations
 
 import asyncio
@@ -8,6 +8,7 @@ from typing import Any
 
 import aiohttp
 import voluptuous as vol
+from whirlpool.appliancesmanager import AppliancesManager
 from whirlpool.auth import Auth
 from whirlpool.backendselector import BackendSelector
 
@@ -50,6 +51,11 @@ async def validate_input(
 
     if not auth.is_access_token_valid():
         raise InvalidAuth
+
+    appliances_manager = AppliancesManager(backend_selector, auth)
+    await appliances_manager.fetch_appliances()
+    if appliances_manager.aircons is None and appliances_manager.washer_dryers is None:
+        raise NoAppliances
 
     return {"title": data[CONF_USERNAME]}
 
@@ -118,6 +124,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
+        except NoAppliances:
+            errors["base"] = "no_appliances"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
@@ -139,3 +147,7 @@ class CannotConnect(exceptions.HomeAssistantError):
 
 class InvalidAuth(exceptions.HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+class NoAppliances(exceptions.HomeAssistantError):
+    """Error to indicate no supported appliances in the user account."""

--- a/homeassistant/components/whirlpool/const.py
+++ b/homeassistant/components/whirlpool/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Whirlpool Sixth Sense integration."""
+"""Constants for the Whirlpool Appliances integration."""
 
 from whirlpool.backendselector import Region
 

--- a/homeassistant/components/whirlpool/manifest.json
+++ b/homeassistant/components/whirlpool/manifest.json
@@ -1,10 +1,11 @@
 {
   "domain": "whirlpool",
-  "name": "Whirlpool Sixth Sense",
+  "name": "Whirlpool Appliances",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/whirlpool",
   "requirements": ["whirlpool-sixth-sense==0.18.0"],
-  "codeowners": ["@abmantis"],
+  "codeowners": ["@abmantis", "@mkmer"],
   "iot_class": "cloud_push",
-  "loggers": ["whirlpool"]
+  "loggers": ["whirlpool"],
+  "integration_type": "hub"
 }

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -79,15 +79,11 @@ def washer_state(washer: WasherDryerClass) -> str | None:
         return "Door open"
 
     machine_state = washer.washdry.get_machine_state()
-    machine_cycle = None
 
-    for func, cycle_name in CYCLE_FUNC:
-        if func(washer.washdry):
-            machine_cycle = cycle_name
-            break
-
-    if machine_state == MachineState.RunningMainCycle and machine_cycle:
-        return machine_cycle
+    if machine_state == MachineState.RunningMainCycle:
+        for func, cycle_name in CYCLE_FUNC:
+            if func(washer.washdry):
+                return cycle_name
 
     return MACHINE_STATE.get(machine_state, STATE_UNKNOWN)
 
@@ -130,7 +126,6 @@ SENSORS: tuple[WhirlpoolSensorEntityDescription, ...] = (
     WhirlpoolSensorEntityDescription(
         key="state",
         name="State",
-        entity_registry_enabled_default=True,
         icon=ICON_W,
         has_entity_name=True,
         value_fn=washer_state,
@@ -141,7 +136,6 @@ SENSORS: tuple[WhirlpoolSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="s",
-        entity_registry_enabled_default=True,
         icon=ICON_W,
         has_entity_name=True,
         value_fn=completion_time,
@@ -150,7 +144,6 @@ SENSORS: tuple[WhirlpoolSensorEntityDescription, ...] = (
         key="DispenseLevel",
         name="Detergent Level",
         state_class=SensorStateClass.MEASUREMENT,
-        entity_registry_enabled_default=True,
         icon=ICON_W,
         has_entity_name=True,
         value_fn=lambda WasherDryer: TANK_FILL[

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -276,6 +276,7 @@ class WasherDryerTimeClass(RestoreSensor):
         ):
             self._running = False
             self._attr_native_value = now
+            self._async_write_ha_state()
 
         if machine_state is MachineState.RunningMainCycle:
             self._running = True
@@ -283,4 +284,4 @@ class WasherDryerTimeClass(RestoreSensor):
                 seconds=int(self._wd.get_attribute("Cavity_TimeStatusEstTimeRemaining"))
             )
 
-        self._async_write_ha_state()
+            self._async_write_ha_state()

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -240,7 +240,7 @@ class WasherDryerTimeClass(SensorEntity):
         self.entity_description: SensorEntityDescription = description
         self._attr_unique_id = f"{said}-{description.key}"
         self._running = True
-        self._timestamp = utcnow()
+        self._timestamp: datetime | None = None
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, said)},
             name=self._name,
@@ -261,7 +261,7 @@ class WasherDryerTimeClass(SensorEntity):
         return self._wd.get_online()
 
     @property
-    def native_value(self) -> datetime | str:
+    def native_value(self) -> datetime | None:
         """Calculate the time stamp for completion."""
         machine_state = self._wd.get_machine_state()
         if (

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
-    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNKNOWN
@@ -134,8 +133,6 @@ SENSORS: tuple[WhirlpoolSensorEntityDescription, ...] = (
         key="timeremaining",
         name="End Time",
         device_class=SensorDeviceClass.TIMESTAMP,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement="s",
         icon=ICON_W,
         has_entity_name=True,
         value_fn=completion_time,
@@ -143,7 +140,6 @@ SENSORS: tuple[WhirlpoolSensorEntityDescription, ...] = (
     WhirlpoolSensorEntityDescription(
         key="DispenseLevel",
         name="Detergent Level",
-        state_class=SensorStateClass.MEASUREMENT,
         icon=ICON_W,
         has_entity_name=True,
         value_fn=lambda WasherDryer: TANK_FILL[

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -1,0 +1,263 @@
+"""The Washer/Dryer Sensor for Whirlpool Appliances."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import logging
+
+from whirlpool.washerdryer import MachineState, WasherDryer
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
+from homeassistant.util.dt import utcnow
+
+from . import WhirlpoolData
+from .const import DOMAIN
+
+TANK_FILL = {
+    "0": "Unknown",
+    "1": "Empty",
+    "2": "25%",
+    "3": "50%",
+    "4": "100%",
+    "5": "Active",
+}
+
+MACHINE_STATE = {
+    MachineState.Standby: "Standby",
+    MachineState.Setting: "Setting",
+    MachineState.DelayCountdownMode: "Delay Countdown",
+    MachineState.DelayPause: "Delay Paused",
+    MachineState.SmartDelay: "Smart Delay",
+    MachineState.SmartGridPause: "Smart Grid Pause",
+    MachineState.Pause: "Pause",
+    MachineState.RunningMainCycle: "Running Maincycle",
+    MachineState.RunningPostCycle: "Running Postcycle",
+    MachineState.Exceptions: "Exception",
+    MachineState.Complete: "Complete",
+    MachineState.PowerFailure: "Power Failure",
+    MachineState.ServiceDiagnostic: "Service Diagnostic Mode",
+    MachineState.FactoryDiagnostic: "Factory Diagnostic Mode",
+    MachineState.LifeTest: "Life Test",
+    MachineState.CustomerFocusMode: "Customer Focus Mode",
+    MachineState.DemoMode: "Demo Mode",
+    MachineState.HardStopOrError: "Hard Stop or Error",
+    MachineState.SystemInit: "System Initialize",
+}
+
+CYCLE_FUNC = [
+    (WasherDryer.get_cycle_status_filling, "Cycle Filling"),
+    (WasherDryer.get_cycle_status_rinsing, "Cycle Rinsing"),
+    (WasherDryer.get_cycle_status_sensing, "Cycle Sensing"),
+    (WasherDryer.get_cycle_status_soaking, "Cycle Soaking"),
+    (WasherDryer.get_cycle_status_spinning, "Cycle Spinning"),
+    (WasherDryer.get_cycle_status_washing, "Cycle Washing"),
+]
+
+
+ICON_D = "mdi:tumble-dryer"
+ICON_W = "mdi:washing-machine"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def washer_state(washer: WasherDryerClass) -> str | None:
+    """Determine correct states for a washer."""
+
+    if washer.washdry.get_attribute("Cavity_OpStatusDoorOpen") == "1":
+        return "Door open"
+
+    machine_state = washer.washdry.get_machine_state()
+    machine_cycle = None
+
+    for func, cycle_name in CYCLE_FUNC:
+        if func(washer.washdry):
+            machine_cycle = cycle_name
+            break
+
+    if machine_state == MachineState.RunningMainCycle and machine_cycle:
+        return machine_cycle
+
+    return MACHINE_STATE.get(machine_state, STATE_UNKNOWN)
+
+
+def completion_time(washer: WasherDryerClass) -> datetime | None:
+    """Calculate the time stamp for completion."""
+    machine_state = washer.washdry.get_machine_state()
+    if (
+        machine_state.value in {MachineState.Complete.value, MachineState.Standby.value}
+        and washer.running
+    ):
+        washer.running = False
+        washer.timestamp = utcnow()
+
+    if machine_state is MachineState.RunningMainCycle:
+        washer.running = True
+        washer.timestamp = utcnow() + timedelta(
+            seconds=int(
+                washer.washdry.get_attribute("Cavity_TimeStatusEstTimeRemaining")
+            )
+        )
+    return washer.timestamp
+
+
+@dataclass
+class WhirlpoolSensorEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable
+
+
+@dataclass
+class WhirlpoolSensorEntityDescription(
+    SensorEntityDescription, WhirlpoolSensorEntityDescriptionMixin
+):
+    """Describes Whirlpool Washer sensor entity."""
+
+
+SENSORS: tuple[WhirlpoolSensorEntityDescription, ...] = (
+    WhirlpoolSensorEntityDescription(
+        key="state",
+        name="State",
+        entity_registry_enabled_default=True,
+        icon=ICON_W,
+        has_entity_name=True,
+        value_fn=washer_state,
+    ),
+    WhirlpoolSensorEntityDescription(
+        key="timeremaining",
+        name="End Time",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="s",
+        entity_registry_enabled_default=True,
+        icon=ICON_W,
+        has_entity_name=True,
+        value_fn=completion_time,
+    ),
+    WhirlpoolSensorEntityDescription(
+        key="DispenseLevel",
+        name="Detergent Level",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=True,
+        icon=ICON_W,
+        has_entity_name=True,
+        value_fn=lambda WasherDryer: TANK_FILL[
+            WasherDryer.washdry.get_attribute("WashCavity_OpStatusBulkDispense1Level")
+        ],
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Config flow entry for Whrilpool Laundry."""
+    entities: list = []
+    whirlpool_data: WhirlpoolData = hass.data[DOMAIN][config_entry.entry_id]
+    for appliance in whirlpool_data.appliances_manager.washer_dryers:
+        _wd = WasherDryer(
+            whirlpool_data.backend_selector,
+            whirlpool_data.auth,
+            appliance["SAID"],
+        )
+        await _wd.connect()
+        entities.extend(
+            [
+                WasherDryerClass(
+                    appliance["SAID"],
+                    appliance["NAME"],
+                    description,
+                    _wd,
+                )
+                for description in SENSORS
+            ]
+        )
+
+    async_add_entities(entities)
+
+
+class WasherDryerClass(SensorEntity):
+    """A class for the whirlpool/maytag washer account."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        said: str,
+        name: str,
+        description: WhirlpoolSensorEntityDescription,
+        washdry: WasherDryer,
+    ) -> None:
+        """Initialize the washer sensor."""
+        self._name = name.capitalize()
+        self._wd: WasherDryer = washdry
+
+        if self._name == "Dryer":
+            self._attr_icon = ICON_D
+
+        self.entity_description: WhirlpoolSensorEntityDescription = description
+        self._attr_unique_id = f"{said}-{description.key}"
+        self._running = True
+        self._timestamp = utcnow()
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, said)},
+            name=self._name,
+            manufacturer="Whirlpool",
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Connect washer/dryer to the cloud."""
+        self._wd.register_attr_callback(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Close Whrilpool Appliance sockets before removing."""
+        await self._wd.disconnect()
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._wd.get_online()
+
+    @property
+    def native_value(self) -> StateType | str:
+        """Return native value of sensor."""
+        return self.entity_description.value_fn(self)
+
+    @property
+    def washdry(self) -> WasherDryer:
+        """Return the washer/dryer."""
+        return self._wd
+
+    @property
+    def running(self) -> bool:
+        """Return the washer/dryer."""
+        return self._running
+
+    @running.setter
+    def running(self, value: bool) -> None:
+        """Set the running state."""
+        self._running = value
+
+    @property
+    def timestamp(self) -> datetime:
+        """Return the washer/dryer last timestamp."""
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, value) -> None:
+        """Set the Timestamp value."""
+        self._timestamp = value

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -120,14 +120,13 @@ SENSORS: tuple[WhirlpoolSensorEntityDescription, ...] = (
     ),
 )
 
-SENSOR_TIMER: tuple[WhirlpoolSensorEntityDescription, ...] = (
-    WhirlpoolSensorEntityDescription(
+SENSOR_TIMER: tuple[SensorEntityDescription] = (
+    SensorEntityDescription(
         key="timeremaining",
         name="End Time",
         device_class=SensorDeviceClass.TIMESTAMP,
         icon=ICON_W,
         has_entity_name=True,
-        value_fn=washer_state,  # not used for class
     ),
 )
 
@@ -228,7 +227,7 @@ class WasherDryerTimeClass(SensorEntity):
         self,
         said: str,
         name: str,
-        description: WhirlpoolSensorEntityDescription,
+        description: SensorEntityDescription,
         washdry: WasherDryer,
     ) -> None:
         """Initialize the washer sensor."""
@@ -238,7 +237,7 @@ class WasherDryerTimeClass(SensorEntity):
         if self._name == "Dryer":
             self._attr_icon = ICON_D
 
-        self.entity_description: WhirlpoolSensorEntityDescription = description
+        self.entity_description: SensorEntityDescription = description
         self._attr_unique_id = f"{said}-{description.key}"
         self._running = True
         self._timestamp = utcnow()

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -219,7 +219,7 @@ class WasherDryerClass(SensorEntity):
 
 
 class WasherDryerTimeClass(SensorEntity):
-    """A class for the whirlpool/maytag washer account."""
+    """A timestamp class for the whirlpool/maytag washer account."""
 
     _attr_should_poll = False
 

--- a/homeassistant/components/whirlpool/strings.json
+++ b/homeassistant/components/whirlpool/strings.json
@@ -11,7 +11,8 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "no_appliances": "No supported appliances found"
     }
   }
 }

--- a/homeassistant/components/whirlpool/translations/en.json
+++ b/homeassistant/components/whirlpool/translations/en.json
@@ -3,6 +3,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
+            "no_appliances": "No supported appliances found",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6018,7 +6018,7 @@
       "iot_class": "local_push"
     },
     "whirlpool": {
-      "name": "Whirlpool Sixth Sense",
+      "name": "Whirlpool Appliances",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "cloud_push"

--- a/tests/components/whirlpool/test_config_flow.py
+++ b/tests/components/whirlpool/test_config_flow.py
@@ -19,7 +19,10 @@ CONFIG_INPUT = {
 }
 
 
-async def test_form(hass, region):
+async def test_form(
+    hass: HomeAssistant,
+    region,
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -36,7 +39,13 @@ async def test_form(hass, region):
     ) as mock_backend_selector, patch(
         "homeassistant.components.whirlpool.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.whirlpool.config_flow.AppliancesManager.aircons",
+        return_value=["test"],
+    ), patch(
+        "homeassistant.components.whirlpool.config_flow.AppliancesManager.fetch_appliances",
+        return_value=True,
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             CONFIG_INPUT | {"region": region[0]},
@@ -54,7 +63,7 @@ async def test_form(hass, region):
     mock_backend_selector.assert_called_once_with(region[2], region[1])
 
 
-async def test_form_invalid_auth(hass, region):
+async def test_form_invalid_auth(hass: HomeAssistant, region) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -65,13 +74,16 @@ async def test_form_invalid_auth(hass, region):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            CONFIG_INPUT | {"region": region[0]},
+            CONFIG_INPUT
+            | {
+                "region": region[0],
+            },
         )
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass, region):
+async def test_form_cannot_connect(hass: HomeAssistant, region) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -82,13 +94,16 @@ async def test_form_cannot_connect(hass, region):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            CONFIG_INPUT | {"region": region[0]},
+            CONFIG_INPUT
+            | {
+                "region": region[0],
+            },
         )
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_auth_timeout(hass, region):
+async def test_form_auth_timeout(hass: HomeAssistant, region) -> None:
     """Test we handle auth timeout error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -99,13 +114,16 @@ async def test_form_auth_timeout(hass, region):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            CONFIG_INPUT | {"region": region[0]},
+            CONFIG_INPUT
+            | {
+                "region": region[0],
+            },
         )
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_generic_auth_exception(hass, region):
+async def test_form_generic_auth_exception(hass: HomeAssistant, region) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -116,17 +134,20 @@ async def test_form_generic_auth_exception(hass, region):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            CONFIG_INPUT | {"region": region[0]},
+            CONFIG_INPUT
+            | {
+                "region": region[0],
+            },
         )
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_already_configured(hass, region):
+async def test_form_already_configured(hass: HomeAssistant, region) -> None:
     """Test we handle cannot connect error."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_USERNAME: "test-username", CONF_PASSWORD: "test-password"},
+        data=CONFIG_INPUT | {"region": region[0]},
         unique_id="test-username",
     )
     mock_entry.add_to_hass(hass)
@@ -141,10 +162,19 @@ async def test_form_already_configured(hass, region):
     with patch("homeassistant.components.whirlpool.config_flow.Auth.do_auth"), patch(
         "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
         return_value=True,
+    ), patch(
+        "homeassistant.components.whirlpool.config_flow.AppliancesManager.aircons",
+        return_value=["test"],
+    ), patch(
+        "homeassistant.components.whirlpool.config_flow.AppliancesManager.fetch_appliances",
+        return_value=True,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            CONFIG_INPUT | {"region": region[0]},
+            CONFIG_INPUT
+            | {
+                "region": region[0],
+            },
         )
         await hass.async_block_till_done()
 
@@ -152,9 +182,35 @@ async def test_form_already_configured(hass, region):
     assert result2["reason"] == "already_configured"
 
 
+async def test_no_appliances_flow(hass: HomeAssistant, region) -> None:
+    """Test we get and error with no appliances."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == config_entries.SOURCE_USER
+
+    with patch("homeassistant.components.whirlpool.config_flow.Auth.do_auth"), patch(
+        "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.whirlpool.config_flow.AppliancesManager.fetch_appliances",
+        return_value=True,
+    ):
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            CONFIG_INPUT | {"region": region[0]},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "no_appliances"}
+
+
 async def test_reauth_flow(hass: HomeAssistant, region) -> None:
     """Test a successful reauth flow."""
-
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
         data=CONFIG_INPUT | {"region": region[0]},
@@ -169,11 +225,7 @@ async def test_reauth_flow(hass: HomeAssistant, region) -> None:
             "unique_id": mock_entry.unique_id,
             "entry_id": mock_entry.entry_id,
         },
-        data={
-            "username": "test-username",
-            "password": "new-password",
-            "region": region[0],
-        },
+        data=CONFIG_INPUT | {"region": region[0]},
     )
 
     assert result["step_id"] == "reauth_confirm"
@@ -185,6 +237,12 @@ async def test_reauth_flow(hass: HomeAssistant, region) -> None:
         return_value=True,
     ), patch("homeassistant.components.whirlpool.config_flow.Auth.do_auth"), patch(
         "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.whirlpool.config_flow.AppliancesManager.aircons",
+        return_value=["test"],
+    ), patch(
+        "homeassistant.components.whirlpool.config_flow.AppliancesManager.fetch_appliances",
         return_value=True,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -220,8 +278,8 @@ async def test_reauth_flow_auth_error(hass: HomeAssistant, region) -> None:
             "entry_id": mock_entry.entry_id,
         },
         data={
-            "username": "test-username",
-            "password": "new-password",
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "new-password",
             "region": region[0],
         },
     )
@@ -246,7 +304,7 @@ async def test_reauth_flow_auth_error(hass: HomeAssistant, region) -> None:
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_reauth_flow_connection_error(hass: HomeAssistant, region) -> None:
+async def test_reauth_flow_connnection_error(hass: HomeAssistant, region) -> None:
     """Test a connection error reauth flow."""
 
     mock_entry = MockConfigEntry(
@@ -263,11 +321,7 @@ async def test_reauth_flow_connection_error(hass: HomeAssistant, region) -> None
             "unique_id": mock_entry.unique_id,
             "entry_id": mock_entry.entry_id,
         },
-        data={
-            CONF_USERNAME: "test-username",
-            CONF_PASSWORD: "new-password",
-            "region": region[0],
-        },
+        data=CONFIG_INPUT | {"region": region[0]},
     )
 
     assert result["step_id"] == "reauth_confirm"

--- a/tests/components/whirlpool/test_init.py
+++ b/tests/components/whirlpool/test_init.py
@@ -14,7 +14,12 @@ from . import init_integration, init_integration_with_entry
 from tests.common import MockConfigEntry
 
 
-async def test_setup(hass: HomeAssistant, mock_backend_selector_api: MagicMock, region):
+async def test_setup(
+    hass: HomeAssistant,
+    mock_backend_selector_api: MagicMock,
+    region,
+    mock_aircon_api_instances: MagicMock,
+):
     """Test setup."""
     entry = await init_integration(hass, region[0])
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
@@ -23,12 +28,15 @@ async def test_setup(hass: HomeAssistant, mock_backend_selector_api: MagicMock, 
 
 
 async def test_setup_region_fallback(
-    hass: HomeAssistant, mock_backend_selector_api: MagicMock
+    hass: HomeAssistant,
+    mock_backend_selector_api: MagicMock,
+    mock_aircon_api_instances: MagicMock,
 ):
     """Test setup when no region is available on the ConfigEntry.
 
     This can happen after a version update, since there was no region in the first versions.
     """
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -42,7 +50,11 @@ async def test_setup_region_fallback(
     mock_backend_selector_api.assert_called_once_with(Brand.Whirlpool, Region.EU)
 
 
-async def test_setup_http_exception(hass: HomeAssistant, mock_auth_api: MagicMock):
+async def test_setup_http_exception(
+    hass: HomeAssistant,
+    mock_auth_api: MagicMock,
+    mock_aircon_api_instances: MagicMock,
+):
     """Test setup with an http exception."""
     mock_auth_api.return_value.do_auth = AsyncMock(
         side_effect=aiohttp.ClientConnectionError()
@@ -52,7 +64,11 @@ async def test_setup_http_exception(hass: HomeAssistant, mock_auth_api: MagicMoc
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_auth_failed(hass: HomeAssistant, mock_auth_api: MagicMock):
+async def test_setup_auth_failed(
+    hass: HomeAssistant,
+    mock_auth_api: MagicMock,
+    mock_aircon_api_instances: MagicMock,
+):
     """Test setup with failed auth."""
     mock_auth_api.return_value.do_auth = AsyncMock()
     mock_auth_api.return_value.is_access_token_valid.return_value = False
@@ -62,7 +78,9 @@ async def test_setup_auth_failed(hass: HomeAssistant, mock_auth_api: MagicMock):
 
 
 async def test_setup_fetch_appliances_failed(
-    hass: HomeAssistant, mock_appliances_manager_api: MagicMock
+    hass: HomeAssistant,
+    mock_appliances_manager_api: MagicMock,
+    mock_aircon_api_instances: MagicMock,
 ):
     """Test setup with failed fetch_appliances."""
     mock_appliances_manager_api.return_value.fetch_appliances.return_value = False
@@ -71,7 +89,11 @@ async def test_setup_fetch_appliances_failed(
     assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_unload_entry(hass: HomeAssistant):
+async def test_unload_entry(
+    hass: HomeAssistant,
+    mock_aircon_api_instances: MagicMock,
+    mock_sensor_api_instances: MagicMock,
+):
     """Test successful unload of entry."""
     entry = await init_integration(hass)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -2,7 +2,6 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
-from attr import dataclass
 from whirlpool.washerdryer import MachineState
 
 from homeassistant.core import CoreState, HomeAssistant, State
@@ -48,18 +47,8 @@ async def test_dryer_sensor_values(
     """Test the sensor value callbacks."""
     await init_integration(hass)
 
-    @dataclass
-    class SensorTestInstance:
-        """Helper class for multiple washer/dryer and mock instances."""
-
-        entity_id: str
-        mock_instance: MagicMock
-        mock_instance_idx: int
-
-    sensor_test_instance = SensorTestInstance("sensor.dryer_state", mock_sensor2_api, 1)
-
-    entity_id = sensor_test_instance.entity_id
-    mock_instance = sensor_test_instance.mock_instance
+    entity_id = "sensor.dryer_state"
+    mock_instance = mock_sensor2_api
     registry = entity_registry.async_get(hass)
     entry = registry.async_get(entity_id)
     assert entry
@@ -103,20 +92,8 @@ async def test_washer_sensor_values(
     """Test the sensor value callbacks."""
     await init_integration(hass)
 
-    @dataclass
-    class SensorTestInstance:
-        """Helper class for multiple climate and mock instances."""
-
-        entity_id: str
-        mock_instance: MagicMock
-        mock_instance_idx: int
-
-    sensor_test_instance = SensorTestInstance(
-        "sensor.washer_state", mock_sensor1_api, 0
-    )
-
-    entity_id = sensor_test_instance.entity_id
-    mock_instance = sensor_test_instance.mock_instance
+    entity_id = "sensor.washer_state"
+    mock_instance = mock_sensor1_api
     registry = entity_registry.async_get(hass)
     entry = registry.async_get(entity_id)
     assert entry

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -81,7 +81,6 @@ async def test_washer_sensor_values(
     hass: HomeAssistant,
     mock_sensor_api_instances: MagicMock,
     mock_sensor1_api: MagicMock,
-    mock_sensor2_api: MagicMock,
 ):
     """Test the sensor value callbacks."""
     await init_integration(hass)
@@ -94,126 +93,126 @@ async def test_washer_sensor_values(
         mock_instance: MagicMock
         mock_instance_idx: int
 
-    for sensor_test_instance in (
-        SensorTestInstance("sensor.washer_state", mock_sensor1_api, 0),
-    ):
-        entity_id = sensor_test_instance.entity_id
-        mock_instance = sensor_test_instance.mock_instance
-        registry = entity_registry.async_get(hass)
-        entry = registry.async_get(entity_id)
-        assert entry
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.state == "Standby"
+    sensor_test_instance = SensorTestInstance(
+        "sensor.washer_state", mock_sensor1_api, 0
+    )
+    entity_id = sensor_test_instance.entity_id
+    mock_instance = sensor_test_instance.mock_instance
+    registry = entity_registry.async_get(hass)
+    entry = registry.async_get(entity_id)
+    assert entry
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "Standby"
 
-        state = await update_sensor_state(hass, entity_id, mock_instance)
-        assert state is not None
-        state_id = f"{entity_id.split('_')[0]}_end_time"
-        state = hass.states.get(state_id)
-        assert state is not None
+    state = await update_sensor_state(hass, entity_id, mock_instance)
+    assert state is not None
+    state_id = f"{entity_id.split('_')[0]}_end_time"
+    state = hass.states.get(state_id)
+    assert state is not None
 
-        state_id = f"{entity_id.split('_')[0]}_detergent_level"
-        state = hass.states.get(state_id)
-        assert state is not None
-        assert state.state == "50%"
+    state_id = f"{entity_id.split('_')[0]}_detergent_level"
+    state = hass.states.get(state_id)
+    assert state is not None
+    assert state.state == "50%"
 
-        # Test the washer cycle states
-        mock_instance.get_machine_state.return_value = MachineState.RunningMainCycle
-        mock_instance.get_cycle_status_filling.return_value = True
-        mock_instance.attr_value_to_bool.side_effect = [
-            True,
-            False,
-            False,
-            False,
-            False,
-            False,
-        ]
+    # Test the washer cycle states
+    mock_instance.get_machine_state.return_value = MachineState.RunningMainCycle
+    mock_instance.get_cycle_status_filling.return_value = True
+    mock_instance.attr_value_to_bool.side_effect = [
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+    ]
 
-        state = await update_sensor_state(hass, entity_id, mock_instance)
-        assert state is not None
-        assert state.state == "Cycle Filling"
+    state = await update_sensor_state(hass, entity_id, mock_instance)
+    assert state is not None
+    assert state.state == "Cycle Filling"
 
-        mock_instance.get_cycle_status_filling.return_value = False
-        mock_instance.get_cycle_status_rinsing.return_value = True
-        mock_instance.attr_value_to_bool.side_effect = [
-            False,
-            True,
-            False,
-            False,
-            False,
-            False,
-        ]
+    mock_instance.get_cycle_status_filling.return_value = False
+    mock_instance.get_cycle_status_rinsing.return_value = True
+    mock_instance.attr_value_to_bool.side_effect = [
+        False,
+        True,
+        False,
+        False,
+        False,
+        False,
+    ]
 
-        state = await update_sensor_state(hass, entity_id, mock_instance)
-        assert state is not None
-        assert state.state == "Cycle Rinsing"
+    state = await update_sensor_state(hass, entity_id, mock_instance)
+    assert state is not None
+    assert state.state == "Cycle Rinsing"
 
-        mock_instance.get_cycle_status_rinsing.return_value = False
-        mock_instance.get_cycle_status_sensing.return_value = True
-        mock_instance.attr_value_to_bool.side_effect = [
-            False,
-            False,
-            True,
-            False,
-            False,
-            False,
-        ]
+    mock_instance.get_cycle_status_rinsing.return_value = False
+    mock_instance.get_cycle_status_sensing.return_value = True
+    mock_instance.attr_value_to_bool.side_effect = [
+        False,
+        False,
+        True,
+        False,
+        False,
+        False,
+    ]
 
-        state = await update_sensor_state(hass, entity_id, mock_instance)
-        assert state is not None
-        assert state.state == "Cycle Sensing"
+    state = await update_sensor_state(hass, entity_id, mock_instance)
+    assert state is not None
+    assert state.state == "Cycle Sensing"
 
-        mock_instance.get_cycle_status_sensing.return_value = False
-        mock_instance.get_cycle_status_soaking.return_value = True
-        mock_instance.attr_value_to_bool.side_effect = [
-            False,
-            False,
-            False,
-            True,
-            False,
-            False,
-        ]
+    mock_instance.get_cycle_status_sensing.return_value = False
+    mock_instance.get_cycle_status_soaking.return_value = True
+    mock_instance.attr_value_to_bool.side_effect = [
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+    ]
 
-        state = await update_sensor_state(hass, entity_id, mock_instance)
-        assert state is not None
-        assert state.state == "Cycle Soaking"
+    state = await update_sensor_state(hass, entity_id, mock_instance)
+    assert state is not None
+    assert state.state == "Cycle Soaking"
 
-        mock_instance.get_cycle_status_soaking.return_value = False
-        mock_instance.get_cycle_status_spinning.return_value = True
-        mock_instance.attr_value_to_bool.side_effect = [
-            False,
-            False,
-            False,
-            False,
-            True,
-            False,
-        ]
+    mock_instance.get_cycle_status_soaking.return_value = False
+    mock_instance.get_cycle_status_spinning.return_value = True
+    mock_instance.attr_value_to_bool.side_effect = [
+        False,
+        False,
+        False,
+        False,
+        True,
+        False,
+    ]
 
-        state = await update_sensor_state(hass, entity_id, mock_instance)
-        assert state is not None
-        assert state.state == "Cycle Spinning"
+    state = await update_sensor_state(hass, entity_id, mock_instance)
+    assert state is not None
+    assert state.state == "Cycle Spinning"
 
-        mock_instance.get_cycle_status_spinning.return_value = False
-        mock_instance.get_cycle_status_washing.return_value = True
-        mock_instance.attr_value_to_bool.side_effect = [
-            False,
-            False,
-            False,
-            False,
-            False,
-            True,
-        ]
+    mock_instance.get_cycle_status_spinning.return_value = False
+    mock_instance.get_cycle_status_washing.return_value = True
+    mock_instance.attr_value_to_bool.side_effect = [
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+    ]
 
-        state = await update_sensor_state(hass, entity_id, mock_instance)
-        assert state is not None
-        assert state.state == "Cycle Washing"
+    state = await update_sensor_state(hass, entity_id, mock_instance)
+    assert state is not None
+    assert state.state == "Cycle Washing"
 
-        mock_instance.get_machine_state.return_value = MachineState.Complete
-        mock_instance.attr_value_to_bool.side_effect = None
-        mock_instance.get_attribute.side_effect = side_effect_function_open_door
-        state = await update_sensor_state(hass, entity_id, mock_instance)
-        assert state is not None
-        assert state.state == "Door open"
+    mock_instance.get_machine_state.return_value = MachineState.Complete
+    mock_instance.attr_value_to_bool.side_effect = None
+    mock_instance.get_attribute.side_effect = side_effect_function_open_door
+    state = await update_sensor_state(hass, entity_id, mock_instance)
+    assert state is not None
+    assert state.state == "Door open"
 
 
 async def test_restore_state(

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -172,7 +172,7 @@ async def test_sensor_values(
             assert state is not None
             assert state.state == "Cycle Washing"
 
-            mock_instance.get_machine_state.return_value = MachineState.RunningMainCycle
+            mock_instance.get_machine_state.return_value = MachineState.Complete
             mock_instance.attr_value_to_bool.side_effect = None
             mock_instance.get_attribute.side_effect = side_effect_function_open_door
             state = await update_sensor_state(hass, entity_id, mock_instance)

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -1,0 +1,180 @@
+"""Test the Whirlpool Sensor domain."""
+from unittest.mock import MagicMock
+
+from attr import dataclass
+from whirlpool.washerdryer import MachineState
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry
+
+from . import init_integration
+
+
+async def update_sensor_state(
+    hass: HomeAssistant,
+    entity_id: str,
+    mock_sensor_api_instance: MagicMock,
+):
+    """Simulate an update trigger from the API."""
+
+    for call in mock_sensor_api_instance.register_attr_callback.call_args_list:
+        update_ha_state_cb = call[0][0]
+        update_ha_state_cb()
+        await hass.async_block_till_done()
+
+    return hass.states.get(entity_id)
+
+
+def side_effect_function_open_door(*args, **kwargs):
+    """Return correct value for attribute."""
+    if args[0] == "Cavity_TimeStatusEstTimeRemaining":
+        return 3540
+
+    if args[0] == "Cavity_OpStatusDoorOpen":
+        return "1"
+
+    if args[0] == "WashCavity_OpStatusBulkDispense1Level":
+        return "3"
+
+
+async def test_sensor_values(
+    hass: HomeAssistant,
+    mock_sensor_api_instances: MagicMock,
+    mock_sensor1_api: MagicMock,
+    mock_sensor2_api: MagicMock,
+    # mock_sensor_api: MagicMock,
+):
+    """Test the sensor value callbacks."""
+    await init_integration(hass)
+
+    @dataclass
+    class SensorTestInstance:
+        """Helper class for multiple climate and mock instances."""
+
+        entity_id: str
+        mock_instance: MagicMock
+        mock_instance_idx: int
+
+    for sensor_test_instance in (
+        SensorTestInstance("sensor.washer_state", mock_sensor1_api, 0),
+        SensorTestInstance("sensor.dryer_state", mock_sensor2_api, 1),
+    ):
+        entity_id = sensor_test_instance.entity_id
+        mock_instance = sensor_test_instance.mock_instance
+        mock_instance_idx = sensor_test_instance.mock_instance_idx
+        registry = entity_registry.async_get(hass)
+        entry = registry.async_get(entity_id)
+        assert entry
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == "Standby"
+
+        state = await update_sensor_state(hass, entity_id, mock_instance)
+        assert state is not None
+        state_id = f"{entity_id.split('_')[0]}_end_time"
+        state = hass.states.get(state_id)
+        assert state is not None
+
+        state_id = f"{entity_id.split('_')[0]}_detergent_level"
+        state = hass.states.get(state_id)
+        assert state is not None
+        assert state.state == "50%"
+
+        if mock_instance_idx == 0:
+            # Test the washer cycle states
+            mock_instance.get_machine_state.return_value = MachineState.RunningMainCycle
+            mock_instance.get_cycle_status_filling.return_value = True
+            mock_instance.attr_value_to_bool.side_effect = [
+                True,
+                False,
+                False,
+                False,
+                False,
+                False,
+            ]
+
+            state = await update_sensor_state(hass, entity_id, mock_instance)
+            assert state is not None
+            assert state.state == "Cycle Filling"
+
+            mock_instance.get_cycle_status_filling.return_value = False
+            mock_instance.get_cycle_status_rinsing.return_value = True
+            mock_instance.attr_value_to_bool.side_effect = [
+                False,
+                True,
+                False,
+                False,
+                False,
+                False,
+            ]
+
+            state = await update_sensor_state(hass, entity_id, mock_instance)
+            assert state is not None
+            assert state.state == "Cycle Rinsing"
+
+            mock_instance.get_cycle_status_rinsing.return_value = False
+            mock_instance.get_cycle_status_sensing.return_value = True
+            mock_instance.attr_value_to_bool.side_effect = [
+                False,
+                False,
+                True,
+                False,
+                False,
+                False,
+            ]
+
+            state = await update_sensor_state(hass, entity_id, mock_instance)
+            assert state is not None
+            assert state.state == "Cycle Sensing"
+
+            mock_instance.get_cycle_status_sensing.return_value = False
+            mock_instance.get_cycle_status_soaking.return_value = True
+            mock_instance.attr_value_to_bool.side_effect = [
+                False,
+                False,
+                False,
+                True,
+                False,
+                False,
+            ]
+
+            state = await update_sensor_state(hass, entity_id, mock_instance)
+            assert state is not None
+            assert state.state == "Cycle Soaking"
+
+            mock_instance.get_cycle_status_soaking.return_value = False
+            mock_instance.get_cycle_status_spinning.return_value = True
+            mock_instance.attr_value_to_bool.side_effect = [
+                False,
+                False,
+                False,
+                False,
+                True,
+                False,
+            ]
+
+            state = await update_sensor_state(hass, entity_id, mock_instance)
+            assert state is not None
+            assert state.state == "Cycle Spinning"
+
+            mock_instance.get_cycle_status_spinning.return_value = False
+            mock_instance.get_cycle_status_washing.return_value = True
+            mock_instance.attr_value_to_bool.side_effect = [
+                False,
+                False,
+                False,
+                False,
+                False,
+                True,
+            ]
+
+            state = await update_sensor_state(hass, entity_id, mock_instance)
+            assert state is not None
+            assert state.state == "Cycle Washing"
+
+            mock_instance.get_machine_state.return_value = MachineState.RunningMainCycle
+            mock_instance.attr_value_to_bool.side_effect = None
+            mock_instance.get_attribute.side_effect = side_effect_function_open_door
+            state = await update_sensor_state(hass, entity_id, mock_instance)
+            assert state is not None
+            assert state.state == "Door open"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Addition of Sensor platform for the washer/dryer appliances.  
State, time_remaining, and dispense level sensors are created under a device for each washer/dryer found in the users account.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [#24107](https://github.com/home-assistant/home-assistant.io/pull/24107)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
