### PR TITLE
Dockerdev: Improve docker caching layers

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,11 +4,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Uninstall pre-installed formatting and linting tools
 # They would conflict with our pinned versions
-RUN pipx uninstall black
-RUN pipx uninstall pydocstyle
-RUN pipx uninstall pycodestyle
-RUN pipx uninstall mypy
-RUN pipx uninstall pylint
+RUN \
+    pipx uninstall black \
+    && pipx uninstall pydocstyle \
+    && pipx uninstall pycodestyle \
+    && pipx uninstall mypy \
+    && pipx uninstall pylint
 
 RUN \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \


### PR DESCRIPTION
It is bad (docker) practice, to have separate RUN statements if they don't have very specific benefits. Lets combine deletion of packages in one docker RUN command to optimize cache layers.

See #85101 for the previous discussion.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Development setup

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (https://github.com/home-assistant/developers.home-assistant/pull/1612)

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.