### PR TITLE
Added get_location

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -40,6 +40,7 @@ SERVICE_RELOAD_CONFIG_ENTRY = "reload_config_entry"
 SERVICE_CHECK_CONFIG = "check_config"
 SERVICE_UPDATE_ENTITY = "update_entity"
 SERVICE_SET_LOCATION = "set_location"
+SERVICE_GET_LOCATION = "get_location"
 SCHEMA_UPDATE_ENTITY = vol.Schema({ATTR_ENTITY_ID: cv.entity_ids})
 SCHEMA_RELOAD_CONFIG_ENTRY = vol.All(
     vol.Schema(
@@ -244,12 +245,24 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
             latitude=call.data[ATTR_LATITUDE], longitude=call.data[ATTR_LONGITUDE]
         )
 
+    async def async_get_location(call: ha.ServiceCall):
+        """Service handler to get location."""
+        location = hass.config.latitude, hass.config.longitude
+        return location
+
     async_register_admin_service(
         hass,
         ha.DOMAIN,
         SERVICE_SET_LOCATION,
         async_set_location,
         vol.Schema({ATTR_LATITUDE: cv.latitude, ATTR_LONGITUDE: cv.longitude}),
+    )
+
+    async_register_admin_service(
+        hass,
+        ha.DOMAIN,
+        SERVICE_GET_LOCATION,
+        async_get_location,
     )
 
     async def async_handle_reload_config_entry(call: ha.ServiceCall) -> None:

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -31,6 +31,10 @@ set_location:
       selector:
         text:
 
+get_location:
+  name: Get location
+  description: Retrieves the Home Assistant location.
+
 stop:
   name: Stop
   description: Stop the Home Assistant service.

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -313,6 +313,20 @@ async def test_setting_location(hass):
     assert hass.config.longitude == 40
 
 
+async def test_getting_location(hass):
+    """Test getting the location."""
+    await async_setup_component(hass, "homeassistant", {})
+    events = async_capture_events(hass, EVENT_CORE_CONFIG_UPDATE)
+    await hass.services.async_call(
+        "homeassistant",
+        "get_location",
+        blocking=True,
+    )
+    assert len(events) == 1
+    assert hass.config.latitude == 30
+    assert hass.config.longitude == 40
+
+
 async def test_require_admin(hass, hass_read_only_user):
     """Test services requiring admin."""
     await async_setup_component(hass, "homeassistant", {})


### PR DESCRIPTION
## Proposed change
I'm proposing the addition of an async service, homeassistant.get_location, which can be used to retrieve the current latitude and longitude as set by homeassistant.set_location. This will allow for core integrations like forecast.solar and tomorrow.io to dynamically update their location data, rather than being statically set.

I'm aware that the hass.config.latitude and hass.config.longitude attributes already exist, but I believe that the homeassistant.get_location service will provide a more intuitive and user-friendly way for users to retrieve their location data. Additionally, some integrations do not currently allow for the location to be updated after initial installation, requiring users to delete and re-install the integration in order to update their location. The homeassistant.get_location service will provide an alternative solution to this issue.

I'm open to feedback on this proposal and am happy to make any necessary changes. I'm also willing to help with updating any necessary documentation.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: https://github.com/home-assistant/core/issues/85079
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25564

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (``)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
- [x] This is my first ever commit to HA and I look forward to helping in the future

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure