### PR TITLE
Add balance entity for Sonos speakers

### DIFF
--- a/homeassistant/components/sonos/number.py
+++ b/homeassistant/components/sonos/number.py
@@ -19,6 +19,7 @@ from .speaker import SonosSpeaker
 LEVEL_TYPES = {
     "audio_delay": (0, 5),
     "bass": (-10, 10),
+    "balance": (-100, 100),
     "treble": (-10, 10),
     "sub_gain": (-15, 15),
     "surround_level": (-15, 15),
@@ -28,6 +29,40 @@ LEVEL_TYPES = {
 SocoFeatures = list[tuple[str, tuple[int, int]]]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _balance_to_number(state: tuple[int, int]) -> float:
+    """Represent a balance measure returned by SoCo as a number.
+
+    SoCo returns a pair of volumes, one for the left side and one
+    for the right side. When the two are equal, sound is centered;
+    HA will show that as 0. When the left side is louder, HA will
+    show a negative value, and a positive value means the right
+    side is louder. Maximum absolute value is 100, which means only
+    one side produces sound at all.
+    """
+    left, right = state
+    return (right - left) * 100 // max(right, left)
+
+
+def _balance_from_number(value: float) -> tuple[int, int]:
+    """Convert a balance value from -100 to 100 into SoCo format.
+
+    0 becomes (100, 100), fully enabling both sides. Note that
+    the master volume control is separate, so this does not
+    turn up the speakers to maximum volume. Negative values
+    reduce the volume of the right side, and positive values
+    reduce the volume of the left side. -100 becomes (100, 0),
+    fully muting the right side, and +100 becomes (0, 100),
+    muting the left side.
+    """
+    left = min(100, 100 - int(value))
+    right = min(100, int(value) + 100)
+    return left, right
+
+
+LEVEL_TO_NUMBER = {"balance": _balance_to_number}
+LEVEL_FROM_NUMBER = {"balance": _balance_from_number}
 
 
 async def async_setup_entry(
@@ -92,9 +127,11 @@ class SonosLevelEntity(SonosEntity, NumberEntity):
     @soco_error()
     def set_native_value(self, value: float) -> None:
         """Set a new value."""
-        setattr(self.soco, self.level_type, value)
+        from_number = LEVEL_FROM_NUMBER.get(self.level_type, int)
+        setattr(self.soco, self.level_type, from_number(value))
 
     @property
     def native_value(self) -> float:
         """Return the current value."""
-        return cast(float, getattr(self.speaker, self.level_type))
+        to_number = LEVEL_TO_NUMBER.get(self.level_type, int)
+        return cast(float, to_number(getattr(self.speaker, self.level_type)))

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -145,6 +145,7 @@ class SonosSpeaker:
         self.volume: int | None = None
         self.muted: bool | None = None
         self.cross_fade: bool | None = None
+        self.balance: tuple[int, int] | None = None
         self.bass: int | None = None
         self.treble: int | None = None
         self.loudness: bool | None = None
@@ -536,7 +537,10 @@ class SonosSpeaker:
         variables = event.variables
 
         if "volume" in variables:
-            self.volume = int(variables["volume"]["Master"])
+            volume = variables["volume"]
+            self.volume = int(volume["Master"])
+            if "LF" in volume and "RF" in volume:
+                self.balance = (int(volume["LF"]), int(volume["RF"]))
 
         if "mute" in variables:
             self.muted = variables["mute"]["Master"] == "1"

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -112,6 +112,7 @@ def soco_fixture(
         mock_soco.loudness = True
         mock_soco.volume = 19
         mock_soco.audio_delay = 2
+        mock_soco.balance = (61, 100)
         mock_soco.bass = 1
         mock_soco.treble = -1
         mock_soco.mic_enabled = False

--- a/tests/components/sonos/test_number.py
+++ b/tests/components/sonos/test_number.py
@@ -11,6 +11,10 @@ async def test_number_entities(
     hass: HomeAssistant, async_autosetup_sonos, soco, entity_registry: er.EntityRegistry
 ) -> None:
     """Test number entities."""
+    balance_number = entity_registry.entities["number.zone_a_balance"]
+    balance_state = hass.states.get(balance_number.entity_id)
+    assert balance_state.state == "39"
+
     bass_number = entity_registry.entities["number.zone_a_bass"]
     bass_state = hass.states.get(bass_number.entity_id)
     assert bass_state.state == "1"


### PR DESCRIPTION
## Proposed change

Add a `number` entity that corresponds to the left-right balance slider in the EQ section of the Sonos app when two speakers are in a stereo pair configuration. The entity has a range from -100 (only left channel) to 100 (only right channel).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Link to documentation pull request: TBD (one word in the "Controllable features" section - honestly would be much faster if someone with push access to the repo just added it themselves)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
