### PR TITLE
Remove redundant CONF_PATH from sabnzbd config flow

### DIFF
--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
     CONF_API_KEY,
     CONF_HOST,
     CONF_NAME,
-    CONF_PATH,
     CONF_PORT,
     CONF_SENSORS,
     CONF_SSL,
@@ -80,7 +79,6 @@ CONFIG_SCHEMA = vol.Schema(
                 {
                     vol.Required(CONF_API_KEY): str,
                     vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-                    vol.Optional(CONF_PATH): str,
                     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
                     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
                     vol.Optional(CONF_SENSORS): vol.All(

--- a/homeassistant/components/sabnzbd/config_flow.py
+++ b/homeassistant/components/sabnzbd/config_flow.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     CONF_API_KEY,
     CONF_HOST,
     CONF_NAME,
-    CONF_PATH,
     CONF_PORT,
     CONF_SSL,
     CONF_URL,
@@ -28,7 +27,6 @@ USER_SCHEMA = vol.Schema(
         vol.Required(CONF_API_KEY): str,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
         vol.Required(CONF_URL): str,
-        vol.Optional(CONF_PATH): str,
     }
 )
 

--- a/homeassistant/components/sabnzbd/sab.py
+++ b/homeassistant/components/sabnzbd/sab.py
@@ -1,21 +1,19 @@
 """Support for the Sabnzbd service."""
 from pysabnzbd import SabnzbdApi, SabnzbdApiException
 
-from homeassistant.const import CONF_API_KEY, CONF_PATH, CONF_URL
+from homeassistant.const import CONF_API_KEY, CONF_URL
 from homeassistant.core import _LOGGER, HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 
 async def get_client(hass: HomeAssistant, data):
     """Get Sabnzbd client."""
-    web_root = data.get(CONF_PATH)
     api_key = data[CONF_API_KEY]
     url = data[CONF_URL]
 
     sab_api = SabnzbdApi(
         url,
         api_key,
-        web_root=web_root,
         session=async_get_clientsession(hass, False),
     )
     try:

--- a/homeassistant/components/sabnzbd/strings.json
+++ b/homeassistant/components/sabnzbd/strings.json
@@ -5,8 +5,7 @@
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "name": "[%key:common::config_flow::data::name%]",
-          "url": "[%key:common::config_flow::data::url%]",
-          "path": "[%key:common::config_flow::data::path%]"
+          "url": "[%key:common::config_flow::data::url%]"
         }
       }
     },

--- a/tests/components/sabnzbd/test_config_flow.py
+++ b/tests/components/sabnzbd/test_config_flow.py
@@ -10,7 +10,6 @@ from homeassistant.const import (
     CONF_API_KEY,
     CONF_HOST,
     CONF_NAME,
-    CONF_PATH,
     CONF_PORT,
     CONF_SSL,
     CONF_URL,
@@ -21,7 +20,6 @@ VALID_CONFIG = {
     CONF_NAME: "Sabnzbd",
     CONF_API_KEY: "edc3eee7330e4fdda04489e3fbc283d0",
     CONF_URL: "http://localhost:8080",
-    CONF_PATH: "",
 }
 
 VALID_CONFIG_OLD = {
@@ -29,7 +27,6 @@ VALID_CONFIG_OLD = {
     CONF_API_KEY: "edc3eee7330e4fdda04489e3fbc283d0",
     CONF_HOST: "localhost",
     CONF_PORT: 8080,
-    CONF_PATH: "",
     CONF_SSL: False,
 }
 
@@ -60,7 +57,6 @@ async def test_create_entry(hass):
         assert result2["data"] == {
             CONF_API_KEY: "edc3eee7330e4fdda04489e3fbc283d0",
             CONF_NAME: "Sabnzbd",
-            CONF_PATH: "",
             CONF_URL: "http://localhost:8080",
         }
         assert len(mock_setup_entry.mock_calls) == 1
@@ -99,5 +95,4 @@ async def test_import_flow(hass) -> None:
         assert result["data"][CONF_API_KEY] == "edc3eee7330e4fdda04489e3fbc283d0"
         assert result["data"][CONF_HOST] == "localhost"
         assert result["data"][CONF_PORT] == 8080
-        assert result["data"][CONF_PATH] == ""
         assert result["data"][CONF_SSL] is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
remove redundant CONF_PATH from sabnzbd config flow
discussed here: https://github.com/home-assistant/home-assistant.io/issues/25037

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/home-assistant.io/issues/25037
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
