### PR TITLE
Dockerdev: Use more native container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,10 @@
 {
   "name": "Home Assistant Dev",
+  "build": {
+    "args": {
+      "BUILD_PYTHON_CONTAINER": "mcr.microsoft.com/vscode/devcontainers/python:0-"
+    }
+  },
   "context": "..",
   "dockerFile": "../Dockerfile.dev",
   "postCreateCommand": "script/setup",

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,12 +4,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Uninstall pre-installed formatting and linting tools
 # They would conflict with our pinned versions
-RUN pipx uninstall black
-RUN pipx uninstall flake8
-RUN pipx uninstall pydocstyle
-RUN pipx uninstall pycodestyle
-RUN pipx uninstall mypy
-RUN pipx uninstall pylint
+RUN \
+    pipx uninstall black && \
+    pipx uninstall flake8 && \
+    pipx uninstall pydocstyle && \
+    pipx uninstall mypy && \
+    pipx uninstall pylint
 
 RUN \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,15 +1,18 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9
+ARG BUILD_PYTHON_CONTAINER='python:'
+
+FROM "${BUILD_PYTHON_CONTAINER}3.9"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Uninstall pre-installed formatting and linting tools
 # They would conflict with our pinned versions
-RUN \
+RUN command -v pipx && ( \
     pipx uninstall black && \
     pipx uninstall flake8 && \
     pipx uninstall pydocstyle && \
     pipx uninstall mypy && \
-    pipx uninstall pylint
+    pipx uninstall pylint ) || \
+    echo "Running in native python container, nothing to remove"
 
 RUN \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \


### PR DESCRIPTION
## Proposed change
The current local dev container might not be appropriate for everyone to
do local, vscode-less development. It is somewhat married to the
`.devcontainer` setup, which is showing its warts a little bit already,
where the existing MS container is being modified to more closely match
our desires.
    
This can easily be fixed by using the normal python container for local
builds, making the runtime container and dev containers closer, which is
always desirable.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Development setup

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (https://github.com/home-assistant/developers.home-assistant/pull/1612)

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.