### PR TITLE
Correct initial config of MQTT climate

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -439,6 +439,9 @@ class MqttClimate(MqttEntity, ClimateEntity):
         discovery_data: DiscoveryInfoType | None,
     ) -> None:
         """Initialize the climate device."""
+        self._attr_fan_mode = None
+        self._attr_hvac_mode = None
+        self._attr_swing_mode = None
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
     @staticmethod
@@ -463,11 +466,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
         self._topic = {key: config.get(key) for key in TOPIC_KEYS}
 
-        # set to None in non-optimistic mode
-        self._attr_target_temperature = None
-        self._attr_fan_mode = None
-        self._attr_hvac_mode = None
-        self._attr_swing_mode = None
         self._attr_target_temperature_low = None
         self._attr_target_temperature_high = None
 

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -440,7 +440,9 @@ class MqttClimate(MqttEntity, ClimateEntity):
     ) -> None:
         """Initialize the climate device."""
         self._attr_fan_mode = None
+        self._attr_hvac_action = None
         self._attr_hvac_mode = None
+        self._attr_is_aux_heat = None
         self._attr_swing_mode = None
         self._attr_target_temperature_low = None
         self._attr_target_temperature_high = None
@@ -498,7 +500,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
         self._optimistic_preset_mode = (
             self._optimistic or CONF_PRESET_MODE_STATE_TOPIC not in config
         )
-        self._attr_hvac_action = None
 
         value_templates: dict[str, Template | None] = {}
         for key in VALUE_TEMPLATE_KEYS:

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -442,6 +442,8 @@ class MqttClimate(MqttEntity, ClimateEntity):
         self._attr_fan_mode = None
         self._attr_hvac_mode = None
         self._attr_swing_mode = None
+        self._attr_target_temperature_low = None
+        self._attr_target_temperature_high = None
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
     @staticmethod
@@ -466,24 +468,23 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
         self._topic = {key: config.get(key) for key in TOPIC_KEYS}
 
-        self._attr_target_temperature_low = None
-        self._attr_target_temperature_high = None
-
         self._optimistic = config[CONF_OPTIMISTIC]
 
-        if self._topic[CONF_TEMP_STATE_TOPIC] is None:
+        if self._topic[CONF_TEMP_STATE_TOPIC] is None or self._optimistic:
             self._attr_target_temperature = config[CONF_TEMP_INITIAL]
-        if self._topic[CONF_TEMP_LOW_STATE_TOPIC] is None:
+        if self._topic[CONF_TEMP_LOW_STATE_TOPIC] is None or self._optimistic:
             self._attr_target_temperature_low = config[CONF_TEMP_INITIAL]
-        if self._topic[CONF_TEMP_HIGH_STATE_TOPIC] is None:
+        if self._topic[CONF_TEMP_HIGH_STATE_TOPIC] is None or self._optimistic:
             self._attr_target_temperature_high = config[CONF_TEMP_INITIAL]
 
-        if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
+        if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None or self._optimistic:
             self._attr_fan_mode = FAN_LOW
-        if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None:
+        if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None or self._optimistic:
             self._attr_swing_mode = SWING_OFF
-        if self._topic[CONF_MODE_STATE_TOPIC] is None:
+        if self._topic[CONF_MODE_STATE_TOPIC] is None or self._optimistic:
             self._attr_hvac_mode = HVACMode.OFF
+        if self._topic[CONF_AUX_STATE_TOPIC] is None or self._optimistic:
+            self._attr_is_aux_heat = False
         self._feature_preset_mode = CONF_PRESET_MODE_COMMAND_TOPIC in config
         if self._feature_preset_mode:
             presets = []
@@ -498,8 +499,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
             self._optimistic or CONF_PRESET_MODE_STATE_TOPIC not in config
         )
         self._attr_hvac_action = None
-
-        self._attr_is_aux_heat = False
 
         value_templates: dict[str, Template | None] = {}
         for key in VALUE_TEMPLATE_KEYS:

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -258,7 +258,7 @@ async def test_set_operation_optimistic(hass, mqtt_mock_entry_with_yaml_config):
     await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.state == "unknown"
+    assert state.state == "off"
 
     await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
@@ -351,7 +351,7 @@ async def test_set_fan_mode_optimistic(hass, mqtt_mock_entry_with_yaml_config):
     await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("fan_mode") is None
+    assert state.attributes.get("fan_mode") == "low"
 
     await common.async_set_fan_mode(hass, "high", ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
@@ -431,7 +431,7 @@ async def test_set_swing_optimistic(hass, mqtt_mock_entry_with_yaml_config):
     await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("swing_mode") is None
+    assert state.attributes.get("swing_mode") == "off"
 
     await common.async_set_swing_mode(hass, "on", ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
@@ -550,7 +550,7 @@ async def test_set_target_temperature_optimistic(
     await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("temperature") is None
+    assert state.attributes.get("temperature") == 21
     await common.async_set_hvac_mode(hass, "heat", ENTITY_CLIMATE)
     await common.async_set_temperature(hass, temperature=17, entity_id=ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
@@ -634,8 +634,8 @@ async def test_set_target_temperature_low_high_optimistic(
     await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("target_temp_low") is None
-    assert state.attributes.get("target_temp_high") is None
+    assert state.attributes.get("target_temp_low") == 21
+    assert state.attributes.get("target_temp_high") == 21
     await common.async_set_temperature(
         hass, target_temp_low=20, target_temp_high=23, entity_id=ENTITY_CLIMATE
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- corrects the initial state when optistic mode used for MQTT climate.
- avoids resetting the state when re-configuring.

It is partly a correction on: https://github.com/home-assistant/core/pull/84777

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
