### PR TITLE
Renovate IQVIA config flow tests

### DIFF
--- a/tests/components/iqvia/conftest.py
+++ b/tests/components/iqvia/conftest.py
@@ -111,4 +111,4 @@ async def setup_config_entry_fixture(hass, config_entry, mock_pyiqvia):
     """Define a fixture to set up iqvia."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield
+    return

--- a/tests/components/iqvia/conftest.py
+++ b/tests/components/iqvia/conftest.py
@@ -1,13 +1,42 @@
 """Define test fixtures for IQVIA."""
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from homeassistant.components.iqvia.const import CONF_ZIP_CODE, DOMAIN
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, load_fixture
+
+TEST_ZIP_CODE = "12345"
+
+
+@pytest.fixture(name="client")
+def client_fixture(
+    data_allergy_forecast,
+    data_allergy_index,
+    data_allergy_outlook,
+    data_asthma_forecast,
+    data_asthma_index,
+    data_disease_forecast,
+    data_disease_index,
+):
+    """Define a mock Client object."""
+    return Mock(
+        allergens=Mock(
+            current=AsyncMock(return_value=data_allergy_index),
+            extended=AsyncMock(return_value=data_allergy_forecast),
+            outlook=AsyncMock(return_value=data_allergy_outlook),
+        ),
+        asthma=Mock(
+            current=AsyncMock(return_value=data_asthma_index),
+            extended=AsyncMock(return_value=data_asthma_forecast),
+        ),
+        disease=Mock(
+            current=AsyncMock(return_value=data_disease_index),
+            extended=AsyncMock(return_value=data_disease_forecast),
+        ),
+    )
 
 
 @pytest.fixture(name="config_entry")
@@ -19,10 +48,10 @@ def config_entry_fixture(hass, config):
 
 
 @pytest.fixture(name="config")
-def config_fixture(hass):
+def config_fixture():
     """Define a config entry data fixture."""
     return {
-        CONF_ZIP_CODE: "12345",
+        CONF_ZIP_CODE: TEST_ZIP_CODE,
     }
 
 
@@ -68,36 +97,18 @@ def data_disease_index_fixture():
     return json.loads(load_fixture("disease_index_data.json", "iqvia"))
 
 
-@pytest.fixture(name="setup_iqvia")
-async def setup_iqvia_fixture(
-    hass,
-    config,
-    data_allergy_forecast,
-    data_allergy_index,
-    data_allergy_outlook,
-    data_asthma_forecast,
-    data_asthma_index,
-    data_disease_forecast,
-    data_disease_index,
-):
-    """Define a fixture to set up IQVIA."""
-    with patch(
-        "pyiqvia.allergens.Allergens.extended", return_value=data_allergy_forecast
-    ), patch(
-        "pyiqvia.allergens.Allergens.current", return_value=data_allergy_index
-    ), patch(
-        "pyiqvia.allergens.Allergens.outlook", return_value=data_allergy_outlook
-    ), patch(
-        "pyiqvia.asthma.Asthma.extended", return_value=data_asthma_forecast
-    ), patch(
-        "pyiqvia.asthma.Asthma.current", return_value=data_asthma_index
-    ), patch(
-        "pyiqvia.disease.Disease.extended", return_value=data_disease_forecast
-    ), patch(
-        "pyiqvia.disease.Disease.current", return_value=data_disease_index
-    ), patch(
-        "homeassistant.components.iqvia.PLATFORMS", []
+@pytest.fixture(name="mock_pyiqvia")
+async def mock_pyiqvia_fixture(client):
+    """Define a fixture to patch pyiqvia."""
+    with patch("homeassistant.components.iqvia.Client", return_value=client), patch(
+        "homeassistant.components.iqvia.config_flow.Client", return_value=client
     ):
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
         yield
+
+
+@pytest.fixture(name="setup_config_entry")
+async def setup_config_entry_fixture(hass, config_entry, mock_pyiqvia):
+    """Define a fixture to set up iqvia."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    yield

--- a/tests/components/iqvia/test_diagnostics.py
+++ b/tests/components/iqvia/test_diagnostics.py
@@ -7,7 +7,10 @@ from tests.typing import ClientSessionGenerator
 
 
 async def test_entry_diagnostics(
-    hass: HomeAssistant, config_entry, hass_client: ClientSessionGenerator, setup_iqvia
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    config_entry,
+    setup_config_entry,
 ) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up the IQVIA config flow tests in a few ways:

1. We now set up the config entry directly (vs. indirectly via `async_setup_component`).
2. We ensure all tests finish with either `data_entry_flow.FlowResultType.CREATE_ENTRY` or `data_entry_flow.FlowResultType.ABORT`.
3. We reorganize some fixtures for maximum clarity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
