### PR TITLE
Assign ISY994 program entities to hub device, simplify device info

### DIFF
--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -15,15 +15,7 @@ from pyisy.helpers import EventListener, NodeProperty
 from pyisy.nodes import Node
 from pyisy.programs import Program
 
-from homeassistant.const import (
-    ATTR_IDENTIFIERS,
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NAME,
-    ATTR_SUGGESTED_AREA,
-    STATE_OFF,
-    STATE_ON,
-)
+from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo, Entity
@@ -87,57 +79,47 @@ class ISYEntity(Entity):
 
         basename = self._name or str(self._node.name)
 
-        if hasattr(node, "protocol") and node.protocol == PROTO_GROUP:
-            # If Group has only 1 Controller, link to that device, otherwise link to ISY Hub
-            if len(node.controllers) != 1:
-                return DeviceInfo(identifiers={(DOMAIN, uuid)})
-
+        if node.protocol == PROTO_GROUP and len(node.controllers) == 1:
+            # If Group has only 1 Controller, link to that device instead of the hub
             node = isy.nodes.get_by_id(node.controllers[0])
             basename = node.name
 
-        if hasattr(node, "parent_node") and node.parent_node is not None:
-            # This is not the parent node, get the parent node.
-            node = node.parent_node
-            basename = node.name
+        if hasattr(node, "parent_node"):  # Verify this is a Node class
+            if node.parent_node is not None:
+                # This is not the parent node, get the parent node.
+                node = node.parent_node
+                basename = node.name
+        else:
+            # Default to the hub device if parent node is not a physical device
+            return DeviceInfo(identifiers={(DOMAIN, uuid)})
 
         device_info = DeviceInfo(
-            manufacturer="Unknown",
-            model="Unknown",
-            name=basename,
+            identifiers={(DOMAIN, f"{uuid}_{node.address}")},
+            manufacturer=str(node.protocol),
+            name=f"{basename} ({(str(node.address).rpartition(' ')[0] or node.address)})",
             via_device=(DOMAIN, uuid),
             configuration_url=url,
+            suggested_area=node.folder,
         )
 
-        if hasattr(node, "address"):
-            assert isinstance(node.address, str)
-            device_info[
-                ATTR_NAME
-            ] = f"{basename} ({(node.address.rpartition(' ')[0] or node.address)})"
-        if hasattr(node, "primary_node"):
-            device_info[ATTR_IDENTIFIERS] = {(DOMAIN, f"{uuid}_{node.address}")}
-        # ISYv5 Device Types
-        if hasattr(node, "node_def_id") and node.node_def_id is not None:
-            model: str = str(node.node_def_id)
-            # Numerical Device Type
-            if hasattr(node, "type") and node.type is not None:
-                model += f" {node.type}"
-            device_info[ATTR_MODEL] = model
-        if hasattr(node, "protocol"):
-            model = str(device_info[ATTR_MODEL])
-            manufacturer = str(node.protocol)
-            if node.protocol == PROTO_ZWAVE:
-                # Get extra information for Z-Wave Devices
-                manufacturer += f" MfrID:{node.zwave_props.mfr_id}"
-                model += (
-                    f" Type:{node.zwave_props.devtype_gen} "
-                    f"ProductTypeID:{node.zwave_props.prod_type_id} "
-                    f"ProductID:{node.zwave_props.product_id}"
-                )
-            device_info[ATTR_MANUFACTURER] = manufacturer
-            device_info[ATTR_MODEL] = model
-        if hasattr(node, "folder") and node.folder is not None:
-            device_info[ATTR_SUGGESTED_AREA] = node.folder
-        # Note: sw_version is not exposed by the ISY for the individual devices.
+        # ISYv5 Device Types can provide model and manufacturer
+        model: str = "Unknown"
+        if node.node_def_id is not None:
+            model = str(node.node_def_id)
+
+        # Numerical Device Type
+        if node.type is not None:
+            model += f" ({node.type})"
+
+        # Get extra information for Z-Wave Devices
+        if node.protocol == PROTO_ZWAVE:
+            device_info[ATTR_MANUFACTURER] = f" MfrID:{node.zwave_props.mfr_id}"
+            model += (
+                f" Type:{node.zwave_props.devtype_gen} "
+                f"ProductTypeID:{node.zwave_props.prod_type_id} "
+                f"ProductID:{node.zwave_props.product_id}"
+            )
+        device_info[ATTR_MODEL] = model
 
         return device_info
 

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -113,7 +113,7 @@ class ISYEntity(Entity):
 
         # Get extra information for Z-Wave Devices
         if node.protocol == PROTO_ZWAVE:
-            device_info[ATTR_MANUFACTURER] = f" MfrID:{node.zwave_props.mfr_id}"
+            device_info[ATTR_MANUFACTURER] = f"Z-Wave MfrID:{node.zwave_props.mfr_id}"
             model += (
                 f" Type:{node.zwave_props.devtype_gen} "
                 f"ProductTypeID:{node.zwave_props.prod_type_id} "

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -95,7 +95,7 @@ class ISYEntity(Entity):
 
         device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{uuid}_{node.address}")},
-            manufacturer=str(node.protocol),
+            manufacturer=node.protocol,
             name=f"{basename} ({(str(node.address).rpartition(' ')[0] or node.address)})",
             via_device=(DOMAIN, uuid),
             configuration_url=url,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to #84933 based on comment https://github.com/home-assistant/core/pull/84933/files#r1059752509

1. Assign "non-physical" (e.g. Program and Variable) entities to the ISY Hub Device. All ISY entities should now be associated with a device, either a physical parent device or the ISY hub itself.
2. Clean-up device info logic to guarantee `identifiers` are always defined and remove unnecessary conditionals.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #84933 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
