### PR TITLE
Renovate Ridwell config flow tests

### DIFF
--- a/tests/components/ridwell/conftest.py
+++ b/tests/components/ridwell/conftest.py
@@ -7,18 +7,19 @@ import pytest
 
 from homeassistant.components.ridwell.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
-ACCOUNT_ID = "12345"
+TEST_ACCOUNT_ID = "12345"
+TEST_PASSWORD = "password"
+TEST_USERNAME = "user@email.com"
 
 
 @pytest.fixture(name="account")
 def account_fixture():
     """Define a Ridwell account."""
     return Mock(
-        account_id=ACCOUNT_ID,
+        account_id=TEST_ACCOUNT_ID,
         address={
             "street1": "123 Main Street",
             "city": "New York",
@@ -42,7 +43,7 @@ def client_fixture(account):
     """Define an aioridwell client."""
     return Mock(
         async_authenticate=AsyncMock(),
-        async_get_accounts=AsyncMock(return_value={ACCOUNT_ID: account}),
+        async_get_accounts=AsyncMock(return_value={TEST_ACCOUNT_ID: account}),
     )
 
 
@@ -58,22 +59,24 @@ def config_entry_fixture(hass, config):
 def config_fixture(hass):
     """Define a config entry data fixture."""
     return {
-        CONF_USERNAME: "user@email.com",
-        CONF_PASSWORD: "password",
+        CONF_USERNAME: TEST_USERNAME,
+        CONF_PASSWORD: TEST_PASSWORD,
     }
 
 
-@pytest.fixture(name="setup_ridwell")
-async def setup_ridwell_fixture(hass, client, config):
-    """Define a fixture to set up Ridwell."""
+@pytest.fixture(name="mock_aioridwell")
+async def mock_aioridwell_fixture(hass, client, config):
+    """Define a fixture to patch aioridwell."""
     with patch(
         "homeassistant.components.ridwell.config_flow.async_get_client",
         return_value=client,
-    ), patch(
-        "homeassistant.components.ridwell.async_get_client", return_value=client
-    ), patch(
-        "homeassistant.components.ridwell.PLATFORMS", []
-    ):
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
+    ), patch("homeassistant.components.ridwell.async_get_client", return_value=client):
         yield
+
+
+@pytest.fixture(name="setup_config_entry")
+async def setup_config_entry_fixture(hass, config_entry, mock_aioridwell):
+    """Define a fixture to set up ridwell."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    yield

--- a/tests/components/ridwell/test_config_flow.py
+++ b/tests/components/ridwell/test_config_flow.py
@@ -14,13 +14,13 @@ from .conftest import TEST_PASSWORD, TEST_USERNAME
 
 
 @pytest.mark.parametrize(
-    "mock_get_client,errors",
+    "get_client_response,errors",
     [
         (AsyncMock(side_effect=InvalidCredentialsError), {"base": "invalid_auth"}),
         (AsyncMock(side_effect=RidwellError), {"base": "unknown"}),
     ],
 )
-async def test_create_entry(hass, config, errors, mock_get_client, mock_aioridwell):
+async def test_create_entry(hass, config, errors, get_client_response, mock_aioridwell):
     """Test creating an entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -31,7 +31,7 @@ async def test_create_entry(hass, config, errors, mock_get_client, mock_aioridwe
     # Test errors that can arise:
     with patch(
         "homeassistant.components.ridwell.config_flow.async_get_client",
-        mock_get_client,
+        get_client_response,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=config

--- a/tests/components/ridwell/test_config_flow.py
+++ b/tests/components/ridwell/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Ridwell config flow."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from aioridwell.errors import InvalidCredentialsError, RidwellError
 import pytest
@@ -10,8 +10,49 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from .conftest import TEST_PASSWORD, TEST_USERNAME
 
-async def test_duplicate_error(hass: HomeAssistant, config, config_entry):
+
+@pytest.mark.parametrize(
+    "mock_get_client,errors",
+    [
+        (AsyncMock(side_effect=InvalidCredentialsError), {"base": "invalid_auth"}),
+        (AsyncMock(side_effect=RidwellError), {"base": "unknown"}),
+    ],
+)
+async def test_create_entry(hass, config, errors, mock_get_client, mock_aioridwell):
+    """Test creating an entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Test errors that can arise:
+    with patch(
+        "homeassistant.components.ridwell.config_flow.async_get_client",
+        mock_get_client,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=config
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == errors
+
+    # Test that we can recover and finish the flow after errors occur:
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=config
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == TEST_USERNAME
+    assert result["data"] == {
+        CONF_USERNAME: TEST_USERNAME,
+        CONF_PASSWORD: TEST_PASSWORD,
+    }
+
+
+async def test_duplicate_error(hass: HomeAssistant, config, setup_config_entry):
     """Test that errors are shown when duplicate entries are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config
@@ -20,56 +61,17 @@ async def test_duplicate_error(hass: HomeAssistant, config, config_entry):
     assert result["reason"] == "already_configured"
 
 
-@pytest.mark.parametrize(
-    "exc,error",
-    [
-        (InvalidCredentialsError, "invalid_auth"),
-        (RidwellError, "unknown"),
-    ],
-)
-async def test_errors(hass: HomeAssistant, config, error, exc) -> None:
-    """Test that various exceptions show the correct error."""
-    with patch(
-        "homeassistant.components.ridwell.config_flow.async_get_client", side_effect=exc
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config
-        )
-        assert result["type"] == FlowResultType.FORM
-        assert result["errors"]["base"] == error
-
-
-async def test_show_form_user(hass: HomeAssistant) -> None:
-    """Test showing the form to input credentials."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] is None
-
-
 async def test_step_reauth(
-    hass: HomeAssistant, config, config_entry, setup_ridwell
+    hass: HomeAssistant, config, config_entry, setup_config_entry
 ) -> None:
     """Test a full reauth flow."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_REAUTH},
-        data={CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"},
+        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=config
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_PASSWORD: "password"},
+        user_input={CONF_PASSWORD: "new_password"},
     )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(hass.config_entries.async_entries()) == 1
-
-
-async def test_step_user(hass: HomeAssistant, config, setup_ridwell) -> None:
-    """Test that the full user step succeeds."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config
-    )
-    assert result["type"] == FlowResultType.CREATE_ENTRY

--- a/tests/components/ridwell/test_config_flow.py
+++ b/tests/components/ridwell/test_config_flow.py
@@ -7,7 +7,6 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components.ridwell.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import TEST_PASSWORD, TEST_USERNAME
@@ -52,7 +51,7 @@ async def test_create_entry(hass, config, errors, get_client_response, mock_aior
     }
 
 
-async def test_duplicate_error(hass: HomeAssistant, config, setup_config_entry):
+async def test_duplicate_error(hass, config, setup_config_entry):
     """Test that errors are shown when duplicate entries are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config
@@ -61,9 +60,7 @@ async def test_duplicate_error(hass: HomeAssistant, config, setup_config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_step_reauth(
-    hass: HomeAssistant, config, config_entry, setup_config_entry
-) -> None:
+async def test_step_reauth(hass, config, config_entry, setup_config_entry) -> None:
     """Test a full reauth flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=config

--- a/tests/components/ridwell/test_diagnostics.py
+++ b/tests/components/ridwell/test_diagnostics.py
@@ -4,7 +4,7 @@ from homeassistant.components.diagnostics import REDACTED
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_ridwell):
+async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up the Ridwell config flow tests in a few ways:

1. We now set up the config entry directly (vs. indirectly via `async_setup_component`).
2. We ensure all tests finish with either `data_entry_flow.FlowResultType.CREATE_ENTRY` or `data_entry_flow.FlowResultType.ABORT`.
3. We reorganize some fixtures for maximum clarity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
