### PR TITLE
Improve error reporting when switchbot auth fails

### DIFF
--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -166,6 +166,7 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the SwitchBot API auth step."""
         errors = {}
         assert self._discovered_adv is not None
+        description_placeholders = {}
         if user_input is not None:
             try:
                 key_details = await self.hass.async_add_executor_job(
@@ -176,8 +177,10 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
             except SwitchbotAccountConnectionError as ex:
                 raise AbortFlow("cannot_connect") from ex
-            except SwitchbotAuthenticationError:
+            except SwitchbotAuthenticationError as ex:
+                _LOGGER.debug("Authentication failed: %s", ex, exc_info=True)
                 errors = {"base": "auth_failed"}
+                description_placeholders = {"error_detail": str(ex)}
             else:
                 return await self.async_step_lock_key(key_details)
 
@@ -195,6 +198,7 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             description_placeholders={
                 "name": name_from_discovery(self._discovered_adv),
+                **description_placeholders,
             },
         )
 

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.36.1"],
+  "requirements": ["PySwitchbot==0.36.2"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "codeowners": [

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -40,7 +40,7 @@
     },
     "error": {
       "encryption_key_invalid": "Key ID or Encryption key is invalid",
-      "auth_failed": "Authentication failed"
+      "auth_failed": "Authentication failed: {error_detail}"
     },
     "abort": {
       "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/switchbot/translations/en.json
+++ b/homeassistant/components/switchbot/translations/en.json
@@ -8,9 +8,8 @@
             "unknown": "Unexpected error"
         },
         "error": {
-            "auth_failed": "Authentication failed",
-            "encryption_key_invalid": "Key ID or Encryption key is invalid",
-            "key_id_invalid": "Key ID or Encryption key is invalid"
+            "auth_failed": "Authentication failed: {error_detail}",
+            "encryption_key_invalid": "Key ID or Encryption key is invalid"
         },
         "flow_title": "{name} ({address})",
         "step": {
@@ -29,13 +28,6 @@
                 "menu_options": {
                     "lock_auth": "SwitchBot account (recommended)",
                     "lock_key": "Enter lock encryption key manually"
-                }
-            },
-            "lock_chose_method": {
-                "description": "Choose configuration method, details can be found in the documentation.",
-                "menu_options": {
-                    "lock_auth": "SwitchBot app login and password",
-                    "lock_key": "Lock encryption key"
                 }
             },
             "lock_key": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,7 +40,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.36.1
+PySwitchbot==0.36.2
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -36,7 +36,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.36.1
+PySwitchbot==0.36.2
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -481,7 +481,7 @@ async def test_user_setup_wolock_auth(hass):
 
     with patch(
         "homeassistant.components.switchbot.config_flow.SwitchbotLock.retrieve_encryption_key",
-        side_effect=SwitchbotAuthenticationError,
+        side_effect=SwitchbotAuthenticationError("error from api"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -494,6 +494,7 @@ async def test_user_setup_wolock_auth(hass):
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "lock_auth"
     assert result["errors"] == {"base": "auth_failed"}
+    assert "error from api" in result["description_placeholders"]["error_detail"]
 
     with patch_async_setup_entry() as mock_setup_entry, patch(
         "homeassistant.components.switchbot.config_flow.SwitchbotLock.verify_encryption_key",


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
related issue #85243

changelog: https://github.com/Danielhiversen/pySwitchbot/compare/0.36.1...0.36.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
