### PR TITLE
Add `free_ebikes` attribute to citybikes provider sensor

### DIFF
--- a/homeassistant/components/citybikes/sensor.py
+++ b/homeassistant/components/citybikes/sensor.py
@@ -43,6 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_EMPTY_SLOTS = "empty_slots"
 ATTR_EXTRA = "extra"
 ATTR_FREE_BIKES = "free_bikes"
+ATTR_FREE_EBIKES = "free_ebikes"
 ATTR_NETWORK = "network"
 ATTR_NETWORKS_LIST = "networks"
 ATTR_STATIONS_LIST = "stations"
@@ -116,7 +117,10 @@ STATION_SCHEMA = vol.Schema(
         vol.Required(ATTR_NAME): cv.string,
         vol.Required(ATTR_TIMESTAMP): cv.string,
         vol.Optional(ATTR_EXTRA): vol.Schema(
-            {vol.Optional(ATTR_UID): cv.string}, extra=vol.REMOVE_EXTRA
+            {
+                vol.Optional(ATTR_UID): cv.string,
+                vol.Optional(ATTR_FREE_EBIKES): cv.positive_int,
+            }, extra=vol.REMOVE_EXTRA
         ),
     },
     extra=vol.REMOVE_EXTRA,
@@ -293,12 +297,14 @@ class CityBikesStation(SensorEntity):
             if station[ATTR_ID] == self._station_id:
                 station_data = station
                 break
+        extra = station_data.get(ATTR_EXTRA, {})
         self._attr_name = station_data.get(ATTR_NAME)
         self._attr_native_value = station_data.get(ATTR_FREE_BIKES)
         self._attr_extra_state_attributes = {
-            ATTR_UID: station_data.get(ATTR_EXTRA, {}).get(ATTR_UID),
+            ATTR_UID: extra.get(ATTR_UID),
             ATTR_LATITUDE: station_data.get(ATTR_LATITUDE),
             ATTR_LONGITUDE: station_data.get(ATTR_LONGITUDE),
             ATTR_EMPTY_SLOTS: station_data.get(ATTR_EMPTY_SLOTS),
+            ATTR_FREE_EBIKES: extra.get(ATTR_FREE_EBIKES),
             ATTR_TIMESTAMP: station_data.get(ATTR_TIMESTAMP),
         }

--- a/homeassistant/components/citybikes/sensor.py
+++ b/homeassistant/components/citybikes/sensor.py
@@ -120,7 +120,8 @@ STATION_SCHEMA = vol.Schema(
             {
                 vol.Optional(ATTR_UID): cv.string,
                 vol.Optional(ATTR_FREE_EBIKES): cv.positive_int,
-            }, extra=vol.REMOVE_EXTRA
+            },
+            extra=vol.REMOVE_EXTRA,
         ),
     },
     extra=vol.REMOVE_EXTRA,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change

This is a reimplementation of #82945. It adds the amount of free e-bikes to the sensor attributes. The reason it uses the attributes instead of creating a new sensor is to be consistent with where the other secondary values are stored (number of empty slots, etc).

The free ebikes value comes from the extras. For example:

```console
$ curl -s http://api.citybik.es/v2/networks/citi-bike-nyc  | jq '[.network.stations[] | select(.extra.ebikes > 0)][0]'
{
  "empty_slots": 24,
  "extra": {
    "ebikes": 1,
    "has_ebikes": true,
    "last_updated": 1672975310,
    "payment": [
      "creditcard",
      "key"
    ],
    "payment-terminal": true,
    "renting": 1,
    "returning": 1,
    "slots": 39,
    "uid": "3328"
  },
  "free_bikes": 6,
  "id": "46a983722ee1f51813a6a3eb6534a6e4",
  "latitude": 40.795,
  "longitude": -73.9645,
  "name": "W 100 St & Manhattan Ave",
  "timestamp": "2023-01-06T03:38:14.678000Z"
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
