### PR TITLE
Improve DataUpdateCoordinator typing in integrations (9)

### DIFF
--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -33,7 +33,7 @@ CONF_SHOW_INACTIVE = "show_inactive"
 class TileData:
     """Define an object to be stored in `hass.data`."""
 
-    coordinators: dict[str, DataUpdateCoordinator]
+    coordinators: dict[str, DataUpdateCoordinator[None]]
     tiles: dict[str, Tile]
 
 
@@ -94,7 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except TileError as err:
             raise UpdateFailed(f"Error while retrieving data: {err}") from err
 
-    coordinators = {}
+    coordinators: dict[str, DataUpdateCoordinator[None]] = {}
     coordinator_init_tasks = []
 
     for tile_uuid, tile in tiles.items():

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -78,13 +78,13 @@ async def async_setup_scanner(
     return True
 
 
-class TileDeviceTracker(CoordinatorEntity, TrackerEntity):
+class TileDeviceTracker(CoordinatorEntity[DataUpdateCoordinator[None]], TrackerEntity):
     """Representation of a network infrastructure device."""
 
     _attr_icon = DEFAULT_ICON
 
     def __init__(
-        self, entry: ConfigEntry, coordinator: DataUpdateCoordinator, tile: Tile
+        self, entry: ConfigEntry, coordinator: DataUpdateCoordinator[None], tile: Tile
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)

--- a/homeassistant/components/twentemilieu/calendar.py
+++ b/homeassistant/components/twentemilieu/calendar.py
@@ -1,7 +1,9 @@
 """Support for Twente Milieu Calendar."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
+
+from twentemilieu import WasteType
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
@@ -33,7 +35,7 @@ class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[dict[WasteType, list[date]]],
         entry: ConfigEntry,
     ) -> None:
         """Initialize the Twente Milieu entity."""

--- a/homeassistant/components/twentemilieu/diagnostics.py
+++ b/homeassistant/components/twentemilieu/diagnostics.py
@@ -1,7 +1,10 @@
 """Diagnostics support for TwenteMilieu."""
 from __future__ import annotations
 
+from datetime import date
 from typing import Any
+
+from twentemilieu import WasteType
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID
@@ -15,8 +18,10 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.data[CONF_ID]]
+    coordinator: DataUpdateCoordinator[dict[WasteType, list[date]]] = hass.data[DOMAIN][
+        entry.data[CONF_ID]
+    ]
     return {
-        waste_type: [waste_date.isoformat() for waste_date in waste_dates]
+        str(waste_type): [waste_date.isoformat() for waste_date in waste_dates]
         for waste_type, waste_dates in coordinator.data.items()
     }

--- a/homeassistant/components/twentemilieu/sensor.py
+++ b/homeassistant/components/twentemilieu/sensor.py
@@ -93,7 +93,7 @@ class TwenteMilieuSensor(TwenteMilieuEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[dict[WasteType, list[date]]],
         description: TwenteMilieuSensorDescription,
         entry: ConfigEntry,
     ) -> None:

--- a/homeassistant/components/wiz/models.py
+++ b/homeassistant/components/wiz/models.py
@@ -1,4 +1,6 @@
 """WiZ integration models."""
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from pywizlight import wizlight
@@ -10,6 +12,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 class WizData:
     """Data for the wiz integration."""
 
-    coordinator: DataUpdateCoordinator
+    coordinator: DataUpdateCoordinator[float | None]
     bulb: wizlight
     scenes: list

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import Any
 
 import async_timeout
 from miio import (
@@ -289,7 +290,7 @@ async def async_create_miio_device_and_coordinator(
     device: MiioDevice | None = None
     migrate = False
     update_method = _async_update_data_default
-    coordinator_class: type[DataUpdateCoordinator] = DataUpdateCoordinator
+    coordinator_class: type[DataUpdateCoordinator[Any]] = DataUpdateCoordinator
 
     if (
         model not in MODELS_HUMIDIFIER

--- a/tests/components/twentemilieu/test_diagnostics.py
+++ b/tests/components/twentemilieu/test_diagnostics.py
@@ -16,9 +16,9 @@ async def test_diagnostics(
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration
     ) == {
-        "0": ["2021-11-01", "2021-12-01"],
-        "1": ["2021-11-02"],
-        "2": [],
-        "6": ["2022-01-06"],
-        "10": ["2021-11-03"],
+        "WasteType.NON_RECYCLABLE": ["2021-11-01", "2021-12-01"],
+        "WasteType.ORGANIC": ["2021-11-02"],
+        "WasteType.PAPER": [],
+        "WasteType.TREE": ["2022-01-06"],
+        "WasteType.PACKAGES": ["2021-11-03"],
     }


### PR DESCRIPTION
## Proposed change
Improve generic typing around `CoordinatorEntity` and `DataUpdateCoordinator`. Only deal with special cases.
The default `CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]` will be added once Mypy supports [PEP 696 - TypeVar defaults](https://peps.python.org/pep-0696/).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
