### PR TITLE
Bump pybravia to 0.3.0

### DIFF
--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Final
 
 from aiohttp import CookieJar
-from pybravia import BraviaTV
+from pybravia import BraviaClient
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, Platform
@@ -30,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     session = async_create_clientsession(
         hass, cookie_jar=CookieJar(unsafe=True, quote_cookie=False)
     )
-    client = BraviaTV(host, mac, session=session)
+    client = BraviaClient(host, mac, session=session)
     coordinator = BraviaTVCoordinator(
         hass=hass,
         client=client,

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["pybravia==0.2.5"],
+  "requirements": ["pybravia==0.3.0"],
   "codeowners": ["@bieniu", "@Drafteed"],
   "ssdp": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1500,7 +1500,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.2.5
+pybravia==0.3.0
 
 # homeassistant.components.nissan_leaf
 pycarwings2==2.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1079,7 +1079,7 @@ pyblackbird==0.5
 pybotvac==0.0.23
 
 # homeassistant.components.braviatv
-pybravia==0.2.5
+pybravia==0.3.0
 
 # homeassistant.components.cloudflare
 pycfdns==2.0.1

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -2,10 +2,10 @@
 from unittest.mock import patch
 
 from pybravia import (
-    BraviaTVAuthError,
-    BraviaTVConnectionError,
-    BraviaTVError,
-    BraviaTVNotSupported,
+    BraviaAuthError,
+    BraviaConnectionError,
+    BraviaError,
+    BraviaNotSupported,
 )
 import pytest
 
@@ -107,10 +107,10 @@ async def test_ssdp_discovery(hass):
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
-    with patch("pybravia.BraviaTV.connect"), patch("pybravia.BraviaTV.pair"), patch(
-        "pybravia.BraviaTV.set_wol_mode"
-    ), patch(
-        "pybravia.BraviaTV.get_system_info",
+    with patch("pybravia.BraviaClient.connect"), patch(
+        "pybravia.BraviaClient.pair"
+    ), patch("pybravia.BraviaClient.set_wol_mode"), patch(
+        "pybravia.BraviaClient.get_system_info",
         return_value=BRAVIA_SYSTEM_INFO,
     ), patch(
         "homeassistant.components.braviatv.async_setup_entry", return_value=True
@@ -195,17 +195,17 @@ async def test_user_invalid_host(hass):
 @pytest.mark.parametrize(
     "side_effect, error_message",
     [
-        (BraviaTVAuthError, "invalid_auth"),
-        (BraviaTVNotSupported, "unsupported_model"),
-        (BraviaTVConnectionError, "cannot_connect"),
+        (BraviaAuthError, "invalid_auth"),
+        (BraviaNotSupported, "unsupported_model"),
+        (BraviaConnectionError, "cannot_connect"),
     ],
 )
 async def test_pin_form_error(hass, side_effect, error_message):
     """Test that PIN form errors are correct."""
     with patch(
-        "pybravia.BraviaTV.connect",
+        "pybravia.BraviaClient.connect",
         side_effect=side_effect,
-    ), patch("pybravia.BraviaTV.pair"):
+    ), patch("pybravia.BraviaClient.pair"):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
         )
@@ -222,15 +222,15 @@ async def test_pin_form_error(hass, side_effect, error_message):
 @pytest.mark.parametrize(
     "side_effect, error_message",
     [
-        (BraviaTVAuthError, "invalid_auth"),
-        (BraviaTVNotSupported, "unsupported_model"),
-        (BraviaTVConnectionError, "cannot_connect"),
+        (BraviaAuthError, "invalid_auth"),
+        (BraviaNotSupported, "unsupported_model"),
+        (BraviaConnectionError, "cannot_connect"),
     ],
 )
 async def test_psk_form_error(hass, side_effect, error_message):
     """Test that PSK form errors are correct."""
     with patch(
-        "pybravia.BraviaTV.connect",
+        "pybravia.BraviaClient.connect",
         side_effect=side_effect,
     ):
         result = await hass.config_entries.flow.async_init(
@@ -248,7 +248,7 @@ async def test_psk_form_error(hass, side_effect, error_message):
 
 async def test_no_ip_control(hass):
     """Test that error are shown when IP Control is disabled on the TV."""
-    with patch("pybravia.BraviaTV.pair", side_effect=BraviaTVError):
+    with patch("pybravia.BraviaClient.pair", side_effect=BraviaError):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "bravia-host"}
         )
@@ -274,10 +274,10 @@ async def test_duplicate_error(hass):
     )
     config_entry.add_to_hass(hass)
 
-    with patch("pybravia.BraviaTV.connect"), patch("pybravia.BraviaTV.pair"), patch(
-        "pybravia.BraviaTV.set_wol_mode"
-    ), patch(
-        "pybravia.BraviaTV.get_system_info",
+    with patch("pybravia.BraviaClient.connect"), patch(
+        "pybravia.BraviaClient.pair"
+    ), patch("pybravia.BraviaClient.set_wol_mode"), patch(
+        "pybravia.BraviaClient.get_system_info",
         return_value=BRAVIA_SYSTEM_INFO,
     ):
         result = await hass.config_entries.flow.async_init(
@@ -298,10 +298,10 @@ async def test_create_entry(hass):
     """Test that entry is added correctly with PIN auth."""
     uuid = await instance_id.async_get(hass)
 
-    with patch("pybravia.BraviaTV.connect"), patch("pybravia.BraviaTV.pair"), patch(
-        "pybravia.BraviaTV.set_wol_mode"
-    ), patch(
-        "pybravia.BraviaTV.get_system_info",
+    with patch("pybravia.BraviaClient.connect"), patch(
+        "pybravia.BraviaClient.pair"
+    ), patch("pybravia.BraviaClient.set_wol_mode"), patch(
+        "pybravia.BraviaClient.get_system_info",
         return_value=BRAVIA_SYSTEM_INFO,
     ), patch(
         "homeassistant.components.braviatv.async_setup_entry", return_value=True
@@ -339,10 +339,10 @@ async def test_create_entry(hass):
 
 async def test_create_entry_psk(hass):
     """Test that entry is added correctly with PSK auth."""
-    with patch("pybravia.BraviaTV.connect"), patch(
-        "pybravia.BraviaTV.set_wol_mode"
+    with patch("pybravia.BraviaClient.connect"), patch(
+        "pybravia.BraviaClient.set_wol_mode"
     ), patch(
-        "pybravia.BraviaTV.get_system_info",
+        "pybravia.BraviaClient.get_system_info",
         return_value=BRAVIA_SYSTEM_INFO,
     ), patch(
         "homeassistant.components.braviatv.async_setup_entry", return_value=True
@@ -390,14 +390,14 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     )
     config_entry.add_to_hass(hass)
 
-    with patch("pybravia.BraviaTV.connect"), patch(
-        "pybravia.BraviaTV.get_power_status",
+    with patch("pybravia.BraviaClient.connect"), patch(
+        "pybravia.BraviaClient.get_power_status",
         return_value="active",
     ), patch(
-        "pybravia.BraviaTV.get_external_status",
+        "pybravia.BraviaClient.get_external_status",
         return_value=BRAVIA_SOURCES,
     ), patch(
-        "pybravia.BraviaTV.send_rest_req",
+        "pybravia.BraviaClient.send_rest_req",
         return_value={},
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -418,7 +418,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
 
         # Test that saving with missing sources is ok
         with patch(
-            "pybravia.BraviaTV.get_external_status",
+            "pybravia.BraviaClient.get_external_status",
             return_value=BRAVIA_SOURCES[1:],
         ):
             result = await hass.config_entries.options.async_init(config_entry.entry_id)
@@ -444,22 +444,22 @@ async def test_options_flow_error(hass: HomeAssistant) -> None:
     )
     config_entry.add_to_hass(hass)
 
-    with patch("pybravia.BraviaTV.connect"), patch(
-        "pybravia.BraviaTV.get_power_status",
+    with patch("pybravia.BraviaClient.connect"), patch(
+        "pybravia.BraviaClient.get_power_status",
         return_value="active",
     ), patch(
-        "pybravia.BraviaTV.get_external_status",
+        "pybravia.BraviaClient.get_external_status",
         return_value=BRAVIA_SOURCES,
     ), patch(
-        "pybravia.BraviaTV.send_rest_req",
+        "pybravia.BraviaClient.send_rest_req",
         return_value={},
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     with patch(
-        "pybravia.BraviaTV.send_rest_req",
-        side_effect=BraviaTVError,
+        "pybravia.BraviaClient.send_rest_req",
+        side_effect=BraviaError,
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
@@ -488,14 +488,14 @@ async def test_reauth_successful(hass, use_psk, new_pin):
     )
     config_entry.add_to_hass(hass)
 
-    with patch("pybravia.BraviaTV.connect"), patch(
-        "pybravia.BraviaTV.get_power_status",
+    with patch("pybravia.BraviaClient.connect"), patch(
+        "pybravia.BraviaClient.get_power_status",
         return_value="active",
     ), patch(
-        "pybravia.BraviaTV.get_external_status",
+        "pybravia.BraviaClient.get_external_status",
         return_value=BRAVIA_SOURCES,
     ), patch(
-        "pybravia.BraviaTV.send_rest_req",
+        "pybravia.BraviaClient.send_rest_req",
         return_value={},
     ):
         result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump [pybravia](https://github.com/Drafteed/pybravia) to [0.3.0](https://github.com/Drafteed/pybravia/releases/tag/v0.3.0). 
In the new version of the pybravia package, the client and exception classes have been renamed (no functional changes).

**Changelog**:
https://github.com/Drafteed/pybravia/compare/v0.2.5...v0.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
