### PR TITLE
Add addtional device classes to ISY994 sensors and bump PyISY to 3.0.11

### DIFF
--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -3,7 +3,7 @@
   "name": "Universal Devices ISY/IoX",
   "integration_type": "hub",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy==3.0.10"],
+  "requirements": ["pyisy==3.0.11"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -60,6 +60,7 @@ SKIP_AUX_PROPERTIES = {PROP_BUSY, PROP_COMMS_ERROR, PROP_STATUS}
 
 # Reference pyisy.constants.COMMAND_FRIENDLY_NAME for API details.
 #   Note: "LUMIN"/Illuminance removed, some devices use non-conformant "%" unit
+#         "VOCLVL"/VOC removed, uses qualitative UOM not ug/m^3
 ISY_CONTROL_TO_DEVICE_CLASS = {
     PROP_BATTERY_LEVEL: SensorDeviceClass.BATTERY,
     PROP_HUMIDITY: SensorDeviceClass.HUMIDITY,
@@ -71,15 +72,29 @@ ISY_CONTROL_TO_DEVICE_CLASS = {
     "CV": SensorDeviceClass.VOLTAGE,
     "DEWPT": SensorDeviceClass.TEMPERATURE,
     "DISTANC": SensorDeviceClass.DISTANCE,
+    "ETO": SensorDeviceClass.PRECIPITATION_INTENSITY,
+    "FATM": SensorDeviceClass.WEIGHT,
+    "FREQ": SensorDeviceClass.FREQUENCY,
+    "MUSCLEM": SensorDeviceClass.WEIGHT,
     "PF": SensorDeviceClass.POWER_FACTOR,
+    "PM10": SensorDeviceClass.PM10,
+    "PM25": SensorDeviceClass.PM25,
+    "PRECIP": SensorDeviceClass.PRECIPITATION,
     "RAINRT": SensorDeviceClass.PRECIPITATION_INTENSITY,
+    "RFSS": SensorDeviceClass.SIGNAL_STRENGTH,
+    "SOILH": SensorDeviceClass.MOISTURE,
     "SOILT": SensorDeviceClass.TEMPERATURE,
     "SOLRAD": SensorDeviceClass.IRRADIANCE,
     "SPEED": SensorDeviceClass.SPEED,
+    "TEMPEXH": SensorDeviceClass.TEMPERATURE,
+    "TEMPOUT": SensorDeviceClass.TEMPERATURE,
     "TPW": SensorDeviceClass.ENERGY,
-    "VOCLVL": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+    "WATERP": SensorDeviceClass.PRESSURE,
     "WATERT": SensorDeviceClass.TEMPERATURE,
+    "WATERTB": SensorDeviceClass.TEMPERATURE,
+    "WATERTD": SensorDeviceClass.TEMPERATURE,
     "WEIGHT": SensorDeviceClass.WEIGHT,
+    "WINDCH": SensorDeviceClass.TEMPERATURE,
 }
 ISY_CONTROL_TO_STATE_CLASS = {
     control: SensorStateClass.MEASUREMENT for control in ISY_CONTROL_TO_DEVICE_CLASS

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1684,7 +1684,7 @@ pyirishrail==0.0.2
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.0.10
+pyisy==3.0.11
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1197,7 +1197,7 @@ pyiqvia==2022.04.0
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.0.10
+pyisy==3.0.11
 
 # homeassistant.components.kaleidescape
 pykaleidescape==1.0.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Additional device class assignments for ISY994 sensors as follow up to PR #85274.

Remove VOC assignment as per @MartinHjelmare comment https://github.com/home-assistant/core/pull/85274#discussion_r1063030063 -- confirmed this uses a qualitative enum not ug/m3.

Bump PyISY to 3.0.11 which adds additional controls descriptions for sensors based on [updates from UDI](https://wiki.universal-devices.com/index.php?title=ISY_Developers:API:V5:Appendix:Status_Names) for Firmware V5.2+ and some minor dependency upgrades and logging cleanup.

Full bump change log: https://github.com/automicus/PyISY/releases/tag/v3.0.11

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #85274
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
