### PR TITLE
Remove workaround for reloading PurpleAir upon device removal

### DIFF
--- a/homeassistant/components/purpleair/__init__.py
+++ b/homeassistant/components/purpleair/__init__.py
@@ -6,12 +6,10 @@ from aiopurpleair.models.sensors import SensorModel
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .config_flow import async_remove_sensor_by_device_id
-from .const import CONF_LAST_UPDATE_SENSOR_ADD, DOMAIN
+from .const import DOMAIN
 from .coordinator import PurpleAirDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -32,26 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_handle_entry_update(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle an options update."""
-    if entry.options.get(CONF_LAST_UPDATE_SENSOR_ADD) is True:
-        # If the last options update was to add a sensor, we reload the config entry:
-        await hass.config_entries.async_reload(entry.entry_id)
-
-
-async def async_remove_config_entry_device(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
-) -> bool:
-    """Remove a config entry from a device."""
-    new_entry_options = async_remove_sensor_by_device_id(
-        hass,
-        config_entry,
-        device_entry.id,
-        # remove_device is set to False because in this instance, the device has
-        # already been removed:
-        remove_device=False,
-    )
-    return hass.config_entries.async_update_entry(
-        config_entry, options=new_entry_options
-    )
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/purpleair/config_flow.py
+++ b/homeassistant/components/purpleair/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for PurpleAir integration."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -14,13 +15,15 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import (
     aiohttp_client,
     config_validation as cv,
     device_registry as dr,
+    entity_registry as er,
 )
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.selector import (
     SelectOptionDict,
     SelectSelector,
@@ -28,7 +31,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import CONF_LAST_UPDATE_SENSOR_ADD, CONF_SENSOR_INDICES, DOMAIN, LOGGER
+from .const import CONF_SENSOR_INDICES, DOMAIN, LOGGER
 
 CONF_DISTANCE = "distance"
 CONF_NEARBY_SENSOR_OPTIONS = "nearby_sensor_options"
@@ -115,50 +118,6 @@ def async_get_remove_sensor_schema(sensors: list[SelectOptionDict]) -> vol.Schem
             )
         }
     )
-
-
-@callback
-def async_get_sensor_index(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
-) -> int:
-    """Get the sensor index related to a config and device entry.
-
-    Note that this method expects that there will always be a single sensor index per
-    DeviceEntry.
-    """
-    sensor_index = next(
-        sensor_index
-        for sensor_index in config_entry.options[CONF_SENSOR_INDICES]
-        if (DOMAIN, str(sensor_index)) in device_entry.identifiers
-    )
-
-    return cast(int, sensor_index)
-
-
-@callback
-def async_remove_sensor_by_device_id(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    device_id: str,
-    *,
-    remove_device: bool = True,
-) -> dict[str, Any]:
-    """Remove a sensor and return update config entry options."""
-    device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get(device_id)
-    assert device_entry
-
-    removed_sensor_index = async_get_sensor_index(hass, config_entry, device_entry)
-    options = deepcopy({**config_entry.options})
-    options[CONF_LAST_UPDATE_SENSOR_ADD] = False
-    options[CONF_SENSOR_INDICES].remove(removed_sensor_index)
-
-    if remove_device:
-        device_registry.async_update_device(
-            device_entry.id, remove_config_entry_id=config_entry.entry_id
-        )
-
-    return options
 
 
 @dataclass
@@ -407,7 +366,6 @@ class PurpleAirOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_abort(reason="already_configured")
 
         options = deepcopy({**self.config_entry.options})
-        options[CONF_LAST_UPDATE_SENSOR_ADD] = True
         options[CONF_SENSOR_INDICES].append(sensor_index)
         return self.async_create_entry(title="", data=options)
 
@@ -432,8 +390,50 @@ class PurpleAirOptionsFlowHandler(config_entries.OptionsFlow):
                 ),
             )
 
-        new_entry_options = async_remove_sensor_by_device_id(
-            self.hass, self.config_entry, user_input[CONF_SENSOR_DEVICE_ID]
+        device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
+
+        device_id = user_input[CONF_SENSOR_DEVICE_ID]
+        device_entry = cast(dr.DeviceEntry, device_registry.async_get(device_id))
+
+        # Determine the entity entries that belong to this device.
+        entity_entries = er.async_entries_for_device(
+            entity_registry, device_id, include_disabled_entities=True
         )
 
-        return self.async_create_entry(title="", data=new_entry_options)
+        device_entities_removed_event = asyncio.Event()
+
+        @callback
+        def async_device_entity_state_changed(_: Event) -> None:
+            """Listen and respond when all device entities are removed."""
+            if all(
+                self.hass.states.get(entity_entry.entity_id) is None
+                for entity_entry in entity_entries
+            ):
+                device_entities_removed_event.set()
+
+        # Track state changes for this device's entities and when they're removed,
+        # finish the flow:
+        cancel_state_track = async_track_state_change_event(
+            self.hass,
+            [entity_entry.entity_id for entity_entry in entity_entries],
+            async_device_entity_state_changed,
+        )
+        device_registry.async_update_device(
+            device_id, remove_config_entry_id=self.config_entry.entry_id
+        )
+        await device_entities_removed_event.wait()
+
+        # Once we're done, we can cancel the state change tracker callback:
+        cancel_state_track()
+
+        # Build new config entry options:
+        removed_sensor_index = next(
+            sensor_index
+            for sensor_index in self.config_entry.options[CONF_SENSOR_INDICES]
+            if (DOMAIN, str(sensor_index)) in device_entry.identifiers
+        )
+        options = deepcopy({**self.config_entry.options})
+        options[CONF_SENSOR_INDICES].remove(removed_sensor_index)
+
+        return self.async_create_entry(title="", data=options)

--- a/homeassistant/components/purpleair/const.py
+++ b/homeassistant/components/purpleair/const.py
@@ -5,6 +5,5 @@ DOMAIN = "purpleair"
 
 LOGGER = logging.getLogger(__package__)
 
-CONF_LAST_UPDATE_SENSOR_ADD = "last_update_sensor_add"
 CONF_READ_KEY = "read_key"
 CONF_SENSOR_INDICES = "sensor_indices"

--- a/tests/components/purpleair/test_config_flow.py
+++ b/tests/components/purpleair/test_config_flow.py
@@ -215,7 +215,6 @@ async def test_options_add_sensor(
     )
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
-        "last_update_sensor_add": True,
         "sensor_indices": [TEST_SENSOR_INDEX1, TEST_SENSOR_INDEX2],
     }
 
@@ -278,7 +277,6 @@ async def test_options_remove_sensor(hass, config_entry, setup_config_entry):
     )
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
-        "last_update_sensor_add": False,
         "sensor_indices": [],
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on [feedback](https://github.com/home-assistant/core/pull/83440#discussion_r1053524622), this PR removes an ugly workaround for a race condition that could happen in PurpleAir when reloading a config entry after device removal. We now wait until all device entities are removed before reloading the config entry.

This PR does eliminate the ability to remove a PurpleAir sensor by deleting the device—the options flow must be used. This is because `async_remove_config_entry_device` doesn't actually remove the device, so listening for entity state changes won't work the same as in the options flow. If this gets in for 2023.1, it won't be a breaking change (since that's the release introducing PurpleAir).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
