### PR TITLE
Run `flake8` on more files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           - flake8-comprehensions==3.10.1
           - flake8-noqa==1.3.0
           - mccabe==0.7.0
-        files: ^(homeassistant|script|tests)/.+\.py$
+        exclude: docs/source/conf.py
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4
     hooks:

--- a/docs/source/_ext/edit_on_github.py
+++ b/docs/source/_ext/edit_on_github.py
@@ -1,6 +1,5 @@
 """
-Sphinx extension to add ReadTheDocs-style "Edit on GitHub" links to the
-sidebar.
+Sphinx extension for ReadTheDocs-style "Edit on GitHub" links on the sidebar.
 
 Loosely based on https://github.com/astropy/astropy/pull/347
 """
@@ -12,6 +11,7 @@ __licence__ = "BSD (3 clause)"
 
 
 def get_github_url(app, view, path):
+    """Build the GitHub URL."""
     return (
         f"https://github.com/{app.config.edit_on_github_project}/"
         f"{view}/{app.config.edit_on_github_branch}/"
@@ -20,6 +20,7 @@ def get_github_url(app, view, path):
 
 
 def html_page_context(app, pagename, templatename, context, doctree):
+    """Build the HTML page."""
     if templatename != "page.html":
         return
 
@@ -38,6 +39,7 @@ def html_page_context(app, pagename, templatename, context, doctree):
 
 
 def setup(app):
+    """Set up the app."""
     app.add_config_value("edit_on_github_project", "", True)
     app.add_config_value("edit_on_github_branch", "master", True)
     app.add_config_value("edit_on_github_src_path", "", True)  # 'eg' "docs/"

--- a/pylint/plugins/hass_constructor.py
+++ b/pylint/plugins/hass_constructor.py
@@ -22,7 +22,7 @@ class HassConstructorFormatChecker(BaseChecker):  # type: ignore[misc]
     options = ()
 
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
-        """Called when a FunctionDef node is visited."""
+        """Check for improperly typed `__init__` definitions.."""
         if not node.is_method() or node.name != "__init__":
             return
 

--- a/pylint/plugins/hass_constructor.py
+++ b/pylint/plugins/hass_constructor.py
@@ -22,7 +22,7 @@ class HassConstructorFormatChecker(BaseChecker):  # type: ignore[misc]
     options = ()
 
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
-        """Check for improperly typed `__init__` definitions.."""
+        """Check for improperly typed `__init__` definitions."""
         if not node.is_method() or node.name != "__init__":
             return
 

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 class _Special(Enum):
-    """Sentinel values"""
+    """Sentinel values."""
 
     UNDEFINED = 1
 
@@ -2837,7 +2837,7 @@ def _has_valid_annotations(
 
 
 def _get_module_platform(module_name: str) -> str | None:
-    """Called when a Module node is visited."""
+    """Return the platform for the module name."""
     if not (module_match := _MODULE_REGEX.match(module_name)):
         # Ensure `homeassistant.components.<component>`
         # Or `homeassistant.components.<component>.<platform>`
@@ -2878,12 +2878,13 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
     )
 
     def __init__(self, linter: PyLinter | None = None) -> None:
+        """Initialize the HassTypeHintChecker."""
         super().__init__(linter)
         self._function_matchers: list[TypeHintMatch] = []
         self._class_matchers: list[ClassTypeHintMatch] = []
 
     def visit_module(self, node: nodes.Module) -> None:
-        """Called when a Module node is visited."""
+        """Build matchers when visiting a nodes.Module."""
         self._function_matchers = []
         self._class_matchers = []
 
@@ -2907,7 +2908,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
         self._class_matchers.reverse()
 
     def visit_classdef(self, node: nodes.ClassDef) -> None:
-        """Called when a ClassDef node is visited."""
+        """Apply relevant class matchers on each nodes.ClassDef."""
         ancestor: nodes.ClassDef
         checked_class_methods: set[str] = set()
         ancestors = list(node.ancestors())  # cache result for inside loop
@@ -2934,7 +2935,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
                     checked_class_methods.add(function_node.name)
 
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
-        """Called when a FunctionDef node is visited."""
+        """Apply relevant function matchers on each nodes.FunctionDef."""
         for match in self._function_matchers:
             if not match.need_to_check_function(node) or node.is_method():
                 continue

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -2884,7 +2884,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
         self._class_matchers: list[ClassTypeHintMatch] = []
 
     def visit_module(self, node: nodes.Module) -> None:
-        """Build matchers when visiting a nodes.Module."""
+        """Populate matchers for a Module node."""
         self._function_matchers = []
         self._class_matchers = []
 
@@ -2908,7 +2908,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
         self._class_matchers.reverse()
 
     def visit_classdef(self, node: nodes.ClassDef) -> None:
-        """Apply relevant class matchers on each nodes.ClassDef."""
+        """Apply relevant class matchers on a ClassDef node."""
         ancestor: nodes.ClassDef
         checked_class_methods: set[str] = set()
         ancestors = list(node.ancestors())  # cache result for inside loop
@@ -2935,7 +2935,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
                     checked_class_methods.add(function_node.name)
 
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
-        """Apply relevant function matchers on each nodes.FunctionDef."""
+        """Apply relevant function matchers on a FunctionDef node."""
         for match in self._function_matchers:
             if not match.need_to_check_function(node) or node.is_method():
                 continue

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -2908,7 +2908,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
         self._class_matchers.reverse()
 
     def visit_classdef(self, node: nodes.ClassDef) -> None:
-        """Apply relevant class matchers on a ClassDef node."""
+        """Apply relevant type hint checks on a ClassDef node."""
         ancestor: nodes.ClassDef
         checked_class_methods: set[str] = set()
         ancestors = list(node.ancestors())  # cache result for inside loop
@@ -2935,7 +2935,7 @@ class HassTypeHintChecker(BaseChecker):  # type: ignore[misc]
                     checked_class_methods.add(function_node.name)
 
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
-        """Apply relevant function matchers on a FunctionDef node."""
+        """Apply relevant type hint checks on a FunctionDef node."""
         for match in self._function_matchers:
             if not match.need_to_check_function(node) or node.is_method():
                 continue

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -396,11 +396,12 @@ class HassImportsFormatChecker(BaseChecker):  # type: ignore[misc]
     options = ()
 
     def __init__(self, linter: PyLinter | None = None) -> None:
+        """Initialize the HassImportsFormatChecker."""
         super().__init__(linter)
         self.current_package: str | None = None
 
     def visit_module(self, node: nodes.Module) -> None:
-        """Called when a Module node is visited."""
+        """Determine current package."""
         if node.package:
             self.current_package = node.name
         else:
@@ -408,7 +409,7 @@ class HassImportsFormatChecker(BaseChecker):  # type: ignore[misc]
             self.current_package = node.name[: node.name.rfind(".")]
 
     def visit_import(self, node: nodes.Import) -> None:
-        """Called when a Import node is visited."""
+        """Check for improper `import _` invocations."""
         if self.current_package is None:
             return
         for module, _alias in node.names:
@@ -430,7 +431,7 @@ class HassImportsFormatChecker(BaseChecker):  # type: ignore[misc]
     def _visit_importfrom_relative(
         self, current_package: str, node: nodes.ImportFrom
     ) -> None:
-        """Called when a ImportFrom node is visited."""
+        """Check for improper 'from ._ import _' invocations."""
         if (
             node.level <= 1
             or not current_package.startswith("homeassistant.components.")
@@ -449,7 +450,7 @@ class HassImportsFormatChecker(BaseChecker):  # type: ignore[misc]
             self.add_message("hass-absolute-import", node=node)
 
     def visit_importfrom(self, node: nodes.ImportFrom) -> None:
-        """Called when a ImportFrom node is visited."""
+        """Check for improper 'from _ import _' invocations."""
         if not self.current_package:
             return
         if node.level is not None:

--- a/pylint/plugins/hass_logger.py
+++ b/pylint/plugins/hass_logger.py
@@ -29,13 +29,13 @@ class HassLoggerFormatChecker(BaseChecker):  # type: ignore[misc]
     options = ()
 
     def visit_call(self, node: nodes.Call) -> None:
-        """Called when a Call node is visited."""
+        """Check for improper log messages."""
         if not isinstance(node.func, nodes.Attribute) or not isinstance(
             node.func.expr, nodes.Name
         ):
             return
 
-        if not node.func.expr.name in LOGGER_NAMES:
+        if node.func.expr.name not in LOGGER_NAMES:
             return
 
         if not node.args:


### PR DESCRIPTION
## Proposed change

In order to hold more of the code to a high standard, this PR enables `flake8` on all Python files, except the auto-generated sphinx config file. This PR uses a denylist instead of an allowlist so new folders/files will get linted without requiring developers to change the linter targeting rules.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
