### PR TITLE
Improve `devolo_home_network` generic typing

### DIFF
--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import async_timeout
 from devolo_plc_api import Device
@@ -80,7 +81,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Disconnect from device."""
         await device.async_disconnect()
 
-    coordinators: dict[str, DataUpdateCoordinator] = {}
+    coordinators: dict[str, DataUpdateCoordinator[Any]] = {}
     if device.plcnet:
         coordinators[CONNECTED_PLC_DEVICES] = DataUpdateCoordinator(
             hass,

--- a/homeassistant/components/devolo_home_network/binary_sensor.py
+++ b/homeassistant/components/devolo_home_network/binary_sensor.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from devolo_plc_api import Device
+from devolo_plc_api.plcnet_api import LogicalNetwork
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -62,9 +64,9 @@ async def async_setup_entry(
 ) -> None:
     """Get all devices and sensors and setup them via config entry."""
     device: Device = hass.data[DOMAIN][entry.entry_id]["device"]
-    coordinators: dict[str, DataUpdateCoordinator] = hass.data[DOMAIN][entry.entry_id][
-        "coordinators"
-    ]
+    coordinators: dict[str, DataUpdateCoordinator[Any]] = hass.data[DOMAIN][
+        entry.entry_id
+    ]["coordinators"]
 
     entities: list[BinarySensorEntity] = []
     if device.plcnet:
@@ -79,12 +81,12 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class DevoloBinarySensorEntity(DevoloEntity, BinarySensorEntity):
+class DevoloBinarySensorEntity(DevoloEntity[LogicalNetwork], BinarySensorEntity):
     """Representation of a devolo binary sensor."""
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[LogicalNetwork],
         description: DevoloBinarySensorEntityDescription,
         device: Device,
         device_name: str,

--- a/homeassistant/components/devolo_home_network/device_tracker.py
+++ b/homeassistant/components/devolo_home_network/device_tracker.py
@@ -88,7 +88,10 @@ class DevoloScannerEntity(
     """Representation of a devolo device tracker."""
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator, device: Device, mac: str
+        self,
+        coordinator: DataUpdateCoordinator[list[ConnectedStationInfo]],
+        device: Device,
+        mac: str,
     ) -> None:
         """Initialize entity."""
         super().__init__(coordinator)

--- a/homeassistant/components/devolo_home_network/entity.py
+++ b/homeassistant/components/devolo_home_network/entity.py
@@ -1,7 +1,11 @@
 """Generic platform."""
 from __future__ import annotations
 
+from typing import TypeVar, Union
+
 from devolo_plc_api.device import Device
+from devolo_plc_api.device_api import ConnectedStationInfo, NeighborAPInfo
+from devolo_plc_api.plcnet_api import LogicalNetwork
 
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -11,14 +15,26 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN
 
+_DataT = TypeVar(
+    "_DataT",
+    bound=Union[
+        LogicalNetwork,
+        list[ConnectedStationInfo],
+        list[NeighborAPInfo],
+    ],
+)
 
-class DevoloEntity(CoordinatorEntity):
+
+class DevoloEntity(CoordinatorEntity[DataUpdateCoordinator[_DataT]]):
     """Representation of a devolo home network device."""
 
     _attr_has_entity_name = True
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator, device: Device, device_name: str
+        self,
+        coordinator: DataUpdateCoordinator[_DataT],
+        device: Device,
+        device_name: str,
     ) -> None:
         """Initialize a devolo home network device."""
         super().__init__(coordinator)


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
