### PR TITLE
Limit Whirlpool timestamp changes to +/- 60 seconds

### DIFF
--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -280,8 +280,13 @@ class WasherDryerTimeClass(RestoreSensor):
 
         if machine_state is MachineState.RunningMainCycle:
             self._running = True
-            self._attr_native_value = now + timedelta(
+            new_timestamp = now + timedelta(
                 seconds=int(self._wd.get_attribute("Cavity_TimeStatusEstTimeRemaining"))
             )
 
-            self._async_write_ha_state()
+            if isinstance(self._attr_native_value, datetime) and abs(
+                new_timestamp - self._attr_native_value
+            ) > timedelta(seconds=60):
+
+                self._attr_native_value = new_timestamp
+                self._async_write_ha_state()

--- a/tests/components/whirlpool/conftest.py
+++ b/tests/components/whirlpool/conftest.py
@@ -63,6 +63,7 @@ def get_aircon_mock(said):
     mock_aircon = mock.Mock(said=said)
     mock_aircon.connect = AsyncMock()
     mock_aircon.disconnect = AsyncMock()
+    mock_aircon.register_attr_callback = AsyncMock()
     mock_aircon.get_online.return_value = True
     mock_aircon.get_power_on.return_value = True
     mock_aircon.get_mode.return_value = whirlpool.aircon.Mode.Cool
@@ -114,6 +115,8 @@ def side_effect_function(*args, **kwargs):
         return "0"
     if args[0] == "WashCavity_OpStatusBulkDispense1Level":
         return "3"
+    if args[0] == "Cavity_TimeStatusEstTimeRemaining":
+        return "4000"
 
 
 def get_sensor_mock(said):
@@ -121,6 +124,7 @@ def get_sensor_mock(said):
     mock_sensor = mock.Mock(said=said)
     mock_sensor.connect = AsyncMock()
     mock_sensor.disconnect = AsyncMock()
+    mock_sensor.register_attr_callback = AsyncMock()
     mock_sensor.get_online.return_value = True
     mock_sensor.get_machine_state.return_value = (
         whirlpool.washerdryer.MachineState.Standby

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -45,6 +45,25 @@ async def test_dryer_sensor_values(
     mock_sensor2_api: MagicMock,
 ):
     """Test the sensor value callbacks."""
+    hass.state = CoreState.not_running
+    thetimestamp: datetime = datetime(2022, 11, 29, 00, 00, 00, 00, timezone.utc)
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State(
+                    "sensor.washer_end_time",
+                    "1",
+                ),
+                {"native_value": thetimestamp, "native_unit_of_measurement": None},
+            ),
+            (
+                State("sensor.dryer_end_time", "1"),
+                {"native_value": thetimestamp, "native_unit_of_measurement": None},
+            ),
+        ),
+    )
+
     await init_integration(hass)
 
     entity_id = "sensor.dryer_state"
@@ -90,6 +109,25 @@ async def test_washer_sensor_values(
     mock_sensor1_api: MagicMock,
 ):
     """Test the sensor value callbacks."""
+    hass.state = CoreState.not_running
+    thetimestamp: datetime = datetime(2022, 11, 29, 00, 00, 00, 00, timezone.utc)
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State(
+                    "sensor.washer_end_time",
+                    "1",
+                ),
+                {"native_value": thetimestamp, "native_unit_of_measurement": None},
+            ),
+            (
+                State("sensor.dryer_end_time", "1"),
+                {"native_value": thetimestamp, "native_unit_of_measurement": None},
+            ),
+        ),
+    )
+
     await init_integration(hass)
 
     entity_id = "sensor.washer_state"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Limit timestamp changes to +/- 60 seconds: Updating timestamp changes for anything less than 60 seconds produces unnecessary state machine updates with no value to the user.   For most cycles this reduces the "changes" by 90%.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
