### PR TITLE
Add query button entities to ISY994 devices and hub

### DIFF
--- a/homeassistant/components/isy994/button.py
+++ b/homeassistant/components/isy994/button.py
@@ -21,11 +21,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up ISY/IoX button from config entry."""
     hass_isy_data = hass.data[ISY994_DOMAIN][config_entry.entry_id]
-    entities: list[ISYNodeQueryButtonEntity | ISYSystemQueryButtonEntity] = []
+    isy: ISY = hass_isy_data[ISY994_ISY]
+    uuid = isy.configuration["uuid"]
+    entities: list[ISYNodeQueryButtonEntity] = []
     for node in hass_isy_data[ISY994_NODES][Platform.BUTTON]:
-        entities.append(ISYNodeQueryButtonEntity(node))
+        entities.append(ISYNodeQueryButtonEntity(node, f"{uuid}_{node.address}"))
 
-    entities.append(ISYSystemQueryButtonEntity(hass_isy_data[ISY994_ISY]))
+    # Add entity to query full system
+    entities.append(ISYNodeQueryButtonEntity(isy, uuid))
 
     async_add_entities(entities)
 
@@ -37,15 +40,12 @@ class ISYNodeQueryButtonEntity(ButtonEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _attr_has_entity_name = True
 
-    def __init__(self, node: Node) -> None:
+    def __init__(self, node: Node | ISY, base_unique_id: str) -> None:
         """Initialize a query ISY device button entity."""
         self._node = node
 
         # Entity class attributes
         self._attr_name = "Query"
-        base_unique_id: str = (
-            f"{self._node.isy.configuration['uuid']}_{self._node.address}"
-        )
         self._attr_unique_id = f"{base_unique_id}_query"
         self._attr_device_info = DeviceInfo(
             identifiers={(ISY994_DOMAIN, base_unique_id)}
@@ -54,27 +54,3 @@ class ISYNodeQueryButtonEntity(ButtonEntity):
     async def async_press(self) -> None:
         """Press the button."""
         self.hass.async_create_task(self._node.query())
-
-
-class ISYSystemQueryButtonEntity(ButtonEntity):
-    """Representation of a system query button entity."""
-
-    _attr_should_poll = False
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_has_entity_name = True
-
-    def __init__(self, isy: ISY) -> None:
-        """Initialize a query ISY system button entity."""
-        self._isy = isy
-
-        # Entity class attributes
-        self._attr_name = "Query"
-        base_unique_id: str = f"{self._isy.configuration['uuid']}"
-        self._attr_unique_id = f"{base_unique_id}_query"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(ISY994_DOMAIN, base_unique_id)}
-        )
-
-    async def async_press(self) -> None:
-        """Press the button."""
-        self.hass.async_create_task(self._isy.query())

--- a/homeassistant/components/isy994/button.py
+++ b/homeassistant/components/isy994/button.py
@@ -1,0 +1,80 @@
+"""Representation of ISY/IoX buttons."""
+from __future__ import annotations
+
+from pyisy import ISY
+from pyisy.nodes import Node
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN as ISY994_DOMAIN, ISY994_ISY, ISY994_NODES
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ISY/IoX button from config entry."""
+    hass_isy_data = hass.data[ISY994_DOMAIN][config_entry.entry_id]
+    entities: list[ISYNodeQueryButtonEntity | ISYSystemQueryButtonEntity] = []
+    for node in hass_isy_data[ISY994_NODES][Platform.BUTTON]:
+        entities.append(ISYNodeQueryButtonEntity(node))
+
+    entities.append(ISYSystemQueryButtonEntity(hass_isy_data[ISY994_ISY]))
+
+    async_add_entities(entities)
+
+
+class ISYNodeQueryButtonEntity(ButtonEntity):
+    """Representation of a device query button entity."""
+
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+
+    def __init__(self, node: Node) -> None:
+        """Initialize a query ISY device button entity."""
+        self._node = node
+
+        # Entity class attributes
+        self._attr_name = "Query"
+        base_unique_id: str = (
+            f"{self._node.isy.configuration['uuid']}_{self._node.address}"
+        )
+        self._attr_unique_id = f"{base_unique_id}_query"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(ISY994_DOMAIN, base_unique_id)}
+        )
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        self.hass.async_create_task(self._node.query())
+
+
+class ISYSystemQueryButtonEntity(ButtonEntity):
+    """Representation of a system query button entity."""
+
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+
+    def __init__(self, isy: ISY) -> None:
+        """Initialize a query ISY system button entity."""
+        self._isy = isy
+
+        # Entity class attributes
+        self._attr_name = "Query"
+        base_unique_id: str = f"{self._isy.configuration['uuid']}"
+        self._attr_unique_id = f"{base_unique_id}_query"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(ISY994_DOMAIN, base_unique_id)}
+        )
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        self.hass.async_create_task(self._isy.query())

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -76,6 +76,7 @@ KEY_STATUS = "status"
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.COVER,
     Platform.FAN,
@@ -188,6 +189,14 @@ NODE_FILTERS: dict[Platform, dict[str, list[str]]] = {
             TYPE_CATEGORY_SAFETY,
         ],  # Does a startswith() match; include the dot
         FILTER_ZWAVE_CAT: (["104", "112", "138"] + list(map(str, range(148, 180)))),
+    },
+    Platform.BUTTON: {
+        # No devices automatically sorted as buttons at this time. Query buttons added elsewhere.
+        FILTER_UOM: [],
+        FILTER_STATES: [],
+        FILTER_NODE_DEF_ID: [],
+        FILTER_INSTEON_TYPE: [],
+        FILTER_ZWAVE_CAT: [],
     },
     Platform.SENSOR: {
         # This is just a more-readable way of including MOST uoms between 1-100

--- a/homeassistant/components/isy994/services.py
+++ b/homeassistant/components/isy994/services.py
@@ -212,7 +212,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
             _LOGGER.debug(
                 "Requesting system query of ISY %s", isy.configuration["uuid"]
             )
-            # await isy.query()
+            await isy.query()
             async_log_deprecated_service_call(
                 hass,
                 call=service,

--- a/homeassistant/components/isy994/services.py
+++ b/homeassistant/components/isy994/services.py
@@ -203,12 +203,9 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
                     entity_registry, config_entry_id
                 )
                 alternate_target = next(
-                    (
-                        entity.entity_id
-                        for entity in entries_for_this_config
-                        if "query" in entity.entity_id and address in entity.unique_id
-                    ),
-                    "",
+                    entity.entity_id
+                    for entity in entries_for_this_config
+                    if f"{address}_query" in entity.unique_id
                 )
                 async_log_deprecated_service_call(
                     hass,

--- a/homeassistant/components/isy994/services.yaml
+++ b/homeassistant/components/isy994/services.yaml
@@ -168,8 +168,8 @@ set_ramp_rate:
           min: 0
           max: 31
 system_query:
-  name: System query
-  description: Request the ISY Query the connected devices.
+  name: System query (Deprecated)
+  description: "Request the ISY Query the connected devices. Deprecated: Use device Query button entity."
   fields:
     address:
       name: Address

--- a/homeassistant/components/isy994/strings.json
+++ b/homeassistant/components/isy994/strings.json
@@ -53,5 +53,18 @@
       "last_heartbeat": "Last Heartbeat Time",
       "websocket_status": "Event Socket Status"
     }
+  },
+  "issues": {
+    "deprecated_service": {
+      "title": "The {deprecated_service} service will be removed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "The {deprecated_service} service will be removed",
+            "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`."
+          }
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/isy994/translations/en.json
+++ b/homeassistant/components/isy994/translations/en.json
@@ -53,5 +53,18 @@
             "last_heartbeat": "Last Heartbeat Time",
             "websocket_status": "Event Socket Status"
         }
+    },
+    "issues": {
+        "deprecated_service": {
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`.",
+                        "title": "The {deprecated_service} service will be removed"
+                    }
+                }
+            },
+            "title": "The {deprecated_service} service will be removed"
+        }
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `isy994.system_query` service is being depreciated and will be removed in a future release, `Query` button entities are now available for each ISY/IoX device and the hub and those should be used instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the `button` platform to ISY994 and create "Query" entities to query nodes on the ISY (similar to the "Ping" button in Z-Wave JS). An entity for the hub will also be created to allow for a system-wide query (recommended by UDI to be run once every day).

These button entities will eliminate the need for the `isy994.system_query` integration-specific service. I've set the warnings for the 2023.5.0 version assuming this makes it into 2023.2.0 + 3-month depreciation period.

This also includes minor cleanup in the `helpers.py` file to use the `Platform` enum instead of importing names from the various platforms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/automicus/PyISY/discussions/340
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25609

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
