### PR TITLE
Add support for extractor hood tuya device (device type yyj)

### DIFF
--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -29,6 +29,7 @@ TUYA_SUPPORT_TYPE = {
     "fsd",  # Fan with Light
     "fskg",  # Fan wall switch
     "kj",  # Air Purifier
+    "yyj",  # Extractor hood
 }
 
 
@@ -204,6 +205,8 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
         """Return true if fan is on."""
         if self._switch is None:
             return None
+        if self._speeds is not None and "off" in self._speeds.range:
+            return self.device.status.get(self._speeds.dpcode) != "off"
         return self.device.status.get(self._switch)
 
     @property

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -210,6 +210,7 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
             )
             return
 
+        # Fake turn off
         if self._speeds is not None and percentage == 0 and "off" in self._speeds.range:
             self._send_command(
                 [
@@ -239,7 +240,7 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
         if self._switch is not None:
             self._send_command([{"code": self._switch, "value": False}])
 
-        # Fake turn on
+        # Fake turn off
         if (
             self._switch is None
             and self._speeds is not None

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -210,7 +210,6 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
             )
             return
 
-        # Fake turn off
         if self._speeds is not None and percentage == 0 and "off" in self._speeds.range:
             self._send_command(
                 [
@@ -288,6 +287,7 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
         if preset_mode is not None and self._presets is not None:
             commands.append({"code": self._presets.dpcode, "value": preset_mode})
 
+        # Fake turn on
         if (
             self._switch is None
             and percentage is None

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -326,6 +326,8 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
             color_temp=DPCode.TEMP_VALUE,
         ),
     ),
+    # Extractor hood
+    "yyj": (TuyaLightEntityDescription(key=DPCode.LIGHT),),
 }
 
 # Socket (duplicate of `kg`)

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -668,6 +668,13 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
             entity_category=EntityCategory.CONFIG,
         ),
     ),
+    # Extractor hood
+    "yyj": (
+        SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            name="Switch",
+        ),
+    ),
 }
 
 # Socket (duplicate of `pc`)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!-- ## Breaking change -->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for device type 'yyj' in the Tuya integration as described in https://github.com/tuya/tuya-home-assistant/issues/892. This is an extractor hood device (Klarstein skyfall). 

This device will come with 2 entities: 
- A light entity which controls the light on the hood.
- A fan entity which can control the the speed of the extractor fan. The switch associated with the fan will turn the whole device on or off

I've found one issue when testing my change: The fan has 4 settings (off/low/middle/high), however in the fan speed slider you can select 5 settings (0%, 25%, 50%, 75%, 100%). Both 0% and 25% translate to 'off'. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/tuya/tuya-home-assistant/issues/892
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
