### PR TITLE
Fix translation keys for NAM sensors

### DIFF
--- a/homeassistant/components/nam/sensor.py
+++ b/homeassistant/components/nam/sensor.py
@@ -1,6 +1,7 @@
 """Support for the Nettigo Air Monitor service."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 from typing import cast
@@ -70,208 +71,224 @@ PARALLEL_UPDATES = 1
 
 _LOGGER = logging.getLogger(__name__)
 
-SENSORS: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
+AQI_LEVEL_STATE_MAPPING = {
+    "very low": "very_low",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "very high": "very_high",
+}
+
+
+@dataclass
+class NAMSensorEntityDescription(SensorEntityDescription):
+    """Describes WLED sensor entity."""
+
+    mapping: dict[str, str] | None = None
+
+
+SENSORS: tuple[NAMSensorEntityDescription, ...] = (
+    NAMSensorEntityDescription(
         key=ATTR_BME280_HUMIDITY,
         name="BME280 humidity",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_BME280_PRESSURE,
         name="BME280 pressure",
         native_unit_of_measurement=UnitOfPressure.HPA,
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_BME280_TEMPERATURE,
         name="BME280 temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_BMP180_PRESSURE,
         name="BMP180 pressure",
         native_unit_of_measurement=UnitOfPressure.HPA,
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_BMP180_TEMPERATURE,
         name="BMP180 temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_BMP280_PRESSURE,
         name="BMP280 pressure",
         native_unit_of_measurement=UnitOfPressure.HPA,
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_BMP280_TEMPERATURE,
         name="BMP280 temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_HECA_HUMIDITY,
         name="HECA humidity",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_HECA_TEMPERATURE,
         name="HECA temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_MHZ14A_CARBON_DIOXIDE,
         name="MH-Z14A carbon dioxide",
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
         device_class=SensorDeviceClass.CO2,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_PMSX003_CAQI,
         name="PMSx003 CAQI",
         icon="mdi:air-filter",
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_PMSX003_CAQI_LEVEL,
         name="PMSx003 CAQI level",
         icon="mdi:air-filter",
         device_class=SensorDeviceClass.ENUM,
-        options=["very low", "low", "medium", "high", "very high"],
+        mapping=AQI_LEVEL_STATE_MAPPING,
         translation_key="caqi_level",
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_PMSX003_P0,
         name="PMSx003 particulate matter 1.0",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.PM1,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_PMSX003_P1,
         name="PMSx003 particulate matter 10",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.PM10,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_PMSX003_P2,
         name="PMSx003 particulate matter 2.5",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SDS011_CAQI,
         name="SDS011 CAQI",
         icon="mdi:air-filter",
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SDS011_CAQI_LEVEL,
         name="SDS011 CAQI level",
         icon="mdi:air-filter",
         device_class=SensorDeviceClass.ENUM,
-        options=["very low", "low", "medium", "high", "very high"],
+        mapping=AQI_LEVEL_STATE_MAPPING,
         translation_key="caqi_level",
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SDS011_P1,
         name="SDS011 particulate matter 10",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.PM10,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SDS011_P2,
         name="SDS011 particulate matter 2.5",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SHT3X_HUMIDITY,
         name="SHT3X humidity",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SHT3X_TEMPERATURE,
         name="SHT3X temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SPS30_CAQI,
         name="SPS30 CAQI",
         icon="mdi:air-filter",
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SPS30_CAQI_LEVEL,
         name="SPS30 CAQI level",
         icon="mdi:air-filter",
         device_class=SensorDeviceClass.ENUM,
-        options=["very low", "low", "medium", "high", "very high"],
+        mapping=AQI_LEVEL_STATE_MAPPING,
         translation_key="caqi_level",
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SPS30_P0,
         name="SPS30 particulate matter 1.0",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.PM1,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SPS30_P1,
         name="SPS30 particulate matter 10",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.PM10,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SPS30_P2,
         name="SPS30 particulate matter 2.5",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SPS30_P4,
         name="SPS30 particulate matter 4.0",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         icon="mdi:molecule",
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_DHT22_HUMIDITY,
         name="DHT22 humidity",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_DHT22_TEMPERATURE,
         name="DHT22 temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_SIGNAL_STRENGTH,
         name="Signal strength",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
@@ -280,7 +297,7 @@ SENSORS: tuple[SensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    NAMSensorEntityDescription(
         key=ATTR_UPTIME,
         name="Uptime",
         device_class=SensorDeviceClass.TIMESTAMP,
@@ -326,11 +343,12 @@ class NAMSensor(CoordinatorEntity[NAMDataUpdateCoordinator], SensorEntity):
     """Define an Nettigo Air Monitor sensor."""
 
     _attr_has_entity_name = True
+    entity_description: NAMSensorEntityDescription
 
     def __init__(
         self,
         coordinator: NAMDataUpdateCoordinator,
-        description: SensorEntityDescription,
+        description: NAMSensorEntityDescription,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
@@ -341,6 +359,11 @@ class NAMSensor(CoordinatorEntity[NAMDataUpdateCoordinator], SensorEntity):
     @property
     def native_value(self) -> StateType | datetime:
         """Return the state."""
+        if self.entity_description.mapping is not None:
+            return self.entity_description.mapping[
+                cast(str, getattr(self.coordinator.data, self.entity_description.key))
+            ]
+
         return cast(
             StateType, getattr(self.coordinator.data, self.entity_description.key)
         )
@@ -357,6 +380,13 @@ class NAMSensor(CoordinatorEntity[NAMDataUpdateCoordinator], SensorEntity):
             available
             and getattr(self.coordinator.data, self.entity_description.key) is not None
         )
+
+    @property
+    def options(self) -> list[str] | None:
+        """If the entity description provides a mapping, use that."""
+        if self.entity_description.mapping:
+            return list(self.entity_description.mapping.values())
+        return super().options
 
 
 class NAMSensorUptime(NAMSensor):

--- a/homeassistant/components/nam/sensor.py
+++ b/homeassistant/components/nam/sensor.py
@@ -82,7 +82,7 @@ AQI_LEVEL_STATE_MAPPING = {
 
 @dataclass
 class NAMSensorEntityDescription(SensorEntityDescription):
-    """Describes WLED sensor entity."""
+    """Describes NAM sensor entity."""
 
     mapping: dict[str, str] | None = None
 

--- a/homeassistant/components/nam/strings.json
+++ b/homeassistant/components/nam/strings.json
@@ -42,11 +42,11 @@
     "sensor": {
       "caqi_level": {
         "state": {
-          "very low": "Very low",
+          "very_low": "Very low",
           "low": "Low",
           "medium": "Medium",
           "high": "High",
-          "very high": "Very high"
+          "very_high": "Very high"
         }
       }
     }

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -231,14 +231,14 @@ async def test_sensor(hass):
 
     state = hass.states.get("sensor.nettigo_air_monitor_pmsx003_caqi_level")
     assert state
-    assert state.state == "very low"
+    assert state.state == "very_low"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENUM
     assert state.attributes.get(ATTR_OPTIONS) == [
-        "very low",
+        "very_low",
         "low",
         "medium",
         "high",
-        "very high",
+        "very_high",
     ]
     assert state.attributes.get(ATTR_ICON) == "mdi:air-filter"
 
@@ -331,14 +331,14 @@ async def test_sensor(hass):
 
     state = hass.states.get("sensor.nettigo_air_monitor_sds011_caqi_level")
     assert state
-    assert state.state == "very low"
+    assert state.state == "very_low"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENUM
     assert state.attributes.get(ATTR_OPTIONS) == [
-        "very low",
+        "very_low",
         "low",
         "medium",
         "high",
-        "very high",
+        "very_high",
     ]
     assert state.attributes.get(ATTR_ICON) == "mdi:air-filter"
 
@@ -377,11 +377,11 @@ async def test_sensor(hass):
     assert state.state == "medium"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENUM
     assert state.attributes.get(ATTR_OPTIONS) == [
-        "very low",
+        "very_low",
         "low",
         "medium",
         "high",
-        "very high",
+        "very_high",
     ]
     assert state.attributes.get(ATTR_ICON) == "mdi:air-filter"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The states of air quality sensors have been standardized to match Home Assistant core rules.
This affect 2 states some sensors of NAM can provide:

- `very low`, which now became `very_low`
- `very high`, which now became `very_high`

If you used those states directly in your automations, scripts, or templates; you will need to adjust those to match these changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While making checks more strict in hassfest in #85221, I came across the NAM integration.

This integration uses states as translations key that:
- Aren't mapped to translations (while can be mapped)
- Is using spaces in its translation keys.

This PR adjusts that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
