### PR TITLE
Add additional device classes and units to ISY994 aux sensors

### DIFF
--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -291,9 +291,9 @@ NODE_FILTERS: dict[Platform, dict[str, list[str]]] = {
 }
 
 UOM_FRIENDLY_NAME = {
-    "1": "A",
+    "1": UnitOfElectricCurrent.AMPERE,
     UOM_ON_OFF: "",  # Binary, no unit
-    "3": f"btu/{UnitOfTime.HOURS}",
+    "3": UnitOfPower.BTU_PER_HOUR,
     "4": UnitOfTemperature.CELSIUS,
     "5": UnitOfLength.CENTIMETERS,
     "6": UnitOfVolume.CUBIC_FEET,
@@ -319,7 +319,7 @@ UOM_FRIENDLY_NAME = {
     "28": UnitOfMass.KILOGRAMS,
     "29": "kV",
     "30": UnitOfPower.KILO_WATT,
-    "31": "kPa",
+    "31": UnitOfPressure.KPA,
     "32": UnitOfSpeed.KILOMETERS_PER_HOUR,
     "33": UnitOfEnergy.KILO_WATT_HOUR,
     "34": "liedu",

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -58,15 +58,28 @@ AUX_DISABLED_BY_DEFAULT_EXACT = {
 }
 SKIP_AUX_PROPERTIES = {PROP_BUSY, PROP_COMMS_ERROR, PROP_STATUS}
 
+# Reference pyisy.constants.COMMAND_FRIENDLY_NAME for API details.
+#   Note: "LUMIN"/Illuminance removed, some devices use non-conformant "%" unit
 ISY_CONTROL_TO_DEVICE_CLASS = {
     PROP_BATTERY_LEVEL: SensorDeviceClass.BATTERY,
     PROP_HUMIDITY: SensorDeviceClass.HUMIDITY,
     PROP_TEMPERATURE: SensorDeviceClass.TEMPERATURE,
-    "BARPRES": SensorDeviceClass.PRESSURE,
+    "BARPRES": SensorDeviceClass.ATMOSPHERIC_PRESSURE,
+    "CC": SensorDeviceClass.CURRENT,
     "CO2LVL": SensorDeviceClass.CO2,
+    "CPW": SensorDeviceClass.POWER,
     "CV": SensorDeviceClass.VOLTAGE,
-    "LUMIN": SensorDeviceClass.ILLUMINANCE,
+    "DEWPT": SensorDeviceClass.TEMPERATURE,
+    "DISTANC": SensorDeviceClass.DISTANCE,
     "PF": SensorDeviceClass.POWER_FACTOR,
+    "RAINRT": SensorDeviceClass.PRECIPITATION_INTENSITY,
+    "SOILT": SensorDeviceClass.TEMPERATURE,
+    "SOLRAD": SensorDeviceClass.IRRADIANCE,
+    "SPEED": SensorDeviceClass.SPEED,
+    "TPW": SensorDeviceClass.ENERGY,
+    "VOCLVL": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+    "WATERT": SensorDeviceClass.TEMPERATURE,
+    "WEIGHT": SensorDeviceClass.WEIGHT,
 }
 ISY_CONTROL_TO_STATE_CLASS = {
     control: SensorStateClass.MEASUREMENT for control in ISY_CONTROL_TO_DEVICE_CLASS


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Barametric Pressure sensors changed from "Pressure" to "Atmospheric Pressure" device class. Luminance sensors device class changed from "Illuminance" to "None" since some devices report value in '%' which is not a valid unit for illuminance.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add additional automatic device class recognition to Aux Sensors and update the units constants to use Home Assistant constants in more places. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85173
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
