### PR TITLE
Add browse media and play media support in Bravia TV

### DIFF
--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_HOST, CONF_MAC, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import CONF_IGNORED_SOURCES, DOMAIN
+from .const import DOMAIN
 from .coordinator import BraviaTVCoordinator
 
 PLATFORMS: Final[list[Platform]] = [
@@ -25,7 +25,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     """Set up a config entry."""
     host = config_entry.data[CONF_HOST]
     mac = config_entry.data[CONF_MAC]
-    ignored_sources = config_entry.options.get(CONF_IGNORED_SOURCES, [])
 
     session = async_create_clientsession(
         hass, cookie_jar=CookieJar(unsafe=True, quote_cookie=False)
@@ -35,7 +34,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         hass=hass,
         client=client,
         config=config_entry.data,
-        ignored_sources=ignored_sources,
     )
     config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
 

--- a/homeassistant/components/braviatv/const.py
+++ b/homeassistant/components/braviatv/const.py
@@ -3,16 +3,25 @@ from __future__ import annotations
 
 from typing import Final
 
+from homeassistant.backports.enum import StrEnum
+
 ATTR_CID: Final = "cid"
 ATTR_MAC: Final = "macAddr"
 ATTR_MANUFACTURER: Final = "Sony"
 ATTR_MODEL: Final = "model"
 
 CONF_CLIENT_ID: Final = "client_id"
-CONF_IGNORED_SOURCES: Final = "ignored_sources"
 CONF_NICKNAME: Final = "nickname"
 CONF_USE_PSK: Final = "use_psk"
 
 DOMAIN: Final = "braviatv"
 LEGACY_CLIENT_ID: Final = "HomeAssistant"
 NICKNAME_PREFIX: Final = "Home Assistant"
+
+
+class SourceType(StrEnum):
+    """Source type for Sony TV Integration."""
+
+    APP = "app"
+    CHANNEL = "channel"
+    INPUT = "input"

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -220,7 +220,6 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             await self.client.set_active_app(uri)
         else:
             await self.client.set_play_content(uri)
-        return
 
     async def async_source_find(
         self, query: str, source_type: SourceType | str

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -122,7 +122,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             if not title or not uri:
                 continue
             self.source_map[uri] = {**item, "type": source_type}
-            if add_to_list:
+            if add_to_list and title not in self.source_list:
                 self.source_list.append(title)
 
     async def _async_update_data(self) -> None:

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -33,6 +33,7 @@ from .const import (
     DOMAIN,
     LEGACY_CLIENT_ID,
     NICKNAME_PREFIX,
+    SourceType,
 )
 
 _BraviaTVCoordinatorT = TypeVar("_BraviaTVCoordinatorT", bound="BraviaTVCoordinator")
@@ -45,7 +46,7 @@ SCAN_INTERVAL: Final = timedelta(seconds=10)
 def catch_braviatv_errors(
     func: Callable[Concatenate[_BraviaTVCoordinatorT, _P], Awaitable[None]]
 ) -> Callable[Concatenate[_BraviaTVCoordinatorT, _P], Coroutine[Any, Any, None]]:
-    """Catch BraviaClient errors."""
+    """Catch Bravia errors."""
 
     @wraps(func)
     async def wrapper(
@@ -53,7 +54,7 @@ def catch_braviatv_errors(
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> None:
-        """Catch BraviaClient errors and log message."""
+        """Catch Bravia errors and log message."""
         try:
             await func(self, *args, **kwargs)
         except BraviaError as err:
@@ -71,7 +72,6 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         hass: HomeAssistant,
         client: BraviaClient,
         config: MappingProxyType[str, Any],
-        ignored_sources: list[str],
     ) -> None:
         """Initialize Bravia TV Client."""
 
@@ -80,11 +80,11 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         self.use_psk = config.get(CONF_USE_PSK, False)
         self.client_id = config.get(CONF_CLIENT_ID, LEGACY_CLIENT_ID)
         self.nickname = config.get(CONF_NICKNAME, NICKNAME_PREFIX)
-        self.ignored_sources = ignored_sources
         self.source: str | None = None
         self.source_list: list[str] = []
         self.source_map: dict[str, dict] = {}
         self.media_title: str | None = None
+        self.media_channel: str | None = None
         self.media_content_id: str | None = None
         self.media_content_type: MediaType | None = None
         self.media_uri: str | None = None
@@ -93,7 +93,6 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         self.volume_target: str | None = None
         self.volume_muted = False
         self.is_on = False
-        self.is_channel = False
         self.connected = False
         self.skipped_updates = 0
 
@@ -107,16 +106,23 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             ),
         )
 
-    def _sources_extend(self, sources: list[dict], source_type: str) -> None:
+    def _sources_extend(
+        self,
+        sources: list[dict],
+        source_type: SourceType,
+        add_to_list: bool = False,
+        sort_by: str | None = None,
+    ) -> None:
         """Extend source map and source list."""
+        if sort_by:
+            sources = sorted(sources, key=lambda d: d.get(sort_by, ""))
         for item in sources:
-            item["type"] = source_type
             title = item.get("title")
             uri = item.get("uri")
             if not title or not uri:
                 continue
-            self.source_map[uri] = item
-            if title not in self.ignored_sources:
+            self.source_map[uri] = {**item, "type": source_type}
+            if add_to_list:
                 self.source_list.append(title)
 
     async def _async_update_data(self) -> None:
@@ -163,25 +169,10 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             self.connected = False
             raise UpdateFailed("Error communicating with device") from err
 
-    async def async_update_sources(self) -> None:
-        """Update sources."""
-        self.source_list = []
-        self.source_map = {}
-
-        externals = await self.client.get_external_status()
-        self._sources_extend(externals, "input")
-
-        apps = await self.client.get_app_list()
-        self._sources_extend(apps, "app")
-
-        channels = await self.client.get_content_list_all("tv")
-        self._sources_extend(channels, "channel")
-
     async def async_update_volume(self) -> None:
         """Update volume information."""
         volume_info = await self.client.get_volume_info()
-        volume_level = volume_info.get("volume")
-        if volume_level is not None:
+        if volume_level := volume_info.get("volume"):
             self.volume_level = volume_level / 100
             self.volume_muted = volume_info.get("mute", False)
             self.volume_target = volume_info.get("target")
@@ -192,26 +183,68 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         self.media_title = playing_info.get("title")
         self.media_uri = playing_info.get("uri")
         self.media_duration = playing_info.get("durationSec")
-        if program_title := playing_info.get("programTitle"):
-            self.media_title = f"{self.media_title}: {program_title}"
+        self.media_channel = None
+        self.media_content_id = None
+        self.media_content_type = None
+        self.source = None
         if self.media_uri:
-            source = self.source_map.get(self.media_uri, {})
-            self.source = source.get("title")
-            self.is_channel = self.media_uri[:2] == "tv"
-            if self.is_channel:
+            self.media_content_id = self.media_uri
+            if self.media_uri[:8] == "extInput":
+                self.source = playing_info.get("title")
+            if self.media_uri[:2] == "tv":
+                self.media_title = playing_info.get("programTitle")
+                self.media_channel = playing_info.get("title")
                 self.media_content_id = playing_info.get("dispNum")
                 self.media_content_type = MediaType.CHANNEL
-            else:
-                self.media_content_id = self.media_uri
-                self.media_content_type = None
-        else:
-            self.source = None
-            self.is_channel = False
-            self.media_content_id = None
-            self.media_content_type = None
         if not playing_info:
             self.media_title = "Smart TV"
             self.media_content_type = MediaType.APP
+
+    async def async_update_sources(self) -> None:
+        """Update all sources."""
+        self.source_list = []
+        self.source_map = {}
+
+        inputs = await self.client.get_external_status()
+        self._sources_extend(inputs, SourceType.INPUT, add_to_list=True)
+
+        apps = await self.client.get_app_list()
+        self._sources_extend(apps, SourceType.APP, sort_by="title")
+
+        channels = await self.client.get_content_list_all("tv")
+        self._sources_extend(channels, SourceType.CHANNEL)
+
+    async def async_source_start(self, uri: str, source_type: SourceType | str) -> None:
+        """Select source by uri."""
+        if source_type == SourceType.APP:
+            await self.client.set_active_app(uri)
+        else:
+            await self.client.set_play_content(uri)
+        return
+
+    async def async_source_find(
+        self, query: str, source_type: SourceType | str
+    ) -> None:
+        """Find and select source by query."""
+        if query.startswith(("extInput:", "tv:", "com.sony.dtv.")):
+            return await self.async_source_start(query, source_type)
+        coarse_uri = None
+        is_numeric_search = source_type == SourceType.CHANNEL and query.isnumeric()
+        for uri, item in self.source_map.items():
+            if item["type"] == source_type:
+                if is_numeric_search:
+                    num = item.get("dispNum")
+                    if num and int(query) == int(num):
+                        return await self.async_source_start(uri, source_type)
+                else:
+                    title: str = item["title"]
+                    if query.lower() == title.lower():
+                        return await self.async_source_start(uri, source_type)
+                    if query.lower() in title.lower():
+                        coarse_uri = uri
+        if coarse_uri:
+            return await self.async_source_start(coarse_uri, source_type)
+        raise ValueError(f"Not found {source_type}: {query}")
 
     @catch_braviatv_errors
     async def async_turn_on(self) -> None:
@@ -261,7 +294,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
     @catch_braviatv_errors
     async def async_media_next_track(self) -> None:
         """Send next track command."""
-        if self.is_channel:
+        if self.media_content_type == MediaType.CHANNEL:
             await self.client.channel_up()
         else:
             await self.client.next_track()
@@ -269,21 +302,24 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
     @catch_braviatv_errors
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
-        if self.is_channel:
+        if self.media_content_type == MediaType.CHANNEL:
             await self.client.channel_down()
         else:
             await self.client.previous_track()
 
     @catch_braviatv_errors
+    async def async_play_media(
+        self, media_type: MediaType | str, media_id: str, **kwargs: Any
+    ) -> None:
+        """Play a piece of media."""
+        if media_type not in (MediaType.APP, MediaType.CHANNEL):
+            raise ValueError(f"Invalid media type: {media_type}")
+        await self.async_source_find(media_id, media_type)
+
+    @catch_braviatv_errors
     async def async_select_source(self, source: str) -> None:
         """Set the input source."""
-        for uri, item in self.source_map.items():
-            if item.get("title") == source:
-                if item.get("type") == "app":
-                    await self.client.set_active_app(uri)
-                else:
-                    await self.client.set_play_content(uri)
-                break
+        await self.async_source_find(source, SourceType.INPUT)
 
     @catch_braviatv_errors
     async def async_send_command(self, command: Iterable[str], repeats: int) -> None:

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -240,7 +240,7 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
             if icon := self.coordinator.source_map[media_content_id].get("icon"):
                 (content, content_type) = await self._async_fetch_image(icon)
                 if content_type:
-                    # Fix invalid Bravia Content-Type header
+                    # Fix invalid Content-Type header returned by Bravia
                     content_type = content_type.replace("Content-Type: ", "")
                 return (content, content_type)
         return None, None

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -238,7 +238,11 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
         """Serve album art. Returns (content, content_type)."""
         if media_content_type == MediaType.APP and media_content_id:
             if icon := self.coordinator.source_map[media_content_id].get("icon"):
-                return await self._async_fetch_image(icon)
+                (content, content_type) = await self._async_fetch_image(icon)
+                if content_type:
+                    # Fix invalid Bravia Content-Type header
+                    content_type = content_type.replace("Content-Type: ", "")
+                return (content, content_type)
         return None, None
 
     async def async_play_media(

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -1,18 +1,23 @@
 """Media player support for Bravia TV integration."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.media_player import (
+    BrowseError,
+    MediaClass,
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
     MediaType,
 )
+from homeassistant.components.media_player.browse_media import BrowseMedia
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, SourceType
 from .entity import BraviaTVEntity
 
 
@@ -49,6 +54,8 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
         | MediaPlayerEntityFeature.SELECT_SOURCE
         | MediaPlayerEntityFeature.PLAY
         | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.BROWSE_MEDIA
     )
 
     @property
@@ -82,6 +89,11 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
     def media_title(self) -> str | None:
         """Title of current playing media."""
         return self.coordinator.media_title
+
+    @property
+    def media_channel(self) -> str | None:
+        """Channel currently playing."""
+        return self.coordinator.media_channel
 
     @property
     def media_content_id(self) -> str | None:
@@ -121,6 +133,119 @@ class BraviaTVMediaPlayer(BraviaTVEntity, MediaPlayerEntity):
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
         await self.coordinator.async_volume_mute(mute)
+
+    async def async_browse_media(
+        self,
+        media_content_type: str | None = None,
+        media_content_id: str | None = None,
+    ) -> BrowseMedia:
+        """Browse apps and channels."""
+        if not media_content_id:
+            await self.coordinator.async_update_sources()
+            return await self.async_browse_media_root()
+
+        path = media_content_id.partition("/")
+        if path[0] == "apps":
+            return await self.async_browse_media_apps(True)
+        if path[0] == "channels":
+            return await self.async_browse_media_channels(True)
+
+        raise BrowseError(f"Media not found: {media_content_type} / {media_content_id}")
+
+    async def async_browse_media_root(self) -> BrowseMedia:
+        """Return root media objects."""
+
+        return BrowseMedia(
+            title="Sony TV",
+            media_class=MediaClass.DIRECTORY,
+            media_content_id="",
+            media_content_type="",
+            can_play=False,
+            can_expand=True,
+            children=[
+                await self.async_browse_media_apps(),
+                await self.async_browse_media_channels(),
+            ],
+        )
+
+    async def async_browse_media_apps(self, expanded: bool = False) -> BrowseMedia:
+        """Return apps media objects."""
+        if expanded:
+            children = [
+                BrowseMedia(
+                    title=item["title"],
+                    media_class=MediaClass.APP,
+                    media_content_id=uri,
+                    media_content_type=MediaType.APP,
+                    can_play=False,
+                    can_expand=False,
+                    thumbnail=self.get_browse_image_url(
+                        MediaType.APP, uri, media_image_id=None
+                    ),
+                )
+                for uri, item in self.coordinator.source_map.items()
+                if item["type"] == SourceType.APP
+            ]
+        else:
+            children = None
+
+        return BrowseMedia(
+            title="Applications",
+            media_class=MediaClass.DIRECTORY,
+            media_content_id="apps",
+            media_content_type=MediaType.APPS,
+            children_media_class=MediaClass.APP,
+            can_play=False,
+            can_expand=True,
+            children=children,
+        )
+
+    async def async_browse_media_channels(self, expanded: bool = False) -> BrowseMedia:
+        """Return channels media objects."""
+        if expanded:
+            children = [
+                BrowseMedia(
+                    title=item["title"],
+                    media_class=MediaClass.CHANNEL,
+                    media_content_id=uri,
+                    media_content_type=MediaType.CHANNEL,
+                    can_play=False,
+                    can_expand=False,
+                )
+                for uri, item in self.coordinator.source_map.items()
+                if item["type"] == SourceType.CHANNEL
+            ]
+        else:
+            children = None
+
+        return BrowseMedia(
+            title="Channels",
+            media_class=MediaClass.DIRECTORY,
+            media_content_id="channels",
+            media_content_type=MediaType.CHANNELS,
+            children_media_class=MediaClass.CHANNEL,
+            can_play=False,
+            can_expand=True,
+            children=children,
+        )
+
+    async def async_get_browse_image(
+        self,
+        media_content_type: str,
+        media_content_id: str,
+        media_image_id: str | None = None,
+    ) -> tuple[bytes | None, str | None]:
+        """Serve album art. Returns (content, content_type)."""
+        if media_content_type == MediaType.APP and media_content_id:
+            if icon := self.coordinator.source_map[media_content_id].get("icon"):
+                return await self._async_fetch_image(icon)
+        return None, None
+
+    async def async_play_media(
+        self, media_type: MediaType | str, media_id: str, **kwargs: Any
+    ) -> None:
+        """Play a piece of media."""
+        await self.coordinator.async_play_media(media_type, media_id, **kwargs)
 
     async def async_select_source(self, source: str) -> None:
         """Set the input source."""

--- a/homeassistant/components/braviatv/strings.json
+++ b/homeassistant/components/braviatv/strings.json
@@ -44,18 +44,5 @@
       "not_bravia_device": "The device is not a Bravia TV.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
-  },
-  "options": {
-    "step": {
-      "user": {
-        "title": "Options for Sony Bravia TV",
-        "data": {
-          "ignored_sources": "List of ignored sources"
-        }
-      }
-    },
-    "abort": {
-      "failed_update": "An error occurred while updating the list of sources.\n\n Ensure that your TV is turned on before trying to set it up."
-    }
   }
 }

--- a/homeassistant/components/braviatv/translations/en.json
+++ b/homeassistant/components/braviatv/translations/en.json
@@ -4,7 +4,8 @@
             "already_configured": "Device is already configured",
             "no_ip_control": "IP Control is disabled on your TV or the TV is not supported.",
             "not_bravia_device": "The device is not a Bravia TV.",
-            "reauth_successful": "Re-authentication was successful"
+            "reauth_successful": "Re-authentication was successful",
+            "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again."
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -15,6 +16,7 @@
         "step": {
             "authorize": {
                 "data": {
+                    "pin": "PIN Code",
                     "use_psk": "Use PSK authentication"
                 },
                 "description": "Make sure that \u00abControl remotely\u00bb is enabled on your TV, go to: \nSettings -> Network -> Remote device settings -> Control remotely. \n\nThere are two authorization methods: PIN code or PSK (Pre-Shared Key). \nAuthorization via PSK is recommended as more stable.",
@@ -37,11 +39,31 @@
                 "description": "To set up PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Set \u00abAuthentication\u00bb to \u00abNormal and Pre-Shared Key\u00bb or \u00abPre-Shared Key\u00bb and define your Pre-Shared-Key string (e.g. sony). \n\nThen enter your PSK here.",
                 "title": "Authorize Sony Bravia TV"
             },
+            "reauth_confirm": {
+                "data": {
+                    "pin": "PIN Code",
+                    "use_psk": "Use PSK authentication"
+                },
+                "description": "Enter the PIN code shown on the Sony Bravia TV. \n\nIf the PIN code is not shown, you have to unregister Home Assistant on your TV, go to: Settings -> Network -> Remote device settings -> Deregister remote device. \n\nYou can use PSK (Pre-Shared-Key) instead of PIN. PSK is a user-defined secret key used for access control. This authentication method is recommended as more stable. To enable PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Then check \u00abUse PSK authentication\u00bb box and enter your PSK instead of PIN."
+            },
             "user": {
                 "data": {
                     "host": "Host"
                 },
                 "description": "Ensure that your TV is turned on before trying to set it up."
+            }
+        }
+    },
+    "options": {
+        "abort": {
+            "failed_update": "An error occurred while updating the list of sources.\n\n Ensure that your TV is turned on before trying to set it up."
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "ignored_sources": "List of ignored sources"
+                },
+                "title": "Options for Sony Bravia TV"
             }
         }
     }

--- a/homeassistant/components/braviatv/translations/en.json
+++ b/homeassistant/components/braviatv/translations/en.json
@@ -4,8 +4,7 @@
             "already_configured": "Device is already configured",
             "no_ip_control": "IP Control is disabled on your TV or the TV is not supported.",
             "not_bravia_device": "The device is not a Bravia TV.",
-            "reauth_successful": "Re-authentication was successful",
-            "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again."
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -16,7 +15,6 @@
         "step": {
             "authorize": {
                 "data": {
-                    "pin": "PIN Code",
                     "use_psk": "Use PSK authentication"
                 },
                 "description": "Make sure that \u00abControl remotely\u00bb is enabled on your TV, go to: \nSettings -> Network -> Remote device settings -> Control remotely. \n\nThere are two authorization methods: PIN code or PSK (Pre-Shared Key). \nAuthorization via PSK is recommended as more stable.",
@@ -39,31 +37,11 @@
                 "description": "To set up PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Set \u00abAuthentication\u00bb to \u00abNormal and Pre-Shared Key\u00bb or \u00abPre-Shared Key\u00bb and define your Pre-Shared-Key string (e.g. sony). \n\nThen enter your PSK here.",
                 "title": "Authorize Sony Bravia TV"
             },
-            "reauth_confirm": {
-                "data": {
-                    "pin": "PIN Code",
-                    "use_psk": "Use PSK authentication"
-                },
-                "description": "Enter the PIN code shown on the Sony Bravia TV. \n\nIf the PIN code is not shown, you have to unregister Home Assistant on your TV, go to: Settings -> Network -> Remote device settings -> Deregister remote device. \n\nYou can use PSK (Pre-Shared-Key) instead of PIN. PSK is a user-defined secret key used for access control. This authentication method is recommended as more stable. To enable PSK on your TV, go to: Settings -> Network -> Home Network Setup -> IP Control. Then check \u00abUse PSK authentication\u00bb box and enter your PSK instead of PIN."
-            },
             "user": {
                 "data": {
                     "host": "Host"
                 },
                 "description": "Ensure that your TV is turned on before trying to set it up."
-            }
-        }
-    },
-    "options": {
-        "abort": {
-            "failed_update": "An error occurred while updating the list of sources.\n\n Ensure that your TV is turned on before trying to set it up."
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "ignored_sources": "List of ignored sources"
-                },
-                "title": "Options for Sony Bravia TV"
             }
         }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `source_list` no longer contains a list of applications and TV channels. Apps and channels have been separated from the input list and moved to the Media Browser. If you have automations or scripts that use `media_player.select_source` to switch apps or channels on the Bravia TV, the automations need to be updated to use `media_player.play_media` service instead.

The options flow has been removed from the integration, as the only one configurable setting `ignored_sources` was no longer relevant and incompatible to this change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support Browse Media to display a list of apps and TV channels. Apps and channels no longer stored into one big list in the `source_list`, which caused problems when the same channel and app names appeared (#70886). Also, a long list containing a mix of inputs, applications and channels is not user friendly. Transferring the list of applications to the Media Browser made it possible to display application icons returned by the Bravia API.

Support for the `play_media` service will also allow more flexible control of media switching on Bravia TV. For example, switch to a channel by its number or an inexact match of the application name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #70886
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25592

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
