### PR TITLE
Revert "Disable sky connect config entry if USB stick is not plugged in"

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon 
     get_addon_manager,
     get_zigbee_socket,
 )
-from homeassistant.config_entries import ConfigEntry, ConfigEntryDisabler
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
@@ -75,12 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if not usb.async_is_plugged_in(hass, matcher):
         # The USB dongle is not plugged in
-        hass.async_create_task(
-            hass.config_entries.async_set_disabled_by(
-                entry.entry_id, ConfigEntryDisabler.INTEGRATION
-            )
-        )
-        return False
+        raise ConfigEntryNotReady
 
     addon_info = await _multi_pan_addon_info(hass, entry)
 

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from homeassistant.components import usb
 from homeassistant.components.homeassistant_hardware import silabs_multiprotocol_addon
-from homeassistant.config_entries import ConfigEntry, ConfigEntryDisabler, ConfigFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
@@ -35,12 +35,7 @@ class HomeAssistantSkyConnectConfigFlow(ConfigFlow, domain=DOMAIN):
         manufacturer = discovery_info.manufacturer
         description = discovery_info.description
         unique_id = f"{vid}:{pid}_{serial_number}_{manufacturer}_{description}"
-        if existing_entry := await self.async_set_unique_id(unique_id):
-            # Re-enable existing config entry which was disabled by USB unplug
-            if existing_entry.disabled_by == ConfigEntryDisabler.INTEGRATION:
-                await self.hass.config_entries.async_set_disabled_by(
-                    existing_entry.entry_id, None
-                )
+        if await self.async_set_unique_id(unique_id):
             self._abort_if_unique_id_configured(updates={"device": device})
         return self.async_create_entry(
             title="Home Assistant Sky Connect",

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -163,7 +163,6 @@ class ConfigEntryChange(StrEnum):
 class ConfigEntryDisabler(StrEnum):
     """What disabled a config entry."""
 
-    INTEGRATION = "integration"
     USER = "user"
 
 


### PR DESCRIPTION
Reverts home-assistant/core#84975

The solution was not reliable - prone to races and deadlocks - and needs to be reworked