### PR TITLE
Fix translation keys for Yamaha MusicCast selectors

### DIFF
--- a/homeassistant/components/yamaha_musiccast/const.py
+++ b/homeassistant/components/yamaha_musiccast/const.py
@@ -55,3 +55,12 @@ TRANSLATION_KEY_MAPPING = {
     "zone_LINK_CONTROL": "zone_link_control",
     "zone_LINK_AUDIO_DELAY": "zone_link_audio_delay",
 }
+
+ZONE_SLEEP_STATE_MAPPING = {
+    "off": "off",
+    "30 min": "30_min",
+    "60 min": "60_min",
+    "90 min": "90_min",
+    "120 min": "120_min",
+}
+STATE_ZONE_SLEEP_MAPPING = {val: key for key, val in ZONE_SLEEP_STATE_MAPPING.items()}

--- a/homeassistant/components/yamaha_musiccast/select.py
+++ b/homeassistant/components/yamaha_musiccast/select.py
@@ -65,7 +65,7 @@ class SelectableCapapility(MusicCastCapabilityEntity, SelectEntity):
         # If the translation key is "zone_sleep", we need to translate
         # the options to make them compatible with Home Assistant
         if self.translation_key == "zone_sleep":
-            return list(ZONE_SLEEP_STATE_MAPPING.values())
+            return list(STATE_ZONE_SLEEP_MAPPING)
         return list(self.capability.options.values())
 
     @property

--- a/homeassistant/components/yamaha_musiccast/select.py
+++ b/homeassistant/components/yamaha_musiccast/select.py
@@ -9,7 +9,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN, MusicCastCapabilityEntity, MusicCastDataUpdateCoordinator
-from .const import TRANSLATION_KEY_MAPPING
+from .const import (
+    STATE_ZONE_SLEEP_MAPPING,
+    TRANSLATION_KEY_MAPPING,
+    ZONE_SLEEP_STATE_MAPPING,
+)
 
 
 async def async_setup_entry(
@@ -47,7 +51,7 @@ class SelectableCapapility(MusicCastCapabilityEntity, SelectEntity):
         # If the translation key is "zone_sleep", we need to translate
         # Home Assistant state back to the MusicCast value
         if self.translation_key == "zone_sleep":
-            value = value.replace("_", " ")
+            value = STATE_ZONE_SLEEP_MAPPING[value]
         await self.capability.set(value)
 
     @property
@@ -61,9 +65,7 @@ class SelectableCapapility(MusicCastCapabilityEntity, SelectEntity):
         # If the translation key is "zone_sleep", we need to translate
         # the options to make them compatible with Home Assistant
         if self.translation_key == "zone_sleep":
-            return [
-                value.replace(" ", "_") for value in self.capability.options.values()
-            ]
+            return list(ZONE_SLEEP_STATE_MAPPING.values())
         return list(self.capability.options.values())
 
     @property
@@ -74,6 +76,6 @@ class SelectableCapapility(MusicCastCapabilityEntity, SelectEntity):
         if (
             value := self.capability.current
         ) is not None and self.translation_key == "zone_sleep":
-            return value.replace(" ", "_")
+            return ZONE_SLEEP_STATE_MAPPING[value]
 
         return value

--- a/homeassistant/components/yamaha_musiccast/select.py
+++ b/homeassistant/components/yamaha_musiccast/select.py
@@ -44,6 +44,10 @@ class SelectableCapapility(MusicCastCapabilityEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Select the given option."""
         value = {val: key for key, val in self.capability.options.items()}[option]
+        # If the translation key is "zone_sleep", we need to translate
+        # Home Assistant state back to the MusicCast value
+        if self.translation_key == "zone_sleep":
+            value = value.replace("_", " ")
         await self.capability.set(value)
 
     @property
@@ -54,9 +58,22 @@ class SelectableCapapility(MusicCastCapabilityEntity, SelectEntity):
     @property
     def options(self) -> list[str]:
         """Return the list possible options."""
+        # If the translation key is "zone_sleep", we need to translate
+        # the options to make them compatible with Home Assistant
+        if self.translation_key == "zone_sleep":
+            return [
+                value.replace(" ", "_") for value in self.capability.options.values()
+            ]
         return list(self.capability.options.values())
 
     @property
     def current_option(self) -> str | None:
         """Return the currently selected option."""
-        return self.capability.options.get(self.capability.current)
+        # If the translation key is "zone_sleep", we need to translate
+        # the value to make it compatible with Home Assistant
+        if (
+            value := self.capability.current
+        ) is not None and self.translation_key == "zone_sleep":
+            return value.replace(" ", "_")
+
+        return value

--- a/homeassistant/components/yamaha_musiccast/strings.json
+++ b/homeassistant/components/yamaha_musiccast/strings.json
@@ -30,10 +30,10 @@
       "zone_sleep": {
         "state": {
           "off": "Off",
-          "30 min": "30 Minutes",
-          "60 min": "60 Minutes",
-          "90 min": "90 Minutes",
-          "120 min": "120 Minutes"
+          "30_min": "30 Minutes",
+          "60_min": "60 Minutes",
+          "90_min": "90 Minutes",
+          "120_min": "120 Minutes"
         }
       },
       "zone_tone_control_mode": {

--- a/homeassistant/components/yamaha_musiccast/translations/en.json
+++ b/homeassistant/components/yamaha_musiccast/translations/en.json
@@ -58,10 +58,10 @@
             },
             "zone_sleep": {
                 "state": {
-                    "120 min": "120 Minutes",
-                    "30 min": "30 Minutes",
-                    "60 min": "60 Minutes",
-                    "90 min": "90 Minutes",
+                    "120_min": "120 Minutes",
+                    "30_min": "30 Minutes",
+                    "60_min": "60 Minutes",
+                    "90_min": "90 Minutes",
                     "off": "Off"
                 }
             },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The raw state/option values of the Yamaha MusicCast zone sleep `select` entities have been standardized to match Home Assistant core rules.

The following states/options have been changed

- `120 min`, which now became `120_min`
- `90 min`, which now became `90_min`
- `60 min`, which now became `60_min`
- `30 min`, which now became `30_min`

If you used those states/options directly in your automations, scripts, or templates; you will need to adjust those to match these changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While making checks more strict in hassfest in #85221, I came across this integration. This integration uses states as translations key that used spaces in its translation key.

I'm pretty sure this could be implemented more nicely. However, I tried to keep the scope of the PR to a bare minimum while still addressing the issue. The main reason for that is that this integration lacks unit tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
