### PR TITLE
Fix lacrosse_view fetching of latest data

### DIFF
--- a/homeassistant/components/lacrosse_view/coordinator.py
+++ b/homeassistant/components/lacrosse_view/coordinator.py
@@ -1,7 +1,8 @@
 """DataUpdateCoordinator for LaCrosse View."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
+from time import time
 
 from lacrosse_view import HTTPError, LaCrosse, Location, LoginError, Sensor
 
@@ -30,7 +31,7 @@ class LaCrosseUpdateCoordinator(DataUpdateCoordinator[list[Sensor]]):
     ) -> None:
         """Initialize DataUpdateCoordinator for LaCrosse View."""
         self.api = api
-        self.last_update = datetime.utcnow()
+        self.last_update = time()
         self.username = entry.data["username"]
         self.password = entry.data["password"]
         self.hass = hass
@@ -45,26 +46,22 @@ class LaCrosseUpdateCoordinator(DataUpdateCoordinator[list[Sensor]]):
 
     async def _async_update_data(self) -> list[Sensor]:
         """Get the data for LaCrosse View."""
-        now = datetime.utcnow()
+        now = int(time())
 
-        if self.last_update < now - timedelta(minutes=59):  # Get new token
+        if self.last_update < now - 59 * 60:  # Get new token once in a hour
             self.last_update = now
             try:
                 await self.api.login(self.username, self.password)
             except LoginError as error:
                 raise ConfigEntryAuthFailed from error
 
-        # Get the timestamp for yesterday at 6 PM (this is what is used in the app, i noticed it when proxying the request)
-        yesterday = now - timedelta(days=1)
-        yesterday = yesterday.replace(hour=18, minute=0, second=0, microsecond=0)
-        yesterday_timestamp = datetime.timestamp(yesterday)
-
         try:
+            # Fetch last hour of data
             sensors = await self.api.get_sensors(
                 location=Location(id=self.id, name=self.name),
                 tz=self.hass.config.time_zone,
-                start=str(int(yesterday_timestamp)),
-                end=str(int(datetime.timestamp(now))),
+                start=str(now - 3600),
+                end=str(now),
             )
         except HTTPError as error:
             raise ConfigEntryNotReady from error


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When using datetime.utcnow(), it only replaces timezone information with UTC making the actual time offset by the timezone. When you are in UTC- timezones, it makes no issue as the offset is in the future, but when in UTC+, the last hour(s) of data are missing.

This commits swtiches to time.time() as UTC timestamp is actually what the API expects.

It also reduces the window to one hour what noticeably improves the API performance.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
