### PR TITLE
Renovate OpenUV config flow tests

### DIFF
--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -111,7 +111,7 @@ class OpenUvFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id=error_step_id,
                 data_schema=error_schema,
-                errors={CONF_API_KEY: "invalid_api_key"},
+                errors={"base": "invalid_api_key"},
                 description_placeholders={
                     CONF_LATITUDE: str(data.latitude),
                     CONF_LONGITUDE: str(data.longitude),

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -111,7 +111,7 @@ class OpenUvFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id=error_step_id,
                 data_schema=error_schema,
-                errors={"base": "invalid_api_key"},
+                errors={CONF_API_KEY: "invalid_api_key"},
                 description_placeholders={
                     CONF_LATITUDE: str(data.latitude),
                     CONF_LONGITUDE: str(data.longitude),

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -32,7 +32,7 @@ async def test_create_entry(hass, client, config, mock_pyopenuv):
         )
         assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "user"
-        assert result["errors"] == {"base": "invalid_api_key"}
+        assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
     # Test that we can recover from the error:
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -1,5 +1,5 @@
 """Define tests for the OpenUV config flow."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from pyopenuv.errors import InvalidApiKeyError
 import voluptuous as vol
@@ -14,8 +14,41 @@ from homeassistant.const import (
     CONF_LONGITUDE,
 )
 
+from .conftest import TEST_API_KEY, TEST_ELEVATION, TEST_LATITUDE, TEST_LONGITUDE
 
-async def test_duplicate_error(hass, config, config_entry):
+
+async def test_create_entry(hass, client, config, mock_pyopenuv):
+    """Test creating an entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Test an error occurring:
+    with patch.object(client, "uv_index", AsyncMock(side_effect=InvalidApiKeyError)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=config
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {"base": "invalid_api_key"}
+
+    # Test that we can recover from the error:
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=config
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"{TEST_LATITUDE}, {TEST_LONGITUDE}"
+    assert result["data"] == {
+        CONF_API_KEY: TEST_API_KEY,
+        CONF_ELEVATION: TEST_ELEVATION,
+        CONF_LATITUDE: TEST_LATITUDE,
+        CONF_LONGITUDE: TEST_LONGITUDE,
+    }
+
+
+async def test_duplicate_error(hass, config, config_entry, setup_config_entry):
     """Test that errors are shown when duplicates are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
@@ -24,60 +57,45 @@ async def test_duplicate_error(hass, config, config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_invalid_api_key(hass, config):
-    """Test that an invalid API key throws an error."""
-    with patch(
-        "homeassistant.components.openuv.Client.uv_index",
-        side_effect=InvalidApiKeyError,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=config
-        )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
-
-
-def _get_schema_marker(data_schema: vol.Schema, key: str) -> vol.Marker:
-    for k in data_schema.schema:
-        if k == key and isinstance(k, vol.Marker):
-            return k
-    return None
-
-
-async def test_options_flow(hass, config_entry):
+async def test_options_flow(hass, config_entry, setup_config_entry):
     """Test config flow options."""
-    with patch("homeassistant.components.openuv.async_setup_entry", return_value=True):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == "init"
-        # Original schema uses defaults for suggested values
-        assert _get_schema_marker(
-            result["data_schema"], CONF_FROM_WINDOW
-        ).description == {"suggested_value": 3.5}
-        assert _get_schema_marker(
-            result["data_schema"], CONF_TO_WINDOW
-        ).description == {"suggested_value": 3.5}
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "init"
 
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_FROM_WINDOW: 3.5, CONF_TO_WINDOW: 2.0}
-        )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-        assert config_entry.options == {CONF_FROM_WINDOW: 3.5, CONF_TO_WINDOW: 2.0}
+    def get_schema_marker(data_schema: vol.Schema, key: str) -> vol.Marker:
+        for k in data_schema.schema:
+            if k == key and isinstance(k, vol.Marker):
+                return k
+        return None
 
-        # Subsequent schema uses previous input for suggested values
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == "init"
-        assert _get_schema_marker(
-            result["data_schema"], CONF_FROM_WINDOW
-        ).description == {"suggested_value": 3.5}
-        assert _get_schema_marker(
-            result["data_schema"], CONF_TO_WINDOW
-        ).description == {"suggested_value": 2.0}
+    # Original schema uses defaults for suggested values:
+    assert get_schema_marker(result["data_schema"], CONF_FROM_WINDOW).description == {
+        "suggested_value": 3.5
+    }
+    assert get_schema_marker(result["data_schema"], CONF_TO_WINDOW).description == {
+        "suggested_value": 3.5
+    }
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_FROM_WINDOW: 3.5, CONF_TO_WINDOW: 2.0}
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert config_entry.options == {CONF_FROM_WINDOW: 3.5, CONF_TO_WINDOW: 2.0}
+
+    # Subsequent schema uses previous input for suggested values:
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert get_schema_marker(result["data_schema"], CONF_FROM_WINDOW).description == {
+        "suggested_value": 3.5
+    }
+    assert get_schema_marker(result["data_schema"], CONF_TO_WINDOW).description == {
+        "suggested_value": 2.0
+    }
 
 
-async def test_step_reauth(hass, config, config_entry, setup_openuv):
+async def test_step_reauth(hass, config, config_entry, setup_config_entry):
     """Test that the reauth step works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_REAUTH}, data=config
@@ -88,33 +106,9 @@ async def test_step_reauth(hass, config, config_entry, setup_openuv):
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    with patch("homeassistant.components.openuv.async_setup_entry", return_value=True):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_API_KEY: "new_api_key"}
-        )
-        await hass.async_block_till_done()
-
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_API_KEY: "new_api_key"}
+    )
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(hass.config_entries.async_entries()) == 1
-
-
-async def test_step_user(hass, config, setup_openuv):
-    """Test that the user step works."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=config
-    )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result["title"] == "51.528308, -0.3817765"
-    assert result["data"] == {
-        CONF_API_KEY: "abcde12345",
-        CONF_ELEVATION: 0,
-        CONF_LATITUDE: 51.528308,
-        CONF_LONGITUDE: -0.3817765,
-    }

--- a/tests/components/openuv/test_diagnostics.py
+++ b/tests/components/openuv/test_diagnostics.py
@@ -5,7 +5,7 @@ from homeassistant.setup import async_setup_component
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_openuv):
+async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
     """Test config entry diagnostics."""
     await async_setup_component(hass, "homeassistant", {})
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up the OpenUV config flow tests in a few ways:

1. We now set up the config entry directly (vs. indirectly via `async_setup_component`).
2. We ensure all tests finish with either `data_entry_flow.FlowResultType.CREATE_ENTRY` or `data_entry_flow.FlowResultType.ABORT`.
3. We reorganize some fixtures for maximum clarity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
