### PR TITLE
Make translations keys check hassfest more strict

### DIFF
--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -109,8 +109,8 @@ def translation_key_validator(value: str) -> str:
     """Validate value is valid translation key."""
     if RE_TRANSLATION_KEY.match(value) is None:
         raise vol.Invalid(
-            f"Invalid translation key '{value}', need to be [a-z0-9_]+ and"
-            " cannot start or end with a lower case"
+            f"Invalid translation key '{value}', need to be [a-z0-9-_]+ and"
+            " cannot start or end with a hyphen or underscore."
         )
 
     return value

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -21,6 +21,7 @@ REQUIRED = 1
 REMOVED = 2
 
 RE_REFERENCE = r"\[\%key:(.+)\%\]"
+RE_TRANSLATION_KEY = re.compile(r"^(?!.+[_-]{2})(?![_-])[a-z0-9-_]+(?<![_-])$")
 
 # Only allow translation of integration names if they contain non-brand names
 ALLOW_NAME_TRANSLATION = {
@@ -86,9 +87,7 @@ def find_references(
             find_references(value, f"{prefix}::{key}", found)
             continue
 
-        match = re.match(RE_REFERENCE, value)
-
-        if match:
+        if match := re.match(RE_REFERENCE, value):
             found.append({"source": f"{prefix}::{key}", "ref": match.groups()[0]})
 
 
@@ -106,10 +105,13 @@ def removed_title_validator(
     return value
 
 
-def lowercase_validator(value: str) -> str:
-    """Validate value is lowercase."""
-    if value.lower() != value:
-        raise vol.Invalid("Needs to be lowercase")
+def translation_key_validator(value: str) -> str:
+    """Validate value is valid translation key."""
+    if RE_TRANSLATION_KEY.match(value) is None:
+        raise vol.Invalid(
+            f"Invalid translation key '{value}', need to be [a-z0-9_]+ and"
+            " cannot start or end with a lower case"
+        )
 
     return value
 
@@ -221,7 +223,7 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                 vol.Optional("trigger_subtype"): {str: cv.string_with_no_html},
             },
             vol.Optional("state"): cv.schema_with_slug_keys(
-                cv.schema_with_slug_keys(str, slug_validator=lowercase_validator),
+                cv.schema_with_slug_keys(str, slug_validator=translation_key_validator),
                 slug_validator=vol.Any("_", cv.slug),
             ),
             vol.Optional("state_attributes"): cv.schema_with_slug_keys(
@@ -229,19 +231,21 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                     {
                         vol.Optional("name"): str,
                         vol.Optional("state"): cv.schema_with_slug_keys(
-                            str, slug_validator=lowercase_validator
+                            str, slug_validator=translation_key_validator
                         ),
                     },
-                    slug_validator=lowercase_validator,
+                    slug_validator=translation_key_validator,
                 ),
                 slug_validator=vol.Any("_", cv.slug),
             ),
             vol.Optional("system_health"): {
-                vol.Optional("info"): {str: cv.string_with_no_html}
+                vol.Optional("info"): cv.schema_with_slug_keys(
+                    cv.string_with_no_html, slug_validator=translation_key_validator
+                ),
             },
             vol.Optional("config_panel"): cv.schema_with_slug_keys(
                 cv.schema_with_slug_keys(
-                    cv.string_with_no_html, slug_validator=lowercase_validator
+                    cv.string_with_no_html, slug_validator=translation_key_validator
                 ),
                 slug_validator=vol.Any("_", cv.slug),
             ),
@@ -273,10 +277,14 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                         vol.Optional("state_attributes"): {
                             str: {
                                 vol.Optional("name"): cv.string_with_no_html,
-                                vol.Optional("state"): {str: cv.string_with_no_html},
+                                vol.Optional("state"): cv.schema_with_slug_keys(
+                                    str, slug_validator=translation_key_validator
+                                ),
                             }
                         },
-                        vol.Optional("state"): {str: cv.string_with_no_html},
+                        vol.Optional("state"): cv.schema_with_slug_keys(
+                            str, slug_validator=translation_key_validator
+                        ),
                     }
                 }
             },
@@ -352,7 +360,7 @@ def gen_platform_strings_schema(config: Config, integration: Integration) -> vol
     return vol.Schema(
         {
             vol.Optional("state"): cv.schema_with_slug_keys(
-                cv.schema_with_slug_keys(str, slug_validator=lowercase_validator),
+                cv.schema_with_slug_keys(str, slug_validator=translation_key_validator),
                 slug_validator=device_class_validator,
             )
         }

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -223,7 +223,9 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                 vol.Optional("trigger_subtype"): {str: cv.string_with_no_html},
             },
             vol.Optional("state"): cv.schema_with_slug_keys(
-                cv.schema_with_slug_keys(str, slug_validator=translation_key_validator),
+                cv.schema_with_slug_keys(
+                    cv.string_with_no_html, slug_validator=translation_key_validator
+                ),
                 slug_validator=vol.Any("_", cv.slug),
             ),
             vol.Optional("state_attributes"): cv.schema_with_slug_keys(
@@ -231,7 +233,8 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                     {
                         vol.Optional("name"): str,
                         vol.Optional("state"): cv.schema_with_slug_keys(
-                            str, slug_validator=translation_key_validator
+                            cv.string_with_no_html,
+                            slug_validator=translation_key_validator,
                         ),
                     },
                     slug_validator=translation_key_validator,
@@ -278,12 +281,14 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                             str: {
                                 vol.Optional("name"): cv.string_with_no_html,
                                 vol.Optional("state"): cv.schema_with_slug_keys(
-                                    str, slug_validator=translation_key_validator
+                                    cv.string_with_no_html,
+                                    slug_validator=translation_key_validator,
                                 ),
                             }
                         },
                         vol.Optional("state"): cv.schema_with_slug_keys(
-                            str, slug_validator=translation_key_validator
+                            cv.string_with_no_html,
+                            slug_validator=translation_key_validator,
                         ),
                     }
                 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This makes the translation keys checks in hassfest more strict to catch out-of-the-ordinary translation keys.

In some places, we check for lowercase strings as keys, in others place we don't. However, we use a snake case style.

Replaced the lowercase check with an stricter variant using the following regular expression:

 `^(?!.+[_-]{2})(?![_-])[a-z0-9-_]+(?<![_-])$`.

Meaning lowercase a-z, numbers, hyphens, and underscores are allowed. As long as it won't start or end with an hyphen or undescore or has a sequence of multiple hypens or underscores in the middle.

Allowed examples:

- `example`
- `example1`
- `1234`
- `another_example`
- `another-example`

Not allowed examples:

- `Example`
- `_example`
- `example_`
- `-example`
- `example-`
- `not_-allowed`
- `not__allowed`
- `not-_allowed`
- `not--allowed`
- `not------allowed`
- `alow.not.allowed`

Currently affected integrations with violations:

- `nam` -> Uses spaces in state translation keys
- `yamaha_musiccast` -> uses in state translation keys


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
