### PR TITLE
Renovate WattTime config flow tests

### DIFF
--- a/homeassistant/components/watttime/__init__.py
+++ b/homeassistant/components/watttime/__init__.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 
 from aiowatttime import Client
-from aiowatttime.emissions import RealTimeEmissionsResponseType
 from aiowatttime.errors import InvalidCredentialsError, WattTimeError
 
 from homeassistant.config_entries import ConfigEntry
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         LOGGER.error("Error while authenticating with WattTime: %s", err)
         return False
 
-    async def async_update_data() -> RealTimeEmissionsResponseType:
+    async def async_update_data() -> dict[str, Any]:
         """Get the latest realtime emissions data."""
         try:
             return await client.emissions.async_get_realtime_emissions(

--- a/homeassistant/components/watttime/__init__.py
+++ b/homeassistant/components/watttime/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 from aiowatttime import Client
 from aiowatttime.errors import InvalidCredentialsError, WattTimeError
@@ -44,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_update_data() -> dict[str, Any]:
         """Get the latest realtime emissions data."""
         try:
-            return await client.emissions.async_get_realtime_emissions(
+            data = await client.emissions.async_get_realtime_emissions(
                 entry.data[CONF_LATITUDE], entry.data[CONF_LONGITUDE]
             )
         except InvalidCredentialsError as err:
@@ -53,6 +53,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise UpdateFailed(
                 f"Error while requesting data from WattTime: {err}"
             ) from err
+
+        return cast(dict[str, Any], data)
 
     coordinator = DataUpdateCoordinator(
         hass,

--- a/homeassistant/components/watttime/config_flow.py
+++ b/homeassistant/components/watttime/config_flow.py
@@ -150,7 +150,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="coordinates",
                 data_schema=STEP_COORDINATES_DATA_SCHEMA,
-                errors={CONF_LATITUDE: "unknown_coordinates"},
+                errors={"base": "unknown_coordinates"},
             )
         except Exception as err:  # pylint: disable=broad-except
             LOGGER.exception("Unexpected exception while getting region: %s", err)

--- a/tests/components/watttime/test_config_flow.py
+++ b/tests/components/watttime/test_config_flow.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.watttime.config_flow import (
     CONF_LOCATION_TYPE,
+    LOCATION_TYPE_COORDINATES,
     LOCATION_TYPE_HOME,
 )
 from homeassistant.components.watttime.const import (
@@ -22,201 +23,153 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
 
-
-@pytest.mark.parametrize(
-    ("exc", "error"),
-    [(InvalidCredentialsError, "invalid_auth"), (Exception, "unknown")],
+from .conftest import (
+    TEST_BALANCING_AUTHORITY,
+    TEST_BALANCING_AUTHORITY_ABBREV,
+    TEST_LATITUDE,
+    TEST_LONGITUDE,
+    TEST_PASSWORD,
+    TEST_USERNAME,
 )
-async def test_auth_errors(
-    hass: HomeAssistant, config_auth, config_location_type, exc, error
-) -> None:
-    """Test that issues with auth show the correct error."""
-    with patch(
-        "homeassistant.components.watttime.config_flow.Client.async_login",
-        side_effect=exc,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config_auth
-        )
-        assert result["type"] == FlowResultType.FORM
-        assert result["errors"] == {"base": error}
 
 
 @pytest.mark.parametrize(
-    ("get_grid_region", "errors"),
+    ("login_response", "login_errors"),
+    [
+        (AsyncMock(side_effect=Exception), {"base": "unknown"}),
+        (AsyncMock(side_effect=InvalidCredentialsError), {"base": "invalid_auth"}),
+    ],
+)
+@pytest.mark.parametrize(
+    ("get_grid_region_response", "get_grid_region_errors"),
     [
         (
             AsyncMock(side_effect=CoordinatesNotFoundError),
-            {"latitude": "unknown_coordinates"},
+            {"base": "unknown_coordinates"},
         ),
-        (
-            AsyncMock(side_effect=Exception),
-            {"base": "unknown"},
-        ),
+        (AsyncMock(side_effect=Exception), {"base": "unknown"}),
     ],
 )
-async def test_coordinate_errors(
+async def test_create_entry(
     hass: HomeAssistant,
+    client,
     config_auth,
     config_coordinates,
-    config_location_type,
-    errors,
-    setup_watttime,
+    get_grid_region_errors,
+    get_grid_region_response,
+    login_errors,
+    login_response,
+    mock_aiowatttime,
 ) -> None:
-    """Test that issues with coordinates show the correct error."""
+    """Test creating an entry."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config_auth
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Test errors that can arise during login:
+    with patch(
+        "homeassistant.components.watttime.config_flow.Client.async_login",
+        login_response,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=config_auth
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == login_errors
+
+    # Test that we can recover from login errors:
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_location_type
+        result["flow_id"], user_input=config_auth
     )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "location"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_LOCATION_TYPE: LOCATION_TYPE_COORDINATES}
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "coordinates"
+
+    # Test errors that can arise when selecting a location:
+    with patch.object(
+        client.emissions, "async_get_grid_region", get_grid_region_response
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=config_coordinates
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "coordinates"
+        assert result["errors"] == get_grid_region_errors
+
+    # Test that we can recover from location errors:
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=config_coordinates
     )
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == errors
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"{TEST_LATITUDE}, {TEST_LONGITUDE}"
+    assert result["data"] == {
+        CONF_USERNAME: TEST_USERNAME,
+        CONF_PASSWORD: TEST_PASSWORD,
+        CONF_LATITUDE: TEST_LATITUDE,
+        CONF_LONGITUDE: TEST_LONGITUDE,
+        CONF_BALANCING_AUTHORITY: TEST_BALANCING_AUTHORITY,
+        CONF_BALANCING_AUTHORITY_ABBREV: TEST_BALANCING_AUTHORITY_ABBREV,
+    }
 
 
-@pytest.mark.parametrize(
-    "config_location_type", [{CONF_LOCATION_TYPE: LOCATION_TYPE_HOME}]
-)
 async def test_duplicate_error(
-    hass: HomeAssistant, config_auth, config_entry, config_location_type, setup_watttime
+    hass: HomeAssistant, config_auth, config_entry, setup_config_entry
 ) -> None:
     """Test that errors are shown when duplicate entries are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config_auth
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_location_type
+        result["flow_id"], user_input={CONF_LOCATION_TYPE: LOCATION_TYPE_HOME}
     )
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
-async def test_options_flow(hass: HomeAssistant, config_entry) -> None:
-    """Test config flow options."""
-    with patch(
-        "homeassistant.components.watttime.async_setup_entry", return_value=True
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == "init"
-
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_SHOW_ON_MAP: False}
-        )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-        assert config_entry.options == {CONF_SHOW_ON_MAP: False}
-
-
-async def test_show_form_coordinates(
-    hass: HomeAssistant, config_auth, config_location_type, setup_watttime
+async def test_options_flow(
+    hass: HomeAssistant, config_entry, setup_config_entry
 ) -> None:
-    """Test showing the form to input custom latitude/longitude."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_auth
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_location_type
-    )
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "coordinates"
-    assert result["errors"] is None
+    """Test config flow options."""
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "init"
 
-
-async def test_show_form_user(hass: HomeAssistant) -> None:
-    """Test showing the form to select the authentication type."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_SHOW_ON_MAP: False}
     )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] is None
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert config_entry.options == {CONF_SHOW_ON_MAP: False}
 
 
 async def test_step_reauth(
-    hass: HomeAssistant, config_auth, config_coordinates, config_entry, setup_watttime
-) -> None:
-    """Test a full reauth flow."""
-    with patch(
-        "homeassistant.components.watttime.async_setup_entry",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_REAUTH},
-            data={
-                **config_auth,
-                **config_coordinates,
-            },
-        )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={CONF_PASSWORD: "password"},
-        )
-
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "reauth_successful"
-    assert len(hass.config_entries.async_entries()) == 1
-
-
-async def test_step_user_coordinates(
     hass: HomeAssistant,
     config_auth,
-    config_location_type,
     config_coordinates,
-    setup_watttime,
+    config_entry,
+    setup_config_entry,
 ) -> None:
-    """Test a full login flow (inputting custom coordinates)."""
+    """Test a full reauth flow."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config_auth
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH},
+        data={
+            **config_auth,
+            **config_coordinates,
+        },
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_location_type
+        result["flow_id"],
+        user_input={CONF_PASSWORD: "password"},
     )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_coordinates
-    )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "32.87336, -117.22743"
-    assert result["data"] == {
-        CONF_USERNAME: "user",
-        CONF_PASSWORD: "password",
-        CONF_LATITUDE: 32.87336,
-        CONF_LONGITUDE: -117.22743,
-        CONF_BALANCING_AUTHORITY: "PJM New Jersey",
-        CONF_BALANCING_AUTHORITY_ABBREV: "PJM_NJ",
-    }
-
-
-@pytest.mark.parametrize(
-    "config_location_type", [{CONF_LOCATION_TYPE: LOCATION_TYPE_HOME}]
-)
-async def test_step_user_home(
-    hass: HomeAssistant, config_auth, config_location_type, setup_watttime
-) -> None:
-    """Test a full login flow (selecting the home location)."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config_auth
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=config_location_type
-    )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "32.87336, -117.22743"
-    assert result["data"] == {
-        CONF_USERNAME: "user",
-        CONF_PASSWORD: "password",
-        CONF_LATITUDE: 32.87336,
-        CONF_LONGITUDE: -117.22743,
-        CONF_BALANCING_AUTHORITY: "PJM New Jersey",
-        CONF_BALANCING_AUTHORITY_ABBREV: "PJM_NJ",
-    }
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert len(hass.config_entries.async_entries()) == 1

--- a/tests/components/watttime/test_diagnostics.py
+++ b/tests/components/watttime/test_diagnostics.py
@@ -8,9 +8,9 @@ from tests.typing import ClientSessionGenerator
 
 async def test_entry_diagnostics(
     hass: HomeAssistant,
-    config_entry,
     hass_client: ClientSessionGenerator,
-    setup_watttime,
+    config_entry,
+    setup_config_entry,
 ) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up the WattTime config flow tests in a few ways:

1. We now set up the config entry directly (vs. indirectly via `async_setup_component`).
2. We ensure all tests finish with either `data_entry_flow.FlowResultType.CREATE_ENTRY` or `data_entry_flow.FlowResultType.ABORT`.
3. We reorganize some fixtures for maximum clarity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
