### PR TITLE
Improve DataUpdateCoordinator typing in integrations (8)

### DIFF
--- a/homeassistant/components/airthings_ble/sensor.py
+++ b/homeassistant/components/airthings_ble/sensor.py
@@ -154,7 +154,7 @@ class AirthingsSensor(
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[AirthingsDevice],
         airthings_device: AirthingsDevice,
         entity_description: SensorEntityDescription,
     ) -> None:

--- a/homeassistant/components/ld2410_ble/binary_sensor.py
+++ b/homeassistant/components/ld2410_ble/binary_sensor.py
@@ -46,7 +46,9 @@ async def async_setup_entry(
     )
 
 
-class LD2410BLEBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class LD2410BLEBinarySensor(
+    CoordinatorEntity[LD2410BLECoordinator], BinarySensorEntity
+):
     """Moving/static sensor for LD2410BLE."""
 
     def __init__(

--- a/homeassistant/components/ld2410_ble/coordinator.py
+++ b/homeassistant/components/ld2410_ble/coordinator.py
@@ -12,7 +12,7 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-class LD2410BLECoordinator(DataUpdateCoordinator):
+class LD2410BLECoordinator(DataUpdateCoordinator[None]):
     """Data coordinator for receiving LD2410B updates."""
 
     def __init__(self, hass: HomeAssistant, ld2410_ble: LD2410BLE) -> None:
@@ -31,7 +31,7 @@ class LD2410BLECoordinator(DataUpdateCoordinator):
     def _async_handle_update(self, state: LD2410BLEState) -> None:
         """Just trigger the callbacks."""
         self.connected = True
-        self.async_set_updated_data(True)
+        self.async_set_updated_data(None)
 
     @callback
     def _async_handle_disconnect(self) -> None:

--- a/homeassistant/components/nanoleaf/__init__.py
+++ b/homeassistant/components/nanoleaf/__init__.py
@@ -41,7 +41,7 @@ class NanoleafEntryData:
     """Class for sharing data within the Nanoleaf integration."""
 
     device: Nanoleaf
-    coordinator: DataUpdateCoordinator
+    coordinator: DataUpdateCoordinator[None]
     event_listener: asyncio.Task
 
 

--- a/homeassistant/components/nanoleaf/button.py
+++ b/homeassistant/components/nanoleaf/button.py
@@ -27,7 +27,9 @@ async def async_setup_entry(
 class NanoleafIdentifyButton(NanoleafEntity, ButtonEntity):
     """Representation of a Nanoleaf identify button."""
 
-    def __init__(self, nanoleaf: Nanoleaf, coordinator: DataUpdateCoordinator) -> None:
+    def __init__(
+        self, nanoleaf: Nanoleaf, coordinator: DataUpdateCoordinator[None]
+    ) -> None:
         """Initialize the Nanoleaf button."""
         super().__init__(nanoleaf, coordinator)
         self._attr_unique_id = f"{nanoleaf.serial_no}_identify"

--- a/homeassistant/components/nanoleaf/entity.py
+++ b/homeassistant/components/nanoleaf/entity.py
@@ -11,10 +11,12 @@ from homeassistant.helpers.update_coordinator import (
 from .const import DOMAIN
 
 
-class NanoleafEntity(CoordinatorEntity):
+class NanoleafEntity(CoordinatorEntity[DataUpdateCoordinator[None]]):
     """Representation of a Nanoleaf entity."""
 
-    def __init__(self, nanoleaf: Nanoleaf, coordinator: DataUpdateCoordinator) -> None:
+    def __init__(
+        self, nanoleaf: Nanoleaf, coordinator: DataUpdateCoordinator[None]
+    ) -> None:
         """Initialize an Nanoleaf entity."""
         super().__init__(coordinator)
         self._nanoleaf = nanoleaf

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -47,7 +47,9 @@ class NanoleafLight(NanoleafEntity, LightEntity):
     _attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
     _attr_supported_features = LightEntityFeature.EFFECT | LightEntityFeature.TRANSITION
 
-    def __init__(self, nanoleaf: Nanoleaf, coordinator: DataUpdateCoordinator) -> None:
+    def __init__(
+        self, nanoleaf: Nanoleaf, coordinator: DataUpdateCoordinator[None]
+    ) -> None:
         """Initialize the Nanoleaf light."""
         super().__init__(nanoleaf, coordinator)
         self._attr_unique_id = nanoleaf.serial_no

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -489,7 +489,7 @@ class SimpliSafe:
         self.systems: dict[int, SystemType] = {}
 
         # This will get filled in by async_init:
-        self.coordinator: DataUpdateCoordinator | None = None
+        self.coordinator: DataUpdateCoordinator[None] | None = None
 
     @callback
     def _async_process_new_notifications(self, system: SystemType) -> None:
@@ -692,7 +692,7 @@ class SimpliSafe:
                 raise UpdateFailed(f"SimpliSafe error while updating: {result}")
 
 
-class SimpliSafeEntity(CoordinatorEntity):
+class SimpliSafeEntity(CoordinatorEntity[DataUpdateCoordinator[None]]):
     """Define a base SimpliSafe entity."""
 
     _attr_has_entity_name = True

--- a/homeassistant/components/solaredge/coordinator.py
+++ b/homeassistant/components/solaredge/coordinator.py
@@ -24,7 +24,7 @@ from .const import (
 class SolarEdgeDataService(ABC):
     """Get and update the latest data."""
 
-    coordinator: DataUpdateCoordinator
+    coordinator: DataUpdateCoordinator[None]
 
     def __init__(self, hass: HomeAssistant, api: Solaredge, site_id: str) -> None:
         """Initialize the data object."""

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -9,7 +9,10 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
 from .const import CONF_SITE_ID, DATA_API_CLIENT, DOMAIN, SENSOR_TYPES
 from .coordinator import (
@@ -108,7 +111,9 @@ class SolarEdgeSensorFactory:
         return sensor_class(self.platform_name, sensor_type, service)
 
 
-class SolarEdgeSensorEntity(CoordinatorEntity, SensorEntity):
+class SolarEdgeSensorEntity(
+    CoordinatorEntity[DataUpdateCoordinator[None]], SensorEntity
+):
     """Abstract class for a solaredge sensor."""
 
     entity_description: SolarEdgeSensorEntityDescription


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
